### PR TITLE
Add tuiview

### DIFF
--- a/recipes/tuiview/bld.bat
+++ b/recipes/tuiview/bld.bat
@@ -1,0 +1,5 @@
+
+set GDAL_HOME=%PREFIX%
+
+%PYTHON% setup.py install
+if errorlevel 1 exit 1

--- a/recipes/tuiview/build.sh
+++ b/recipes/tuiview/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+python setup.py install --prefix=$PREFIX

--- a/recipes/tuiview/build.sh
+++ b/recipes/tuiview/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python setup.py install --prefix=$PREFIX
+$PYTHON setup.py install --prefix=$PREFIX

--- a/recipes/tuiview/meta.yaml
+++ b/recipes/tuiview/meta.yaml
@@ -16,12 +16,12 @@ requirements:
     build:
         - python
         - numpy
-        - gdal
+        - gdal 2.0.2
         - pyqt
     run:
         - python
         - numpy
-        - gdal
+        - gdal 2.0.2
         - pyqt
 
 test:

--- a/recipes/tuiview/meta.yaml
+++ b/recipes/tuiview/meta.yaml
@@ -5,8 +5,12 @@ package:
     version: {{ version }}
 
 source:
-    hg_url: https://bitbucket.org/chchrsc/tuiview
-    hg_tag: tuiview-{{ version }}
+    fn: TuiView-{{ version }}.tar.gz  # [unix]
+    fn: TuiView-{{ version }}.zip  # [win]
+    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-1.1.8.tar.gz  # [unix]
+    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-1.1.8.zip  # [win]
+    md5: ed4591054414514cf106e7718069930e  # [unix]
+    md5: e41c7641d709b7e2e51231077712b384  # [win]
 
 build:
     number: 0

--- a/recipes/tuiview/meta.yaml
+++ b/recipes/tuiview/meta.yaml
@@ -1,13 +1,12 @@
-{% set version = "1.1.7" %}
+{% set version = "1.1.8" %}
 
 package:
     name: tuiview
     version: {{ version }}
 
 source:
-    fn: TuiView-{{ version }}.tar.gz
-    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-{{ version }}.tar.gz
-    md5: f52e2b81e3c95f7757bfd7e1b90d560b
+    hg_url: https://bitbucket.org/chchrsc/tuiview
+    hg_tag: tuiview-{{ version }}
 
 build:
     number: 0

--- a/recipes/tuiview/meta.yaml
+++ b/recipes/tuiview/meta.yaml
@@ -5,12 +5,9 @@ package:
     version: {{ version }}
 
 source:
-    fn: TuiView-{{ version }}.tar.gz  # [unix]
-    fn: TuiView-{{ version }}.zip  # [win]
-    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-1.1.8.tar.gz  # [unix]
-    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-1.1.8.zip  # [win]
-    md5: ed4591054414514cf106e7718069930e  # [unix]
-    md5: e41c7641d709b7e2e51231077712b384  # [win]
+    fn: TuiView-{{ version }}.zip
+    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-{{ version }}.zip
+    md5: e41c7641d709b7e2e51231077712b384
 
 build:
     number: 0

--- a/recipes/tuiview/meta.yaml
+++ b/recipes/tuiview/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "1.1.7" %}
+
+package:
+    name: tuiview
+    version: {{ version }}
+
+source:
+    fn: TuiView-{{ version }}.tar.gz
+    url: https://bitbucket.org/chchrsc/tuiview/downloads/TuiView-{{ version }}.tar.gz
+    md5: f52e2b81e3c95f7757bfd7e1b90d560b
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - python
+        - numpy
+        - gdal
+        - pyqt
+    run:
+        - python
+        - numpy
+        - gdal
+        - pyqt
+
+test:
+    imports:
+        - tuiview
+
+about:
+    home: http://tuiview.org/
+    license: GPLv2
+    summary: Simple raster viewer. Supports Geolinked Windows, Raster Attribute Querying and Editing and Geographic Selection, Vector Overlay, Flicker, Profile Tool. 
+
+extra:
+    recipe-maintainers:
+        - gillins


### PR DESCRIPTION
http://tuiview.org/

I noticed there doesn't seem to be any viewers for remotely sensed data, so I've added this lightweight one (I'm main author so a bit biased). Let me know if not suitable.

I'm not sure if the gdal version needs to be pinned like we did for RIOS?