### PR TITLE
New recipe for Babel

### DIFF
--- a/recipes/babel/meta.yaml
+++ b/recipes/babel/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "2.3.2" %}
+
+package:
+  name: babel
+  version: {{ version }}
+
+source:
+  fn: Babel-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/B/Babel/Babel-{{ version }}.tar.gz
+  md5: 95ad5c32d28defb0ca543756ca335031
+
+build:
+  number: 0
+  script: python setup.py install
+  entry_points:
+    - pybabel = babel.messages.frontend:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pytz
+  run:
+    - python
+    - pytz
+
+test:
+  imports:
+    - babel
+  commands:
+    - pybabel --help
+
+about:
+  home: http://babel.pocoo.org/
+  license: BSD 3-clause
+  summary: An integrated collection of utilities that assist in internationalizing and localizing Python applications, with an emphasis on web-based applications.
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[Babel](http://babel.pocoo.org) is an integrated collection of utilities that assist in internationalizing and localizing Python applications, with an emphasis on web-based applications.