### PR TITLE
Restrict `conda-build` downgrade to Python 3.4 64-bit.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,8 +77,9 @@ install:
     - cmd: conda install --yes --quiet obvious-ci conda-build-all
     - cmd: obvci_install_conda_build_tools.py
     # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: remove this once a new conda-build is released!
-    - cmd: conda install --yes conda-build=1.20.0
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
     - cmd: conda info
 
 # Skip .NET project specific build phase.


### PR DESCRIPTION
Tweak workaround for this issue ( https://github.com/conda/conda-build/issues/895 ). Related change in staged-recipes ( https://github.com/conda-forge/staged-recipes/pull/452 ). Related issue ( https://github.com/conda-forge/staged-recipes/issues/448 ).

Applies this workaround only to Python 3.4 64-bit where the issues were seen. This way Python 2.7 64-bit on Windows still benefits from the nice fixes from @patricksnape and @msarahan.