### PR TITLE
No mingwpy

### DIFF
--- a/recipes/netcdf4/meta.yaml
+++ b/recipes/netcdf4/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
     skip: True  # [win and py35]
-    number: 0
+    number: 1
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo
         - nc4tonc3 = netCDF4.utils:nc4tonc3
@@ -23,7 +23,6 @@ requirements:
         - cython
         - hdf5
         - libnetcdf
-        - mingwpy  # [win]
     run:
         - python
         - numpy x.x


### PR DESCRIPTION
I believe we do not need `mingwpy` for c-stuff on AppVeyor.  That was a remnant from my local build.