### PR TITLE
Add pickleshare and python-pathlib2.

### DIFF
--- a/recipes/pickleshare/meta.yaml
+++ b/recipes/pickleshare/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "0.7.1" %}
+
+package:
+  name: pickleshare
+  version: {{ version }}
+
+source:
+  fn: pickleshare-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pickleshare/pickleshare-{{ version }}.tar.gz
+  md5: d039ea7dc706180fc4b7953da3bcb3cb
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - python-pathlib2  # [py<34]
+
+test:
+  imports:
+    - pickleshare
+
+about:
+  home: https://github.com/vivainio/pickleshare
+  license: MIT
+  summary: "Tiny 'shelve'-like database with concurrency support"
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - takluyver

--- a/recipes/python-pathlib2/meta.yaml
+++ b/recipes/python-pathlib2/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "2.1.0" %}
+
+package:
+  name: python-pathlib2
+  version: {{ version }}
+
+source:
+  fn: pathlib2-{{ version }}.tar.gz
+  url: https://github.com/mcmtroffaes/pathlib2/archive/{{ version }}.tar.gz
+  md5: 5ef144f5050f17962e9cef35c0e93ed7
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - pathlib2
+
+about:
+  home: https://github.com/mcmtroffaes/pathlib2
+  license: MIT
+  summary: "Fork of pathlib aiming to support the full stdlib Python API."
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - takluyver


### PR DESCRIPTION
**PickleShare** - a small 'shelve' like datastore with concurrency support

Like shelve, a PickleShareDB object acts like a normal dictionary. Unlike shelve, many processes can access the database simultaneously. Changing a value in database is immediately visible to other processes accessing the same database.

-----

**python-pathlib2**

Fork of pathlib aiming to support the full stdlib Python API.

The old pathlib module on bitbucket is in bugfix-only mode. The goal of pathlib2 is to provide a backport of standard pathlib module which tracks the standard library module, so all the newest features of the standard pathlib can be used also on older Python versions.