### PR TITLE
Add libsodium

### DIFF
--- a/recipes/libsodium/bld.bat
+++ b/recipes/libsodium/bld.bat
@@ -1,1 +1,0 @@
-msbuild libsodium.vcxproj

--- a/recipes/libsodium/bld.bat
+++ b/recipes/libsodium/bld.bat
@@ -1,0 +1,1 @@
+msbuild libsodium.vcxproj

--- a/recipes/libsodium/build.sh
+++ b/recipes/libsodium/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# default is 10.5 for some reason, which doesn't work
+export MACOSX_DEPLOYMENT_TARGET=10.7
+
+./configure --prefix=$PREFIX
+make
+make check
+make install

--- a/recipes/libsodium/meta.yaml
+++ b/recipes/libsodium/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "1.0.8" %}
+
+package:
+  name: libsodium
+  version: {{ version }}
+
+source:
+  fn: libsodium-{{ version }}.tar.gz
+  url: https://github.com/jedisct1/libsodium/releases/download/{{ version }}/libsodium-{{ version }}.tar.gz
+  sha1: 3d53b827da88d6c2e391fb377bddcd592515ab79
+
+build:
+  number: 0
+  features:
+    - vc9       # [win and py27]
+    - vc10      # [win and py34]
+    - vc14      # [win and py35]
+
+requirements:
+  build:
+    - python    # [win]
+
+test:
+  requires:
+    - python    # [win]
+
+  commands:
+    - test -f ${PREFIX}/lib/libsodium.a          # [unix]
+    - test -f ${PREFIX}/lib/libsodium.dylib      # [osx]
+    - test -f ${PREFIX}/lib/libsodium.so         # [linux]
+
+about:
+  home: https://github.com/jedisct1/libsodium
+  license: ISC
+  summary: A modern and easy-to-use crypto library.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libsodium/meta.yaml
+++ b/recipes/libsodium/meta.yaml
@@ -10,20 +10,10 @@ source:
   sha1: 3d53b827da88d6c2e391fb377bddcd592515ab79
 
 build:
+  skip: true    # [win]
   number: 0
-  features:
-    - vc9       # [win and py27]
-    - vc10      # [win and py34]
-    - vc14      # [win and py35]
-
-requirements:
-  build:
-    - python    # [win]
 
 test:
-  requires:
-    - python    # [win]
-
   commands:
     - test -f ${PREFIX}/lib/libsodium.a          # [unix]
     - test -f ${PREFIX}/lib/libsodium.dylib      # [osx]


### PR DESCRIPTION
Adds a recipe to build libsodium on all platforms. Borrows the recipe from conda-recipes. Makes some tweaks for better integration in conda-forge.