### PR TITLE
rasterio

### DIFF
--- a/recipes/affine/bld.bat
+++ b/recipes/affine/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/affine/meta.yaml
+++ b/recipes/affine/meta.yaml
@@ -1,0 +1,32 @@
+package:
+    name: affine
+    version: 1.2.0
+
+source:
+    fn: affine-1.2.0.tar.gz
+    url: https://pypi.python.org/packages/source/a/affine/affine-1.2.0.tar.gz
+    md5: 8167ffb06ecc2da4d44c7f3ed8f3b504
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - affine
+
+about:
+    home: https://github.com/sgillies/affine
+    license: BSD 3-Clause
+    summary: Matrices describing affine transformation of the plane
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/rasterio/bld.bat
+++ b/recipes/rasterio/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py build_ext -I"%LIBRARY_INC%" -lgdal_i -L"%LIBRARY_LIB%" install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/rasterio/build.sh
+++ b/recipes/rasterio/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py build_ext -I$PREFIX/include -L$PREFIX/lib -lgdal install --single-version-externally-managed --record record.txt

--- a/recipes/rasterio/meta.yaml
+++ b/recipes/rasterio/meta.yaml
@@ -1,0 +1,44 @@
+package:
+    name: rasterio
+    version: 0.32.0
+
+source:
+    fn: rasterio-0.32.0.post1.tar.gz
+    url: https://pypi.python.org/packages/source/r/rasterio/rasterio-0.32.0.post1.tar.gz
+    md5: 0cc07d16345ad281ab4e7faf24d40f97
+
+build:
+    number: 0
+    skip: True  # [win and py35]
+    entry_points:
+        - rio = rasterio.rio.main:cli
+
+requirements:
+    build:
+        - python
+        - numpy x.x
+        - cython
+        - gdal ==1.11.4
+        - setuptools
+    run:
+        - python
+        - affine
+        - cligj
+        - enum34  # [py27]
+        - numpy x.x
+        - snuggs
+        - gdal ==1.11.4
+        - click-plugins
+
+test:
+    imports:
+        - rasterio
+
+about:
+    home: https://github.com/mapbox/rasterio
+    license: BSD 3-Clause
+    summary: Rasterio reads and writes geospatial raster datasets
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/rasterio/run_test.py
+++ b/recipes/rasterio/run_test.py
@@ -1,0 +1,24 @@
+import numpy
+import rasterio
+from rasterio.features import rasterize
+from rasterio.transform import IDENTITY
+
+
+rows = cols = 10
+geometry = {'type': 'Polygon',
+            'coordinates': [[(2, 2), (2, 4.25), (4.25, 4.25),
+                             (4.25, 2), (2, 2)]]}
+
+with rasterio.drivers():
+    result = rasterize([geometry], out_shape=(rows, cols))
+    with rasterio.open(
+            "test.tif", 'w',
+            driver='GTiff',
+            width=cols,
+            height=rows,
+            count=1,
+            dtype=numpy.uint8,
+            nodata=0,
+            transform=IDENTITY,
+            crs={'init': "EPSG:4326"}) as out:
+        out.write_band(1, result.astype(numpy.uint8))


### PR DESCRIPTION
Adding latest `rasterio` and `affine` that are not in the default channel.

Note that I am using `gdal 1.11.4` even though `rasterio` works fine with `gdal 2`. The reason for that is because `fiona` does not play nice with `gdal 2`, and most people installing `fiona` also installs `rasterio`. This ensures a working installation. (I am not aware of any loss in functionality.)

PS: `post1` releases might be a problem for those who are fans of jinjying everything on to of the recipe :wink: 