### PR TITLE
functools32 3.2.3.2

### DIFF
--- a/recipes/functools32/bld.bat
+++ b/recipes/functools32/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/recipes/functools32/build.sh
+++ b/recipes/functools32/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install

--- a/recipes/functools32/meta.yaml
+++ b/recipes/functools32/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: functools32
+  version: "3.2.3.2"
+
+source:
+  fn: functools32-3.2.3-2.tar.gz
+  url: https://pypi.python.org/packages/source/f/functools32/functools32-3.2.3-2.tar.gz
+  md5: 09f24ffd9af9f6cd0f63cb9f4e23d4b2
+
+requirements:
+  build:
+    - python 2.7.*
+
+  run:
+    - python 2.7.*
+
+test:
+  imports:
+    - functools32
+
+about:
+  home: https://github.com/MiCHiLU/python-functools32
+  license: PSF license
+  summary: 'Backport of the functools module from Python 3.2.3 for use on 2.7 and PyPy.'


### PR DESCRIPTION
This recipe is mostly straight from https://github.com/conda/conda-recipes/tree/master/functools32

See https://github.com/matplotlib/matplotlib/pull/5629#issuecomment-163097490

> I would suggest a healthier choice would be to look at extending conda-forge to include functools32. I'm happy to support you in doing this (see https://github.com/conda-forge/staged-recipes).