### PR TITLE
Adds cdat_lite and cfchecker

### DIFF
--- a/recipes/cdat-lite/meta.yaml
+++ b/recipes/cdat-lite/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "6.0rc2" %}
+
+package:
+    name: cdat-lite
+    version: {{ version }}
+
+source:
+    fn: cdat_lite-{{ version }}.tar.gz
+    url: http://ndg.nerc.ac.uk/dist/cdat_lite-{{ version }}.tar.gz
+    sha256: 6cbfdf9b47fdbc189ca7d2819dafb6cf958116e0f6077b325c375a0ddfab2a95
+
+build:
+    number: 0
+    skip: True  # [win or py3k]
+    script:
+        - export NETCDF_HOME=$PREFIX
+        - export HDF5_HOME=$PREFIX
+        - python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - numpy
+        - libnetcdf 4.3*
+    run:
+        - python
+        - numpy
+        - libnetcdf 4.3*
+
+test:
+    commands:
+        - cddump -h
+        - cdscan -h
+    imports:
+        - cdat_lite
+        - cdtime
+        - cdms2
+
+about:
+    home: http://proj.badc.rl.ac.uk/cedaservices/wiki/CdatLite
+    summary: A Python package for managing and analysing climate science data
+    license: http://www-pcmdi.llnl.gov/software-portal/cdat/docs/cdat-license
+
+extra:
+    recipe-maintainers:
+        - ocefpaf

--- a/recipes/cfchecker/ctypes.patch
+++ b/recipes/cfchecker/ctypes.patch
@@ -1,0 +1,23 @@
+--- src/cfchecker/cfchecks.py	2013-11-11 10:43:16.000000000 -0300
++++ src/cfchecker/cfchecks.py	2016-05-04 12:53:14.153974154 -0300
+@@ -48,8 +48,18 @@
+ 
+ # Use ctypes to interface to the UDUNITS-2 shared library
+ # The udunits2 library needs to be in a standard path o/w export LD_LIBRARY_PATH
+-from ctypes import *
+-udunits=CDLL("libudunits2.so")
++from ctypes import CDLL
++import os.path
++import sys
++
++if 'linux' in sys.platform:
++  ext = 'so'
++elif 'darwin' in sys.platform:
++  ext = 'dylib'
++else:
++  raise ValueError('Unrecognized platform %s' % sys.platform)
++  
++udunits = CDLL(os.path.join(sys.prefix, 'lib', 'libudunits2.%s' % ext))
+  
+ STANDARDNAME = 'http://cf-pcmdi.llnl.gov/documents/cf-standard-names/standard-name-table/current/cf-standard-name-table.xml'
+ AREATYPES = 'http://cf-pcmdi.llnl.gov/documents/cf-standard-names/area-type-table/current/area-type-table.xml'

--- a/recipes/cfchecker/meta.yaml
+++ b/recipes/cfchecker/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "2.0.9" %}
+
+package:
+    name: cfchecker
+    version: {{ version }}
+
+source:
+    fn: cfchecker-{{ version }}.tar.gz
+    url: https://pypi.io/packages/source/c/cfchecker/cfchecker-{{ version }}.tar.gz
+    md5: e36c556454e21d88aaa9f0394429032f
+    patches:
+        # Ensure our udunits2 lib is used on all platforms.
+        - ctypes.patch
+
+build:
+    skip: True  # [win or py3k]
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    entry_points:
+        - cfchecks = cfchecker:cfchecks_main
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - numpy
+        - cdat-lite
+        - udunits2
+    run:
+        - python
+        - setuptools
+        - numpy
+        - cdat-lite
+        - udunits2
+
+test:
+    commands:
+        - cfchecks -h
+    imports:
+        - cfchecker
+
+about:
+  home: https://pypi.python.org/pypi/cfchecker
+  license: BSD 3-Clause
+  summary: The NetCDF Climate Forcast Conventions compliance checker
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
The `cdat_lite` module needs `numpy <1.9` because it still uses `oldnumeric` and `cfchecker` depends on `cdat_lite`. Even though we no longer use `numpy 1.8` for builds I would like to get these two in the channel to make conda-forge the 1-place to get all the Earth Science software we need.

If others are OK with this we can merge it and then I revert the numpy change back to 1.9 here in staged recipes. I am also aware that I will need to change the feedstock manually, but that will be done probably only once.