### PR TITLE
yt: add recipe for yt

### DIFF
--- a/recipes/yt/bld.bat
+++ b/recipes/yt/bld.bat
@@ -1,0 +1,3 @@
+:: windows builds are disabled for now
+:: "%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+:: if errorlevel 1 exit 1

--- a/recipes/yt/build.sh
+++ b/recipes/yt/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py --quiet install --single-version-externally-managed --record=record.txt

--- a/recipes/yt/meta.yaml
+++ b/recipes/yt/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "3.2.3" %}
+
+package:
+  name: yt
+  version: {{ version }}
+
+source:
+  fn: yt-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/y/yt/yt-{{ version }}.tar.gz
+  sha256: 4d6ccf345d9fab965335c9faf8708c7eea79366b81d77f0f302808be3e82c0ed
+
+build:
+  skip: true   #  [win]
+  entry_points:
+    - yt = yt.utilities.command_line:run_main
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+    - cython
+    - setuptools 
+  run:
+    - python
+    - numpy x.x
+    - h5py
+    - sympy
+    - matplotlib
+    - ipython
+
+test:
+  requires:
+    - nose
+  commands:
+    - yt -h
+  imports:
+    - yt
+
+about:
+  home: http://yt-project.org/
+  license: BSD 3-clause
+  summary: Analysis and visualization toolkit for volumetric data
+
+extra:
+    recipe-maintainers:
+      - ngoldbaum
+      - xarthisius

--- a/recipes/yt/run_test.py
+++ b/recipes/yt/run_test.py
@@ -1,0 +1,2 @@
+import yt
+#yt.run_nose()


### PR DESCRIPTION
Adapted from the recipe on conda-recipes.

It wasn't immediately obvious what to do with the sha256 hash hard-coded in the recipe - do I also need to update that when I bump the version?