### PR TITLE
Improvements to AppVeyor setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,5 +64,5 @@ test_script:
     - '%CMD_IN_ENV% obvci_conda_build_dir recipes conda-forge --channel main  --build-condition "numpy >=1.8" "%PY_CONDITION%"'
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
-    - cmd: 'copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages'
-    - cmd: 'copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages'
+    - cmd: 'copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages || cmd /c "exit /b 0"'
+    - cmd: 'copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages || cmd /c "exit /b 0"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,12 +40,11 @@ install:
     - cmd: set CONDA_NPY=19
 
     # Use the pre-installed Miniconda for the desired arch
-    - ps: if($env:TARGET_ARCH -eq 'x86') {
-            $env:path="C:\Miniconda;C:\Miniconda\Scripts;C:Miniconda\Library\bin;$($env:path)"
-            }
-            else {
-            $env:path="C:\Miniconda-x64;C:\Miniconda-x64\Scripts;C:Miniconda-x64\Library\bin;$($env:path)"
-            }
+    - ps: if($env:TARGET_ARCH -eq 'x86') 
+            {$root = "C:\Miniconda"}
+          else 
+            {$root = "C:\Miniconda-x64"}
+          $env:path="$root;$root\Scripts;$root\Library\bin;$($env:path)"
     - cmd: conda update --yes --quiet conda
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,5 +64,7 @@ test_script:
     - '%CMD_IN_ENV% obvci_conda_build_dir recipes conda-forge --channel main  --build-condition "numpy >=1.8" "%PY_CONDITION%"'
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
-    - cmd: 'copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages || cmd /c "exit /b 0"'
-    - cmd: 'copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages || cmd /c "exit /b 0"'
+    # Uncomment the following two lines to make any conda packages created
+    # available as build artifacts in AppVeyor
+    #- cmd: 'copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages || cmd /c "exit /b 0"'
+    #- cmd: 'copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages || cmd /c "exit /b 0"'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,5 +64,5 @@ test_script:
     - '%CMD_IN_ENV% obvci_conda_build_dir recipes conda-forge --channel main  --build-condition "numpy >=1.8" "%PY_CONDITION%"'
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
-    - cmd: "copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages"
-    - cmd: "copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages"
+    - cmd: 'copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages'
+    - cmd: 'copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,9 +39,14 @@ install:
     # Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.
     - cmd: set CONDA_NPY=19
 
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
-    - cmd: set PATH=%PATH%;%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts
+    # Use the pre-installed Miniconda for the desired arch
+    - ps: if($env:TARGET_ARCH -eq 'x86') {
+            $env:path="C:\Miniconda;C:\Miniconda\Scripts;C:Miniconda\Library\bin;$($env:path)"
+            }
+            else {
+            $env:path="C:\Miniconda-x64;C:\Miniconda-x64\Scripts;C:Miniconda-x64\Library\bin;$($env:path)"
+            }
+    - cmd: conda update --yes --quiet conda
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda config --set show_channel_urls yes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,10 @@ environment:
       CONDA_PY: "34"
       PY_CONDITION: "python >=3.4,<3.5"
 
+artifacts:
+    # Store built conda packages as artifacts
+    - path: 'conda_packages\*.bz2'
+
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable (which is used by CMD_IN_ENV).
 platform:
@@ -58,3 +62,7 @@ build: off
 
 test_script:
     - '%CMD_IN_ENV% obvci_conda_build_dir recipes conda-forge --channel main  --build-condition "numpy >=1.8" "%PY_CONDITION%"'
+    # copy any newly created conda packages into the conda_packages dir
+    - cmd: mkdir conda_packages
+    - cmd: "copy /Y C:\Miniconda\conda-bld\win-32\*.bz2 conda_packages"
+    - cmd: "copy /Y C:\Miniconda-x64\conda-bld\win-64\*.bz2 conda_packages"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script interpreter
   # See: http://stackoverflow.com/a/13751649/163740


### PR DESCRIPTION
* AppVeyor uses the pre-installed version of Miniconda on the VM image.
* Python 2.7 is always used as the root environment, the build environment can be any version of Python (2.6, 2.7, 3.3, 3.4, 3.5)
* Any conda packages build are stored as artifacts and can be downloaded and tested, even from un-merged Pull Requests.