### PR TITLE
Add vigra

### DIFF
--- a/recipes/vigra/build.sh
+++ b/recipes/vigra/build.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+EXTRA_CMAKE_ARGS=""
+if [[ `uname` == 'Darwin' ]];
+then
+    export DYLIB_EXT=dylib
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+    export MACOSX_VERSION_MIN="10.7"
+    export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export LINKFLAGS="${LINKFLAGS} -stdlib=libc++ -std=c++11 -L${LIBRARY_PATH}"
+    EXTRA_CMAKE_ARGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
+else
+    DYLIB_EXT=so
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+    export CXXFLAGS="-pthread -std=c++11 ${CXXFLAGS}"
+fi
+export EXTRA_CMAKE_ARGS
+
+export VIGRA_CXX_FLAGS="${CXXFLAGS}"
+
+# In release mode, we use -O2 because gcc is known to miscompile certain vigra functionality at the O3 level.
+# (This is probably due to inappropriate use of undefined behavior in vigra itself.)
+export VIGRA_CXX_FLAGS_RELEASE="-O2 -DNDEBUG ${VIGRA_CXX_FLAGS}"
+export VIGRA_LDFLAGS="${CXX_LDFLAGS} -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
+
+# Configure
+mkdir build
+cd build
+cmake ..\
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_PREFIX_PATH=${PREFIX} \
+\
+        -DCMAKE_CXX_LINK_FLAGS="${VIGRA_LDFLAGS}" \
+        -DCMAKE_EXE_LINKER_FLAGS="${VIGRA_LDFLAGS}" \
+        -DCMAKE_CXX_FLAGS="${VIGRA_CXX_FLAGS}" \
+        -DCMAKE_CXX_FLAGS_RELEASE="${VIGRA_CXX_FLAGS_RELEASE}" \
+        -DCMAKE_CXX_FLAGS_DEBUG="${VIGRA_CXX_FLAGS}" \
+\
+        -DWITH_VIGRANUMPY=TRUE \
+        -DWITH_BOOST_THREAD=1 \
+        -DDEPENDENCY_SEARCH_PREFIX=${PREFIX} \
+\
+        -DFFTW3F_INCLUDE_DIR=${PREFIX}/include \
+        -DFFTW3F_LIBRARY=${PREFIX}/lib/libfftw3f.${DYLIB_EXT} \
+        -DFFTW3_INCLUDE_DIR=${PREFIX}/include \
+        -DFFTW3_LIBRARY=${PREFIX}/lib/libfftw3.${DYLIB_EXT} \
+\
+        -DHDF5_CORE_LIBRARY=${PREFIX}/lib/libhdf5.${DYLIB_EXT} \
+        -DHDF5_HL_LIBRARY=${PREFIX}/lib/libhdf5_hl.${DYLIB_EXT} \
+        -DHDF5_INCLUDE_DIR=${PREFIX}/include \
+\
+        -DBoost_INCLUDE_DIR=${PREFIX}/include \
+        -DBoost_LIBRARY_DIRS=${PREFIX}/lib \
+\
+        -DPYTHON_EXECUTABLE=${PYTHON} \
+        -DPYTHON_INCLUDE_PATH=${PREFIX}/include \
+\
+        -DZLIB_INCLUDE_DIR=${PREFIX}/include \
+        -DZLIB_LIBRARY=${PREFIX}/lib/libz.${DYLIB_EXT} \
+\
+        -DPNG_LIBRARY=${PREFIX}/lib/libpng.${DYLIB_EXT} \
+        -DPNG_PNG_INCLUDE_DIR=${PREFIX}/include \
+\
+        -DTIFF_LIBRARY=${PREFIX}/lib/libtiff.${DYLIB_EXT} \
+        -DTIFF_INCLUDE_DIR=${PREFIX}/include \
+\
+        -DJPEG_INCLUDE_DIR=${PREFIX}/include \
+        -DJPEG_LIBRARY=${PREFIX}/lib/libjpeg.${DYLIB_EXT} \
+        ${EXTRA_CMAKE_ARGS}
+
+make
+# Can't run tests due to a bug in the clang compiler provided with XCode.
+# For more details see here ( https://llvm.org/bugs/show_bug.cgi?id=21083 ).
+# Also, these tests are very intensive, which makes them challenging to run in CI.
+#eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
+make install

--- a/recipes/vigra/meta.yaml
+++ b/recipes/vigra/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "1.11.0" %}
+
+package:
+  name: vigra
+  version: {{ version }}
+
+source:
+  {% set version_tag = "Version-%s" % version.replace(".", "-") %}
+  fn: vigra-{{ version_tag }}-src.tar.gz
+  url: https://github.com/ukoethe/vigra/archive/{{ version_tag }}.tar.gz
+  sha1: 67788d181e759e625769bf0678887718d3dc02e2
+
+build:
+  skip: true  # [win]
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - gcc         # [linux]
+    - cmake
+    - python
+    - nose
+    - numpy x.x
+    - jpeg
+    - libtiff
+    - libpng
+    - fftw
+    - hdf5
+    - boost
+    - zlib
+    
+  run:
+    - libgcc      # [linux]
+    - python
+    - numpy x.x
+    - jpeg
+    - libtiff
+    - libpng
+    - fftw
+    - hdf5
+    - boost
+    - zlib
+
+test:
+  imports:
+    - vigra
+
+about:
+  home: http://ukoethe.github.io/vigra
+  license: MIT
+  summary: Generic Programming for Computer Vision
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build VIGRA on Mac and Linux. Borrowed from [here]( https://github.com/jakirkham/nanshe-build/tree/59e38b43244178c406a400726039d1e21b2e5ca1/vigra ).