### PR TITLE
Add terminado.

### DIFF
--- a/recipes/terminado/meta.yaml
+++ b/recipes/terminado/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "0.6" %}
+
+package:
+  name: terminado
+  version: {{ version }}
+
+source:
+  fn: terminado-{{ version }}.tar.gz
+  url: https://github.com/takluyver/terminado/archive/0.6.tar.gz
+  sha256: 6a1cfe8ede41962827ca8260bc64f387de85be62fd4e936bdde2ecf2a433931c
+
+build:
+  number: 0
+  script: python setup.py install
+  skip: True  # [win]
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - ptyprocess
+    - tornado >=4
+
+test:
+  imports:
+    - terminado
+
+  requires:
+    - nose
+
+  commands:
+    # Failing test on osx: https://github.com/conda-forge/staged-recipes/pull/313#issuecomment-208426267
+    - nosetests terminado  # [not osx]
+
+about:
+  home: http://github.com/mitsuhiko/markupsafe
+  license: BSD 3-clause
+  summary: Terminals served by tornado websockets
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - takluyver 


### PR DESCRIPTION
Terminado is a Tornado websocket backend for the term.js Javascript terminal emulator library.

It evolved out of pyxterm, which was part of GraphTerm (as lineterm.py), v0.57.0 (2014-07-18), and ultimately derived from the public-domain Ajaxterm code, v0.11 (2008-11-13) (also on Github as part of QWeb).

-----
@takluyver - I've added you as a maintainer. Hope that is OK?
