### PR TITLE
pkg-config: Add recipe for pkg-config

### DIFF
--- a/recipes/pkg-config/build.sh
+++ b/recipes/pkg-config/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export CFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+
+libtoolize
+aclocal
+autoreconf -i
+
+./configure --prefix=$PREFIX   \
+            --with-internal-glib
+
+make
+make install

--- a/recipes/pkg-config/meta.yaml
+++ b/recipes/pkg-config/meta.yaml
@@ -1,0 +1,42 @@
+package:
+  name: pkg-config
+  version: 0.28
+
+source:
+  fn: pkg-config-0.28.zip
+  url: https://github.com/tpn/pkg-config/archive/pkg-config-0.28.zip
+
+build:
+  skip: True  # [win]
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - zlib
+    - autoconf
+    - python
+    - automake
+    - libtool
+  run:
+    - zlib
+
+test:
+  commands:
+    - pkg-config --help
+    - '[ "$(pkg-config freetype2 --cflags)" == "-I$PREFIX/include/freetype2 " ]'
+
+  requires:
+    - freetype
+
+about:
+  home: http://www.freedesktop.org/wiki/Software/pkg-config/
+  license: GPL 2
+  summary: Interface for querying installed libraries for use during compilation.
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - mdboom
+    - ocefpaf
+    - tacaswell


### PR DESCRIPTION
Requires: https://github.com/conda-forge/staged-recipes/pull/117

Adds a recipe to build pkg-config. Borrowed from conda recipes. Still needs maintainers added. Needs libtool.