### PR TITLE
Add curl and ca-certificates

### DIFF
--- a/recipes/ca-certificates/bld.bat
+++ b/recipes/ca-certificates/bld.bat
@@ -1,0 +1,16 @@
+:: Windows really uses a different store of certificates (see
+::   http://superuser.com/questions/411909/where-is-the-certificate-folder-in-windows-7)
+
+:: The certs here are probably only useful for unix-type apps, such as git, that don't necessarily
+::    respect the windows way of doing things.
+
+:: version at time of writing is 1.25
+curl -O https://raw.githubusercontent.com/curl/curl/master/lib/mk-ca-bundle.pl
+if ( $($(CertUtil -hashfile mk-ca-bundle.pl SHA256)[1] -replace " ","") -eq "6fbdd1c76a41b7ab41cd616b19e52522e2b7efb636120950f053ef2c22de44af" ) { echo "mk-ca-bundle download ok" } else {echo "mk-ca-bundle.pl checksum bad.  Has it changed?" && exit 1}
+
+perl mk-ca-bundle.pl
+
+MKDIR %LIBRARY_PREFIX%/etc/ssl/certs && COPY ca-bundle.crt %LIBRARY_PREFIX%/etc/ssl/certs/ca-certificates.crt
+MKDIR %LIBRARY_PREFIX%/etc/pki/tls/certs && COPY ca-bundle.crt %LIBRARY_PREFIX%/etc/pki/tls/certs/ca-bundle.crt
+MKDIR %LIBRARY_PREFIX%/etc/ssl && COPY ca-bundle.crt %LIBRARY_PREFIX%/etc/ssl/ca-bundle.pem
+MKDIR %LIBRARY_PREFIX%/etc/pki/tls && COPY ca-bundle.crt %LIBRARY_PREFIX%/etc/pki/tls/cacert.pem

--- a/recipes/ca-certificates/build.sh
+++ b/recipes/ca-certificates/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+curl -O https://raw.githubusercontent.com/curl/curl/master/lib/mk-ca-bundle.pl
+shasum -a 256 mk-ca-bundle.pl |
+    awk '$1=="6fbdd1c76a41b7ab41cd616b19e52522e2b7efb636120950f053ef2c22de44af"{print "mk-ca-bundle downloaded OK"}'
+if [ $? -neq 0 ]; then
+    echo "mk-ca-bundle did not pass checksum verification.  Has it changed at cURL's source?"
+    exit 1
+fi
+
+perl mk-ca-bundle.pl
+
+mkdir -p $PREFIX/etc/ssl/certs && cp ca-bundle.crt $PREFIX/etc/ssl/certs/ca-certificates.crt  # Debian/Ubuntu/Gentoo etc.
+mkdir -p $PREFIX/etc/pki/tls/certs && cp ca-bundle.crt $PREFIX/etc/pki/tls/certs/ca-bundle.crt   # Fedora/RHEL
+mkdir -p $PREFIX/etc/ssl && cp ca-bundle.crt $PREFIX/etc/ssl/ca-bundle.pem             # OpenSUSE
+mkdir -p $PREFIX/etc/pki/tls && cp ca-bundle.crt $PREFIX/etc/pki/tls/cacert.pem            # OpenELEC

--- a/recipes/ca-certificates/meta.yaml
+++ b/recipes/ca-certificates/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name:  ssl_certs
+  # version is last build date - not to be confused with version of mk-ca-bundle.pl
+  version:  20160321
+
+requirements:
+  build:
+    - perl  [win]
+
+test:
+  requires:
+    - curl
+  commands:
+    # download an HTTPS site - should fail if certs are not present or incorrect
+    - curl --capath $PREFIX/etc/ssl/certs/ca-certificates.crt https://www.google.com  # [unix]
+    - curl --capath $PREFIX/etc/pki/tls/certs/ca-bundle.crt https://www.google.com    # [unix]
+    - curl --capath $PREFIX/etc/ssl/ca-bundle.pem https://www.google.com              # [unix]
+    - curl --capath $PREFIX/etc/pki/tls/cacert.pem https://www.google.com             # [unix]
+    - curl --capath %LIBRARY_PREFIX%/etc/ssl/certs/ca-certificates.crt https://www.google.com  # [win]
+    - curl --capath %LIBRARY_PREFIX%/etc/pki/tls/certs/ca-bundle.crt https://www.google.com    # [win]
+    - curl --capath %LIBRARY_PREFIX%/etc/ssl/ca-bundle.pem https://www.google.com              # [win]
+    - curl --capath %LIBRARY_PREFIX%/etc/pki/tls/cacert.pem https://www.google.com             # [win]
+
+about:
+  home: https://curl.haxx.se/docs/mk-ca-bundle.html
+  license: MIT
+  summary: bundler for SSL certificates, using cURL's mk-ca-bundle script
+
+extra:
+  recipe-maintainers:
+    - msarahan

--- a/recipes/curl/bld.bat
+++ b/recipes/curl/bld.bat
@@ -1,0 +1,34 @@
+setlocal enabledelayedexpansion
+cd winbuild
+
+if %ARCH% == 32 (
+    set ARCH_STRING=x86
+) else (
+    set ARCH_STRING=x64
+)
+
+:: These are here to map cl.exe version numbers, which we use to figure out which
+::   compiler we are using
+:: Update this with any new MSVC compiler you might use.
+echo @echo 15=9 >> msvc_versions.bat
+echo @echo 16=10 >> msvc_versions.bat
+echo @echo 19=14 >> msvc_versions.bat
+
+for /f "delims=" %%A in ('cl /? 2^>^&1 ^| findstr /C:"Version"') do set "CL_TEXT=%%A"
+FOR /F "tokens=1,2 delims==" %%i IN ('msvc_versions.bat') DO echo %CL_TEXT% | findstr /C:"Version %%i" > nul && set VSTRING=%%j && goto FOUND
+EXIT 1
+:FOUND
+
+REM This is implicitly using WinSSL.  See Makefile.vc for more info.
+nmake /f Makefile.vc mode=dll VC=%VSTRING% WITH_DEVEL=%LIBRARY_PREFIX% WITH_ZLIB=dll DEBUG=no ENABLE_IDN=no MACHINE=%ARCH_STRING%
+
+call :TRIM %VSTRING% VSTRING
+
+robocopy ..\builds\libcurl-vc%VSTRING%-%ARCH_STRING%-release-dll-zlib-dll-ipv6-sspi-winssl\ %LIBRARY_PREFIX% *.* /E
+if %ERRORLEVEL% GEQ 8 exit 1
+
+exit /B
+
+:TRIM
+  SET %2=%1
+  GOTO :EOF

--- a/recipes/curl/build.sh
+++ b/recipes/curl/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+export DYLD_LIBRARY_PATH=$PREFIX/lib
+
+./configure \
+    --disable-ldap \
+    --with-ssl=$PREFIX \
+    --with-zlib=$PREFIX \
+    --prefix=$PREFIX
+
+make
+make install

--- a/recipes/curl/meta.yaml
+++ b/recipes/curl/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "7.47.1" %}
+
+package:
+  name:    curl
+  version: {{ version }}
+
+source:
+  fn: curl-{{ version}}.tar.bz2
+  url: http://curl.haxx.se/download/curl-{{ version }}.tar.bz2
+  sha256: ddc643ab9382e24bbe4747d43df189a0a6ce38fcb33df041b9cb0b3cd47ae98f
+
+build:
+  features:
+    - vc9     # [win and py27]
+    - vc10    # [win and py34]
+    - vc14    # [win and py35]
+
+requirements:
+  build:
+    # python is a build requirement on Windows to resolve features.
+    - python    # [win]
+    - openssl   # [unix]
+    - zlib
+  run:
+    - openssl   # [unix]
+    - zlib
+
+test:
+  commands:
+    # curl help commands on Windows have non-zero status codes.  Need other test.
+    - curl --help                  # [not osx]
+    - curl-config --features
+    - curl-config --protocols
+
+about:
+  home: http://curl.haxx.se/
+  license: MIT/X derivate (http://curl.haxx.se/docs/copyright.html)
+  license_family: MIT
+  license_file: COPYING
+  summary: tool and library for transferring data with URL syntax
+
+extra:
+  recipe-maintainers:
+    - msarahan

--- a/recipes/curl/run_test.py
+++ b/recipes/curl/run_test.py
@@ -1,0 +1,2 @@
+# this file exists only to trick the conda-build test env creator to install
+#    python of the correct version.  The actual tests are commands in meta.yaml.


### PR DESCRIPTION
This provides cURL and the ca certificates, which git on OSX needs for HTTPS communication.  Other programs that don't need this are packaging these certs themselves, or using the system ones.  It would be good to centralize them here to reduce maintenance.

After this recipe is merged, the git recipe should depend on it, and adjust its post-link script that tries to set up gitconfig to find these certs.

ping @jakirkham 