### PR TITLE
add ECMWF eccodes

### DIFF
--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -10,9 +10,11 @@ export PYTHON=
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
+src_dir="$(pwd)"
+mkdir ..\build
+cd ..\build
+cmake $scr_dir \
+         -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DENABLE_JASPER=1 \
          -DENABLE_NETCDF=1 \
          -DENABLE_PNG=1 \

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
+         -DENABLE_JASPER=1 \
+         -DENABLE_NETCDF=1 \
+         -DENABLE_PNG=1 \
+         -DENABLE_PYTHON=0 \
+         -DENABLE_FORTRAN=0
+
+make
+ctest
+make install

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -10,5 +10,6 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DENABLE_FORTRAN=0
 
 make
-make install
+export ECCODES_TEST_VERBOSE_OUTPUT=1
 ctest
+make install

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -13,7 +13,7 @@ export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 src_dir="$(pwd)"
 mkdir ../build
 cd ../build
-cmake $scr_dir \
+cmake $src_dir \
          -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DENABLE_JASPER=1 \
          -DENABLE_NETCDF=1 \

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -10,5 +10,5 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DENABLE_FORTRAN=0
 
 make
-ctest
 make install
+ctest

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+if [[ $(uname) == Darwin ]]; then
+  export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [[ $(uname) == Linux ]]; then
+  export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+export PYTHON=
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
+export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
+
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -11,5 +21,5 @@ cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
 
 make
 export ECCODES_TEST_VERBOSE_OUTPUT=1
-ctest
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib ctest
 make install

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -25,5 +25,5 @@ cmake $src_dir \
 make
 export ECCODES_TEST_VERBOSE_OUTPUT=1
 eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib
-ctest ctestarg
+ctest $ctestarg
 make install

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -16,7 +16,7 @@ mkdir ../build
 cd ../build
 cmake $src_dir \
          -DCMAKE_INSTALL_PREFIX=$PREFIX \
-         -DENABLE_JASPER=1 \
+         -DENABLE_JPG=1 \
          -DENABLE_NETCDF=1 \
          -DENABLE_PNG=1 \
          -DENABLE_PYTHON=0 \

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -2,6 +2,7 @@
 
 if [[ $(uname) == Darwin ]]; then
   export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+  ctestarg="-E gts_ls"
 elif [[ $(uname) == Linux ]]; then
   export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
 fi
@@ -23,5 +24,6 @@ cmake $src_dir \
 
 make
 export ECCODES_TEST_VERBOSE_OUTPUT=1
-eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib ctest
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib
+ctest ctestarg
 make install

--- a/recipes/eccodes/build.sh
+++ b/recipes/eccodes/build.sh
@@ -11,8 +11,8 @@ export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 
 src_dir="$(pwd)"
-mkdir ..\build
-cd ..\build
+mkdir ../build
+cd ../build
 cmake $scr_dir \
          -DCMAKE_INSTALL_PREFIX=$PREFIX \
          -DENABLE_JASPER=1 \

--- a/recipes/eccodes/meta.yaml
+++ b/recipes/eccodes/meta.yaml
@@ -18,14 +18,14 @@ requirements:
     - cmake
     - boost
     - jasper
-    - libpng
-    - libnetcdf
+    - libpng 1.6*
+    - libnetcdf 4.3*
     
   run:
     - boost
     - jasper
-    - libpng
-    - libnetcdf
+    - libpng 1.6*
+    - libnetcdf 4.3*
 
 test:
   commands:

--- a/recipes/eccodes/meta.yaml
+++ b/recipes/eccodes/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.13.0" %}
+
+package:
+  name: eccodes
+  version: {{ version }}
+
+source:
+  url: https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-{{ version }}-Source.tar.gz?api=v2
+  fn: eccodes-{{ version }}-Source.tar.gz
+  md5: 46a0a520f647cfa2fb5f287f22269603
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - cmake
+    - boost
+    - jasper
+    - libpng
+    - libnetcdf
+    
+  run:
+    - boost
+    - jasper
+    - libpng
+    - libnetcdf
+
+test:
+  commands:
+    - codes_info
+    - ls $(codes_info -s)
+    - ls $(codes_info -d)
+    
+about:
+  home: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
+  license: Apache License Version 2.0, January 2004
+  summary: ECMWF ecCodes Copyright 2005-2016 ECMWF.
+
+extra:
+  recipe-maintainers:
+    - kmuehlbauer

--- a/recipes/eccodes/meta.yaml
+++ b/recipes/eccodes/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-{{ version }}-Source.tar.gz?api=v2
+  url: https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-{{ version }}-Source.tar.gz
   fn: eccodes-{{ version }}-Source.tar.gz
   md5: 46a0a520f647cfa2fb5f287f22269603
 

--- a/recipes/eccodes/meta.yaml
+++ b/recipes/eccodes/meta.yaml
@@ -42,3 +42,4 @@ about:
 extra:
   recipe-maintainers:
     - kmuehlbauer
+    - pelson

--- a/recipes/eccodes/meta.yaml
+++ b/recipes/eccodes/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   skip: true  # [win]
+  detect_binary_files_with_prefix: true
 
 requirements:
   build:


### PR DESCRIPTION
This adds the ECMWF eccodes library, the successor of grib_api and bufr_lib. This library is in beta status, but nevertheless usable.

