### PR TITLE
Add 2 (now 1) backports

### DIFF
--- a/recipes/backports.shutil_get_terminal_size/meta.yaml
+++ b/recipes/backports.shutil_get_terminal_size/meta.yaml
@@ -1,0 +1,33 @@
+package:
+    name: backports.shutil_get_terminal_size
+    version: 1.0.0
+
+source:
+    fn: backports.shutil_get_terminal_size-1.0.0.tar.gz
+    url: https://pypi.python.org/packages/ec/9c/368086faa9c016efce5da3e0e13ba392c9db79e3ab740b763fe28620b18b/backports.shutil_get_terminal_size-1.0.0.tar.gz
+    md5: 03267762480bd86b50580dc19dff3c66
+
+build:
+    number: 0
+    script: pip install --no-deps .
+
+requirements:
+    build:
+        - python
+        - pip
+    run:
+        - python
+
+test:
+    imports:
+        - backports
+        - backports.shutil_get_terminal_size
+
+about:
+    home: https://github.com/chrippa/backports.shutil_get_terminal_size
+    license: MIT
+    summary: A backport of the get_terminal_size function from Python 3.3's shutil
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
`backports.ssl_match_hostname` is a tornado dependency (see https://github.com/ipython/ipython/issues/5911) and I guess we should add it to https://github.com/conda-forge/tornado-feedstock/blob/master/recipe/meta.yaml.

`backports.shutil_get_terminal_size` is an `IPython 4.2.0`dependency.

Ping @pelson, @minrk, @takluyver, @jakirkham. Is that correct? Should I add all of you as maintainers?