### PR TITLE
Add tifffile

### DIFF
--- a/recipes/tifffile/bld.bat
+++ b/recipes/tifffile/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/recipes/tifffile/build.sh
+++ b/recipes/tifffile/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/tifffile/meta.yaml
+++ b/recipes/tifffile/meta.yaml
@@ -10,11 +10,11 @@ source:
 requirements:
   build:
     - python
-    - numpy
+    - numpy x.x
 
   run:
     - python
-    - numpy
+    - numpy x.x
 
 test:
   imports:

--- a/recipes/tifffile/meta.yaml
+++ b/recipes/tifffile/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: tifffile
+  version: 0.3.1
+
+source:
+  fn: tifffile-0.3.1.tar.gz
+  url: https://pypi.python.org/packages/source/t/tifffile/tifffile-0.3.1.tar.gz
+  md5: bd8718457f3578a6016d6dd3c6a041ed
+
+requirements:
+  build:
+    - python
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - tifffile
+
+about:
+  home: https://github.com/blink1073/tifffile
+  license:  BSD License
+  summary: 'Read and write image data from and to TIFF files.'


### PR DESCRIPTION
This adds a tifffile recipe. I once built this on appveyor (the packages are [here](https://anaconda.org/soft-matter/tifffile)) but I'm now fuzzy on the details about how it went. I need to build packages for Python 3.5 and, I think, numpy 1.10, so I thought we could try conda-forge.

Where do I go from here?