### PR TITLE
Add pandoc package

### DIFF
--- a/recipes/pandoc/bld.bat
+++ b/recipes/pandoc/bld.bat
@@ -1,0 +1,3 @@
+msiexec /a pandoc-%PKG_VERSION%-windows.msi /qb TARGETDIR=%TEMP%
+mkdir %SCRIPTS%
+copy %TEMP%\Pandoc\*.exe %SCRIPTS%

--- a/recipes/pandoc/build.sh
+++ b/recipes/pandoc/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ `uname` == Linux ]; then
+    ar vx pandoc*.deb
+    tar -xzvf data.tar.gz
+    mkdir $PREFIX/bin
+    mv usr/bin/* $PREFIX/bin
+fi
+
+
+if [ `uname` == Darwin ]; then
+    pkgutil --expand pandoc-$PKG_VERSION.pkg pandoc
+    cpio -i -I pandoc/pandoc.pkg/Payload
+    mkdir $PREFIX/bin
+    cp usr/local/bin/* $PREFIX/bin/
+fi

--- a/recipes/pandoc/meta.yaml
+++ b/recipes/pandoc/meta.yaml
@@ -1,17 +1,19 @@
+{% set v = "1.16.0.2" %}
+
 package:
   name: pandoc
-  version: 1.16.0.2
+  version: {{ v }}
 
 source:
-  fn:   pandoc-1.16.0.2-amd64.deb                                                             # [linux64]
-  url:  https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb  # [linux64]
-  md5:  00e0b312e764ada376444fb5835d0574                                                      # [linux64]
-  fn:   pandoc-1.16.0.2.pkg                                                                   # [osx]
-  url:  https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-osx.pkg      # [osx]
-  md5:  c0a3e7af327e33c58e81ee567655304d                                                      # [osx]
-  fn:   pandoc-1.16.0.2-windows.msi                                                           # [win]
-  url:  https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-windows.msi  # [win]
-  md5:  6be571c106d4099ca1066b8a9baa8f2b                                                      # [win]
+  fn:   pandoc-{{ v }}-amd64.deb                                                            # [linux64]
+  url:  https://github.com/jgm/pandoc/releases/download/{{ v }}/pandoc-{{ v }}-1-amd64.deb  # [linux64]
+  md5:  00e0b312e764ada376444fb5835d0574                                                    # [linux64]
+  fn:   pandoc-{{ v }}.pkg                                                                  # [osx]
+  url:  https://github.com/jgm/pandoc/releases/download/{{ v }}/pandoc-{{ v }}-osx.pkg      # [osx]
+  md5:  c0a3e7af327e33c58e81ee567655304d                                                    # [osx]
+  fn:   pandoc-{{ v }}-windows.msi                                                          # [win]
+  url:  https://github.com/jgm/pandoc/releases/download/{{ v }}/pandoc-{{ v }}-windows.msi  # [win]
+  md5:  6be571c106d4099ca1066b8a9baa8f2b                                                    # [win]
 
 requirements:
   run:

--- a/recipes/pandoc/meta.yaml
+++ b/recipes/pandoc/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: pandoc
+  version: 1.16.0.2
+
+source:
+  fn:   pandoc-1.16.0.2-amd64.deb                                                             # [linux64]
+  url:  https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-1-amd64.deb  # [linux64]
+  md5:  00e0b312e764ada376444fb5835d0574                                                      # [linux64]
+  fn:   pandoc-1.16.0.2.pkg                                                                   # [osx]
+  url:  https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-osx.pkg      # [osx]
+  md5:  c0a3e7af327e33c58e81ee567655304d                                                      # [osx]
+  fn:   pandoc-1.16.0.2-windows.msi                                                           # [win]
+  url:  https://github.com/jgm/pandoc/releases/download/1.16.0.2/pandoc-1.16.0.2-windows.msi  # [win]
+  md5:  6be571c106d4099ca1066b8a9baa8f2b                                                      # [win]
+
+requirements:
+  run:
+    - gmp               # [linux64]
+    - zlib              # [linux64]
+
+test:
+  commands:
+    - pandoc --help
+
+about:
+  home: http://johnmacfarlane.net/pandoc/
+  license: GPL
+  summary: Universal markup converter
+
+extra:
+  recipe-maintainers:
+    -janschulz

--- a/recipes/pandoc/meta.yaml
+++ b/recipes/pandoc/meta.yaml
@@ -21,6 +21,7 @@ requirements:
 test:
   commands:
     - pandoc --help
+    - pandoc --version
 
 about:
   home: http://johnmacfarlane.net/pandoc/

--- a/recipes/pandoc/meta.yaml
+++ b/recipes/pandoc/meta.yaml
@@ -26,7 +26,7 @@ test:
 about:
   home: http://johnmacfarlane.net/pandoc/
   license: GPL
-  summary: Universal markup converter
+  summary: Universal markup converter (repackaged binaries)
 
 extra:
   recipe-maintainers:

--- a/recipes/pandoc/notes.md
+++ b/recipes/pandoc/notes.md
@@ -1,0 +1,3 @@
+* The Linux package doesn't work on systems older than CentOS 6
+* The OS X package works on 10.7+
+* The Windows package works on 32 and 64 bit archs


### PR DESCRIPTION
This package is taken from https://github.com/conda/conda-recipes
and only updated to the latest version.

This is part of my plan to get pdf building working in the notebook on windows... A miktex package is next...

The original conda packaging is by asmeurer,  @jschueller and @ccordoba12 (Only linked the people which updated the package recently: https://github.com/conda/conda-recipes/commits/master/pandoc).