### PR TITLE
New recipe for "rejected"

### DIFF
--- a/recipes/rejected/meta.yaml
+++ b/recipes/rejected/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "3.12.2" %}
+
+package:
+  name: rejected
+  version: {{ version }}
+
+source:
+  fn: rejected-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/r/rejected/rejected-{{ version }}.tar.gz
+  md5: 1bd216f95124a4a29f3722fe00d1f800
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - rejected = rejected.controller:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - helper
+    - pika >=0.10.0
+    - psutil
+    - pyyaml
+    - tornado >=4.2,<4.3
+
+  run:
+    - python
+    - helper
+    - pika >=0.10.0
+    - psutil
+    - pyyaml
+    - tornado >=4.2,<4.3
+
+test:
+  imports:
+    - rejected
+  commands:
+    - rejected --help
+
+about:
+  home: https://rejected.readthedocs.io
+  license: BSD 3-clause
+  summary: An AMQP (RabbitMQ) consumer daemon and message processing framework
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[Rejected](http://rejected.readthedocs.org) is an AMQP consumer daemon and message processing framework. It enables rapid development of message processing consumers by handling all of the core functionality of communicating with RabbitMQ and management of consumer processes.

NOTE: This recipe requires packages, which haven't been merged yet:

* Pika - #487
* Helper - #493