### PR TITLE
New recipe for PyWebHDFS

### DIFF
--- a/recipes/pywebhdfs/meta.yaml
+++ b/recipes/pywebhdfs/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.4.1" %}
+
+package:
+  name: pywebhdfs
+  version: {{ version }}
+
+source:
+  fn: pywebhdfs-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pywebhdfs/pywebhdfs-{{ version }}.tar.gz
+  md5: 4e7866940d77bf880cce5eba2ef75ece
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr
+
+  run:
+    - python
+    - requests
+    - six
+
+test:
+  imports:
+    - pywebhdfs
+
+about:
+  home: https://github.com/pywebhdfs/pywebhdfs/
+  license: Apache License, Version 2.0
+  summary: Python wrapper for the hadoop WebHDFS Rest API
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[PyWebHDFS](http://pywebhdfs.org) is a Python wrapper for the Hadoop WebHDFS Rest API.