### PR TITLE
snuggs

### DIFF
--- a/recipes/snuggs/bld.bat
+++ b/recipes/snuggs/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/snuggs/meta.yaml
+++ b/recipes/snuggs/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "1.3.1" %}
+
+package:
+    name: snuggs
+    version: {{ version }}
+
+source:
+    fn: snuggs-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/s/snuggs/snuggs-{{ version }}.tar.gz
+    md5: f812255b9b89d178a96c39395dba263d
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - click
+        - numpy
+        - pyparsing
+
+test:
+    imports:
+        - snuggs
+
+about:
+    home: https://github.com/mapbox/snuggs
+    license: MIT
+    summary: Snuggs are s-expressions for Numpy
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
Snuggs is present in the default channel but it has a unneeded numpy build string. The `np<ver>` string is preventing us from using `snuggs` as a dependency in packages that do need numpy build string and are using `np111` (`rasterio`).