### PR TITLE
WIP: Add nss and nspr

### DIFF
--- a/recipes/nspr/build.sh
+++ b/recipes/nspr/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+
+if [[ `uname` == "Darwin" ]]
+then
+    export MACOSX_DEPLOYMENT_TARGET=10.7
+    export MAC_FLAGS="--enable-macos-target=${MACOSX_DEPLOYMENT_TARGET}"
+fi
+
+export ARCH_FLAG=""
+if [[ "${ARCH}" == 64 ]]
+then
+    export ARCH_FLAG="--enable-64bit"
+fi
+
+
+cd nspr
+./configure \
+             --prefix="${PREFIX}" \
+             $ARCH_FLAG \
+             $MAC_FLAGS
+make
+make install

--- a/recipes/nspr/build.sh
+++ b/recipes/nspr/build.sh
@@ -3,6 +3,9 @@
 
 if [[ `uname` == "Darwin" ]]
 then
+    export CC=clang
+    export CXX=clang++
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
     export MACOSX_DEPLOYMENT_TARGET=10.7
     export MAC_FLAGS="--enable-macos-target=${MACOSX_DEPLOYMENT_TARGET}"
 fi

--- a/recipes/nspr/meta.yaml
+++ b/recipes/nspr/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "4.12" %}
+
+package:
+  name: nspr
+  version: {{ version }}
+
+source:
+  fn: nspr-{{ version }}.tgz
+  url: https://ftp.mozilla.org/pub/nspr/releases/v{{ version }}/src/nspr-{{ version }}.tar.gz
+  sha256: e0b10a1e569153668ff8bdea6c7e491b389fab69c2f18285a1ebf7c2ea4269de
+
+build:
+  number: 0
+  skip: true  # [win]
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libnspr4.a         # [unix]
+    - test -f ${PREFIX}/lib/libnspr4.a         # [unix]
+    - test -f ${PREFIX}/lib/libnspr4.so        # [linux]
+    - test -f ${PREFIX}/lib/libplc4.a          # [unix]
+    - test -f ${PREFIX}/lib/libplc4.so         # [linux]
+    - test -f ${PREFIX}/lib/libplc4.dylib      # [osx]
+    - test -f ${PREFIX}/lib/libplds4.a         # [unix]
+    - test -f ${PREFIX}/lib/libplds4.so        # [linux]
+    - test -f ${PREFIX}/lib/libplds4.dylib     # [osx]
+
+about:
+  home: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSPR
+  license: MPL 2
+  summary: A platform-neutral API for system level and libc-like functions.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/nss/build.sh
+++ b/recipes/nss/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+
+if [[ `uname` == "Darwin" ]]
+then
+    export CC=clang
+    export CXX=clang++
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export MACOSX_DEPLOYMENT_TARGET=10.7
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+else
+    export CC=gcc
+    export CXX=g++
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+export ARCH_FLAG=""
+if [[ "${ARCH}" == 64 ]]
+then
+    export USE_64=true
+fi
+
+cd nss
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make \
+      PREFIX="${PREFIX}" \
+      NSPR_PREFIX="${PREFIX}" \
+      NSPR_INCLUDE_DIR="${PREFIX}/include/nspr" \
+      CC=$CC \
+      CXX=$CXX \
+      C_INCLUDE_PATH="${PREFIX}/include:${PREFIX}/include/nspr" \
+      LIBRARY_PATH="${PREFIX}/lib" \
+      USE_SYSTEM_ZLIB=1 \
+      NSS_USE_SYSTEM_SQLITE=1 \
+
+# test
+cd tests
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib HOST=localhost DOMSUF=localdomain ./all.sh

--- a/recipes/nss/meta.yaml
+++ b/recipes/nss/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "3.23" %}
+{% set version_us = version.replace(".", "_") %}
+
+package:
+  name: nss
+  version: {{ version }}
+
+source:
+  fn: nss-{{ version }}.tgz
+  url: https://ftp.mozilla.org/pub/security/nss/releases/NSS_{{ version_us }}_RTM/src/nss-{{ version }}.tar.gz
+  sha256: 94b383e31c9671e9dfcca81084a8a813817e8f05a57f54533509b318d26e11cf
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - autoconf
+    - cmake
+    - nspr
+    - sqlite
+    - zlib
+
+  run:
+    - nspr
+    - sqlite
+    - zlib
+
+test:
+  commands:
+    - true  # [unix]
+
+about:
+  home: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS
+  license: MPL 2
+  summary: A set of libraries designed to support cross-platform development of security-enabled client and server applications.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds recipes to build `nss` and `nspr`. The are used by Mozilla's Firefox to handle various security protocols. Some of them are not supported by OpenSSL. It comes with some useful tools to work with certs of various kinds too.

This is still WIP and I'm not sure if I want to carry this forward at this point. Though I'm putting this out there in case someone else feels compelled to carry it forward.
