### PR TITLE
python-cdo

### DIFF
--- a/recipes/python-cdo/meta.yaml
+++ b/recipes/python-cdo/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "1.3.0" %}
+
+package:
+    name: python-cdo
+    version: {{ version }}
+
+source:
+    fn: cdo-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/c/cdo/cdo-{{ version }}.tar.gz
+    md5: 08d0bf10cbc7451b73a68441ed477a9d
+
+build:
+    number: 0
+    skip: True  # [win]
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - cdo
+    run:
+        - python
+        - cdo
+
+test:
+    imports:
+        - cdo
+
+about:
+    home: https://code.zmaw.de/projects/cdo/wiki/Cdo%7Brbpy%7D
+    license: GPLv2
+    summary: Use CDO in the context of Python as if it would be a native library.
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
Adding the cdo python binding.

Note that I am using the same convention used in OpenSUSE, and I guess Debian too. See https://github.com/conda-forge/staged-recipes/pull/182#issuecomment-200199885, which adds the prefix `python-` to packages that are wrapping a library with the same name.