### PR TITLE
New recipe for ISL (Integer Set Library)

### DIFF
--- a/recipes/isl/build.sh
+++ b/recipes/isl/build.sh
@@ -1,0 +1,10 @@
+./configure --prefix="$PREFIX" --with-gmp-prefix="$PREFIX"
+make
+
+if [ "$(uname)" = 'Darwin' ]
+then
+    export DYLD_FALLBACK_LIBRARY_PATH="$PREFIX/lib"
+fi
+make check
+
+make install-strip

--- a/recipes/isl/meta.yaml
+++ b/recipes/isl/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "0.16.1" %}
+
+package:
+  name: isl
+  version: {{ version }}
+
+source:
+  fn: isl-{{ version }}.tar.bz2
+  url: http://isl.gforge.inria.fr/isl-{{ version }}.tar.bz2
+  md5: ac1f25a0677912952718a51f5bc20f32
+
+build:
+  number: 0
+  skip: True  # [not unix]
+
+requirements:
+  build:
+    - gmp
+  run:
+    - gmp
+
+test:
+  commands:
+    - test -f "$PREFIX/lib/libisl.a"
+    - test -f "$PREFIX/lib/libisl.la"
+    - test -f "$PREFIX/lib/libisl.so"  # [linux]
+    - test -f "$PREFIX/lib/libisl.dylib"  # [osx]
+    - test -d "$PREFIX/include/isl"
+
+about:
+  home: http://isl.gforge.inria.fr/
+  license: MIT
+  summary: a thread-safe C library for manipulating sets and relations of integer points bounded by affine constraints.
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[Integer Set Library](http://isl.gforge.inria.fr/) is a library for manipulating sets and relations of integer points bounded by linear constraints.

I'm pushing this recipe because it is a dependency for GCC.