### PR TITLE
megaman recipe

### DIFF
--- a/recipes/megaman/build.sh
+++ b/recipes/megaman/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# On OSX, we need to ensure we're using conda's gcc/g++
+# This is because flann (one of the build dependencies) uses OpenMP
+if [[ `uname` == Darwin ]]; then
+    export CC=gcc
+    export CXX=g++
+fi
+
+$PYTHON setup.py install

--- a/recipes/megaman/meta.yaml
+++ b/recipes/megaman/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.1.1" %}
+
+package:
+    name: megaman
+    version: {{ version }}
+
+source:
+    fn: megaman-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/m/megaman/megaman-{{ version }}.tar.gz
+    md5: 924d05877a3bcfc86d4f48ea9436cdd4
+
+build:
+    number: 0
+    skip: true    # [win]
+
+requirements:
+    build:
+        - python
+        - numpy x.x
+        - cython
+        - flann
+        - gcc 4.8*  # [osx]
+    run:
+        - python
+        - numpy x.x
+        - scipy >=0.16
+        - scikit-learn >=0.17
+        - pyamg
+        - pyflann
+        - libgcc 4.8*  # [osx]
+
+test:
+    requires:
+        - nose
+    imports:
+        - megaman
+        - megaman.geometry
+        - megaman.embedding
+        - megaman.utils
+
+about:
+    home: http://mmp2.github.io/megaman
+    license: BSD 2-clause
+    license_file: LICENSE
+    summary: "Manifold Learning for Millions of Points"
+
+extra:
+    recipe-maintainers:
+        - jakevdp

--- a/recipes/megaman/run_test.py
+++ b/recipes/megaman/run_test.py
@@ -1,0 +1,3 @@
+import nose
+config = nose.config.Config(verbosity=2)
+nose.runmodule('megaman', config=config)


### PR DESCRIPTION
This is a recipe for the [megaman](http://mmp2.github.io/megaman/) package, which implements scalable manifold learning based on flann and pyamg.

The build is skipped on windows because it requires flann, which currently does not build on windows within conda-forge.