### PR TITLE
Add ncurses recipe that fixes ContinuumIO/anaconda-issues#455

### DIFF
--- a/recipes/ncurses/build.sh
+++ b/recipes/ncurses/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir $PREFIX/lib
+
+sh ./configure --prefix=$PREFIX \
+    --without-debug --without-ada --without-manpages \
+    --with-shared --disable-overwrite --enable-termcap \
+    --with-termlib \
+    --enable-widec --with-terminfo-dirs=/usr/share/terminfo
+
+make -j$(getconf _NPROCESSORS_ONLN)
+make install

--- a/recipes/ncurses/fix.patch
+++ b/recipes/ncurses/fix.patch
@@ -1,0 +1,42 @@
+diff -ruNp ncurses-5.8.orig/c++/cursesf.h ncurses-5.8/c++/cursesf.h
+--- c++/cursesf.h	2005-08-13 21:08:24.000000000 +0300
++++ c++/cursesf.h	2011-04-03 18:29:29.000000000 +0300
+@@ -681,7 +681,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, with_frame, autoDelete_Fields) {
++    : NCursesForm (&Fields, with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -694,7 +694,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Fields=FALSE)
+-    : NCursesForm (Fields, nlines, ncols, begin_y, begin_x,
++    : NCursesForm (&Fields, nlines, ncols, begin_y, begin_x,
+ 		   with_frame, autoDelete_Fields) {
+       if (form)
+ 	set_user (const_cast<void *>(p_UserData));
+diff -ruNp ncurses-5.8.orig/c++/cursesm.h ncurses-5.8/c++/cursesm.h
+--- c++/cursesm.h	2005-08-13 21:10:36.000000000 +0300
++++ c++/cursesm.h	2011-04-03 18:31:42.000000000 +0300
+@@ -639,7 +639,7 @@ public:
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE,
+ 		   bool autoDelete_Items=FALSE)
+-    : NCursesMenu (Items, with_frame, autoDelete_Items) {
++    : NCursesMenu (&Items, with_frame, autoDelete_Items) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };
+@@ -651,7 +651,7 @@ public:
+ 		   int begin_x = 0,
+ 		   const T* p_UserData = STATIC_CAST(T*)(0),
+ 		   bool with_frame=FALSE)
+-    : NCursesMenu (Items, nlines, ncols, begin_y, begin_x, with_frame) {
++    : NCursesMenu (&Items, nlines, ncols, begin_y, begin_x, with_frame) {
+       if (menu)
+ 	set_user (const_cast<void *>(p_UserData));
+   };

--- a/recipes/ncurses/meta.yaml
+++ b/recipes/ncurses/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: ncurses
+  version: 5.9
+
+source:
+  fn: ncurses-5.9.tar.gz
+  url: http://ftp.gnu.org/pub/gnu/ncurses/ncurses-5.9.tar.gz
+  md5: 8cb9c412e5f2d96bc6f459aa8c6282a1
+  patches:
+    # http://lists.gnu.org/archive/html/bug-ncurses/2011-04/txtkWQqiQvcZe.txt
+    - fix.patch
+    - ncurses-5.9-gcc-5.patch
+
+build:
+  number: 5 # [linux64]
+  number: 6 # [linux32]
+  number: 1 # [osx]
+  detect_binary_files_with_prefix: true
+
+about:
+  home: http://www.gnu.org/software/ncurses/
+  license:  Free software (X11 License)

--- a/recipes/ncurses/ncurses-5.9-gcc-5.patch
+++ b/recipes/ncurses/ncurses-5.9-gcc-5.patch
@@ -1,0 +1,47 @@
+from https://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/sys-libs/ncurses/files/ncurses-5.9-gcc-5.patch?revision=1.1
+https://bugs.gentoo.org/545114
+
+extracted from the upstream change (which had many unrelated commits in one)
+
+From 97bb4678dc03e753290b39bbff30ba2825df9517 Mon Sep 17 00:00:00 2001
+From: "Thomas E. Dickey" <dickey@invisible-island.net>
+Date: Sun, 7 Dec 2014 03:10:09 +0000
+Subject: [PATCH] ncurses 5.9 - patch 20141206
+
++ modify MKlib_gen.sh to work around change in development version of
+  gcc introduced here:
+	  https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
+	  https://gcc.gnu.org/ml/gcc-patches/2014-07/msg00236.html
+  (reports by Marcus Shawcroft, Maohui Lei).
+
+diff --git a/ncurses/base/MKlib_gen.sh b/ncurses/base/MKlib_gen.sh
+index d8cc3c9..b91398c 100755
+--- ncurses/base/MKlib_gen.sh
++++ ncurses/base/MKlib_gen.sh
+@@ -474,11 +474,22 @@ sed -n -f $ED1 \
+	-e 's/gen_$//' \
+	-e 's/  / /g' >>$TMP
+
++cat >$ED1 <<EOF
++s/  / /g
++s/^ //
++s/ $//
++s/P_NCURSES_BOOL/NCURSES_BOOL/g
++EOF
++
++# A patch discussed here:
++#	https://gcc.gnu.org/ml/gcc-patches/2014-06/msg02185.html
++# introduces spurious #line markers.  Work around that by ignoring the system's
++# attempt to define "bool" and using our own symbol here.
++sed -e 's/bool/P_NCURSES_BOOL/g' $TMP > $ED2
++cat $ED2 >$TMP
++
+ $preprocessor $TMP 2>/dev/null \
+-| sed \
+-	-e 's/  / /g' \
+-	-e 's/^ //' \
+-	-e 's/_Bool/NCURSES_BOOL/g' \
++| sed -f $ED1 \
+ | $AWK -f $AW2 \
+ | sed -f $ED3 \
+ | sed \

--- a/recipes/ncurses/run_test.py
+++ b/recipes/ncurses/run_test.py
@@ -1,0 +1,13 @@
+import curses
+
+if __name__ == '__main__':
+    screen = curses.initscr()
+    try:
+        curses.cbreak()
+        pad = curses.newpad(10, 10)
+        size = screen.getmaxyx()
+        pad.refresh(0, 0, 0, 0, size[0] - 1, size[1] - 1)
+
+    finally:
+        curses.nocbreak()
+        curses.endwin()


### PR DESCRIPTION
This should fix ContinuumIO/anaconda-issues#455, at least for arch linux and every other system where the terminfo database is in `/usr/share/terminfo`.

If there are more places where `terminfo` database is often installed, I can also add them.