### PR TITLE
Added tornado, certifi and ssl_match_hostname.

### DIFF
--- a/recipes/certifi/meta.yaml
+++ b/recipes/certifi/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "2016.2.28" %}
+
+package:
+  name: certifi
+  version: {{ version }}
+
+source:
+  fn: certifi-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/c/certifi/certifi-{{ version }}.tar.gz
+  sha256: 5e8eccf95924658c97b990b50552addb64f55e1e3dfe4880456ac1f287dc79d0
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - certifi
+
+about:
+  home: http://certifi.io/
+  license: ISC
+  summary: Python package for providing Mozilla's CA Bundle.
+
+extra:
+  recipe-maintainers:
+    - dan-blanchard
+    - pelson

--- a/recipes/ssl_match_hostname/meta.yaml
+++ b/recipes/ssl_match_hostname/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "3.5.0.1" %}
+package:
+  name: ssl_match_hostname
+  version: {{ version }}
+
+source:
+  fn: backports.ssl_match_hostname-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/b/backports.ssl_match_hostname/backports.ssl_match_hostname-{{ version }}.tar.gz
+  sha256: 502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2
+
+build:
+  number: 0
+  script: python setup.py install
+  skip: True  # [py>=35]
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - backports
+    - backports.ssl_match_hostname
+
+about:
+  home: http://bitbucket.org/brandon/backports.ssl_match_hostname
+  license:  Python Software Foundation License
+  summary: 'The ssl.match_hostname() function from Python 3.5'
+
+extra:
+  recipe-maintainers:
+    - mwcraig
+    - pelson

--- a/recipes/tornado/meta.yaml
+++ b/recipes/tornado/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "4.2.1" %}
+
+package:
+  name: tornado
+  version: {{ version }}
+
+source:
+  fn: tornado-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/t/tornado/tornado-{{ version }}.tar.gz
+  md5: d523204389cfb70121bb69709f551b20
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - ssl_match_hostname  # [py<35]
+    - certifi
+  run:
+    - python
+    - ssl_match_hostname  # [py<35]
+    - certifi
+
+test:
+  imports:
+    - tornado
+    - tornado.platform
+    - tornado.test
+
+about:
+  home: http://www.tornadoweb.org/
+  license: Apache Software License
+  summary: 'Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed.'
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - pelson


### PR DESCRIPTION
Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed. By using non-blocking network I/O, Tornado can scale to tens of thousands of open connections, making it ideal for long polling, WebSockets, and other applications that require a long-lived connection to each user.

----

Certifi is a carefully curated collection of Root Certificates for validating the trustworthiness of SSL certificates while verifying the identity of TLS hosts. It has been extracted from the Requests project.

----

The Secure Sockets Layer is only actually *secure* 
if you check the hostname in the certificate returned 
by the server to which you are connecting, 
and verify that it matches to hostname 
that you are trying to reach. 

Brandon Craig Rhodes is merely the packager of ssl_match_hostname; 
the actual code inside comes from Python 3.5 with small changes for 
portability. 