### PR TITLE
Pin conda-smithy to 0.5.1

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -5,6 +5,6 @@ wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obviou
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
 conda config --set show_channel_urls True
 conda config --add channels conda-forge
-conda install --yes --quiet conda-smithy
+conda install --yes --quiet conda-smithy=0.5.1
 
 python .CI/create_feedstocks.py


### PR DESCRIPTION
Related: https://github.com/conda-forge/staged-recipes/issues/179

Tries to pin `conda-smithy` to 0.5.1 to avoid feedstock creation error. Not sure if this is the cause, but it is a known difference. So, creating the PR in case we do need it.