### PR TITLE
Py27 and 35

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -20,5 +20,5 @@ if [ -z "$GH_TOKEN" ]; then
     brew remove --force $(brew list)
 
     # We just want to build all of the recipes.
-    conda-build-all ./recipes --matrix-condition "numpy >=1.9" "python >=2.7,<3|>=3.4"
+    conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.4"
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ install:
 build: off
 
 test_script:
-    - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.9" "%PY_CONDITION%"'
+    - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.10" "%PY_CONDITION%"'
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
     # Uncomment the following two lines to make any conda packages created

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -47,6 +47,6 @@ find conda-recipes -mindepth 2 -maxdepth 2 -type f -name "yum_requirements.txt" 
     | xargs -n1 cat | grep -v -e "^#" -e "^$" | \
     xargs -r yum install -y
 
-conda-build-all /conda-recipes --matrix-conditions "numpy >=1.9" "python >=2.7,<3|>=3.4"
+conda-build-all /conda-recipes --matrix-conditions "numpy >=1.10" "python >=2.7,<3|>=3.4"
 
 EOF


### PR DESCRIPTION
We are testing more on staged-recipes than is being deployed in the feedstocks since https://github.com/conda-forge/conda-smithy/pull/111. In that PR, I updated the minimum numpy version to v1.10 but repented with the removal of py34 based on the fact that the build process is still arduous for py35 on Windows. In this PR, I maintain the py34 for Windows, but remove it for Linux and OSX (where py35 is just as easy to build for as py34).

No rush on this, but we can talk about it in the next developer meeting. https://conda-forge.hackpad.com/conda-forge-meeting-notes-2YkV96cvxPG