### PR TITLE
Add mock

### DIFF
--- a/recipes/mock/meta.yaml
+++ b/recipes/mock/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "1.3.0" %}
+
+package:
+  name: mock
+  version: {{ version }}
+
+source:
+  fn: mock-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/m/mock/mock-{{ version }}.tar.gz
+  md5: 73ee8a4afb3ff4da1b4afa287f39fdeb
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - funcsigs    # [py<33]
+    - pbr
+    - six
+
+  run:
+    - python
+    - funcsigs    # [py<33]
+    - pbr
+    - six
+
+test:
+  imports:
+    - mock
+
+about:
+  home: https://github.com/testing-cabal/mock
+  license: BSD 2-Clause
+  summary: A library for testing in Python.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build mock. Based off the recipe in conda-recipes. This is cleaned up a bit. Has some other dependencies in some cases. Also, a more recent version is used.