### PR TITLE
Add primesieve (with python bindings)

### DIFF
--- a/recipes/primesieve/bld.bat
+++ b/recipes/primesieve/bld.bat
@@ -1,0 +1,17 @@
+nmake /f Makefile.msvc
+if errorlevel 1 exit 1
+
+nmake /f Makefile.msvc check
+if errorlevel 1 exit 1
+
+cp include\primesieve.h %LIBRARY_INC%
+if errorlevel 1 exit 1
+
+cp include\primesieve.hpp %LIBRARY_INC%
+if errorlevel 1 exit 1
+
+cp primesieve.lib %LIBRARY_LIB%
+if errorlevel 1 exit 1
+
+cp primesieve.exe %LIBRARY_BIN%
+if errorlevel 1 exit 1

--- a/recipes/primesieve/build.sh
+++ b/recipes/primesieve/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [[ `uname` == 'Darwin' ]];
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+else
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+./configure --prefix="${PREFIX}"
+make
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make check
+make install

--- a/recipes/primesieve/meta.yaml
+++ b/recipes/primesieve/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "5.6.0" %}
+
+package:
+  name: primesieve
+  version: {{ version }}
+
+source:
+  fn: primesieve-{{ version }}.tar.gz
+  url: https://dl.bintray.com/kimwalisch/primesieve/primesieve-{{ version }}.tar.gz
+  sha1: 86d0fb98c7e1d6bc47e1923138de3d0c0eb4904c
+
+build:
+  # Seem to be encountering hangs on Windows with Python 2.7; so, they are skipped.
+  skip: true  # [win and py2k]
+  number: 0
+
+requirements:
+  build:
+    - gcc     # [osx]
+
+  run:
+    - libgcc  # [osx]
+
+test:
+  commands:
+    # Check libraries exist
+    - test -f "${PREFIX}/lib/libprimesieve.a"      # [unix]
+    - test -f "${PREFIX}/lib/libprimesieve.so"     # [linux]
+    - test -f "${PREFIX}/lib/libprimesieve.dylib"  # [osx]
+
+    # Test CLIs.
+    - primesieve -n 1
+
+about:
+  home: http://primesieve.org/
+  license: BSD 2-Clause
+  summary: Fast C/C++ prime number generator
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/python-primesieve/bld.bat
+++ b/recipes/python-primesieve/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/python-primesieve/meta.yaml
+++ b/recipes/python-primesieve/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: python-primesieve
+  version: {{ version }}
+
+source:
+  fn: primesieve-{{ version }}.zip
+  url: https://pypi.python.org/packages/source/p/primesieve/primesieve-{{ version }}.zip
+  md5: 37458cd8ca2757e17fd0446c395fc87b
+
+build:
+  # Seem primesieve is encountering hangs on Windows with Python 2.7.
+  # So, neither primesieve nor these Python bindings are built in that case.
+  skip: true  # [win and py2k]
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - gcc     # [osx]
+    - python
+    - cython
+    - numpy x.x
+    - primesieve
+
+  run:
+    - libgcc  # [osx]
+    - python
+    - numpy x.x
+    - primesieve
+
+test:
+  imports:
+    - primesieve
+
+  commands:
+    - python -c "import primesieve; assert primesieve.nth_prime(1) == 2"
+
+about:
+  home: https://github.com/hickford/primesieve-python
+  license: MIT
+  summary: Fast prime number generator. Python bindings for primesieve C/C++ library
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds recipes to build the C/C++ primesieve library and a separate package that provides Python bindings to it. Based off of a recipe in conda-recipes with some gaps filled in.