### PR TITLE
Add package for pep8-naming

### DIFF
--- a/recipes/pep8-naming/bld.bat
+++ b/recipes/pep8-naming/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/pep8-naming/meta.yaml
+++ b/recipes/pep8-naming/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.3.3" %}
+
+package:
+  name: pep8-naming
+  version: {{ version }}
+
+source:
+  fn: pep8-naming-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pep8-naming/pep8-naming-{{ version }}.tar.gz
+  md5: 566f05660200993191312d51cd5a6cc9
+
+build:
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - flake8
+
+test:
+  commands:
+    - "flake8 --version | grep naming:"
+
+about:
+  home: https://github.com/PyCQA/pep8-naming
+  license: MIT License
+  summary: 'Plug-in for flake 8 to check the PEP-8 naming conventions'
+
+extra:
+  recipe-maintainers:
+    - dopplershift


### PR DESCRIPTION
It's a flake8 plugin to enforce pep8 "rules" for naming. I hate blind enforcement, but it's been nice having consistency from the outset.

I *think* this gives me a complete dev environment using just defaults + conda-forge. 