### PR TITLE
Fix the `build`/`run` ordering in `requirements`

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -12,9 +12,9 @@ build:
   number: 0
 
 requirements:
-  run:
-    - python
   build:
+    - python
+  run:
     - python
 
 test:


### PR DESCRIPTION
Should specify `build` before `run` in the `requirements` section. Simply makes more sense chronologically. Plus, it is easier on reviewers' eyes. :wink: