### PR TITLE
Clear Homebrew packages after removal

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -18,6 +18,8 @@ if [ -z "$GH_TOKEN" ]; then
 
     # Remove homebrew.
     brew remove --force $(brew list)
+    brew cleanup -s
+    rm -rf $(brew --cache)
 
     # We just want to build all of the recipes.
     conda-build-all ./recipes --matrix-condition "numpy >=1.9" "python >=2.7,<3|>=3.4"


### PR DESCRIPTION
Even after removing Homebrew packages, the tarballs remain afterwards. These use up memory on the CI, which could be used for other things like intensive compilation. Here we make sure all remnants of these are deleted. The whole process is pretty quick. Similar change is proposed for `staged-recipes` in this PR ( https://github.com/conda-forge/conda-smithy/pull/146 ).