### PR TITLE
WIP: Add Boost

### DIFF
--- a/recipes/boost/bld.bat
+++ b/recipes/boost/bld.bat
@@ -1,0 +1,48 @@
+:: Set the right msvc version according to Python version
+REM write a temporary batch file to map cl.exe version to visual studio version
+echo @echo 15=9 > msvc_versions.bat
+echo @echo 16=10 >> msvc_versions.bat
+echo @echo 17=11 >> msvc_versions.bat
+echo @echo 18=12 >> msvc_versions.bat
+echo @echo 19=14 >> msvc_versions.bat
+
+REM Run cl.exe to find which version our compiler is
+for /f "delims=" %%A in ('cl /? 2^>^&1 ^| findstr /C:"Version"') do set "CL_TEXT=%%A"
+FOR /F "tokens=1,2 delims==" %%i IN ('msvc_versions.bat') DO echo %CL_TEXT% | findstr /C:"Version %%i" > nul && set VSTRING=%%j && goto FOUND
+EXIT 1
+:FOUND
+
+call :TRIM VSTRING %VSTRING%
+
+:: Start with bootstrap
+call bootstrap.bat
+if errorlevel 1 exit 1
+
+:: Build step
+.\b2 install ^
+    --build-dir=buildboost ^
+    --prefix=%LIBRARY_PREFIX% ^
+    toolset=msvc-%VSTRING%.0 ^
+    address-model=%ARCH% ^
+    variant=release ^
+    threading=multi ^
+    link=shared ^
+    -j%CPU_COUNT% ^
+    -s ZLIB_INCLUDE="%LIBRARY_INC%" ^
+    -s ZLIB_LIBPATH="%LIBRARY_LIB%"
+if errorlevel 1 exit 1
+
+:: Install fix-up for a non version-specific boost include
+move %LIBRARY_INC%\boost-1_60\boost %LIBRARY_INC%
+if errorlevel 1 exit 1
+
+:: Move dll's to LIBRARY_BIN
+move %LIBRARY_LIB%\*vc%VSTRING%0-mt-1_60.dll "%LIBRARY_BIN%"
+if errorlevel 1 exit 1
+
+
+:TRIM
+  SetLocal EnableDelayedExpansion
+  set Params=%*
+  for /f "tokens=1*" %%a in ("!Params!") do EndLocal & set %1=%%b
+  exit /B

--- a/recipes/boost/build.sh
+++ b/recipes/boost/build.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Hints:
+# http://boost.2283326.n4.nabble.com/how-to-build-boost-with-bzip2-in-non-standard-location-td2661155.html
+# http://www.gentoo.org/proj/en/base/amd64/howtos/?part=1&chap=3
+# http://www.boost.org/doc/libs/1_55_0/doc/html/bbv2/reference.html
+
+# Hints for OSX:
+# http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc
+
+set -x -e
+
+INCLUDE_PATH="${PREFIX}/include"
+LIBRARY_PATH="${PREFIX}/lib"
+
+if [ "$(uname)" == "Darwin" ]; then
+    MACOSX_VERSION_MIN=10.7
+    CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    LINKFLAGS="${LINKFLAGS} -stdlib=libc++ -std=c++11 -L${LIBRARY_PATH}"
+
+    ./bootstrap.sh \
+        --prefix="${PREFIX}" \
+        --with-python="${PYTHON}" \
+        --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
+        --with-icu="${PREFIX}" \
+        | tee bootstrap.log 2>&1
+
+    ./b2 -q \
+        variant=release \
+        address-model=64 \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        link=shared \
+        toolset=clang \
+        python="${PY_VER}" \
+        include="${INCLUDE_PATH}" \
+        cxxflags="${CXXFLAGS}" \
+        linkflags="${LINKFLAGS}" \
+        -j"$(sysctl -n hw.ncpu)" \
+        install | tee b2.log 2>&1
+fi
+
+if [ "$(uname)" == "Linux" ]; then
+    CXXFLAGS="${CXXFLAGS} -std=c++11"
+    LINKFLAGS="${LINKFLAGS} -std=c++11 -L${LIBRARY_PATH}"
+
+    ./bootstrap.sh \
+        --prefix="${PREFIX}" \
+        --with-python="${PYTHON}" \
+        --with-python-root="${PREFIX} : ${PREFIX}/include/python${PY_VER}m ${PREFIX}/include/python${PY_VER}" \
+        --with-icu="${PREFIX}" \
+        | tee bootstrap.log 2>&1
+
+    ./b2 -q \
+        variant=release \
+        address-model="${ARCH}" \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        runtime-link=shared \
+        link=shared \
+        toolset=gcc \
+        python="${PY_VER}" \
+        include="${INCLUDE_PATH}" \
+        cxxflags="${CXXFLAGS}" \
+        linkflags="${LINKFLAGS}" \
+        --layout=system \
+        -j"${CPU_COUNT}" \
+        install | tee b2.log 2>&1
+fi

--- a/recipes/boost/meta.yaml
+++ b/recipes/boost/meta.yaml
@@ -40,72 +40,44 @@ test:
     - test -f $PREFIX/lib/libboost_timer.a                    # [unix]
 
     # Verify dynamic libraries.
-    - test -f $PREFIX/lib/libboost_atomic.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_chrono.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_container.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_context.dylib              # [osx]
-    - test -f $PREFIX/lib/libboost_coroutine.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_date_time.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_filesystem.dylib           # [osx]
-    - test -f $PREFIX/lib/libboost_graph.dylib                # [osx]
-    - test -f $PREFIX/lib/libboost_iostreams.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_locale.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_log.dylib                  # [osx]
-    - test -f $PREFIX/lib/libboost_log_setup.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_math_c99.dylib             # [osx]
-    - test -f $PREFIX/lib/libboost_math_c99f.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_math_c99l.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_math_tr1.dylib             # [osx]
-    - test -f $PREFIX/lib/libboost_math_tr1f.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_math_tr1l.dylib            # [osx]
-    - test -f $PREFIX/lib/libboost_prg_exec_monitor.dylib     # [osx]
-    - test -f $PREFIX/lib/libboost_program_options.dylib      # [osx]
-    - test -f $PREFIX/lib/libboost_python.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_random.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_regex.dylib                # [osx]
-    - test -f $PREFIX/lib/libboost_serialization.dylib        # [osx]
-    - test -f $PREFIX/lib/libboost_signals.dylib              # [osx]
-    - test -f $PREFIX/lib/libboost_system.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_thread.dylib               # [osx]
-    - test -f $PREFIX/lib/libboost_timer.dylib                # [osx]
-    - test -f $PREFIX/lib/libboost_type_erasure.dylib         # [osx]
-    - test -f $PREFIX/lib/libboost_unit_test_framework.dylib  # [osx]
-    - test -f $PREFIX/lib/libboost_wave.dylib                 # [osx]
-    - test -f $PREFIX/lib/libboost_wserialization.dylib       # [osx]
-
-    # Verify shared object.
-    - test -f $PREFIX/lib/libboost_atomic.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_chrono.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_container.so               # [linux]
-    - test -f $PREFIX/lib/libboost_context.so                 # [linux]
-    - test -f $PREFIX/lib/libboost_coroutine.so               # [linux]
-    - test -f $PREFIX/lib/libboost_date_time.so               # [linux]
-    - test -f $PREFIX/lib/libboost_filesystem.so              # [linux]
-    - test -f $PREFIX/lib/libboost_graph.so                   # [linux]
-    - test -f $PREFIX/lib/libboost_iostreams.so               # [linux]
-    - test -f $PREFIX/lib/libboost_locale.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_log.so                     # [linux]
-    - test -f $PREFIX/lib/libboost_log_setup.so               # [linux]
-    - test -f $PREFIX/lib/libboost_math_c99.so                # [linux]
-    - test -f $PREFIX/lib/libboost_math_c99f.so               # [linux]
-    - test -f $PREFIX/lib/libboost_math_c99l.so               # [linux]
-    - test -f $PREFIX/lib/libboost_math_tr1.so                # [linux]
-    - test -f $PREFIX/lib/libboost_math_tr1f.so               # [linux]
-    - test -f $PREFIX/lib/libboost_math_tr1l.so               # [linux]
-    - test -f $PREFIX/lib/libboost_prg_exec_monitor.so        # [linux]
-    - test -f $PREFIX/lib/libboost_program_options.so         # [linux]
-    - test -f $PREFIX/lib/libboost_python.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_random.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_regex.so                   # [linux]
-    - test -f $PREFIX/lib/libboost_serialization.so           # [linux]
-    - test -f $PREFIX/lib/libboost_signals.so                 # [linux]
-    - test -f $PREFIX/lib/libboost_system.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_thread.so                  # [linux]
-    - test -f $PREFIX/lib/libboost_timer.so                   # [linux]
-    - test -f $PREFIX/lib/libboost_type_erasure.so            # [linux]
-    - test -f $PREFIX/lib/libboost_unit_test_framework.so     # [linux]
-    - test -f $PREFIX/lib/libboost_wave.so                    # [linux]
-    - test -f $PREFIX/lib/libboost_wserialization.so          # [linux]
+    {% set boost_libs = [
+            "atomic",
+            "chrono",
+            "container",
+            "context",
+            "coroutine",
+            "date_time",
+            "filesystem",
+            "graph",
+            "iostreams",
+            "locale",
+            "log",
+            "log_setup",
+            "math_c99",
+            "math_c99f",
+            "math_c99l",
+            "math_tr1",
+            "math_tr1f",
+            "math_tr1l",
+            "prg_exec_monitor",
+            "program_options",
+            "python",
+            "random",
+            "regex",
+            "serialization",
+            "signals",
+            "system",
+            "thread",
+            "timer",
+            "type_erasure",
+            "unit_test_framework",
+            "wave",
+            "wserialization"
+    ] %}
+    {% for each_boost_lib in boost_libs %}
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.dylib  # [osx]
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.so     # [linux]
+    {% endfor %}
 
 about:
   home: http://www.boost.org/

--- a/recipes/boost/meta.yaml
+++ b/recipes/boost/meta.yaml
@@ -40,6 +40,7 @@ test:
     - test -f $PREFIX/lib/libboost_timer.a                    # [unix]
 
     # Verify dynamic libraries.
+    {% set win_vstr = "_".join(version.split(".")[:2]) %}
     {% set boost_libs = [
             "atomic",
             "chrono",
@@ -75,8 +76,14 @@ test:
             "wserialization"
     ] %}
     {% for each_boost_lib in boost_libs %}
-    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.dylib  # [osx]
-    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.so     # [linux]
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.dylib                                             # [osx]
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.so                                                # [linux]
+    - if not exist %PREFIX%\\Library\\bin\\boost_{{ each_boost_lib }}-vc90-mt-{{ win_vstr }}.dll exit 1   # [win and py27]
+    - if not exist %PREFIX%\\Library\\bin\\boost_{{ each_boost_lib }}-vc100-mt-{{ win_vstr }}.dll exit 1  # [win and py34]
+    - if not exist %PREFIX%\\Library\\bin\\boost_{{ each_boost_lib }}-vc140-mt-{{ win_vstr }}.dll exit 1  # [win and py35]
+    - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc90-mt-{{ win_vstr }}.lib exit 1   # [win and py27]
+    - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc100-mt-{{ win_vstr }}.lib exit 1  # [win and py34]
+    - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc140-mt-{{ win_vstr }}.lib exit 1  # [win and py35]
     {% endfor %}
 
 about:

--- a/recipes/boost/meta.yaml
+++ b/recipes/boost/meta.yaml
@@ -1,0 +1,119 @@
+{% set version = "1.60.0" %}
+{% set filename = "boost_%s.tar.bz2" % version.replace(".", "_") %}
+
+package:
+  name: boost
+  version: {{ version }}
+
+source:
+  fn:  {{ filename }}
+  url: http://sourceforge.net/projects/boost/files/boost/{{ version }}/{{ filename }}
+  md5: 65a840e1a0b13a558ff19eeb2c4f0cbe
+
+build:
+  features:
+    - vc9               # [win and py27]
+    - vc10              # [win and py34]
+    - vc14              # [win and py35]
+
+requirements:
+  build:
+    - gcc               # [linux]
+    - python
+    - icu               # [unix]
+    - bzip2             # [unix]
+    - zlib
+
+  run:
+    - libgcc            # [linux]
+    - python
+    - icu               # [unix]
+    - zlib
+
+test:
+  commands:
+    # Verify static libraries.
+    - test -f $PREFIX/lib/libboost_chrono.a                   # [unix]
+    - test -f $PREFIX/lib/libboost_exception.a                # [unix]
+    - test -f $PREFIX/lib/libboost_system.a                   # [unix]
+    - test -f $PREFIX/lib/libboost_test_exec_monitor.a        # [unix]
+    - test -f $PREFIX/lib/libboost_timer.a                    # [unix]
+
+    # Verify dynamic libraries.
+    - test -f $PREFIX/lib/libboost_atomic.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_chrono.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_container.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_context.dylib              # [osx]
+    - test -f $PREFIX/lib/libboost_coroutine.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_date_time.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_filesystem.dylib           # [osx]
+    - test -f $PREFIX/lib/libboost_graph.dylib                # [osx]
+    - test -f $PREFIX/lib/libboost_iostreams.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_locale.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_log.dylib                  # [osx]
+    - test -f $PREFIX/lib/libboost_log_setup.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_math_c99.dylib             # [osx]
+    - test -f $PREFIX/lib/libboost_math_c99f.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_math_c99l.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_math_tr1.dylib             # [osx]
+    - test -f $PREFIX/lib/libboost_math_tr1f.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_math_tr1l.dylib            # [osx]
+    - test -f $PREFIX/lib/libboost_prg_exec_monitor.dylib     # [osx]
+    - test -f $PREFIX/lib/libboost_program_options.dylib      # [osx]
+    - test -f $PREFIX/lib/libboost_python.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_random.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_regex.dylib                # [osx]
+    - test -f $PREFIX/lib/libboost_serialization.dylib        # [osx]
+    - test -f $PREFIX/lib/libboost_signals.dylib              # [osx]
+    - test -f $PREFIX/lib/libboost_system.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_thread.dylib               # [osx]
+    - test -f $PREFIX/lib/libboost_timer.dylib                # [osx]
+    - test -f $PREFIX/lib/libboost_type_erasure.dylib         # [osx]
+    - test -f $PREFIX/lib/libboost_unit_test_framework.dylib  # [osx]
+    - test -f $PREFIX/lib/libboost_wave.dylib                 # [osx]
+    - test -f $PREFIX/lib/libboost_wserialization.dylib       # [osx]
+
+    # Verify shared object.
+    - test -f $PREFIX/lib/libboost_atomic.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_chrono.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_container.so               # [linux]
+    - test -f $PREFIX/lib/libboost_context.so                 # [linux]
+    - test -f $PREFIX/lib/libboost_coroutine.so               # [linux]
+    - test -f $PREFIX/lib/libboost_date_time.so               # [linux]
+    - test -f $PREFIX/lib/libboost_filesystem.so              # [linux]
+    - test -f $PREFIX/lib/libboost_graph.so                   # [linux]
+    - test -f $PREFIX/lib/libboost_iostreams.so               # [linux]
+    - test -f $PREFIX/lib/libboost_locale.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_log.so                     # [linux]
+    - test -f $PREFIX/lib/libboost_log_setup.so               # [linux]
+    - test -f $PREFIX/lib/libboost_math_c99.so                # [linux]
+    - test -f $PREFIX/lib/libboost_math_c99f.so               # [linux]
+    - test -f $PREFIX/lib/libboost_math_c99l.so               # [linux]
+    - test -f $PREFIX/lib/libboost_math_tr1.so                # [linux]
+    - test -f $PREFIX/lib/libboost_math_tr1f.so               # [linux]
+    - test -f $PREFIX/lib/libboost_math_tr1l.so               # [linux]
+    - test -f $PREFIX/lib/libboost_prg_exec_monitor.so        # [linux]
+    - test -f $PREFIX/lib/libboost_program_options.so         # [linux]
+    - test -f $PREFIX/lib/libboost_python.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_random.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_regex.so                   # [linux]
+    - test -f $PREFIX/lib/libboost_serialization.so           # [linux]
+    - test -f $PREFIX/lib/libboost_signals.so                 # [linux]
+    - test -f $PREFIX/lib/libboost_system.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_thread.so                  # [linux]
+    - test -f $PREFIX/lib/libboost_timer.so                   # [linux]
+    - test -f $PREFIX/lib/libboost_type_erasure.so            # [linux]
+    - test -f $PREFIX/lib/libboost_unit_test_framework.so     # [linux]
+    - test -f $PREFIX/lib/libboost_wave.so                    # [linux]
+    - test -f $PREFIX/lib/libboost_wserialization.so          # [linux]
+
+about:
+  home: http://www.boost.org/
+  license: Boost-1.0
+  summary: Free peer-reviewed portable C++ source libraries.
+
+extra:
+  recipe-maintainers:
+    - ccordoba12
+    - jakirkham
+    - msarahan


### PR DESCRIPTION
Builds Boost from source. This is largely borrowed from conda-recipes.

However, we build Boost on Mac and Linux with C++11 support. Not doing this has resulted in issues with other C++11 compiled libraries on Mac that require Boost support. However, we have not found this to be a problem when intermixing libraries that don't use C++11. Also, this means that we use `clang` and `libc++` on Mac. That all being said, we are able to keep compatibility with Mac 10.7. Maybe this will be controversial so I am laying it out here so we can discuss. IMHO this is the right way forward as `gcc` on Mac is ancient and support for it ends up being removed.

This strategy cannot easily be applied to Windows as C++11 only exists in limited form on older Windows compilers. Though if someone with more expertise in that area would like to share a possible approach forward, I am open to discussion.