### PR TITLE
Add docstring-coverage

### DIFF
--- a/recipes/docstring-coverage/meta.yaml
+++ b/recipes/docstring-coverage/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.3.4" %}
+
+package:
+  name: docstring-coverage
+  version: {{ version }}
+
+source:
+  fn: docstring-coverage-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/d/docstring-coverage/docstring-coverage-{{ version }}.tar.gz
+  md5: 460d006800d8045c00b1763583222452
+
+build:
+  number: 0
+  skip: true  # [py3k]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - docstring-coverage = docstringcoverage.cover:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - docstringcoverage
+
+  commands:
+    - docstring-coverage --help
+
+about:
+  home: https://bitbucket.org/DataGreed/docstring-coverage/
+  license: MIT
+  summary: A simple audit tool for examining python source files for missing docstrings.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Used `conda skeleton pypi` to generate the recipe and made some edits to make it work nicely here at conda-forge.