### PR TITLE
Xonsh now builds on windows.

### DIFF
--- a/recipes/xonsh/bld.bat
+++ b/recipes/xonsh/bld.bat
@@ -1,0 +1,1 @@
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/xonsh/meta.yaml
+++ b/recipes/xonsh/meta.yaml
@@ -10,7 +10,7 @@ build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
   entry_points:
     - xonsh = xonsh.main:main
-  skip: True  # [py2k or win]
+  skip: True  # [py2k]
 
 requirements:
   build:


### PR DESCRIPTION
Ping @scopatz.

It seems that conda isn't making use of the script section in ``meta.yaml``, despite that being the described behaviour. I'll look into the underlying conda bug shortly.