### PR TITLE
Add Python 3 recipe

### DIFF
--- a/recipes/python3/bld.bat
+++ b/recipes/python3/bld.bat
@@ -1,0 +1,77 @@
+set version=3.5.1
+
+if exist %PREFIX%\python3.exe  (
+  echo "This is a placeholder file for the python3 package in a python=3 env" > $PREFIX/share/python3_pkg_placeholder
+  exit 0
+)
+
+REM ========== prepare source
+
+if "%ARCH%"=="64" (
+    set DMSW=-DMS_WIN64
+) else (
+    set DMSW=
+)
+
+%REPLACE% "@DMSW@" "%DMSW%" Lib\distutils\cygwinccompiler.py
+if errorlevel 1 exit 1
+
+REM ========== actual compile step
+
+vcbuild PCbuild\pcbuild.sln "%RELEASE_TARGET%"
+
+if "%ARCH%"=="64" (
+    copy PCbuild\amd64\* PCbuild\
+    if errorlevel 1 exit 1
+)
+
+REM ========== add stuff from official python.org msi
+
+set MSI_DIR=\Pythons\%version%-%ARCH%
+for %%x in (DLLs Doc libs tcl Tools) do (
+    xcopy /s %MSI_DIR%\%%x %PREFIX%\%%x\
+    if errorlevel 1 exit 1
+)
+copy %MSI_DIR%\LICENSE.txt %PREFIX%\LICENSE_PYTHON3.txt
+if errorlevel 1 exit 1
+
+REM ========== add stuff from our own build
+
+set PCB=%SRC_DIR%\PCbuild
+
+xcopy /s %SRC_DIR%\Include %PREFIX%\include\
+if errorlevel 1 exit 1
+copy %SRC_DIR%\PC\pyconfig.h %PREFIX%\include\
+if errorlevel 1 exit 1
+
+copy %PCB%\python35.dll %PREFIX%
+if errorlevel 1 exit 1
+copy %PCB%\python.exe %PREFIX%\python3.exe
+if errorlevel 1 exit 1
+copy %PCB%\python35.dll %PREFIX%\python3w.exe
+if errorlevel 1 exit 1
+
+copy %PCB%\python35.lib %PREFIX%\libs\
+if errorlevel 1 exit 1
+del %PREFIX%\libs\libpython*.a
+if errorlevel 1 exit 1
+
+copy %PCB%\w9xpopen.exe %PREFIX%\
+if errorlevel 1 exit 1
+
+xcopy /s %SRC_DIR%\Lib %STDLIB_DIR%\
+if errorlevel 1 exit 1
+rd /s /q %PREFIX%\Lib\test
+if errorlevel 1 exit 1
+
+REM ========== bytecode compile standard library
+
+%PREFIX%\python3.exe -Wi %STDLIB_DIR%\compileall.py -f -q -x "bad_coding|badsyntax|py3_" %STDLIB_DIR%
+if errorlevel 1 exit 1
+
+REM ========== add idle script
+
+mkdir %SCRIPTS%
+if errorlevel 1 exit 1
+copy %SRC_DIR%\Tools\scripts\idle %SCRIPTS%\idle3
+if errorlevel 1 exit 1

--- a/recipes/python3/build.sh
+++ b/recipes/python3/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [ -x $PREFIX/bin/python3 ]; then
+  echo "This is a placeholder file for the python3 package in a python=3 env" > $PREFIX/share/python3_pkg_placeholder
+  exit 0
+fi
+
+# If we have got here, we in a Python 2 environment, so we should build and
+# install Python 3.
+
+./configure --enable-shared --enable-ipv6 --prefix=$PREFIX
+make
+make install

--- a/recipes/python3/meta.yaml
+++ b/recipes/python3/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "3.5.1" %}
+
+package:
+  name: python3
+  version: {{ version }}
+
+source:
+  url: https://www.python.org/ftp/python/{{version}}/Python-{{version}}.tgz
+  fn: Python-{{version}}.tgz
+  md5: be78e48cdfc1a7ad90efff146dce6cfe
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - python
+    - openssl
+    - sqlite
+    - readline
+    - tk
+    - zlib
+  build:
+    - python
+    - openssl
+    - sqlite
+    - readline
+    - tk
+    - zlib
+
+test:
+  commands:
+    - python3 -c "import random"
+
+about:
+  home: https://www.python.org/
+  license: PSF
+  summary: The latest version of the high-level programming language
+
+extra:
+  recipe-maintainers:
+    - takluyver


### PR DESCRIPTION
I know this sounds ridiculous and superfluous, but [bear with me](https://xkcd.com/365/), there is a point. ;-)

At present, conda forces you to choose between Python 2 and 3 in each environment. This mostly makes sense, and it avoids having to maintain parallel packages for every module we're interested in (as in Debian, `python-matplotlib` and `python3-matplotlib`). However, it's awkward for applications: it shouldn't matter to the user if an application requires Python 3, but you can't install it in a Python 2 environment. [Flit](http://flit.readthedocs.org/en/latest/) is one example - it would be nice to be able to use it to create the packages for e.g. [entrypoints](https://github.com/conda-forge/entrypoints-feedstock). We may also make the `jupyter-notebook` application require Python 3 at some point, while still supporting a Python 2 kernel to run user code.

There's no reason why the two Python versions can't coexist in one environment, and that's what I'm aiming for here. In a Python 3 environment, this will be an empty package that can satisfy requirements. In a Python 2 environment, it should contain a `python3` executable, along with the libraries that needs and the Python 3 standard library. It should never override the executable provided by the main `python` package.

The idea is that applications such as flit or jupyter-notebook would be packaged with a dependency on `python3`, and with a shebang that runs them with `$PREFIX/bin/python3`. Only the libraries needed for those applications would be available (either bundled into the application packages, or packaged separately), so if you want to develop on Python 3, you should still do so in a proper `python=3` environment.

Ping @Carreau

(`bld.bat` is very likely wrong at the moment - I copied from [here](https://github.com/conda/conda-recipes/blob/master/python/python-2.7.8/bld.bat) as a starting point, and I can't conveniently debug it. But I'm sure we can work that out if I can convince people of this approach.)