### PR TITLE
Skip AppVeyor on `master` (Pt. 2)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,8 +40,12 @@ platform:
     - x64
 
 install:
+    # We don't need to build the example recipe.
+    - cmd: rmdir recipes\example /s /q
     # Skip if we are not in a PR.
-    - cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER exit 0
+    - cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER rmdir /q /s recipes
+    # Make sure the `recipes` directory exists if we removed it.
+    - cmd: if not exist recipes mkdir recipes
 
     # If there is a newer build queued for the same PR, cancel this one.
     # The AppVeyor 'rollout builds' option is supposed to serve the same
@@ -81,8 +85,6 @@ install:
 build: off
 
 test_script:
-    # We don't need to build the example recipe.
-    - cmd: rmdir recipes\example /s /q
     - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.9" "%PY_CONDITION%"'
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages


### PR DESCRIPTION
Related: https://github.com/conda-forge/staged-recipes/pull/329

Try deleting all recipes if we are on `master` as we shouldn't be spending time building. Also, exiting with a zero status doesn't work, so this is the easiest way to finish these builds fast without getting an ugly exit status (and badge) for AppVeyor.