### PR TITLE
Add mahotas

### DIFF
--- a/recipes/mahotas/bld.bat
+++ b/recipes/mahotas/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/recipes/mahotas/meta.yaml
+++ b/recipes/mahotas/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "1.4.1" %}
+
+package:
+  name: mahotas
+  version: {{ version }}
+
+source:
+  fn: mahotas-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/m/mahotas/mahotas-{{ version }}.tar.gz
+  md5: 1bc9a6a12db5edfacf4e25ec79c9826b
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+
+  run:
+    - python
+    - numpy x.x
+
+test:
+  imports:
+    - mahotas
+
+about:
+  home: http://luispedro.org/software/mahotas/
+  license: MIT
+  summary: "Mahotas: Computer Vision Library"
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds mahotas, a computer vision library. Recipes borrowed from conda recipes. Cleaned up to be a bit nicer and match the style here at conda forge. Builds on all platforms.