### PR TITLE
netcdf4 1.2.2

### DIFF
--- a/recipes/netcdf4/meta.yaml
+++ b/recipes/netcdf4/meta.yaml
@@ -1,15 +1,15 @@
 package:
     name: netcdf4
-    version: "1.2.1"
+    version: "1.2.2"
 
 source:
-    fn: netCDF4-1.2.1.tar.gz
-    url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-1.2.1.tar.gz
-    md5: 9d9a7015ee98ec6766adc811d95b82c3
+    fn: netCDF4-1.2.2.tar.gz
+    url: https://pypi.python.org/packages/source/n/netCDF4/netCDF4-1.2.2.tar.gz
+    md5: c8a80cb2bbfaae2faaff7d1d699b4b61
 
 build:
     skip: True  # [win and py35]
-    number: 2
+    number: 0
     entry_points:
         - ncinfo = netCDF4.utils:ncinfo
         - nc4tonc3 = netCDF4.utils:nc4tonc3

--- a/recipes/netcdf4/run_test.py
+++ b/recipes/netcdf4/run_test.py
@@ -1,7 +1,7 @@
 import netCDF4
 
 # OPeNDAP.
-url = 'http://test.opendap.org:80/opendap/data/ncml/sample_virtual_dataset.ncml'
+url = 'http://omgsrv1.meas.ncsu.edu:8080/thredds/dodsC/fmrc/sabgom/SABGOM_Forecast_Model_Run_Collection_best.ncd'
 nc = netCDF4.Dataset(url)
 
 # Compiled with cython.


### PR DESCRIPTION
 version 1.2.2 (tag v1.2.2rel)
 =============================
 * fix failing tests on python 2.6 (issue 497). Change minimum required
   python from 2.5 to 2.6.
 * Potential memory leaks fixed by freeing string pointers internally allocated 
   in netcdf-c using nc_free_string. Also use nc_free_vlens to free space allocated
   for vlens inside netcdf-c (issue 495).
 * invoke str on filename argument to Dataset constructor, so pathlib 
   instances can be used (issue 489).
 * don't use hardwired NC_MAX_DIMS or NC_MAX_VARS internally to allocate space
   for dimension or variable ids.  Instead, find out the number of dims
   and vars and use malloc.  NC_MAX_NAME is still used to allocate space
   for attribute and variable names, since there is no obvious way to
   determine the length of these names.
 * if trying to write a unicode attribute, check to see if it exists
   first and is NC_CHAR, and if so, delete it and recreate it.  Workaround for C
   lib bug discovered in issue 485.
 * support for NETCDF3_64BIT_DATA format supported in netcdf-c 4.4.0.
   Similar to NETCDF3_64BIT (now NETCDF3_64BIT_OFFSET), but includes
   64 bit dimensions and sizes, plus unsigned and 64 bit integer
   data types.
 * make sure chunksize does not exceed dimension size
   (for non-unlimited dimensions) on variable creation (issue 480).
 * add 'size' attribute to Dimension (same as len(d), where
   d is a Dimension instance, issue 477).
 * fix bug in nc3tonc4 with --unpackshort=1 (issue 474).
 * dates do not have to be contiguous, i.e. can be before and after the 
   missing dates in Gregorian calendar (pull request 476).