### PR TITLE
Add ipyparallel

### DIFF
--- a/recipes/ipyparallel/meta.yaml
+++ b/recipes/ipyparallel/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "5.0.1" %}
+
+package:
+  name: ipyparallel
+  version: {{ version }}
+
+source:
+  fn: ipyparallel-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/i/ipyparallel/ipyparallel-{{ version }}.tar.gz
+  md5: e771add417b0d1b98d3ae92099becce5
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - futures               # [py<32]
+    - decorator
+    - tornado >=4
+    - pyzmq >=13
+    - ipython_genutils
+    - ipython >=4
+    - jupyter_client
+    - ipykernel
+    - tornado >=4
+
+  run:
+    - python
+    - futures               # [py<32]
+    - decorator
+    - tornado >=4
+    - pyzmq >=13
+    - ipython_genutils
+    - ipython >=4
+    - jupyter_client
+    - ipykernel
+
+test:
+  imports:
+    - ipyparallel
+    - ipyparallel.apps
+    - ipyparallel.client
+    - ipyparallel.controller
+    - ipyparallel.engine
+    - ipyparallel.serialize
+
+about:
+  home: http://ipython.org
+  license: BSD 3-Clause
+  summary: Interactive Parallel Computing with IPython
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build `ipyparallel`. Based roughly off the one in conda-recipes.