### PR TITLE
Add jq

### DIFF
--- a/recipes/jq/build.sh
+++ b/recipes/jq/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+chmod +x configure
+
+./configure --disable-maintainer-mode --prefix=$PREFIX --with-oniguruma=$PREFIX
+
+make -j${CPU_COUNT}
+make check
+make install

--- a/recipes/jq/meta.yaml
+++ b/recipes/jq/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "1.5" %}
+
+package:
+  name: jq
+  version: {{ version }}
+
+source:
+  fn: jq-{{ version }}.tar.gz
+  url: https://github.com/stedolan/jq/releases/download/jq-{{ version }}/jq-{{ version }}.tar.gz
+  md5: 0933532b086bd8b6a41c1b162b1731f9
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - oniguruma
+  run:
+    - oniguruma
+
+test:
+  commands:
+    - jq --help  # [not win]
+
+about:
+  home: http://stedolan.github.io/jq/
+  license: MIT
+  summary: A command-line JSON processor.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/oniguruma/build.sh
+++ b/recipes/oniguruma/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+chmod +x configure
+
+./configure --disable-maintainer-mode --prefix=$PREFIX
+
+make -j${CPU_COUNT}
+make check
+make install

--- a/recipes/oniguruma/meta.yaml
+++ b/recipes/oniguruma/meta.yaml
@@ -1,0 +1,27 @@
+{% set version = "5.9.6" %}
+
+package:
+  name: oniguruma
+  version: {{ version }}
+
+source:
+  fn: onig-{{ version }}.tar.gz
+  url: https://github.com/kkos/oniguruma/releases/download/v{{ version }}/onig-{{ version }}.tar.gz
+  md5: d08f10ea5c94919780e6b7bed1ef9830
+
+build:
+  number: 0
+  skip: True  # [win]
+
+test:
+  commands:
+    - exit $(test -f ${PREFIX}/lib/libonig.a)          # [not win]
+
+about:
+    home: https://github.com/kkos/oniguruma
+    license: BSD 2-Clause
+    summary: A regular expression library.
+
+extra:
+    recipe-maintainers:
+        - jakirkham


### PR DESCRIPTION
Adds jq and its dependencies. Builds on Mac and Linux. Recipes borrowed from conda recipes. Cleaned up a bit.