### PR TITLE
Add patchelf

### DIFF
--- a/recipes/patchelf/build.sh
+++ b/recipes/patchelf/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX
+make
+make tests
+make install

--- a/recipes/patchelf/meta.yaml
+++ b/recipes/patchelf/meta.yaml
@@ -1,0 +1,27 @@
+{% set version = "0.9" %}
+
+package:
+  name: patchelf
+  version: {{ version }}
+
+source:
+  fn: patchelf-{{ version }}.tar.gz
+  url: http://nixos.org/releases/patchelf/patchelf-{{ version }}/patchelf-{{ version }}.tar.gz
+  md5: 3c265508526760f233620f35d79c79fc
+
+build:
+  number: 0
+  skip: true  # [not linux]
+
+test:
+  commands:
+    - patchelf --help
+
+about:
+  home: http://nixos.org/patchelf.html
+  license: GPL 3
+  summary: A small utility to modify the dynamic linker and RPATH of ELF executables.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build `patchelf`. Based off of the recipe from conda-recipes. Cleaned up a bit to fit into conda-forge.