### PR TITLE
Do we need the Token in appveyor.yml [ci skip]    [skip appveyor]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,6 @@ environment:
   # Workaround for https://github.com/conda/conda-build/issues/636
   PYTHONIOENCODING: "UTF-8"
 
-  BINSTAR_TOKEN:
-    # Generated with "binstar auth --create --name ScitoolsRecipesAppVeyor -o conda-forge" and encrypted on ci.appveyor.com/tools/encrypt.
-    secure: wtylLGtp/ID3G3DFT2uxuLFXuijFqmxI6phj60izpNC3pxd585bR6k2oonf5iGGb
-
   matrix:
     # Note: Because we have to separate the py2 and py3 components due to compiler version, we have a race condition for non-python packages.
     # Not sure how to resolve this, but maybe we should be tracking the VS version in the build string anyway?


### PR DESCRIPTION
We don't do any uploads in staged-recipes, so I am guessing this is safe. @pelson if so we could also change the AppVeyor account as suggested in #244, right?