### PR TITLE
Add entrypoints and configparser

### DIFF
--- a/recipes/configparser/meta.yaml
+++ b/recipes/configparser/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "3.5.0b2" %}
+
+package:
+    name: configparser
+    version: {{ version }}
+
+source:
+    fn: configparser-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/c/configparser/configparser-{{ version }}.tar.gz
+    md5: ad2a71db8bd9a017ed4735eac7acfa07
+
+build:
+    number: 0
+    skip: True  # [py35]
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - backports
+        - backports.configparser
+        - configparser
+
+about:
+    home: http://docs.python.org/3/library/configparser.html
+    license: MIT
+    summary: This library brings the updated configparser from Python 3.5 to Python 2.6-3.5
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/entrypoints/bld.bat
+++ b/recipes/entrypoints/bld.bat
@@ -1,0 +1,1 @@
+copy entrypoints.py %SP_DIR% || exit 1

--- a/recipes/entrypoints/build.sh
+++ b/recipes/entrypoints/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cp entrypoints.py $SP_DIR

--- a/recipes/entrypoints/meta.yaml
+++ b/recipes/entrypoints/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.2" %}
+
+package:
+    name: entrypoints
+    version: {{ version }}
+
+source:
+    fn: {{ version }}.tar.gz
+    url: https://github.com/takluyver/entrypoints/archive/{{ version }}.tar.gz
+    md5: bcbad7a52241a7e604657675f94f2f08
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+    run:
+        - python
+        - configparser  # [not py35]
+
+test:
+    imports:
+        - entrypoints
+
+about:
+    home: http://entrypoints.readthedocs.org/en/latest/
+    license: MIT
+    summary: Discover and load entry points from installed packages
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - minrk
+    - takluyver


### PR DESCRIPTION
The `configparser` module is a `entrypoints` dependency, and `entrypoints` is used in the latest `nbconvert`. (See https://github.com/conda-forge/nbconvert-feedstock/pull/1)