### PR TITLE
Add cairo

### DIFF
--- a/recipes/cairo/Notes.md
+++ b/recipes/cairo/Notes.md
@@ -1,0 +1,4 @@
+To compile this package on Windows you need to:
+
+1. Install MSYS and add it to your PATH: http://www.mingw.org/wiki/msys
+2. Download xz binaries, copy xz to unxz and add them to your PATH

--- a/recipes/cairo/bld.bat
+++ b/recipes/cairo/bld.bat
@@ -1,0 +1,37 @@
+setlocal enableextensions enabledelayedexpansion
+
+@echo off
+
+:: Setting variables in Cygwin style
+set LIBRARY_INC_CW=!LIBRARY_INC:\=/!
+set LIBRARY_INC_CW=!LIBRARY_INC_CW::=!
+set LIBRARY_INC_CW=/%LIBRARY_INC_CW%
+
+set LIBRARY_LIB_CW=!LIBRARY_LIB:\=/!
+set LIBRARY_LIB_CW=!LIBRARY_LIB_CW::=!
+set LIBRARY_LIB_CW=/%LIBRARY_LIB_CW%
+
+:: Compiling
+make -f Makefile.win32 CFG=release ^
+  PIXMAN_CFLAGS=-I%LIBRARY_INC_CW%/pixman ^
+  PIXMAN_LIBS=%LIBRARY_LIB_CW%/pixman-1.lib ^
+  ZLIB_CFLAGS=-I%LIBRARY_INC_CW% ^
+  LIBPNG_CFLAGS=-I%LIBRARY_INC_CW% ^
+  CAIRO_LIBS='gdi32.lib msimg32.lib user32.lib %LIBRARY_LIB_CW%/libpng.lib %LIBRARY_LIB_CW%/zlib.lib'
+
+:: Installing
+set CAIRO_INC=%LIBRARY_INC%\cairo
+mkdir %CAIRO_INC%
+move cairo-version.h %CAIRO_INC%
+move src\cairo-features.h %CAIRO_INC%
+move src\cairo.h %CAIRO_INC%
+move src\cairo-deprecated.h %CAIRO_INC%
+move src\cairo-win32.h %CAIRO_INC%
+move src\cairo-script.h %CAIRO_INC%
+move src\cairo-ps.h %CAIRO_INC%
+move src\cairo-pdf.h %CAIRO_INC%
+move src\cairo-svg.h %CAIRO_INC%
+
+move src\release\cairo.dll %LIBRARY_BIN%
+move src\release\cairo.lib %LIBRARY_LIB%
+move src\release\cairo-static.lib %LIBRARY_LIB%

--- a/recipes/cairo/build.sh
+++ b/recipes/cairo/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+export CFLAGS="-I$PREFIX/include -L$PREFIX/lib"
+
+# As of Mac OS 10.8, X11 is no longer included by default
+# (See https://support.apple.com/en-us/HT201341 for the details).
+# Due to this change, we disable building X11 support for cairo on Mac by
+# default.
+export XWIN_ARGS=""
+if [ `uname` == Darwin ]; then
+   export XWIN_ARGS="--disable-xlib -disable-xcb --disable-glitz"
+fi
+
+./configure                                  \
+    --prefix="${PREFIX}"                     \
+    --disable-gobject                        \
+    --enable-warnings                        \
+    --enable-ft                              \
+    --enable-ps                              \
+    --enable-pdf                             \
+    --enable-svg                             \
+    --disable-gtk-doc                        \
+    $XWIN_ARGS
+
+make
+make install
+
+rm -rf $PREFIX/share

--- a/recipes/cairo/build.sh
+++ b/recipes/cairo/build.sh
@@ -8,7 +8,7 @@ export CFLAGS="-I$PREFIX/include -L$PREFIX/lib"
 # default.
 export XWIN_ARGS=""
 if [ `uname` == Darwin ]; then
-   export XWIN_ARGS="--disable-xlib -disable-xcb --disable-glitz"
+    export XWIN_ARGS="--disable-xlib -disable-xcb --disable-glitz"
 fi
 
 ./configure                                  \

--- a/recipes/cairo/meta.yaml
+++ b/recipes/cairo/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "1.12.18" %}
+
+package:
+  name: cairo
+  version: {{ version }}
+
+source:
+  fn: cairo-{{ version }}.tar.xz
+  url: http://cairographics.org/releases/cairo-{{ version }}.tar.xz
+  md5: 8e4ff32b82c3b39387eb6f5c59ef848e
+
+build:
+  number: 0
+  features:
+    - vc9                # [win and py27]
+    - vc10               # [win and py34]
+    - vc14               # [win and py35]
+
+requirements:
+  build:
+    - python                  # [win]
+    - pkg-config              # [unix]
+    - xz                      # [unix]
+    - freetype 2.5.*          # [unix]
+    - fontconfig 2.11.*       # [unix]
+    - pixman
+    - libpng 1.6*
+    - zlib 1.2*
+  run:
+    - freetype                # [unix]
+    - fontconfig 2.11.*       # [unix]
+    - libpng 1.6*
+    - pixman
+    - zlib 1.2*
+
+test:
+  commands:
+    # Check commands.
+    - cairo-trace --help
+
+    # Verify libraries.
+    {% set cairo_libs = [
+            "libcairo",
+            "libcairo-script-interpreter",
+    ] %}
+    {% for each_cairo_lib in cairo_libs %}
+    - test -f $PREFIX/lib/{{ each_cairo_lib }}.a                                                 # [unix]
+    - test -f $PREFIX/lib/{{ each_cairo_lib }}.dylib                                             # [osx]
+    - test -f $PREFIX/lib/{{ each_cairo_lib }}.so                                                # [linux]
+    {% endfor %}
+
+about:
+  home: http://cairographics.org/
+  license: LGPL 2.1 or MPL 1.1
+  summary: Cairo is a 2D graphics library with support for multiple output devices.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/cairo/meta.yaml
+++ b/recipes/cairo/meta.yaml
@@ -56,4 +56,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - ccordoba12
     - jakirkham

--- a/recipes/cairo/meta.yaml
+++ b/recipes/cairo/meta.yaml
@@ -23,14 +23,14 @@ requirements:
     - xz                      # [unix]
     - freetype 2.5.*          # [unix]
     - fontconfig 2.11.*       # [unix]
-    - pixman
+    - pixman                  # [unix]
     - libpng 1.6*
     - zlib 1.2*
   run:
     - freetype                # [unix]
     - fontconfig 2.11.*       # [unix]
     - libpng 1.6*
-    - pixman
+    - pixman                  # [unix]
     - zlib 1.2*
 
 test:

--- a/recipes/cairo/meta.yaml
+++ b/recipes/cairo/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true             # [win]
   features:
     - vc9                # [win and py27]
     - vc10               # [win and py34]


### PR DESCRIPTION
Adds a recipe to build cairo. This is largely based off of the recipe from conda-recipes, but has been cleaned up a bit.

Also, as some dependencies do (or will) exist for Mac and Linux (and in some cases Windows). This has a bit more functionality enabled.

The Windows build may need `xz`, which I don't believe exists yet. However, it may be possible to build it for Windows as others seem to have done this.