### PR TITLE
add recipes for pyface and traitsui

### DIFF
--- a/recipes/pyface/meta.yaml
+++ b/recipes/pyface/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "5.0.0" %}
+
+package:
+  name: pyface
+  version: {{ version }}
+
+source:
+  fn: pyface-5.0.0.tar.bz2
+  url: https://pypi.python.org/packages/source/p/pyface/pyface-5.0.0.tar.bz2
+  md5: 0468d6a44adba0b70ec5171d1af9350a
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  run:
+    - python
+    - traits
+    - pyqt
+    - pygments
+  build:
+    - python
+    - setuptools
+    - pyqt  # pyface requires pyqt, pyside or wxpython
+    - traits
+    - pygments
+
+test:
+  imports:
+    - pyface
+
+about:
+  home: http://docs.enthought.com/pyface/
+  license: BSD 3-clause
+  summary: pyface - traits-capable windowing framework
+
+extra:
+  recipe-maintainers:
+    - grlee77

--- a/recipes/pyface/meta.yaml
+++ b/recipes/pyface/meta.yaml
@@ -9,9 +9,10 @@ source:
   url: https://pypi.python.org/packages/source/p/pyface/pyface-{{ version }}.tar.bz2
   md5: 0468d6a44adba0b70ec5171d1af9350a
   patches:
-    - pyface_fix.patch
     # fix for issue https://github.com/enthought/pyface#188 following the
     # solution from https://github.com/enthought/pyface/commit/06d85f8
+    # and raise syntax fix from https://github.com/enthought/pyface/pull/211
+    - pyface_fix.patch
 
 build:
   number: 0

--- a/recipes/pyface/meta.yaml
+++ b/recipes/pyface/meta.yaml
@@ -5,25 +5,25 @@ package:
   version: {{ version }}
 
 source:
-  fn: pyface-5.0.0.tar.bz2
-  url: https://pypi.python.org/packages/source/p/pyface/pyface-5.0.0.tar.bz2
+  fn: pyface-{{ version }}.tar.bz2
+  url: https://pypi.python.org/packages/source/p/pyface/pyface-{{ version }}.tar.bz2
   md5: 0468d6a44adba0b70ec5171d1af9350a
 
 build:
   number: 0
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-  run:
-    - python
-    - traits
-    - pyqt
-    - pygments
   build:
     - python
     - setuptools
     - pyqt  # pyface requires pyqt, pyside or wxpython
     - traits
+    - pygments
+  run:
+    - python
+    - traits
+    - pyqt
     - pygments
 
 test:

--- a/recipes/pyface/meta.yaml
+++ b/recipes/pyface/meta.yaml
@@ -8,6 +8,8 @@ source:
   fn: pyface-{{ version }}.tar.bz2
   url: https://pypi.python.org/packages/source/p/pyface/pyface-{{ version }}.tar.bz2
   md5: 0468d6a44adba0b70ec5171d1af9350a
+  patches:
+    - pyface_fix.patch
 
 build:
   number: 0

--- a/recipes/pyface/meta.yaml
+++ b/recipes/pyface/meta.yaml
@@ -10,6 +10,8 @@ source:
   md5: 0468d6a44adba0b70ec5171d1af9350a
   patches:
     - pyface_fix.patch
+    # fix for issue https://github.com/enthought/pyface#188 following the
+    # solution from https://github.com/enthought/pyface/commit/06d85f8
 
 build:
   number: 0

--- a/recipes/pyface/pyface_fix.patch
+++ b/recipes/pyface/pyface_fix.patch
@@ -1,0 +1,24 @@
+--- pyface/ipython_widget.py.orig  2015-10-27 14:57:28.000000000 -0400
++++ pyface/ipython_widget.py    2016-04-18 23:05:18.000000000 -0400
+@@ -13,18 +13,17 @@
+ #------------------------------------------------------------------------------
+ """ The implementation of an IPython shell. """
+
++from __future__ import absolute_import
+
+ # Import the toolkit specific version.
+ try:
+     import IPython.frontend
+ except ImportError:
+-    raise ImportError, '''
++    raise ImportError('''
+ ________________________________________________________________________________
+ Could not load the Wx frontend for ipython.
+-You need to have ipython >= 0.9 installed to use the ipython widget.'''
+-
++You need to have ipython >= 0.9 installed to use the ipython widget.''')
+
+-from __future__ import absolute_import
+
+ from .toolkit import toolkit_object
+ IPythonWidget= toolkit_object('ipython_widget:IPythonWidget')

--- a/recipes/traitsui/meta.yaml
+++ b/recipes/traitsui/meta.yaml
@@ -5,23 +5,21 @@ package:
   version: {{ version }}
 
 source:
-  fn: traitsui-5.0.0.tar.bz2
-  url: https://pypi.python.org/packages/source/t/traitsui/traitsui-5.0.0.tar.bz2
+  fn: traitsui-{{ version }}.tar.bz2
+  url: https://pypi.python.org/packages/source/t/traitsui/traitsui-{{ version }}.tar.bz2
   md5: 4a388a881aa48b0ec2710fd5764ddada
 
 build:
   number: 0
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
-  run:
-    - python
-    - traits
-    - pyface
   build:
     - python
     - setuptools
-    - traits
+    - pyface
+  run:
+    - python
     - pyface
 
 test:

--- a/recipes/traitsui/meta.yaml
+++ b/recipes/traitsui/meta.yaml
@@ -18,9 +18,11 @@ requirements:
     - python
     - setuptools
     - pyface
+    - traits
   run:
     - python
     - pyface
+    - traits
 
 test:
   imports:

--- a/recipes/traitsui/meta.yaml
+++ b/recipes/traitsui/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "5.0.0" %}
+
+package:
+  name: traitsui
+  version: {{ version }}
+
+source:
+  fn: traitsui-5.0.0.tar.bz2
+  url: https://pypi.python.org/packages/source/t/traitsui/traitsui-5.0.0.tar.bz2
+  md5: 4a388a881aa48b0ec2710fd5764ddada
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  run:
+    - python
+    - traits
+    - pyface
+  build:
+    - python
+    - setuptools
+    - traits
+    - pyface
+
+test:
+  imports:
+    - traitsui
+
+about:
+  home: http://docs.enthought.com/traitsui/
+  license: BSD 3-clause
+  summary: TraitsUI - Traits-capable windowing framework
+
+extra:
+  recipe-maintainers:
+    - grlee77


### PR DESCRIPTION
Add traitsui and pyface as required by #285.

This recipe depends upon #391 (traits)

**Two questions on this one:**
1.) TraitsUI requires pyface.  Should I list `traits` and `pyqt` under the `traitsui` dependencies too or just let these be pulled in by pyface?

2.)  Please provide guidance on setting the GUI backend.  For now I set it to `pyqt` (Qt4).  wx is the default for version 5.0 which is the currrent release, but the pending 5.1 release will change the default to qt4.

From the `pyface` documentation:

>Currently, the supported GUI toolkits are
>
>wxPython (>= 2.8, including experimental support for WxPython 3.0)
>    PySide
>    PyQt (Qt4 only, but Qt5 support is in development)
>While all toolkits funtion with Pyface, integration with wxPython is currently more complete. Future >development, however, will be more focused on supporting Qt.
>
>Warning
>
>The default toolkit if none is supplied is qt4. This changed from wx in Pyface 5.0.

