### PR TITLE
Add recipe for pytest-cov (py.test coverage plugin)

### DIFF
--- a/recipes/pytest-cov/bld.bat
+++ b/recipes/pytest-cov/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/recipes/pytest-cov/meta.yaml
+++ b/recipes/pytest-cov/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "2.2.1" %}
+
+package:
+  name: pytest-cov
+  version: {{ version }}
+
+source:
+  fn: pytest-cov-{{version}}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pytest-cov/pytest-cov-{{version}}.tar.gz
+  md5: d4c65c5561343e6c6a583d5fd29e6a63
+
+build:
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+    - pytest
+    - coverage
+
+test:
+  commands:
+    - "py.test --version | grep pytest-cov-{{version}}"
+
+about:
+  home: https://github.com/pytest-dev/pytest-cov
+  license: MIT
+  summary: 'Pytest plugin for measuring coverage'
+
+extra:
+  recipe-maintainers:
+    - dopplershift

--- a/recipes/pytest-cov/meta.yaml
+++ b/recipes/pytest-cov/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   commands:
-    - "py.test --version | grep pytest-cov-{{version}}"
+    - "py.test --traceconfig | grep pytest-cov-{{version}}"
 
 about:
   home: https://github.com/pytest-dev/pytest-cov


### PR DESCRIPTION
It's only pure python, and I'm not sure in general how many of these we want in conda-forge (just the like the rest of my recipes). But since I can't get conda to `pip install` something from `environment.yml` successfully, this is my only option.