### PR TITLE
Add markupsafe and pygments.

### DIFF
--- a/recipes/markupsafe/meta.yaml
+++ b/recipes/markupsafe/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "0.18" %}
+
+package:
+  name: markupsafe
+  version: {{ version }}
+
+source:
+  fn: MarkupSafe-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-{{ version }}.tar.gz
+  md5: f8d252fd05371e51dec2fe9a36890687
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - markupsafe
+
+about:
+  home: http://github.com/mitsuhiko/markupsafe
+  license: BSD 3-clause
+  summary: A Python module that implements the jinja2.Markup string
+
+extra:
+  recipe-maintainers:
+    - pelson

--- a/recipes/pygments/meta.yaml
+++ b/recipes/pygments/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "1.6" %}
+
+package:
+  name: pygments
+  version: {{ version }}
+
+source:
+  fn: Pygments-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/P/Pygments/Pygments-{{ version }}.tar.gz
+  md5: a18feedf6ffd0b0cc8c8b0fbdb2027b1
+
+build:
+  number: 0
+  entry_points:
+    - pygmentize = pygments.cmdline:main
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - pygments.styles
+    - pygments
+    - pygments.lexers
+    - pygments.filters
+    - pygments.formatters
+
+  commands:
+    - pygmentize -h
+
+about:
+  home: http://pygments.org/
+  license: BSD 2-clause
+  summary: "Pygments is a generic syntax highlighter suitable for use in code hosting, forums, wikis or other applications that need to prettify source code."
+
+extra:
+  recipe-maintainers:
+    - pelson


### PR DESCRIPTION
Pygments is a generic syntax highlighter suitable for use in code hosting, forums, wikis or other applications that need to prettify source code. Highlights are:

 * a wide range of over 300 languages and other text formats is supported
 * special attention is paid to details that increase highlighting quality
 * support for new languages and formats are added easily; most languages use a simple regex-based lexing mechanism
 * a number of output formats is available, among them HTML, RTF, LaTeX and ANSI sequences
 * it is usable as a command-line tool and as a library
 * ... and it highlights even Perl 6!

-----

MarkupSafe is a library for Python that implements a unicode string that is aware of HTML escaping rules and can be used to implement automatic string escaping. It is used by Jinja 2, the Mako templating engine, the Pylons web framework and many more.