### PR TITLE
Added pexpect and ptyprocess.

### DIFF
--- a/recipes/pexpect/meta.yaml
+++ b/recipes/pexpect/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "3.2" %}
+
+package:
+  name: pexpect
+  version: {{ version }}
+
+source:
+  fn: pexpect-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pexpect/pexpect-{{ version }}.tar.gz
+  md5: 3f316a668b03a567387e76e05e20d8a5
+
+build:
+  number: 0
+  script: python setup.py install
+  # We can't build on windows until v4.0.
+  skip: true  # [py3k or win]
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - pexpect
+
+about:
+  home: http://pexpect.sourceforge.net/
+  license: ISC
+  summary: Pexpect makes Python a better tool for controlling other applications.
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - takluyver

--- a/recipes/ptyprocess/meta.yaml
+++ b/recipes/ptyprocess/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.5.1" %}
+
+package:
+  name: ptyprocess
+  version: {{ version }}
+
+source:
+  fn: ptyprocess-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/p/ptyprocess/ptyprocess-{{ version }}.tar.gz
+  md5: 94e537122914cc9ec9c1eadcd36e73a1
+
+build:
+  number: 0
+  script: python setup.py install
+  skip: true  # [py3k or win]
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - ptyprocess
+
+about:
+  home: https://github.com/pexpect/ptyprocess
+  license: ISC
+  summary: 'Run a subprocess in a pseudo terminal'
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - takluyver


### PR DESCRIPTION
Pexpect is a pure Python module for spawning child applications; controlling them; and responding to expected patterns in their output. Pexpect works like Don Libes’ Expect. Pexpect allows your script to spawn a child application and control it as if a human were typing commands.


------

pytprocess

Sometimes, piping stdin and stdout is not enough. There might be a password prompt that doesn't read from stdin, output that changes when it's going to a pipe rather than a terminal, or curses-style interfaces that rely on a terminal. If you need to automate these things, running the process in a pseudo terminal (pty) is the answer.