### PR TITLE
mkdocs

### DIFF
--- a/recipes/livereload/meta.yaml
+++ b/recipes/livereload/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "2.4.1" %}
+
+package:
+    name: livereload
+    version: {{ version }}
+
+source:
+    fn: livereload-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/l/livereload/livereload-{{ version }}.tar.gz
+    md5: e79d3de78f11b459392f347f7bb20309
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    entry_points:
+        - livereload = livereload.cli:main
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - tornado
+        - six
+
+test:
+    imports:
+        - livereload
+    commands:
+        - livereload --help
+
+about:
+    home: https://github.com/lepture/python-livereload
+    license: BSD-3-Clause
+    summary: Python LiveReload is an awesome tool for web developers
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/mkdocs-bootstrap/meta.yaml
+++ b/recipes/mkdocs-bootstrap/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "0.1.1" %}
+
+package:
+    name: mkdocs-bootstrap
+    version: {{ version }}
+
+source:
+    fn: mkdocs-bootstrap-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/m/mkdocs-bootstrap/mkdocs-bootstrap-{{ version }}.tar.gz
+    md5: db8fb7216b1098cd084685a647b9b6b3
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    preserve_egg_dir: True
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - mkdocs_bootstrap
+
+about:
+    home: http://www.mkdocs.org
+    license: BSD-2-Clause
+    summary: Bootstrap theme for MkDocs
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/mkdocs-bootswatch/meta.yaml
+++ b/recipes/mkdocs-bootswatch/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.4.0" %}
+
+package:
+    name: mkdocs-bootswatch
+    version: {{ version }}
+
+source:
+    fn: mkdocs-bootswatch-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/m/mkdocs-bootswatch/mkdocs-bootswatch-{{ version }}.tar.gz
+    md5: 9761b14bb6745074932c3a79ea395911
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    preserve_egg_dir: True
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - mkdocs_bootswatch
+        - mkdocs_bootswatch.amelia
+        - mkdocs_bootswatch.cerulean
+        - mkdocs_bootswatch.cosmo
+        - mkdocs_bootswatch.cyborg
+        - mkdocs_bootswatch.flatly
+        - mkdocs_bootswatch.journal
+        - mkdocs_bootswatch.readable
+        - mkdocs_bootswatch.simplex
+        - mkdocs_bootswatch.slate
+        - mkdocs_bootswatch.spacelab
+        - mkdocs_bootswatch.united
+        - mkdocs_bootswatch.yeti
+
+about:
+    home: http://www.mkdocs.org
+    license: BSD-2-Clause
+    summary: Bootswatch themes for MkDocs
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/mkdocs/meta.yaml
+++ b/recipes/mkdocs/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "0.15.3" %}
+
+package:
+    name: mkdocs
+    version: {{ version }}
+
+source:
+    fn: mkdocs-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/m/mkdocs/mkdocs-{{ version }}.tar.gz
+    md5: 389e268822ecee2af5f5c0b00d89fb4a
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    preserve_egg_dir: True
+    entry_points:
+        - mkdocs = mkdocs.__main__:cli
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - click >=3.3
+        - jinja2 >=2.7.1
+        - livereload >=2.3.2
+        - markdown >=2.3.1
+        - mkdocs-bootstrap >=0.1.1
+        - mkdocs-bootswatch >=0.1.0
+        - pyyaml >=3.10
+        - tornado >=4.1
+
+test:
+    imports:
+        - mkdocs
+        - mkdocs.commands
+        - mkdocs.config
+        - mkdocs.tests
+        - mkdocs.tests.config
+        - mkdocs.tests.utils
+        - mkdocs.themes
+        - mkdocs.themes.mkdocs
+        - mkdocs.themes.readthedocs
+        - mkdocs.utils
+    commands:
+        - mkdocs --help
+
+about:
+    home: http://www.mkdocs.org
+    license: BSD-2-Clause
+    summary: Project documentation with Markdown
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
MkDocs is a fast, simple and downright gorgeous static site generator that's geared towards building project documentation. Documentation source files are written in Markdown, and configured with a single YAML configuration file.