### PR TITLE
Remove homebrew

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -17,6 +17,9 @@ if [ -z "$GH_TOKEN" ]; then
     # We don't need to build the example recipe.
     rm -rf ./recipes/example
 
+    # Remove homebrew.
+    brew remove --force $(brew list)
+
     # We just want to build all of the recipes.
     conda-build-all ./recipes --matrix-condition "numpy >=1.9" "python >=2.7,<3|>=3.4"
 fi


### PR DESCRIPTION
These will be removed.

```
- apple-gcc42
- autoconf
- automake
- boost
- cgal
- cloog
- cloog-ppl015
- cloog018
- cmake
- freexl
- gcc
- gcc46
- gcc48
- gdal
- geos
- giflib
- gmp
- gmp4
- go
- gpp
- isl
- isl011
- jpeg
- json-c
- libgeotiff
- libgpg-error
- libksba
- liblwgeom
- libmpc
- libmpc08
- libpng
- libspatialite
- libtiff
- libtool
- libxml2
- libyaml
- lzlib
- maven
- mercurial
- mpfr
- mpfr2
- node
- openssl
- ossp-uuid
- pkg-config
- postgis
- postgresql
- ppl011
- proj
- pyenv
- readline
- sfcgal
- sqlite
- subversion
- wget
- xctool
```