### PR TITLE
Pin `conda-build` to 1.20.0 on Travis CI

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -11,7 +11,7 @@ if [ -z "$GH_TOKEN" ]; then
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
     conda install --yes --quiet conda-build-all
-    conda install --yes --quiet conda-build jinja2 anaconda-client setuptools
+    conda install --yes --quiet conda-build=1.20.0 jinja2 anaconda-client setuptools
 
     # We don't need to build the example recipe.
     rm -rf ./recipes/example


### PR DESCRIPTION
It appears that conda-build 1.20.1 introduced a bug when trying to fix shebangs as explained in this issue ( https://github.com/conda/conda-build/issues/889 ). This uses the same strategy as was used for `conda-smithy` in this PR ( https://github.com/conda-forge/conda-smithy/pull/143 ).