### PR TITLE
Added pyfftw

### DIFF
--- a/recipes/pyfftw/build.sh
+++ b/recipes/pyfftw/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export C_INCLUDE_PATH=$PREFIX/include  # required as fftw3.h installed here
+
+$PYTHON setup.py build
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt --optimize=1

--- a/recipes/pyfftw/meta.yaml
+++ b/recipes/pyfftw/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.10.1" %}
+
+package:
+    name: pyfftw
+    version: {{ version }}
+
+source:
+    fn: pyFFTW-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/p/pyFFTW/pyFFTW-{{ version }}.tar.gz
+    md5: dab57de9d23f3b333115265914f3d240
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+    build:
+        - cython
+        - python
+        - numpy x.x
+        - fftw
+
+    run:
+        - python
+        - numpy x.x
+        - fftw
+
+test:
+    imports:
+        - pyfftw
+        - pyfftw.builders
+        - pyfftw.interfaces
+
+about:
+    home: http://hgomersall.github.com/pyFFTW/
+    license: BSD or GPL 2
+    summary: 'A pythonic wrapper around FFTW, the FFT library, presenting a unified interface for all the supported transforms.'
+
+extra:
+    recipe-maintainers:
+        - jakirkham
+        - jjhelmus


### PR DESCRIPTION
Adds a recipe to build pyfftw for Mac and Linux. This is based on the conda recipe. Some changes were made to conform to conda forge specifications. Also the recipe has been cleaned up a bit to make it a little nicer and easier to maintain.