### PR TITLE
add netcdf-cxx4 recipe

### DIFF
--- a/recipes/netcdf-cxx4/build.sh
+++ b/recipes/netcdf-cxx4/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# See http://www.unidata.ucar.edu/support/help/MailArchives/netcdf/msg11939.html
+if [ "$(uname)" == "Darwin" ]; then
+    export DYLD_LIBRARY_PATH=${PREFIX}/lib
+fi
+
+CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
+
+make
+make check
+make install

--- a/recipes/netcdf-cxx4/meta.yaml
+++ b/recipes/netcdf-cxx4/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "4.2.1" %}
+
+package:
+  name: netcdf-cxx4
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/Unidata/netcdf-cxx4
+  git_tag: v{{ version }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - libnetcdf
+  run:
+    - libnetcdf
+
+test:
+  commands:
+    - ncxx4-config --all
+
+about:
+  home: https://github.com/Unidata/netcdf-cxx4
+  license: http://www.unidata.ucar.edu/software/netcdf/copyright.html
+  summary: Unidata NetCDF C++ Library
+
+extra:
+  recipe-maintainers:
+    - kmuehlbauer


### PR DESCRIPTION
This adds the v4.2.1 (latest) version of the netcdf c++ libraries.

Pre-tested locally on linux-64 without flaws

I gladly add volunteers for the maintainer section.