### PR TITLE
Adds the ca-certificates package

### DIFF
--- a/recipes/ca-certificates/bld.bat
+++ b/recipes/ca-certificates/bld.bat
@@ -1,0 +1,9 @@
+:: Create the directory to hold the certificates.
+if not exist %LIBRARY_PREFIX%\ssl mkdir %LIBRARY_PREFIX%\ssl
+if errorlevel 1 exit 1
+
+:: Copy the certificates from certifi.
+copy /y %SP_DIR%\certifi\cacert.pem %LIBRARY_PREFIX%\ssl
+if errorlevel 1 exit 1
+copy /y %LIBRARY_PREFIX%\ssl\cacert.pem %LIBRARY_PREFIX%\ssl\cert.pem
+if errorlevel 1 exit 1

--- a/recipes/ca-certificates/build.sh
+++ b/recipes/ca-certificates/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Create the directory to hold the certificates.
+mkdir -p "${PREFIX}/ssl"
+
+# Copy the certificates from certifi.
+cp -f "${SP_DIR}/certifi/cacert.pem" "${PREFIX}/ssl"
+ln -fs "${PREFIX}/ssl/cacert.pem" "${PREFIX}/ssl/cert.pem"

--- a/recipes/ca-certificates/meta.yaml
+++ b/recipes/ca-certificates/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "2016.2.28" %}
+
+package:
+  name: ca-certificates
+  version: {{ version }}
+
+# This does not have a source because it pulls these from certifi at present.
+
+build:
+  number: 0
+  skip: true  # [not py35]
+  # As openssl includes these (dependency of Python), they will be removed afterwards.
+  # This is our way of ensuring these files are kept anyways. Once conda-forge has its
+  # own openssl, this will no longer be necessary.
+  #
+  # Note: The Windows copy of openssl does not include these.
+  always_include_files:
+    - ssl/cert.pem      # [unix]
+    - ssl/cacert.pem    # [unix]
+
+requirements:
+  build:
+    - python
+    - certifi {{ version }}
+
+test:
+  requires:
+    - curl
+
+  commands:
+    # Verify the certificates are there.
+    - test -f "${PREFIX}/ssl/cacert.pem"                                      # [unix]
+    - test -f "${PREFIX}/ssl/cert.pem"                                        # [unix]
+    - if not exist %LIBRARY_PREFIX%\\ssl\\cacert.pem exit 1                   # [win]
+    - if not exist %LIBRARY_PREFIX%\\ssl\\cert.pem exit 1                     # [win]
+
+    # Use the certificates to download something.
+    - curl --cacert "${PREFIX}/ssl/cacert.pem" https://www.google.com         # [unix]
+    - curl --cacert %LIBRARY_PREFIX%\\ssl\\cacert.pem https://www.google.com  # [win]
+
+about:
+  home: https://github.com/conda-forge/ca-certificates-feedstock
+  license: ISC
+  summary: Certificates for use with other packages.
+
+extra:
+  recipe-maintainers:
+     - jakirkham
+     - msarahan
+     - pelson


### PR DESCRIPTION
This bundles the certificates from `certifi` at present. So, has nothing to do with the package included in this PR ( https://github.com/conda-forge/staged-recipes/pull/378 ), but this will replace that one.

However, no matter how we get them in the future, this is the package to depend on if you need certificates. The versioning here should always be based on date as it will always depends on *when* we got the certificates. This should have similar behavior to what happens with `defaults` version of `openssl`, but won't be exactly the same as there are somethings like the `openssl.cnf` or `misc` directory that are not included.

xref: https://github.com/conda-forge/git-feedstock/pull/7

cc @msarahan @pelson