### PR TITLE
Add lmdb

### DIFF
--- a/recipes/lmdb/Makefile.patch
+++ b/recipes/lmdb/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git libraries/liblmdb/Makefile libraries/liblmdb/Makefile
+index 0940c49..2550f1d 100644
+--- libraries/liblmdb/Makefile
++++ libraries/liblmdb/Makefile
+@@ -26,7 +26,7 @@ OPT = -O2 -g
+ CFLAGS	= $(THREADS) $(OPT) $(W) $(XCFLAGS)
+ LDLIBS	=
+ SOLIBS	=
+-prefix	= /usr/local
++prefix	=
+ exec_prefix = $(prefix)
+ bindir = $(exec_prefix)/bin
+ libdir = $(exec_prefix)/lib

--- a/recipes/lmdb/build.sh
+++ b/recipes/lmdb/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd libraries/liblmdb/
+export DESTDIR=$PREFIX
+make
+make test
+make install

--- a/recipes/lmdb/meta.yaml
+++ b/recipes/lmdb/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "0.9.18" %}
+
+package:
+  name: lmdb
+  version: {{ version }}
+
+source:
+  fn: LMDB_{{ version }}.tar.gz
+  url: https://github.com/LMDB/lmdb/archive/LMDB_{{ version }}.tar.gz
+  sha1: 375e31bd0a4d8426e5fc4bfdb00d532c206d4f2b
+  patches:
+    - Makefile.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+
+test:
+  commands:
+    - mdb_copy -V                                    # [unix]
+    - mdb_dump -V                                    # [unix]
+    - mdb_load -V                                    # [unix]
+    - mdb_stat -V                                    # [unix]
+    - test -f ${PREFIX}/lib/liblmdb.a                # [unix]
+    - test -f ${PREFIX}/lib/liblmdb.so               # [unix]
+
+about:
+  home: http://symas.com/mdb/
+  license: OpenLDAP Public License
+  summary: A high-performance embedded transactional key-value store database.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build the Lightning Memory-Mapped Database on Mac and Linux.