### PR TITLE
Add ffmpeg (2nd Attempt)

### DIFF
--- a/recipes/ffmpeg/build.sh
+++ b/recipes/ffmpeg/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+export CFLAGS="-Wall -g -m64 -pipe -O3 -march=x86-64 -fPIC"
+export CXXFLAGS="${CFLAGS}"
+
+if [ "$(uname)" == "Darwin" ];
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [ "$(uname)" == "Linux" ];
+then
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+./configure \
+        --prefix="${PREFIX}" \
+        --enable-shared \
+        --enable-pic \
+        --enable-libx264 \
+        --disable-doc \
+        --enable-gpl
+make
+make install

--- a/recipes/ffmpeg/meta.yaml
+++ b/recipes/ffmpeg/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "2.8.6" %}
+
+package:
+    name: ffmpeg
+    version: {{ version }}
+
+source:
+    fn: ffmpeg-{{ version }}.tar.gz
+    url: https://ffmpeg.org/releases/ffmpeg-{{ version }}.tar.gz
+    md5: 7b9449795790c46331dae2c6e8e28f15
+
+build:
+    skip: true         # [win]
+    number: 0
+
+requirements:
+    build:
+        - pkg-config
+        - libtool
+        - yasm
+        - gcc          # [osx]
+        - x264
+        - zlib
+    run:
+        - libgcc       # [osx]
+        - x264
+        - zlib
+
+test:
+    commands:
+        - ffmpeg --help
+
+about:
+    home: http://www.ffmpeg.org/
+    license: GPL 2
+    summary: Cross-platform solution to record, convert and stream audio and video.
+
+extra:
+    recipe-maintainers:
+        - danielballan
+        - jakirkham


### PR DESCRIPTION
As the dependencies are basically in for Mac and Linux (though not Windows yet), this attempts to build a Linux and Mac version of FFMPEG. In the future, after the previous patches for Windows support amongst the dependencies are applied, we can revisit Windows support for FFMPEG. This continues off the work in this PR ( https://github.com/conda-forge/staged-recipes/pull/111 ) and also cleans it up quite a bit.