### PR TITLE
recipe for mpl-probscale

### DIFF
--- a/recipes/mpl-probscale/meta.yaml
+++ b/recipes/mpl-probscale/meta.yaml
@@ -1,0 +1,46 @@
+package:
+  name: mpl-probscale
+  version: 0.1.1
+
+source:
+  git_url: https://github.com/phobson/mpl-probscale.git
+  git_tag: v0.1.1
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+build:
+  number: 1
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - numpy
+    - matplotlib
+
+  run:
+    - python
+    - numpy
+    - matplotlib
+    - nose
+
+test:
+  imports:
+    - probscale
+
+  commands:
+    - python -c "import matplotlib; matplotlib.use('agg'); import probscale; probscale.test()"
+
+about:
+  home: http://phobson.github.io/mpl-probscale/
+  license:  BSD 3-clause
+  summary: 'Probability scales for matplotlib.'
+
+extra:
+    recipe-maintainers:
+        - phobson
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml/configure

--- a/recipes/mpl-probscale/meta.yaml
+++ b/recipes/mpl-probscale/meta.yaml
@@ -5,12 +5,9 @@ package:
 source:
   git_url: https://github.com/phobson/mpl-probscale.git
   git_tag: v0.1.1
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install
 
 requirements:
@@ -40,7 +37,3 @@ about:
 extra:
     recipe-maintainers:
         - phobson
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml/configure


### PR DESCRIPTION
Only tested/released for python 2.7, 3.4, 3.5. Do I need to specify that anywhere, @ocefpaf ?