### PR TITLE
Guile Recipe

### DIFF
--- a/recipes/guile/build.sh
+++ b/recipes/guile/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+./autogen.sh
+./configure --disable-dependency-tracking --prefix=${PREFIX}
+make
+make check
+make install

--- a/recipes/guile/build.sh
+++ b/recipes/guile/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-./configure --disable-dependency-tracking --prefix=${PREFIX}
+./configure --disable-dependency-tracking --disable-nls --prefix=${PREFIX}
 make
 make check
 make install

--- a/recipes/guile/build.sh
+++ b/recipes/guile/build.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-./autogen.sh
 ./configure --disable-dependency-tracking --prefix=${PREFIX}
 make
 make check

--- a/recipes/guile/meta.yaml
+++ b/recipes/guile/meta.yaml
@@ -15,6 +15,7 @@ build:
 
 requirements:
   build:
+    - autoconf
     - pkg-config
     - libtool
     - libffi

--- a/recipes/guile/meta.yaml
+++ b/recipes/guile/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "v2.1.2" %}
+
+package:
+  name: guile
+  version: {{ version }}
+
+source:
+  git_url: http://git.savannah.gnu.org/r/guile.git
+  git_tag: f9490cdb3fd9c99de6976077cb87ef77c591967a
+
+build:
+  number: 0
+  skip: True # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - libtool
+    - libffi
+    - libunistring
+    - bdw-gc
+    - gmp
+    - readline
+
+test:
+  commands:
+    - guile -h
+
+about:
+  home: http://www.gnu.org/software/guile/
+  license: GNU AGPL
+  summary: Guile is an implementation of the Scheme programming language.
+
+extra:
+  recipe-maintainers:
+    - stefan-balke

--- a/recipes/guile/meta.yaml
+++ b/recipes/guile/meta.yaml
@@ -1,16 +1,17 @@
-{% set version = "v2.1.2" %}
+{% set version = "v2.0.11" %}
 
 package:
   name: guile
   version: {{ version }}
 
 source:
-  git_url: http://git.savannah.gnu.org/r/guile.git
-  git_tag: f9490cdb3fd9c99de6976077cb87ef77c591967a
+  fn: guile-2.0.11.tar.gz
+  url: https://ftp.gnu.org/pub/gnu/guile/guile-2.0.11.tar.gz
+  sha1: 3cdd1c4956414bffadea13e5a1ca08949016a802
 
 build:
   number: 0
-  skip: True # [win]
+  skip: True  # [win]
 
 requirements:
   build:
@@ -28,7 +29,7 @@ test:
 
 about:
   home: http://www.gnu.org/software/guile/
-  license: GNU AGPL
+  license: AGPL, version 3 or later
   summary: Guile is an implementation of the Scheme programming language.
 
 extra:


### PR DESCRIPTION
We are still missing the following packages:
- [x] libffi (https://github.com/Homebrew/homebrew/blob/master/Library/Formula/libffi.rb)
- [x] libunistring (https://github.com/Homebrew/homebrew/blob/master/Library/Formula/libunistring.rb)
- [x] bdw-gc (https://github.com/Homebrew/homebrew/blob/master/Library/Formula/bdw-gc.rb)

This should be just a matter of creating those recipes...maybe there is an end to the dependencies :)
