### PR TITLE
Add JSONSchema 2.5.1

### DIFF
--- a/recipes/jsonschema/meta.yaml
+++ b/recipes/jsonschema/meta.yaml
@@ -5,8 +5,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/Julian/jsonschema.git
-  git_tag: 3f459b73a2c27fcbf9356e7bd9ff5ac27fb5bac7
+  fn: jsonschema-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/58/0d/c816f5ea5adaf1293a1d81d32e4cdfdaf8496973aa5049786d7fdb14e7e7/jsonschema-{{ version }}.tar.gz
+  md5: 374e848fdb69a3ce8b7e778b47c30640
 
 build:
   number: 0

--- a/recipes/jsonschema/meta.yaml
+++ b/recipes/jsonschema/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "2.5.1" %}
+
+package:
+  name: jsonschema
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/Julian/jsonschema.git
+  git_tag: 3f459b73a2c27fcbf9356e7bd9ff5ac27fb5bac7
+
+build:
+  number: 0
+  script: pip install .
+
+requirements:
+  build:
+    - python
+    - pip
+    - vcversioner
+  run:
+    - python
+    - functools32  # [py27]
+
+test:
+  imports:
+    - jsonschema
+
+about:
+  home: https://github.com/Julian/jsonschema
+  license: MIT
+  summary: Python implementation of JSON Schema
+
+extra:
+  recipe-maintainers:
+    - minrk

--- a/recipes/vcversioner/meta.yaml
+++ b/recipes/vcversioner/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "2.16.0.0" %}
+
+package:
+  name: vcversioner
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/habnabit/vcversioner.git
+  git_tag: 72f8f0a7e0121cf5989a2cb00d5e1395e02a0445
+
+build:
+  number: 0
+  script: pip install .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - vcversioner
+
+about:
+  home: https://github.com/habnabit/vcversioner
+  license: ISC
+  summary: Take version numbers from version control
+
+extra:
+  recipe-maintainers:
+    - minrk

--- a/recipes/vcversioner/meta.yaml
+++ b/recipes/vcversioner/meta.yaml
@@ -5,8 +5,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/habnabit/vcversioner.git
-  git_tag: 72f8f0a7e0121cf5989a2cb00d5e1395e02a0445
+  fn: vcversioner-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/c5/cc/33162c0a7b28a4d8c83da07bc2b12cee58c120b4a9e8bba31c41c8d35a16/vcversioner-{{ version }}.tar.gz
+  md5: aab6ef5e0cf8614a1b1140ed5b7f107d
 
 build:
   number: 0


### PR DESCRIPTION
requires vcversioner for build step, so add that, too.

Anaconda hasn't updated JSON Schema from 2.4, which has a serious memory leak. Great thing about conda-forge? I can fix this myself!

This is my first new feedstock, so fingers crossed.

I'm not sure what the preferred way to get sources is, so I followed the example and used git tags.