### PR TITLE
New recipe for "helper"

### DIFF
--- a/recipes/helper/meta.yaml
+++ b/recipes/helper/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "2.4.1" %}
+
+package:
+  name: helper
+  version: {{ version }}
+
+source:
+  fn: helper-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/h/helper/helper-{{ version }}.tar.gz
+  sha256: 4e33dde42ad4df30fb7790689f93d77252cff26a565610d03ff2e434865a53a2
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyyaml
+
+  run:
+    - python
+    - pyyaml
+
+test:
+  imports:
+    - helper
+
+about:
+  home: http://helper.readthedocs.org
+  license: BSD 3-clause
+  summary: development library for quickly writing configurable applications and daemons
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[helper](http://helper.readthedocs.io/en/latest/index.html) is a command-line/daemon application wrapper package with the aim of creating a consistent and fast way to creating applications.

It is a dependency of Rejected project: #492.