### PR TITLE
Re-add apptools again

### DIFF
--- a/recipes/apptools/meta.yaml
+++ b/recipes/apptools/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "4.4.0" %}
+
+package:
+  name: apptools
+  version: {{ version }}
+
+source:
+  fn: apptools-{{ version }}.tar.bz2
+  url: https://pypi.python.org/packages/source/a/apptools/apptools-{{ version }}.tar.bz2
+  md5: cf122251faec4d3dff0a9480d6f6f9f7
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - traits
+    - pyface
+    - traitsui
+    - configobj
+  run:
+    - python
+    - traits
+    - pyface
+    - traitsui
+    - configobj
+
+test:
+  imports:
+    - apptools
+
+about:
+  home: http://docs.enthought.com/apptools/
+  license: BSD 3-clause
+  summary: application tools
+
+extra:
+  recipe-maintainers:
+    - grlee77


### PR DESCRIPTION
Related: https://github.com/conda-forge/staged-recipes/pull/395
Related: https://github.com/conda-forge/staged-recipes/issues/458

Once we figure out what is going on with CircleCI, this can be merged. CI is not required as this already has been tested in the original PR.