### PR TITLE
Add h5py

### DIFF
--- a/recipes/h5py/bld.bat
+++ b/recipes/h5py/bld.bat
@@ -1,0 +1,5 @@
+"%PYTHON%" setup.py configure --hdf5="%LIBRARY_PREFIX%"
+if errorlevel 1 exit 1
+
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/h5py/bld.bat
+++ b/recipes/h5py/bld.bat
@@ -1,5 +1,0 @@
-"%PYTHON%" setup.py configure --hdf5="%LIBRARY_PREFIX%"
-if errorlevel 1 exit 1
-
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/recipes/h5py/build.sh
+++ b/recipes/h5py/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+"${PYTHON}" setup.py configure --hdf5="${PREFIX}"
+"${PYTHON}" setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/h5py/h5py_tests_old_test_file.py.patch
+++ b/recipes/h5py/h5py_tests_old_test_file.py.patch
@@ -1,0 +1,19 @@
+diff --git h5py/tests/old/test_file.py h5py/tests/old/test_file.py
+index ff9d19c..14b997b 100644
+--- h5py/tests/old/test_file.py
++++ h5py/tests/old/test_file.py
+@@ -45,7 +45,13 @@ class TestFileOpen(TestCase):
+         try:
+             with File(fname) as f:
+                 self.assertTrue(f)
+-                self.assertEqual(f.mode, 'r')
++                # This appears to be a broken comparison in some cases.
++                # See the following issues for more details.
++                #
++                # https://github.com/h5py/h5py/issues/696
++                # https://github.com/h5py/h5py/issues/554
++                #
++                # self.assertEqual(f.mode, 'r')
+         finally:
+             os.chmod(fname, stat.S_IWRITE)
+ 

--- a/recipes/h5py/meta.yaml
+++ b/recipes/h5py/meta.yaml
@@ -17,6 +17,10 @@ source:
     #
     - h5py_tests_old_test_file.py.patch
 
+build:
+  number: 0
+  skip: true  # [win]
+
 requirements:
   build:
     - python

--- a/recipes/h5py/meta.yaml
+++ b/recipes/h5py/meta.yaml
@@ -8,6 +8,14 @@ source:
   fn: h5py-{{ version }}.tar.gz
   url: https://github.com/h5py/h5py/archive/{{ version }}.tar.gz
   md5: 613c5776192eaf02ff96a82dfc6d2e78
+  patches:
+    # Patch a test that appears to be failing in some cases.
+    # This patch has been submitted to upstream.
+    # See the linked PR for more information.
+    #
+    # https://github.com/h5py/h5py/pull/697
+    #
+    - h5py_tests_old_test_file.py.patch
 
 requirements:
   build:

--- a/recipes/h5py/meta.yaml
+++ b/recipes/h5py/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "2.6.0" %}
+
+package:
+  name: h5py
+  version: {{ version }}
+
+source:
+  fn: h5py-{{ version }}.tar.gz
+  url: https://github.com/h5py/h5py/archive/{{ version }}.tar.gz
+  md5: 613c5776192eaf02ff96a82dfc6d2e78
+
+requirements:
+  build:
+    - python
+    - numpy
+    - hdf5
+    - cython
+    - six
+    - pkgconfig
+
+  run:
+    - python
+    - numpy
+    - hdf5
+    - six
+    - unittest2    #[py26]
+
+test:
+  imports:
+    - h5py
+
+about:
+  home: http://www.h5py.org/
+  license: BSD 3-Clause
+  summary: Read and write HDF5 files from Python.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/h5py/run_test.py
+++ b/recipes/h5py/run_test.py
@@ -1,0 +1,24 @@
+import h5py
+import h5py._conv
+import h5py._errors
+import h5py._objects
+import h5py._proxy
+import h5py.defs
+import h5py.h5
+import h5py.h5a
+import h5py.h5d
+import h5py.h5f
+import h5py.h5fd
+import h5py.h5g
+import h5py.h5i
+import h5py.h5l
+import h5py.h5o
+import h5py.h5p
+import h5py.h5r
+import h5py.h5s
+import h5py.h5t
+import h5py.h5z
+import h5py.utils
+
+from sys import exit
+exit(0) if h5py.run_tests().wasSuccessful() else exit(1)


### PR DESCRIPTION
Adds a recipe to build h5py. Largely based off of the one in conda-recipes. However, tweaked to work nicely in conda-forge.