### PR TITLE
add initial recipe for cygwin package

### DIFF
--- a/recipes/cygwin/bld.bat
+++ b/recipes/cygwin/bld.bat
@@ -1,0 +1,28 @@
+REM this bat file adapted from: https://gist.github.com/wjrogers/1016065
+REM -- Automates cygwin installation
+
+SETLOCAL
+
+REM -- These are the packages we will install (in addition to the default packages)
+SET PACKAGES=make,automake,autoconf,readline,libncursesw-devel
+set HASH_TYPE=SHA256
+set HASH=dd0754a9b238954b7cca407a4e4146de4a8281d1825bc2328d992e0d8d8005fe
+set FILENAME=setup.exe
+
+curl -L https://cygwin.com/setup-x86_64.exe -o %FILENAME%
+set command="if ( $($(CertUtil -hashfile %FILENAME% %HASH_TYPE%)[1] -replace ' ','') -eq '%HASH%' ) { echo 'setup download ok' } else {echo 'setup checksum bad.  Has it changed/been updated?' -and exit 1}"
+powershell -Command %command%
+if errorlevel 1 exit 1
+
+REM -- Configure our paths
+SET SITE=http://mirrors.kernel.org/sourceware/cygwin/
+SET LOCALDIR=%LIBRARY_PREFIX%/cygwin
+SET ROOTDIR=%LIBRARY_PREFIX%
+
+REM -- Do it!
+ECHO *** INSTALLING PACKAGES
+%FILENAME% -B -q -D -L -d -g -o -s %SITE% -l "%LOCALDIR%" -R "%ROOTDIR%" -C Base -P %PACKAGES%
+
+ENDLOCAL
+
+EXIT /B 0

--- a/recipes/cygwin/meta.yaml
+++ b/recipes/cygwin/meta.yaml
@@ -1,0 +1,24 @@
+package:
+  name: cygwin
+  version: "2.4.1"    # this is the version of the cygwin dll.  Not sure how relevant it is.
+
+# don't download source here - seems there might be some redirect that leads to a different file.
+#    instead, use curl in bld.bat and verify file in there.
+
+requirements:
+  build:
+    - curl
+
+test:
+  commands:
+    - bash --version
+    - make -v
+
+about:
+  home: https://cygwin.com/index.html
+  license: GPLv3
+  summary: Cygwin is a set of unix utilities and a DLL that implements a POSIX API on Windows
+
+extra:
+  recipe-maintainers:
+    - msarahan


### PR DESCRIPTION
This recipe does not work without https://github.com/conda/conda-build/pull/850 - cygwin has some files with very strange permissions.

There's a limited subset of packages selected here.  Mostly only enough to build ICU (and that's not tested yet.)  I'm open to expanding the list of packages, but a MUCH better way to do this will be the broken-out MSYS2 collection that @mingwandroid is working on.