### PR TITLE
WIP: Add pango

### DIFF
--- a/recipes/pango/build.sh
+++ b/recipes/pango/build.sh
@@ -1,0 +1,7 @@
+ln -s "${PREFIX}/lib" "${PREFIX}/lib64"
+
+./configure --prefix="${PREFIX}"
+make
+make install
+
+rm "${PREFIX}/lib64"

--- a/recipes/pango/meta.yaml
+++ b/recipes/pango/meta.yaml
@@ -1,0 +1,48 @@
+{% set major_version = "1" %}
+{% set minor_version = "40" %}
+{% set patch_version = "1" %}
+{% set major_minor_version = major_version + "." + minor_version %}
+{% set version = major_version + "." + minor_version + "." + patch_version %}
+
+package:
+  name: pango
+  version: {{ version }}
+
+source:
+  url: http://ftp.gnome.org/pub/GNOME/sources/pango/{{ major_minor_version }}/pango-{{ version }}.tar.xz
+  fn: pango-{{ version }}.tar.xz
+  sha256: e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40
+
+build:
+  number: 0
+  skip: true  # [not linux]
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - cairo
+    - fontconfig
+    - freetype
+    - harfbuzz
+    - glib
+    - libffi
+    - libpng
+    - xz
+
+  run:
+    - cairo
+    - fontconfig
+    - freetype
+    - harfbuzz
+    - glib
+    - libffi
+    - libpng
+
+about:
+  home: http://www.pango.org/
+  license: LGPL 2
+  summary: "Pango is a library for laying out and rendering of text, with an emphasis on internationalization."
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build pango. This is still missing some dependencies that are in progress so is not ready for testing yet, but soon will be. Based largely off the version in conda-recipes, this has been cleaned up a bit, but is still Linux only. It would be nice to get this working on Mac too.

* [ ] Add pinnings.
* [ ] Add tests.
* [ ] Support Mac.