### PR TITLE
qimage2ndarray: Add recipe to build qimage2ndarray

### DIFF
--- a/recipes/qimage2ndarray/bld.bat
+++ b/recipes/qimage2ndarray/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/recipes/qimage2ndarray/meta.yaml
+++ b/recipes/qimage2ndarray/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: qimage2ndarray
+  version: "1.5.1"
+
+source:
+  fn: qimage2ndarray-1.5.1.tar.gz
+  url: https://pypi.python.org/packages/source/q/qimage2ndarray/qimage2ndarray-1.5.1.tar.gz
+  md5: 73743819ccf6043f237c6b7f63732674
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - numpy
+    - sip
+    - pyqt
+
+  run:
+    - python
+    - numpy
+    - sip
+    - pyqt
+
+test:
+  imports:
+    - qimage2ndarray
+
+about:
+  home: https://github.com/hmeine/qimage2ndarray
+  license: BSD License
+  summary: 'Conversion between QImages and numpy.ndarrays.'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
A simple library that provides "conversion between QImages and numpy.ndarrays".

Doesn't actually link against NumPy so the version it built against does not need to be the same one it uses at runtime.

Picked PyQt, but could use PySide.