### PR TITLE
Add cmt

### DIFF
--- a/recipes/cmt/build.sh
+++ b/recipes/cmt/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+pushd code/liblbfgs
+./autogen.sh
+./configure --enable-sse2
+make CFLAGS="-fPIC"
+popd
+
+${PYTHON} setup.py build
+${PYTHON} setup.py install

--- a/recipes/cmt/images.py.patch
+++ b/recipes/cmt/images.py.patch
@@ -1,0 +1,13 @@
+diff --git code/cmt/python/tools/images.py code/cmt/python/tools/images.py
+index c050d89..e176077 100644
+--- code/cmt/python/tools/images.py
++++ code/cmt/python/tools/images.py
+@@ -1,4 +1,7 @@
+-import Image
++try:
++	from PIL import Image
++except ImportError:
++	pass
+ from numpy import array, asarray, squeeze, abs, min, max, percentile
+ 
+ def imread(filename):

--- a/recipes/cmt/mcbm_test.py.patch
+++ b/recipes/cmt/mcbm_test.py.patch
@@ -1,0 +1,14 @@
+diff --git code/cmt/python/tests/mcbm_test.py code/cmt/python/tests/mcbm_test.py
+index 0ca6396..0d5d2d8 100644
+--- code/cmt/python/tests/mcbm_test.py
++++ code/cmt/python/tests/mcbm_test.py
+@@ -316,6 +316,9 @@ class Tests(unittest.TestCase):
+ 
+ 
+ 
++        @unittest.skip("Skipping test as it has a pickling error."
++                       "See issue ( https://github.com/lucastheis/cmt/issues/12 )."
++        )
+ 	def test_patchmcbm_pickle(self):
+ 		xmask = ones([2, 2], dtype='bool')
+ 		ymask = zeros([2, 2], dtype='bool')

--- a/recipes/cmt/mcgsm_test.py.patch
+++ b/recipes/cmt/mcgsm_test.py.patch
@@ -1,0 +1,14 @@
+diff --git code/cmt/python/tests/mcgsm_test.py code/cmt/python/tests/mcgsm_test.py
+index fa02aa6..ff212f7 100644
+--- code/cmt/python/tests/mcgsm_test.py
++++ code/cmt/python/tests/mcgsm_test.py
+@@ -253,6 +253,9 @@ class Tests(unittest.TestCase):
+ 
+ 
+ 
++        @unittest.skip("Skipping test as it has a sporadic numerical error."
++                       "See issue ( https://github.com/lucastheis/cmt/issues/16 )."
++        )
+ 	def test_gradient(self):
+ 		mcgsm = MCGSM(5, 2, 2, 4, 10)
+ 

--- a/recipes/cmt/meta.yaml
+++ b/recipes/cmt/meta.yaml
@@ -42,14 +42,14 @@ requirements:
   build:
     - automake
     - libtool
-    - gcc         # [osx]
+    - gcc
     - python
     - numpy x.x
     - scipy
     - pillow
 
   run:
-    - libgcc      # [osx]
+    - libgcc
     - python
     - numpy x.x
     - scipy

--- a/recipes/cmt/meta.yaml
+++ b/recipes/cmt/meta.yaml
@@ -1,0 +1,92 @@
+{% set version = "0.5.0" %}
+
+package:
+  name: cmt
+  version: {{ version }}
+
+source:
+  fn: cmt-v{{ version }}.tar.gz
+  url: https://github.com/lucastheis/cmt/archive/v{{ version }}.tar.gz
+  sha1: 7482caefa5359a351ac834920a092b5594098d70
+  patches:
+    # Workaround to ensure `gcc` compiler is used on Mac.
+    # See issue ( https://github.com/lucastheis/cmt/issues/10 ).
+    # No patch submitted as this will require discussion with the developer.
+    - setup.py.patch
+    # Incorrect import here makes tests fail and reduces functionality.
+    # See issue ( https://github.com/lucastheis/cmt/issues/14 ).
+    # Patch for this has been submitted.
+    # See pull request ( https://github.com/lucastheis/cmt/pull/18 ).
+    - images.py.patch
+    # Test failure here is caused due to an inability to pickle.
+    # See issue ( https://github.com/lucastheis/cmt/issues/12 ).
+    # Patch for this has been submitted.
+    # See pull request ( https://github.com/lucastheis/cmt/pull/17 ).
+    - mcbm_test.py.patch
+    # Test failure here is caused due to sporadic numerical issue.
+    # See issue ( https://github.com/lucastheis/cmt/issues/16 ).
+    # Patch for this has been submitted.
+    # See pull request ( https://github.com/lucastheis/cmt/pull/20 ).
+    - mcgsm_test.py.patch
+    # Test failure here is caused due to numerical issue.
+    # See issue ( https://github.com/lucastheis/cmt/issues/15 ).
+    # Patch for this has been submitted.
+    # See pull request ( https://github.com/lucastheis/cmt/pull/19 ).
+    - univariate_test.py.patch
+
+build:
+  number: 0
+  skip: true      # [win or py3k]
+
+requirements:
+  build:
+    - automake
+    - libtool
+    - gcc         # [osx]
+    - python
+    - numpy x.x
+    - scipy
+    - pillow
+
+  run:
+    - libgcc      # [osx]
+    - python
+    - numpy x.x
+    - scipy
+    - pillow
+
+test:
+  imports:
+    - cmt
+
+  commands:
+    - python ${SRC_DIR}/code/cmt/python/tests/fvbn_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/glm_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/gsm_test.py
+    # Test failure here is caused due to an inability to pickle.
+    # See issue ( https://github.com/lucastheis/cmt/issues/12 ).
+    - python ${SRC_DIR}/code/cmt/python/tests/mcbm_test.py
+    # Test failure here is caused due to sporadic numerical issue.
+    # See issue ( https://github.com/lucastheis/cmt/issues/16 ).
+    - python ${SRC_DIR}/code/cmt/python/tests/mcgsm_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/mixture_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/mlr_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/nonlinear_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/preconditioner_test.py
+    - python ${SRC_DIR}/code/cmt/python/tests/speed.py
+    - python ${SRC_DIR}/code/cmt/python/tests/stm_test.py
+    # Test failure here is caused due to a missing/incorrect import.
+    # See issue ( https://github.com/lucastheis/cmt/issues/14 ).
+    - python ${SRC_DIR}/code/cmt/python/tests/tools_test.py
+    # Test failure here is caused due to numerical issue.
+    # See issue ( https://github.com/lucastheis/cmt/issues/15 ).
+    - python ${SRC_DIR}/code/cmt/python/tests/univariate_test.py
+
+about:
+  home: https://github.com/lucastheis/cmt
+  license: MIT
+  summary: Fast implementations of several probabilistic models.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/cmt/setup.py.patch
+++ b/recipes/cmt/setup.py.patch
@@ -1,0 +1,23 @@
+diff --git setup.py setup.py
+index f9a2866..d1c2c1c 100644
+--- setup.py
++++ setup.py
+@@ -41,18 +41,6 @@ if any(['intel' in arg for arg in sys.argv]) or 'intel' in get_default_compiler(
+ 		if os.path.exists(path):
+ 			library_dirs += [path]
+ 
+-elif sys.platform == 'darwin':
+-	# clang-specific options
+-	include_dirs = []
+-	library_dirs = []
+-	libraries = []
+-	extra_compile_args = ['-std=c++0x', '-stdlib=libc++']
+-	extra_link_args = []
+-
+-	os.environ['CC'] = 'clang++'
+-	os.environ['CXX'] = 'clang++'
+-	os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
+-
+ else:
+ 	# gcc-specific options
+ 	include_dirs = []

--- a/recipes/cmt/univariate_test.py.patch
+++ b/recipes/cmt/univariate_test.py.patch
@@ -1,0 +1,14 @@
+diff --git code/cmt/python/tests/univariate_test.py code/cmt/python/tests/univariate_test.py
+index 0059e85..bedaa2d 100644
+--- code/cmt/python/tests/univariate_test.py
++++ code/cmt/python/tests/univariate_test.py
+@@ -89,6 +89,9 @@ class Tests(unittest.TestCase):
+ 
+ 
+ 
++        @unittest.skip("Skipping test as it has a numerical error."
++                       "See issue ( https://github.com/lucastheis/cmt/issues/15 )."
++        )
+ 	def test_binomial_sample(self):
+ 		T = 1000
+ 


### PR DESCRIPTION
Apparently my description got wiped out when I moved it on ZenHub boards. So, I'm re-writing based on what I remember. :cry:

We have tried to package [`cmt`]( https://github.com/lucastheis/cmt ). This is a brand new recipe. A number of issues were found with the latest release. These have all been submitted upstream. All patches that made sense have been submitted upstream. There is one workaround patch (compiler change for Mac), which has not been submitted upstream. However, an issue has been opened to discuss changes that would make it unnecessary. Below is a list of either PRs (with issues referenced) or issues (if no PR was submitted). Also, a list of otherwise related issues has been compiled below.

Patches:
* https://github.com/lucastheis/cmt/issues/10
* https://github.com/lucastheis/cmt/pull/18
* https://github.com/lucastheis/cmt/pull/17
* https://github.com/lucastheis/cmt/pull/20
* https://github.com/lucastheis/cmt/pull/19

Related issues:

* https://github.com/lucastheis/cmt/issues/8
* https://github.com/lucastheis/cmt/issues/9
* https://github.com/lucastheis/cmt/issues/11
* https://github.com/lucastheis/cmt/issues/13
* https://github.com/lucastheis/cmt/issues/21