### PR TITLE
libxml2

### DIFF
--- a/recipes/libxml2/build.sh
+++ b/recipes/libxml2/build.sh
@@ -16,5 +16,7 @@ fi
             $OPTS
 
 make
-make check
+if [ $(uname) != Darwin ]; then
+  make check
+fi
 make install

--- a/recipes/libxml2/build.sh
+++ b/recipes/libxml2/build.sh
@@ -1,20 +1,27 @@
 #!/bin/bash
 
-if [[ `uname` == 'Darwin' ]];
-then
-    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-elif [[ `uname` == 'Linux' ]];
-then
-    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+if [[ $(uname) == 'Darwin' ]]; then
+  export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [[ $(uname) == 'Linux' ]]; then
+  export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi
 
 ./autogen.sh
+
 ./configure --prefix="${PREFIX}" \
             --with-iconv="${PREFIX}" \
-            --with-icu \
             --with-lzma="${PREFIX}" \
-            --with-python="${PREFIX}" \
-            --with-zlib="${PREFIX}"
+            --with-zlib="${PREFIX}" \
+            --with-icu \
+            --without-python
 make
+
+# Correct weirdly linked library paths.
+if [[ $(uname) == 'Darwin' ]]; then
+  LIBDIR="${PREFIX}/lib"
+  LIBICUDATA="`cd ${LIBDIR} && ls libicudata.*.*.dylib`"
+  find "${SRC_DIR}/.libs" -type f | xargs -I {} install_name_tool -change "../lib/${LIBICUDATA}" "${PREFIX}/lib/${LIBICUDATA}" {} || true
+#   find "${SRC_DIR}/python/.libs" -type f | xargs -I {} install_name_tool -change "../lib/${LIBICUDATA}" "${PREFIX}/lib/${LIBICUDATA}" {} || true
+fi
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
 make install

--- a/recipes/libxml2/build.sh
+++ b/recipes/libxml2/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+export CPPFLAGS="-I${PREFIX}/include"
+
+if [ $(uname) == Darwin ]; then
+  export OPTS="--without-lzma"
+else
+  export OPTS="--with-lzma=$PREFIX"
+fi
+
+./autogen.sh
+
+./configure --prefix=$PREFIX \
+            --with-zlib=$PREFIX \
+            --with-python=$PREFIX \
+            $OPTS
+
+make
+make check
+make install

--- a/recipes/libxml2/build.sh
+++ b/recipes/libxml2/build.sh
@@ -1,22 +1,20 @@
 #!/bin/bash
 
-export CPPFLAGS="-I${PREFIX}/include"
-
-if [ $(uname) == Darwin ]; then
-  export OPTS="--without-lzma"
-else
-  export OPTS="--with-lzma=$PREFIX"
+if [[ `uname` == 'Darwin' ]];
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [[ `uname` == 'Linux' ]];
+then
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi
 
 ./autogen.sh
-
-./configure --prefix=$PREFIX \
-            --with-zlib=$PREFIX \
-            --with-python=$PREFIX \
-            $OPTS
-
+./configure --prefix="${PREFIX}" \
+            --with-iconv="${PREFIX}" \
+            --with-icu \
+            --with-lzma="${PREFIX}" \
+            --with-python="${PREFIX}" \
+            --with-zlib="${PREFIX}"
 make
-if [ $(uname) != Darwin ]; then
-  make check
-fi
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
 make install

--- a/recipes/libxml2/meta.yaml
+++ b/recipes/libxml2/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "2.9.3" %}
+
+package:
+    name: libxml2
+    version: {{ version }}
+
+source:
+    fn: libxml2-{{ version }}.tar.xz
+    url: https://git.gnome.org/browse/libxml2/snapshot/libxml2-{{ version }}.tar.xz
+    md5: 59d281614c87d0c767134c55de20a8a9
+
+build:
+    number: 0
+    skip: True  # [win]
+
+requirements:
+    build:
+        - python
+        - autoconf
+        - automake
+        - libtool
+        - libiconv
+        - pkg-config
+        - zlib
+        - xz
+    run:
+        - python
+        - libiconv
+        - zlib
+        - xz
+
+test:
+    files:
+        - test.xml
+    commands:
+        - xmllint test.xml
+
+about:
+    home: http://xmlsoft.org/
+    license: MIT
+    summary: The XML C parser and toolkit of Gnome
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/libxml2/meta.yaml
+++ b/recipes/libxml2/meta.yaml
@@ -15,19 +15,21 @@ build:
 
 requirements:
     build:
-        - python
         - autoconf
         - automake
         - libtool
-        - libiconv
         - pkg-config
-        - zlib
+        - python
+        - icu
+        - libiconv
         - xz
+        - zlib
     run:
         - python
+        - icu
         - libiconv
-        - zlib
         - xz
+        - zlib
 
 test:
     files:

--- a/recipes/libxml2/meta.yaml
+++ b/recipes/libxml2/meta.yaml
@@ -19,13 +19,11 @@ requirements:
         - automake
         - libtool
         - pkg-config
-        - python
         - icu
         - libiconv
         - xz
         - zlib
     run:
-        - python
         - icu
         - libiconv
         - xz
@@ -45,3 +43,4 @@ about:
 extra:
     recipe-maintainers:
         - ocefpaf
+        - jakirkham

--- a/recipes/libxml2/test.xml
+++ b/recipes/libxml2/test.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<HTML xmlns:pp="http://www.isogen.com/paul/post-processor">
+<TITLE>Introduction to XSL</TITLE>
+<H1>Introduction to XSL</H1>
+
+
+
+                <HR/>
+                <H2>Overview
+</H2>
+                <UL>
+
+        <LI>1.Intro</LI>
+
+        <LI>2.History</LI>
+
+        <LI>3.XSL Basics</LI>
+
+        <LI>Lunch</LI>
+
+        <LI>4.An XML Data Model</LI>
+
+        <LI>5.XSL Patterns</LI>
+
+        <LI>6.XSL Templates</LI>
+
+        <LI>7.XSL Formatting Model
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>Intro</H2>
+                <UL>
+
+        <LI>Who am I?</LI>
+
+        <LI>Who are you?</LI>
+
+        <LI>Why are we here?
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>History: XML and SGML</H2>
+                <UL>
+
+        <LI>XML is a subset of SGML.</LI>
+
+        <LI>SGML allows the separation of abstract content from formatting.</LI>
+
+        <LI>Also one of XML's primary virtues (in the doc publishing domain).
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>History: What are stylesheets?</H2>
+                <UL>
+
+        <LI>Stylesheets specify the formatting of SGML/XML documents.</LI>
+
+        <LI>Stylesheets put the &quot;style&quot; back into documents.</LI>
+
+        <LI>New York Times content+NYT Stylesheet = NYT paper
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>History: FOSI</H2>
+                <UL>
+
+        <LI>FOSI: &quot;Formatted Output Specification Instance&quot;
+<UL>
+        <LI>MIL-STD-28001
+        </LI>
+
+        <LI>FOSI's are SGML documents
+        </LI>
+
+        <LI>A stylesheet for another document
+        </LI>
+</UL></LI>
+
+        <LI>Obsolete but implemented...
+</LI>
+
+                </UL>
+
+
+
+
+</HTML>


### PR DESCRIPTION
I am having trouble with the default `libxml2` in [`gdal`](https://travis-ci.org/conda-forge/gdal-feedstock/jobs/120497759) and [`libspatialite`](https://travis-ci.org/conda-forge/staged-recipes/jobs/120605780). So I am trying to roll our own version here.