### PR TITLE
Add dateutils

### DIFF
--- a/recipes/dateutils/meta.yaml
+++ b/recipes/dateutils/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.6.6" %}
+
+package:
+    name: dateutils
+    version: {{ version }}
+
+source:
+    fn: dateutils-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/d/dateutils/dateutils-{{ version }}.tar.gz
+    md5: 2ba7fcac03635f1f1cad0d94d785001b
+
+build:
+    number: 0
+    skip: True  # [py3k]
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    entry_points:
+        - dateadd = dateutils.dateadd:main
+        - datediff = dateutils.datediff:main
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - argparse  # [py26]
+        - python-dateutil
+        - pytz
+
+test:
+    imports:
+        - dateutils
+    commands:
+        - dateadd --help
+        - datediff --help
+
+about:
+    home: https://pypi.python.org/pypi/dateutils/
+    license: BSD
+    summary: Various utilities for working with date and datetime objects
+
+extra:
+    recipe-maintainers:
+        - kwilcox
+        - ocefpaf


### PR DESCRIPTION
Ping @kwilcox.

PS: `dateutils` is the same as the default channel `dateutil`. The latter seems to the `python-dateutil` while the former uses `python-dateutil` as a dependency.