### PR TITLE
cyordereddict 1.0

### DIFF
--- a/recipes/cyordereddict/bld.bat
+++ b/recipes/cyordereddict/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/recipes/cyordereddict/meta.yaml
+++ b/recipes/cyordereddict/meta.yaml
@@ -1,0 +1,34 @@
+package:
+    name: cyordereddict
+    version: 1.0.0
+
+source:
+    fn: cyordereddict-1.0.0.tar.gz
+    url: https://pypi.python.org/packages/source/c/cyordereddict/cyordereddict-1.0.0.tar.gz
+    md5: 8924331ec3bb754c92fd2603d3a29489
+
+build:
+    number: 0
+    script: python setup.py install
+
+requirements:
+    build:
+        - python
+        - cython
+    run:
+        - python
+
+test:
+    imports:
+        - cyordereddict
+        - cyordereddict.benchmark
+
+about:
+    home: https://github.com/shoyer/cyordereddict
+    license: BSD License
+    summary: Cython implementation of Python's collections.OrderedDict
+
+extra:
+    recipe-maintainers:
+        - ocefpaf
+        - jhamman


### PR DESCRIPTION
@jhamman and @shoyer I am slowly packaging all of `xarray` dependencies in `conda-forge`. If you want to be added as maintainers of the recipe (commit rights to the recipe feedstock) please let me know.

I am also available to answer any question you might have about conda-forge.


PS:

```
**This library is obsolete!** Python 3.5's ``collections.OrderedDict`` was `rewritten in C`_, and is now significantly faster than ``cyordereddict.OrderedDict`` for almost all operations.

.. _rewritten in C: https://bugs.python.org/issue16991
```