### PR TITLE
Provide a mechanism for installing/documenting yum requirements

### DIFF
--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -57,6 +57,9 @@ yum install -y libXext libXrender libSM tk libX11-devel mesa-libGL-devel
 # We don't need to build the example recipe.
 rm -rf /conda-recipes/example
 
+# Installs anything from a \`yum_requirements.txt\` file in a recipe with \`yum\`.
+find conda-recipes -mindepth 2 -maxdepth 2 -type f -name "yum_requirements.txt" | xargs -n1 cat | xargs -r yum install -y
+
 conda-build-all /conda-recipes --matrix-conditions "numpy >=1.9" "python >=2.7,<3|>=3.4"
 
 EOF


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/pull/346

This solves yum requirements in a simple manner that comes out of this discussion on this issue ( https://github.com/conda-forge/conda-forge.github.io/issues/82 ) and this proposed PR ( https://github.com/conda-forge/conda-smithy/pull/135 ).

What we do here is allow for a `yum_requirements.txt` file to be included in each recipe. If present, we install anything listed in there with `yum`.

The original proposal and example can be seen in this PR ( https://github.com/conda-forge/staged-recipes/pull/346 ).