### PR TITLE
fftw: Add a recipe to build FFTW

### DIFF
--- a/recipes/fftw/build.sh
+++ b/recipes/fftw/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Depending on our platform, shared libraries end with either .so or .dylib
+if [[ `uname` == 'Darwin' ]]; then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+    export DYLIB_EXT=dylib
+    export CC=clang
+    export CXX=clang++
+    export CXXFLAGS="-stdlib=libc++"
+    export CXX_LDFLAGS="-stdlib=libc++"
+else
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+    export DYLIB_EXT=so
+    export CC=gcc
+    export CXX=g++
+fi
+
+export LDFLAGS="-L${PREFIX}/lib"
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+
+CONFIGURE="./configure --prefix=$PREFIX --enable-shared --enable-threads --disable-fortran"
+
+# (Note exported LDFLAGS and CFLAGS vars provided above.)
+BUILD_CMD="make -j${CPU_COUNT}"
+INSTALL_CMD="make install"
+
+# Test suite
+# tests are performed during building as they are not available in the
+# installed package.
+# Additional tests can be run with "make smallcheck" and "make bigcheck"
+TEST_CMD="eval cd tests && ${LIBRARY_SEARCH_VAR}=\"$PREFIX/lib\" make check-local && cd -"
+
+#
+# We build 3 different versions of fftw:
+#
+
+# (1) Single precision (fftw libraries have "f" suffix)
+$CONFIGURE --enable-float --enable-sse
+${BUILD_CMD}
+${INSTALL_CMD}
+${TEST_CMD}
+
+# (2) Long double precision (fftw libraries have "l" suffix)
+$CONFIGURE --enable-long-double
+${BUILD_CMD}
+${INSTALL_CMD}
+${TEST_CMD}
+
+# (3) Double precision (fftw libraries have no precision suffix)
+$CONFIGURE --enable-sse2
+${BUILD_CMD}
+${INSTALL_CMD}
+${TEST_CMD}
+
+unset LIBRARY_SEARCH_VAR
+unset DYLIB_EXT
+unset CC
+unset CXX
+unset CXXFLAGS
+unset CXX_LDFLAGS
+unset LDFLAGS
+unset CFLAGS

--- a/recipes/fftw/meta.yaml
+++ b/recipes/fftw/meta.yaml
@@ -1,0 +1,31 @@
+package:
+    name: fftw
+    version: "3.3.4"
+
+source:
+    fn: fftw-3.3.4.tar.gz
+    url: http://www.fftw.org/fftw-3.3.4.tar.gz
+    md5: 2edab8c06b24feeb3b82bbb3ebf3e7b3
+
+build:
+    skip: True  # [win]
+    number: 0
+
+test:
+    commands:
+        - exit $(test -f ${PREFIX}/lib/libfftw3f.a)          # [not win]
+        - exit $(test -f ${PREFIX}/lib/libfftw3.a)           # [not win]
+        - exit $(test -f ${PREFIX}/lib/libfftw3l.a)          # [not win]
+        - exit $(test -f ${PREFIX}/lib/libfftw3f_threads.a)  # [not win]
+        - exit $(test -f ${PREFIX}/lib/libfftw3_threads.a)   # [not win]
+        - exit $(test -f ${PREFIX}/lib/libfftw3l_threads.a)  # [not win]
+
+about:
+    home: http://fftw.org
+    license: GPL 2
+    summary: "The fastest Fourier transform in the west."
+
+
+extra:
+    recipe-maintainers:
+        - jakirkham


### PR DESCRIPTION
Based off the Archlinux build ( https://projects.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/fftw ).

Basically taking my own recipe for this ( https://github.com/nanshe-org/nanshe-build/tree/master/fftw ) with a few minor tweaks. Mac and Linux. No Windows yet.