### PR TITLE
flex: Add recipe to build flex

### DIFF
--- a/recipes/flex/build.sh
+++ b/recipes/flex/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make check
+make install

--- a/recipes/flex/meta.yaml
+++ b/recipes/flex/meta.yaml
@@ -1,0 +1,31 @@
+{% set version = "2.5.39" %}
+
+package:
+  name: flex
+  version: {{ version }}
+
+source:
+  fn: flex-{{ version }}.tar.gz
+  url: http://sourceforge.net/projects/flex/files/flex-{{ version }}.tar.gz
+  md5: e133e9ead8ec0a58d81166b461244fde
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m4
+
+  run:
+    - m4
+
+about:
+    home: http://flex.sourceforge.net/
+    license: BSD
+    summary: The Fast Lexical Analyzer
+
+extra:
+    recipe-maintainers:
+        - jakirkham
+        - ocefpaf


### PR DESCRIPTION
Builds flex for Linux and Mac. Borrowed with some modifications from conda recipes.