### PR TITLE
Add drmaa (for Python)

### DIFF
--- a/recipes/python-drmaa/meta.yaml
+++ b/recipes/python-drmaa/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.7.6" %}
+
+package:
+  name: python-drmaa
+  version: {{ version }}
+
+source:
+  fn: drmaa-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/d/drmaa/drmaa-{{ version }}.tar.gz
+  md5: 3cb6dade683d0621fb14871ef1261f9b
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  files:
+    - run_test.py
+  commands:
+    - python run_test.py
+
+about:
+  home: https://github.com/pygridtools/drmaa-python
+  license: BSD 3-Clause
+  summary: Python wrapper around the C DRMAA library.
+
+extra:
+  recipe-maintainers:
+    - dan-blanchard
+    - jakirkham

--- a/recipes/python-drmaa/post-link.bat
+++ b/recipes/python-drmaa/post-link.bat
@@ -1,0 +1,3 @@
+echo 'To use the Python bindings to DRMAA, please make sure that you have a working install.'
+echo 'Set relevant environment variables for your cluster queue (e.g. `SGE_ROOT` and `SGE_CELL` for SGE).'
+echo 'Also, set the path to the DRMAA shared object with the `DRMAA_LIBRARY_PATH` environment variable.'

--- a/recipes/python-drmaa/post-link.sh
+++ b/recipes/python-drmaa/post-link.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo 'To use the Python bindings to DRMAA, please make sure that you have a working install.'
+echo 'Set relevant environment variables for your cluster queue (e.g. `SGE_ROOT` and `SGE_CELL` for SGE).'
+echo 'Also, set the path to the DRMAA shared object with the `DRMAA_LIBRARY_PATH` environment variable.'

--- a/recipes/python-drmaa/run_test.py
+++ b/recipes/python-drmaa/run_test.py
@@ -1,0 +1,4 @@
+try:
+    import drmaa
+except RuntimeError as e:
+    assert str(e) == "Could not find drmaa library.  Please specify its full path using the environment variable DRMAA_LIBRARY_PATH"


### PR DESCRIPTION
Adds the Python DRMAA bindings package. Basically built using `conda skeleton pypi` with some tweaks to make it fit nicely in conda-forge.

* [x] Needs some notes explaining how to configure after installing.
    * [x] Also printed to the terminal when installed.
    * [x] Ideally, this will be brief, but clear.