### PR TITLE
New recipe for GNU Binutils

### DIFF
--- a/recipes/binutils/build.sh
+++ b/recipes/binutils/build.sh
@@ -1,0 +1,6 @@
+mkdir build
+cd build
+
+../configure --prefix="$PREFIX"
+make
+make install-strip

--- a/recipes/binutils/meta.yaml
+++ b/recipes/binutils/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "2.26" %}
+
+package:
+  name: binutils
+  version: {{ version }}
+
+source:
+  fn: binutils-{{ version }}.tar.bz2
+  url: https://ftp.gnu.org/gnu/binutils/binutils-{{ version }}.tar.bz2
+  sha256: c2ace41809542f5237afc7e3b8f32bb92bc7bc53c6232a84463c423b0714ecd9
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+test:
+  commands:
+    - addr2line --help
+    - ar --help
+    - as --help
+    - c++filt --help
+    - elfedit --help
+    - gprof --help
+    - ld --help
+    - ld.bfd --help
+    - nm --help
+    - objcopy --help
+    - objdump --help
+    - ranlib --help
+    - readelf --help
+    - size --help
+    - strings --help
+    - strip --help
+
+about:
+  home: https://www.gnu.org/software/binutils/
+  license: GPL 3
+  summary: A set of programming tools for creating and managing binary programs, object files, libraries, profile data, and assembly source code.
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
The [GNU Binutils](https://www.gnu.org/software/binutils/) are a collection of binary tools.

The main ones are:

* ld - the GNU linker.
* as - the GNU assembler.

But they also include:

* addr2line - Converts addresses into filenames and line numbers.
* ar - A utility for creating, modifying and extracting from archives.
* c++filt - Filter to demangle encoded C++ symbols.
* gprof - Displays profiling information.
* nm - Lists symbols from object files.
* objcopy - Copies and translates object files.
* objdump - Displays information from object files.
* ranlib - Generates an index to the contents of an archive.
* readelf - Displays information from any ELF format object file.
* size - Lists the section sizes of an object or archive file.
* strings - Lists printable strings from files.
* strip - Discards symbols.

P.S. This is useful on the systems with outdated binutils package (e.g. CentOS 6 couldn't build Boost with GCC 5.3 for me using the old binutils package from their repo), or in chroot environments without other package managers but conda.