### PR TITLE
New recipe for Colorlog

### DIFF
--- a/recipes/colorlog/meta.yaml
+++ b/recipes/colorlog/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "2.6.1" %}
+
+package:
+  name: colorlog
+  version: {{ version }}
+
+source:
+  fn: colorlog-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/c/colorlog/colorlog-{{ version }}.tar.gz
+  md5: 712c85c4c44db0098bed09ed30a18a37
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - colorama  # [win]
+
+  run:
+    - python
+    - colorama  # [win]
+
+test:
+  imports:
+    - colorlog
+
+about:
+  home: https://github.com/borntyping/python-colorlog
+  license: MIT
+  summary: Log formatting with colors!
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[Colorlog](https://github.com/borntyping/python-colorlog) is a helper module which helps to have colorful logs in Python.