### PR TITLE
Add x264

### DIFF
--- a/recipes/x264/build.sh
+++ b/recipes/x264/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+mkdir -vp ${PREFIX}/bin;
+
+if [[ $ARCH = 64 ]]; then
+    export CFLAGS="-Wall -g -m64 -pipe -O2 -march=x86-64 -fPIC"
+else
+    export CFLAGS="-Wall -g -m32 -pipe -O2 -march=i386 -fPIC"
+fi
+export CXXLAGS="${CFLAGS}"
+#export CPPFLAGS="-I${PREFIX}/include"
+#export LDFLAGS="-L${PREFIX}/lib"
+
+ARCH="$(uname 2>/dev/null)"
+
+LinuxInstallation() {
+    # Build dependencies:
+    # yasm
+    # yasm-devel
+
+    chmod +x configure;
+
+    ./configure \
+        --enable-pic \
+        --enable-shared \
+        --prefix=${PREFIX} || return 1;
+    make || return 1;
+    make install || return 1;
+
+    return 0;
+}
+
+DarwinInstallation() {
+
+    chmod +x configure;
+
+    ./configure \
+        --enable-pic \
+        --enable-shared \
+        --prefix=${PREFIX} || return 1;
+    make || return 1;
+    make install || return 1;
+
+    return 0;
+}
+
+case ${ARCH} in
+    'Linux')
+        LinuxInstallation || exit 1;
+        ;;
+    'Darwin')
+	DarwinInstallation || exit 1;
+	;;
+    *)
+        echo -e "Unsupported machine type: ${ARCH}";
+        exit 1;
+        ;;
+esac

--- a/recipes/x264/build.sh
+++ b/recipes/x264/build.sh
@@ -2,13 +2,6 @@
 
 mkdir -vp ${PREFIX}/bin
 
-if [[ `uname` == Darwin ]];
-then
-    export LD=clang
-    export CC=clang
-    export CXX=clang++
-fi
-
 CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC"
 if [[ $ARCH = 64 ]]; then
     CFLAGS="${CFLAGS} -march=x86-64"

--- a/recipes/x264/build.sh
+++ b/recipes/x264/build.sh
@@ -15,6 +15,7 @@ chmod +x configure
 ./configure \
         --enable-pic \
         --enable-shared \
+        --enable-static \
         --prefix=${PREFIX}
 make
 make install

--- a/recipes/x264/build.sh
+++ b/recipes/x264/build.sh
@@ -2,6 +2,13 @@
 
 mkdir -vp ${PREFIX}/bin
 
+if [[ `uname` == Darwin ]];
+then
+    export LD=clang
+    export CC=clang
+    export CXX=clang++
+fi
+
 CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC"
 if [[ $ARCH = 64 ]]; then
     CFLAGS="${CFLAGS} -march=x86-64"

--- a/recipes/x264/build.sh
+++ b/recipes/x264/build.sh
@@ -1,58 +1,20 @@
 #!/bin/bash
 
-mkdir -vp ${PREFIX}/bin;
+mkdir -vp ${PREFIX}/bin
 
+CFLAGS="-Wall -g -m64 -pipe -O2 -fPIC"
 if [[ $ARCH = 64 ]]; then
-    export CFLAGS="-Wall -g -m64 -pipe -O2 -march=x86-64 -fPIC"
+    CFLAGS="${CFLAGS} -march=x86-64"
 else
-    export CFLAGS="-Wall -g -m32 -pipe -O2 -march=i386 -fPIC"
+    CFLAGS="${CFLAGS} -march=i386"
 fi
+export CFLAGS
 export CXXLAGS="${CFLAGS}"
-#export CPPFLAGS="-I${PREFIX}/include"
-#export LDFLAGS="-L${PREFIX}/lib"
 
-ARCH="$(uname 2>/dev/null)"
-
-LinuxInstallation() {
-    # Build dependencies:
-    # yasm
-    # yasm-devel
-
-    chmod +x configure;
-
-    ./configure \
+chmod +x configure
+./configure \
         --enable-pic \
         --enable-shared \
-        --prefix=${PREFIX} || return 1;
-    make || return 1;
-    make install || return 1;
-
-    return 0;
-}
-
-DarwinInstallation() {
-
-    chmod +x configure;
-
-    ./configure \
-        --enable-pic \
-        --enable-shared \
-        --prefix=${PREFIX} || return 1;
-    make || return 1;
-    make install || return 1;
-
-    return 0;
-}
-
-case ${ARCH} in
-    'Linux')
-        LinuxInstallation || exit 1;
-        ;;
-    'Darwin')
-	DarwinInstallation || exit 1;
-	;;
-    *)
-        echo -e "Unsupported machine type: ${ARCH}";
-        exit 1;
-        ;;
-esac
+        --prefix=${PREFIX}
+make
+make install

--- a/recipes/x264/meta.yaml
+++ b/recipes/x264/meta.yaml
@@ -24,6 +24,7 @@ requirements:
 test:
     commands:
         - test -f ${PREFIX}/include/x264.h         # [unix]
+        - test -f ${PREFIX}/lib/libx264.a          # [unix]
         - test -f ${PREFIX}/lib/libx264.dylib      # [osx]
         - test -f ${PREFIX}/lib/libx264.so         # [linux]
         - x264 --help                              # [unix]

--- a/recipes/x264/meta.yaml
+++ b/recipes/x264/meta.yaml
@@ -11,11 +11,15 @@ source:
 
 build:
     number: 0
-    skip: true  #[win]
+    skip: true  # [win]
 
 requirements:
     build:
       - yasm
+      - gcc     # [osx]
+
+    run:
+      - libgcc  # [osx]
 
 test:
     commands:

--- a/recipes/x264/meta.yaml
+++ b/recipes/x264/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "20131217" %}
+
+package:
+    name: x264
+    version: 20131217
+
+source:
+    fn: x264-snapshot-{{ version }}-2245-stable.tar.bz2
+    url: http://download.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-{{ version }}-2245-stable.tar.bz2
+    md5: cfd27222c7aa9983259ddb10f7f570a6
+
+build:
+    number: 0
+    skip: true  #[win]
+
+requirements:
+    build:
+      - yasm
+
+test:
+    commands:
+        - test -f ${PREFIX}/include/x264.h         # [unix]
+        - test -f ${PREFIX}/lib/libx264.dylib      # [osx]
+        - test -f ${PREFIX}/lib/libx264.so         # [linux]
+        - x264 --help                              # [unix]
+
+about:
+    home: http://www.videolan.org/developers/x264.html
+    license: GPL 2
+    summary: A free software library for encoding video streams into the H.264/MPEG-4 AVC format.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build x264. This is borrowed from conda-recipes, but has been cleaned up quite a bit. Still needs some more cleaning up though.

Pulled from the FFMPEG PR ( https://github.com/conda-forge/staged-recipes/pull/111 ).