### PR TITLE
Add recipe for vcrpy

### DIFF
--- a/ready_recipes/vcrpy/bld.bat
+++ b/ready_recipes/vcrpy/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/ready_recipes/vcrpy/meta.yaml
+++ b/ready_recipes/vcrpy/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "1.7.4" %}
+
+package:
+  name: vcrpy
+  version: {{ version }}
+
+source:
+  fn: vcrpy-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/v/vcrpy/vcrpy-{{ version }}.tar.gz
+  md5: 27fde8879e74e670fe9142a195249f2a
+
+build:
+  script: python setup.py install
+  number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyyaml
+    - wrapt
+    - six >=1.5
+    - mock # [py27]
+    - contextlib2 # [py27]
+
+  run:
+    - python
+    - pyyaml
+    - wrapt
+    - six >=1.5
+    - mock # [py27]
+    - contextlib2 # [py27]
+
+test:
+  # Python imports
+  imports:
+    - vcr
+    - vcr.persisters
+    - vcr.serializers
+    - vcr.stubs
+
+about:
+  home: https://github.com/kevin1024/vcrpy
+  license: MIT License
+  summary: 'Automatically mock your HTTP interactions to simplify and speed up testing'
+
+extra:
+  recipe-maintainers:
+    - dopplershift


### PR DESCRIPTION
This is a tool for automatically recording and mocking http requests. Used for testing Siphon.