### PR TITLE
add libgcc for c++/fortran/libgcc/libgomp runtimes

### DIFF
--- a/recipes/libgcc/build.sh
+++ b/recipes/libgcc/build.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-SRC=$SYS_PREFIX/lib
+if [ $ARCH == 32 ]; then
+  ARCH=""
+fi
+
+# This is meant to be run on a docker image where gcc is installed to /usr/local
+SRC=/usr/local/lib${ARCH}
 DST=$PREFIX/lib
 
 mkdir $DST

--- a/recipes/libgcc/build.sh
+++ b/recipes/libgcc/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+SRC=$SYS_PREFIX/lib
+DST=$PREFIX/lib
+
+mkdir $DST
+cd $DST
+
+cp $SRC/libgcc_s.so.1 .
+ln -s   libgcc_s.so.1 libgcc_s.so
+
+cp $SRC/libgomp.so.1.0.0 .
+ln -s   libgomp.so.1.0.0 libgomp.so
+ln -s   libgomp.so.1.0.0 libgomp.so.1
+
+cp $SRC/libstdc++.so.6.0.21 .
+ln -s   libstdc++.so.6.0.21 libstdc++.so
+ln -s   libstdc++.so.6.0.21 libstdc++.so.6
+
+cp $SRC/libgfortran.so.3.0.0 .
+ln -s   libgfortran.so.3.0.0 libgfortran.so.3
+ln -s   libgfortran.so.3.0.0 libgfortran.so
+
+cp $SRC/libquadmath.so.0.0.0 .
+ln -s   libquadmath.so.0.0.0 libquadmath.so
+ln -s   libquadmath.so.0.0.0 libquadmath.so.0

--- a/recipes/libgcc/meta.yaml
+++ b/recipes/libgcc/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: libgcc
+  version: 5.2.0
+
+build:
+  number: 0
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Shared libraries for the GNU Compiler Collection
+  license: GPL
+
+extra:
+  recipe-maintainers:
+    - msarahan


### PR DESCRIPTION
I anticipate that this will create a lot of discussion.  Please don't merge this until we have reached consensus on both this recipe and on what the details of the Docker image we're using are.

Conda/continuum really probably ought to break these out individually.  This reflects how it is done currently.  This one large package needs to stay, for backwards compatibility reasons, but it can become a metapackage instead, so that recipes can be migrated to individual libraries in the future.

This is coded to run from the Continuum Docker image "conda_builder_linux" at https://github.com/ContinuumIO/docker-images/pull/20/files - it copies files that are created/installed in specific locations in that image.  This recipe is NOT portable.

To make this recipe portable, one could create a GCC package as is done on conda-recipes:

https://github.com/conda/conda-recipes/tree/master/gcc-5
https://github.com/conda/conda-recipes/tree/master/libgcc-5

However, if you do that, then people are free to use that compiler on any Linux distribution they want.  That means we won't know which glibc a package is linked against (without something like auditwheel).  Providing compilers only on isolated, known-good platforms (like CentOS 5) is advisable here.