### PR TITLE
Submitting geos and shapely

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,7 @@ platform:
     - x64
 
 install:
-    - cmd: python -c "from urllib2 import urlopen; open('bootstrap-obvious-ci-and-miniconda.py', 'w').write(urlopen('https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py').read())"
+    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
     - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
     - cmd: set PYTHONUNBUFFERED=1

--- a/recipes/geos/bld.bat
+++ b/recipes/geos/bld.bat
@@ -1,0 +1,14 @@
+mkdir build
+cd build
+
+set LIB=%LIBRARY_LIB%;%LIB%
+set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
+set INCLUDE=%LIBRARY_INC%;%INCLUDE%
+
+cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% -DCMAKE_BUILD_TYPE=Release
+
+nmake install || exit 1
+
+copy ..\include\geos.h %LIBRARY_INC%\geos.h || exit 1
+copy lib\*.exp %LIBRARY_LIB%\ || exit 1
+copy lib\*.lib %LIBRARY_LIB%\ || exit 1

--- a/recipes/geos/build.sh
+++ b/recipes/geos/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+# Problems with cartopy if the -m{32,64} flag is not defined.
+# See https://taskman.eionet.europa.eu/issues/14817.
+
+MACHINE_TYPE=`uname -m`
+if [ ${MACHINE_TYPE} == 'x86_64' ]; then
+  ARCH="-m64"
+else
+  ARCH="-m32"
+fi
+
+CFLAGS=${ARCH} CPPFLAGS=${ARCH} CXXFLAGS=${ARCH} LDFLAGS=${ARCH} FFLAGS=${ARCH} \
+    ./configure --prefix=$PREFIX --without-jni
+
+make
+make install

--- a/recipes/geos/cmake.win.patch
+++ b/recipes/geos/cmake.win.patch
@@ -1,0 +1,11 @@
+--- capi\CMakeLists.txt.orig	Sun Aug 25 15:10:32 2013
++++ capi\CMakeLists.txt	Mon Jan 19 15:10:24 2015
+@@ -25,7 +25,7 @@
+   # if building OS X framework, CAPI built into C++ library 
+   add_library(geos_c SHARED ${geos_c_SOURCES}) 
+ 
+-  target_link_libraries(geos_c geos)
++  target_link_libraries(geos_c geos-static)
+ 
+   if (WIN32)
+     set_target_properties(geos_c

--- a/recipes/geos/meta.yaml
+++ b/recipes/geos/meta.yaml
@@ -1,0 +1,22 @@
+package:
+    name: geos
+    version: "3.4.2"
+
+source:
+    fn:  geos-3.4.2.tar.bz2
+    url: http://download.osgeo.org/geos/geos-3.4.2.tar.bz2
+    patches:
+        - cmake.win.patch  # [win]
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - msinttypes  # [win]
+    run:
+
+about:
+    home: http://trac.osgeo.org/geos/
+    license: LGPL
+    summary: 'Geometry Engine - Open Source'

--- a/recipes/shapely/bld.bat
+++ b/recipes/shapely/bld.bat
@@ -1,0 +1,9 @@
+set LIB=%LIBRARY_LIB%;%LIB%
+set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
+set INCLUDE=%LIBRARY_INC%;%INCLUDE%;%RECIPE_DIR%
+
+set GEOS_LIBRARY_PATH=%LIBRARY_BIN%\geos_c.dll
+
+%PYTHON% setup.py build_ext -I %LIBRARY_INC% -L %LIBRARY_LIB% -l geos_c
+%PYTHON% setup.py install
+if errorlevel 1 exit 1

--- a/recipes/shapely/build.sh
+++ b/recipes/shapely/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export GEOS_DIR=$PREFIX
+
+$PYTHON setup.py install

--- a/recipes/shapely/geos_c.win.patch
+++ b/recipes/shapely/geos_c.win.patch
@@ -1,0 +1,16 @@
+--- shapely/geos.py	2015-10-10 00:49:23.000000000 -0300
++++ shapely/geos.py	2015-10-13 13:48:29.687225436 -0300
+@@ -133,9 +133,10 @@
+                                    "DLLs"))
+         wininst_dlls = os.path.abspath(os.__file__ + "../../../DLLs")
+         original_path = os.environ['PATH']
+-        os.environ['PATH'] = "%s;%s;%s" % \
+-            (egg_dlls, wininst_dlls, original_path)
+-        _lgeos = CDLL("geos.dll")
++        os.environ['PATH'] = "%s;%s;%s;%s" % \
++	  (egg_dlls, wininst_dlls, original_path,
++           os.path.join(sys.prefix, "Library", "bin"))
++        _lgeos = CDLL("geos_c.dll")
+     except (ImportError, WindowsError, OSError):
+         raise
+ 

--- a/recipes/shapely/meta.yaml
+++ b/recipes/shapely/meta.yaml
@@ -1,0 +1,37 @@
+package:
+    name: shapely
+    version: 1.5.13
+
+source:
+    fn: Shapely-1.5.13.tar.gz
+    url: https://pypi.python.org/packages/source/S/Shapely/Shapely-1.5.13.tar.gz
+    md5: 5ee549862ae84326f5f5525bbd0b8a50
+    patches:
+        - geos_c.win.patch  # [win]
+        - osx-geos.patch # [osx]
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - geos >=3.4
+        - cython
+        - numpy
+        - msinttypes  # [win]
+    run:
+        - python
+        - geos >=3.4
+        - numpy
+
+test:
+    imports:
+        - shapely
+        - shapely.speedups._speedups
+        - shapely.vectorized._vectorized
+
+about:
+    home: https://github.com/Toblerity/Shapely
+    license: BSD
+    summary: 'Python package for manipulation and analysis of geometric objects in the Cartesian plane'

--- a/recipes/shapely/osx-geos.patch
+++ b/recipes/shapely/osx-geos.patch
@@ -1,0 +1,63 @@
+--- shapely/geos.py	2015-10-10 00:49:23.000000000 -0300
++++ shapely/geos.py	2015-10-13 13:56:02.994252176 -0300
+@@ -69,59 +69,7 @@
+     free.restype = None
+ 
+ elif sys.platform == 'darwin':
+-    # First: have we already loaded GEOS through a Fiona or Rasterio?
+-    # If so, let's obtain a handle to it instead of loading this module's
+-    # copy to side step the mysterious issue described at
+-    # https://github.com/Toblerity/Shapely/issues/324.
+-    geos_mod = sys.modules.get('fiona') or sys.modules.get('rasterio')
+-    if geos_mod:
+-        dll_path = os.path.join(
+-            os.path.dirname(geos_mod.__file__), '.dylibs',
+-            'libgeos_c.1.dylib')
+-        try:
+-            _lgeos = CDLL(dll_path, mode=(DEFAULT_MODE | 16))
+-        except OSError:
+-            LOG.debug("GEOS DLL in fiona or rasterio .dylibs not found.")
+-            alt_paths = [
+-                # The Framework build from Kyng Chaos
+-                "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
+-                # macports
+-                '/opt/local/lib/libgeos_c.dylib',
+-            ]
+-            _lgeos = load_dll('geos_c', fallbacks=alt_paths,
+-                              mode=(DEFAULT_MODE | 16))
+-        if _lgeos:
+-            LOG.debug("Found %r already loaded, using it.", _lgeos)
+-
+-    # If neither fiona nor rasterio have been imported, or if the block
+-    # above failed to assign _lgeos, we will locate and load the GEOS
+-    # DLL.
+-    if not _lgeos:
+-        # Test to see if we have a delocated wheel with a GEOS dylib.
+-        geos_whl_dylib = os.path.abspath(os.path.join(os.path.dirname(
+-            __file__), '.dylibs/libgeos_c.1.dylib'))
+-        if os.path.exists(geos_whl_dylib):
+-            _lgeos = CDLL(geos_whl_dylib)
+-            LOG.debug("Found GEOS DLL: %r, using it.", _lgeos)
+-
+-        else:
+-            if hasattr(sys, 'frozen'):
+-                try:
+-                    # .app file from py2app
+-                    alt_paths = [os.path.join(os.environ['RESOURCEPATH'],
+-                                '..', 'Frameworks', 'libgeos_c.dylib')]
+-                except KeyError:
+-                    # binary from pyinstaller
+-                    alt_paths = [
+-                        os.path.join(sys.executable, 'libgeos_c.dylib')]
+-            else:
+-                alt_paths = [
+-                    # The Framework build from Kyng Chaos
+-                    "/Library/Frameworks/GEOS.framework/Versions/Current/GEOS",
+-                    # macports
+-                    '/opt/local/lib/libgeos_c.dylib',
+-                ]
+-            _lgeos = load_dll('geos_c', fallbacks=alt_paths)
++    _lgeos = CDLL(os.path.join(sys.prefix, 'lib', 'libgeos_c.dylib'))
+ 
+     free = load_dll('c').free
+     free.argtypes = [c_void_p]

--- a/recipes/shapely/run_test.py
+++ b/recipes/shapely/run_test.py
@@ -1,0 +1,13 @@
+from shapely import speedups;
+
+assert speedups.available;
+
+speedups.enable()
+
+from shapely.geometry import LineString
+
+ls = LineString([(0, 0), (10, 0)])
+# On OSX causes an abort trap, due to https://github.com/Toblerity/Shapely/issues/177 
+r = ls.wkt
+area = ls.buffer(10).area
+


### PR DESCRIPTION
Submitting `geos-3.4.2` and `Shapely 1.5.12`.

- This is the latest version of shapely that is not yet in any channel (default, ioos, nor scitools).
- The geos library has a 3.5.0 version that I was unable to build on windows.
- Note that the shapely recipe no longer ships `stdint.h`.  The recipe is using @pelson's `msinttypes` package now.

If these packages are OK and the @conda-forge contributor give a :+1: I guess the next step is to create feedstocks for each recipe.