### PR TITLE
Add recipe for pygrib

### DIFF
--- a/recipes/pygrib/build.sh
+++ b/recipes/pygrib/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export GRIBAPI_DIR=$PREFIX
+export JASPER_DIR=$PREFIX
+export PNG_DIR=$PREFIX
+$PYTHON setup.py install

--- a/recipes/pygrib/meta.yaml
+++ b/recipes/pygrib/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "2.0.1" %}
+
+package:
+  name: pygrib
+  version: {{ version }}
+
+source:
+  fn: pygrib-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/p/pygrib/pygrib-{{ version }}.tar.gz
+  md5: e9ae04cb987992691b388b16be53214a
+
+build:
+  number: 0
+  skip: true  # [win or py3k]
+
+requirements:
+  build:
+    - python
+    - ecmwf_grib
+    - jasper
+    - libpng
+    - pyproj
+
+  run:
+    - python
+    - ecmwf_grib
+    - jasper
+    - libpng
+    - pyproj
+    - numpy
+
+test:
+  commands:
+    - grib_repack -h
+  imports:
+    - pygrib
+
+about:
+  home: http://github.com/jswhit/pygrib
+  license: MIT
+  summary: 'python GRIB (editions 1 and 2) reader'
+
+extra:
+  recipe-maintainers:
+    - dopplershift


### PR DESCRIPTION
With a few items borrowed from @jjhelmus 's 1.9.8 recipe since I was too lazy to figure out building it myself (this is actually my first compiled conda-forge package).

Python 3 support would be nice, but means that ecmwf_grib needs to have a C-API only version that doesn't depend on Python 3 (conda-forge/ecmwf_grib-feedstock#1).

