### PR TITLE
Add fontconfig

### DIFF
--- a/recipes/fontconfig/build.sh
+++ b/recipes/fontconfig/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+
+if [[ `uname` == 'Darwin' ]];
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [[ `uname` == 'Linux' ]];
+then
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+sed -i.orig s:'@PREFIX@':"${PREFIX}":g src/fccfg.c
+
+chmod +x configure
+
+./configure --prefix "${PREFIX}" \
+	    --enable-libxml2 \
+	    --enable-static \
+	    --disable-docs
+
+make
+eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
+eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make install
+
+# Remove computed cache with local fonts
+rm -Rf "${PREFIX}/var/cache/fontconfig"
+
+# Leave cache directory, in case it's needed
+mkdir -p "${PREFIX}/var/cache/fontconfig"
+touch "${PREFIX}/var/cache/fontconfig/.leave"

--- a/recipes/fontconfig/fc-cache.patch
+++ b/recipes/fontconfig/fc-cache.patch
@@ -1,0 +1,11 @@
+--- fc-cache/fc-cache.c
++++ fc-cache/fc-cache.c
+@@ -388,7 +388,7 @@ main (int argc, char **argv)
+     list = FcStrListCreate (updateDirs);
+     if (list)
+     {
+-	ret += scanDirs (list, config, FcTrue, really_force, verbose, FcFalse, &changed, NULL);
++	ret += scanDirs (list, config, FcTrue, FcFalse, verbose, FcFalse, &changed, NULL);
+ 	FcStrListDone (list);
+     }
+     FcStrSetDestroy (updateDirs);

--- a/recipes/fontconfig/fcf.patch
+++ b/recipes/fontconfig/fcf.patch
@@ -1,0 +1,15 @@
+diff --git src/fccfg.c src/fccfg.c
+index 6377fd7..8175f85 100644
+--- src/fccfg.c
++++ src/fccfg.c
+@@ -1830,9 +1830,7 @@ DllMain (HINSTANCE hinstDLL,
+ 
+ #endif /* !_WIN32 */
+ 
+-#ifndef FONTCONFIG_FILE
+-#define FONTCONFIG_FILE	"fonts.conf"
+-#endif
++#define FONTCONFIG_FILE	"@PREFIX@/etc/fonts/fonts.conf"
+ 
+ static FcChar8 *
+ FcConfigFileExists (const FcChar8 *dir, const FcChar8 *file)

--- a/recipes/fontconfig/meta.yaml
+++ b/recipes/fontconfig/meta.yaml
@@ -1,0 +1,66 @@
+{% set version = "2.11.1" %}
+
+package:
+  name: fontconfig
+  version: {{ version }}
+
+source:
+  fn: fontconfig-{{ version }}.tar.bz2
+  url: http://www.freedesktop.org/software/fontconfig/release/fontconfig-{{ version }}.tar.bz2
+  md5: 824d000eb737af6e16c826dd3b2d6c90
+  patches:
+    # Fixes a bug seen on Linux ( https://bugs.freedesktop.org/show_bug.cgi?id=77252 ).
+    # The patch is already present in upstream. See link below.
+    # ( https://cgit.freedesktop.org/fontconfig/commit/?id=f44157c809d280e2a0ce87fb078fc4b278d24a67 ).
+    - fc-cache.patch  # [linux]
+    # This patch won't be submitted upstream. It's use here is to ensure the prefix used
+    # to refer to the `fonts.conf` file.
+    - fcf.patch       # [linux]
+
+build:
+  number: 0
+  skip: true                      # [win]
+  binary_has_prefix_files:        # [linux]
+    - lib/libfontconfig.so.1.8.0  # [linux]
+
+requirements:
+  build:
+    - pkg-config
+    - libtool
+    - freetype >=2.5.2
+    - libiconv
+    - libpng
+    - libxml2
+
+  run:
+    - freetype >=2.5.2
+    - libiconv
+    - libpng
+    - libxml2
+
+test:
+  commands:
+    # Test CLI.
+    - fc-cache --help
+    - fc-cat --help
+    - fc-list --help
+    - fc-match --help
+    - fc-pattern --help
+    - fc-query --help
+    - fc-scan --help
+    - fc-validate --help
+
+    # Test for libraries.
+    - test -f "${PREFIX}/lib/libfontconfig.a"
+    - test -f "${PREFIX}/lib/libfontconfig.dylib"  # [osx]
+    - test -f "${PREFIX}/lib/libfontconfig.so"     # [linux]
+
+about:
+  home: http://www.freedesktop.org/wiki/Software/fontconfig/
+  license: MIT
+  summary: A library for configuring and customizing font access.
+
+extra:
+  recipe-maintainers:
+    - ccordoba12
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build font-config. This is loosely based off of one in conda-recipes and includes some from my own recipe. Has been cleaned up so that it will fix nicely here at conda-forge.