### PR TITLE
Appveyor setting of CONDA_PY correctly for Obvious-CI.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,13 +18,13 @@ environment:
       CONDA_PY: "27"
       PY_CONDITION: "python >=2.7,<3"
     - TARGET_ARCH: "x86"
-      CONDA_PY: "3"
+      CONDA_PY: "34"
       PY_CONDITION: "python >=3.4,<3.5"
     - TARGET_ARCH: "x64"
       CONDA_PY: "27"
       PY_CONDITION: "python >=2.7,<3"
     - TARGET_ARCH: "x64"
-      CONDA_PY: "3"
+      CONDA_PY: "34"
       PY_CONDITION: "python >=3.4,<3.5"
 
 # We always use a 64-bit machine, but can build x86 distributions


### PR DESCRIPTION
Doh, this is why the tests were failing. Replaces #4.