### PR TITLE
Add freeglut

### DIFF
--- a/recipes/freeglut/build.sh
+++ b/recipes/freeglut/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+mkdir build && cd build
+cmake \
+	-DCMAKE_INSTALL_PREFIX=$PREFIX          \
+	-DCMAKE_BUILD_TYPE=Release              \
+	-DFREEGLUT_BUILD_DEMOS=OFF              \
+	..
+make
+make install
+mv $PREFIX/lib64 $PREFIX/lib

--- a/recipes/freeglut/meta.yaml
+++ b/recipes/freeglut/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "3.0.0" %}
+
+package:
+  name: freeglut
+  version: {{ version }}
+
+source:
+  fn: freeglut-{{ version }}.tar.bz2
+  url: http://sourceforge.net/projects/freeglut/files/freeglut/{{ version }}/freeglut-{{ version }}.tar.gz
+  md5: 90c3ca4dd9d51cf32276bc5344ec9754
+
+build:
+  number: 0
+  skip: true                      # [not linux]
+
+requirements:
+  build:
+    - cmake
+
+test:
+  commands:
+    # Test includes.
+    - test -d "${PREFIX}/include/GL"
+
+      # Test libraries.
+    - test -f "${PREFIX}/lib/libglut.a"
+    - test -f "${PREFIX}/lib/libglut.so"
+    - ldd "${PREFIX}/lib/libglut.so"
+
+about:
+  home: http://freeglut.sourceforge.net/
+  license: MIT
+  summary: A GUI based on OpenGL.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/freeglut/yum_requirements.txt
+++ b/recipes/freeglut/yum_requirements.txt
@@ -1,0 +1,2 @@
+libXi-devel
+mesa-libGLU-devel


### PR DESCRIPTION
Attempts to build `freeglut` from source.

This is Linux only right now. Windows support is possible as people have and do build this on that platform.

It requires X11 support for Mac, which is not guaranteed for later versions of the OS. Mac OS 10.7 is the last to have XQuartz (Mac's X11) by default. On later OS versions it can be installed optionally, but we shouldn't have it as a hard dependency. See this issue ( https://github.com/dcnieho/FreeGLUT/issues/27 ) from a fork of FreeGLUT for a fading glimmer for hope. :cry: