### PR TITLE
Skip Circle CI and AppVeyor on `master`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,9 @@
+branches:
+  except:
+    # We only want to build pull requests for testing. If something is merged,
+    # then we are prepping for release an there is no need to build it again.
+    - master
+
 environment:
 
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,3 @@
-branches:
-  except:
-    # We only want to build pull requests for testing. If something is merged,
-    # then we are prepping for release an there is no need to build it again.
-    - master
-
 environment:
 
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
@@ -46,6 +40,9 @@ platform:
     - x64
 
 install:
+    # Skip if we are not in a PR.
+    - cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER exit 0
+
     # If there is a newer build queued for the same PR, cancel this one.
     # The AppVeyor 'rollout builds' option is supposed to serve the same
     # purpose but it is problematic because it tends to cancel builds pushed

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
+general:
+  branches:
+    ignore:
+      # We only want to build pull requests for testing. If something is merged,
+      # then we are prepping for release an there is no need to build it again.
+      - master
+
 machine:
   services:
     - docker


### PR DESCRIPTION
This is both a test of concept and also an optimization.

The goal here is basically to never run Circle CI or AppVeyor with commits on `master`. Nobody should be putting commits on `master` other than through merging PRs. When we do a merge to `master` it is normally to make a release, so we should just not run these anyways as the release is done through a Travis CI matrix build.

If this works correctly, testing will still run on Circle CI and AppVeyor in this PR. Though nothing should happen. We should try to test this though by restarting an existing PR after merging this to make sure their tests still run.