### PR TITLE
Adds cloog

### DIFF
--- a/recipes/cloog/build.sh
+++ b/recipes/cloog/build.sh
@@ -1,0 +1,3 @@
+./configure --prefix=$PREFIX --with-isl=$PREFIX --with-gmp-prefix=$PREFIX
+make
+make install

--- a/recipes/cloog/meta.yaml
+++ b/recipes/cloog/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.18.1" %}
+
+package:
+  name: cloog
+  version: {{ version }}
+
+source:
+  fn: cloog-{{ version }}.tar.gz
+  url: http://www.bastoul.net/cloog/pages/download/count.php3?url=./cloog-{{ version }}.tar.gz
+  md5: e34fca0540d840e5d0f6427e98c92252
+
+build:
+  number: 1
+  skip: true    # [win]
+
+requirements:
+  build:
+    - gmp 5.1.2
+    - isl 0.12.2
+
+  run:
+    - gmp 5.1.2
+    - isl 0.12.2
+
+test:
+  commands:
+    - test -f "$PREFIX/lib/libcloog-isl.a"        # [unix]
+    - test -f "$PREFIX/lib/libcloog-isl.so"       # [linux]
+    - test -f "$PREFIX/lib/libcloog-isl.dylib"    # [osx]
+
+about:
+  home: http://www.cloog.org/
+  license: LGPL 2.1
+  summary: A free software and library to generate code for scanning Z-polyhedra.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/436

This add a recipe to build `cloog` so that we can add a `gcc` compiler. Not sure if we want to do this, but this is the last dependency we don't have here. We pin the dependencies [exactly]( https://github.com/conda-forge/staged-recipes/issues/436#issuecomment-212319400 ) to those found when installing `defaults` `gcc` to avoid this causing any breakages. 