### PR TITLE
WIP: Add caffe

### DIFF
--- a/recipes/caffe/build.sh
+++ b/recipes/caffe/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Setup CMake build location
+mkdir build
+cd build
+
+# Configure, build, test, and install.
+cmake -DCPU_ONLY=1 -DBLAS="open" -DCMAKE_INSTALL_PREFIX="${PREFIX}" ..
+make
+make runtest
+make install
+
+# Python installation is non-standard. So, we're fixing it.
+mv "${PREFIX}/python/caffe" "${SP_DIR}/"
+for FILENAME in $( cd "${PREFIX}/python/" && find . -name "*.py" | sed 's|./||' );
+do
+    chmod +x "${PREFIX}/python/${FILENAME}"
+    cp "${PREFIX}/python/${FILENAME}" "${PREFIX}/bin/${FILENAME//.py}"
+done
+rm -rf "${PREFIX}/python/"

--- a/recipes/caffe/meta.yaml
+++ b/recipes/caffe/meta.yaml
@@ -1,0 +1,121 @@
+{% set base_version = "1.0.0" %}
+{% set version_postfix = "rc3" %}
+{% set version = base_version + version_postfix %}
+
+package:
+  name: caffe
+  version: {{ version }}
+
+source:
+  fn: caffe_{{ version }}.tar.gz
+  url: https://github.com/BVLC/caffe/archive/{{ version_postfix }}.tar.gz
+  sha1: 79e075d06bea856164c926b92a40242b0369965b
+
+build:
+  number: 0
+  skip: true  # [not (linux and py27)]
+  features:
+    - nomkl
+
+requirements:
+  build:
+    - cmake
+    - cython
+    - nomkl
+    - openblas
+    - boost
+    - hdf5
+    - gflags
+    - glog
+    - h5py
+    - hdf5
+    - ipython
+    - leveldb
+    - lmdb
+    - matplotlib
+    - networkx
+    - nose
+    - numpy
+    - opencv 2.*
+    - pandas
+    - pillow
+    - protobuf
+    - python
+    - python-dateutil
+    - python-gflags
+    - python-leveldb
+    - pyyaml
+    - scikit-image
+    - scipy
+    - six
+    - snappy
+
+  run:
+    - nomkl
+    - openblas
+    - boost
+    - hdf5
+    - gflags
+    - glog
+    - h5py
+    - hdf5
+    - ipython
+    - leveldb
+    - lmdb
+    - matplotlib
+    - networkx
+    - numpy
+    - opencv 2.*
+    - pandas
+    - pillow
+    - protobuf
+    - python
+    - python-dateutil
+    - python-gflags
+    - python-leveldb
+    - pyyaml
+    - scikit-image
+    - scipy
+    - six
+    - snappy
+
+test:
+  commands:
+    # Test commands.
+    - command -v "${PREFIX}/bin/caffe"
+    - command -v "${PREFIX}/bin/classification"
+    - command -v "${PREFIX}/bin/classify"
+    - command -v "${PREFIX}/bin/compute_image_mean"
+    - command -v "${PREFIX}/bin/convert_cifar_data"
+    - command -v "${PREFIX}/bin/convert_imageset"
+    - command -v "${PREFIX}/bin/convert_mnist_data"
+    - command -v "${PREFIX}/bin/convert_mnist_siamese_data"
+    - command -v "${PREFIX}/bin/detect"
+    - command -v "${PREFIX}/bin/device_query"
+    - command -v "${PREFIX}/bin/draw_net"
+    - command -v "${PREFIX}/bin/extract_features"
+    - command -v "${PREFIX}/bin/finetune_net"
+    - command -v "${PREFIX}/bin/net_speed_benchmark"
+    - command -v "${PREFIX}/bin/test_net"
+    - command -v "${PREFIX}/bin/train_net"
+    - command -v "${PREFIX}/bin/upgrade_net_proto_binary"
+    - command -v "${PREFIX}/bin/upgrade_net_proto_text"
+    - command -v "${PREFIX}/bin/upgrade_solver_proto_text"
+
+    # Test includes.
+    - test -d "${PREFIX}/include/caffe"
+
+    # Test libraries.
+    - test -f "${PREFIX}/lib/libcaffe.so"
+
+  imports:
+    - caffe
+
+about:
+  home: http://caffe.berkeleyvision.org/
+  license: BSD 2-Clause
+  summary: A deep learning framework made with expression, speed, and modularity in mind.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Builds caffe from source. Currently, this supports Linux only, but Mac should be feasible. However, this will likely require feature-based BLAS support. Getting Windows support will be challenging as many of the dependencies don't support Windows. Also, this does not enable GPU support. That will likely require modifications to CI packages installed and use of features. Though should be possible. While somewhat limited, this both demonstrates the build is possible and creates a base for building on going forward.