### PR TITLE
Add gnureadline

### DIFF
--- a/recipes/gnureadline/meta.yaml
+++ b/recipes/gnureadline/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "6.3.3" %}
+
+package:
+    name: gnureadline
+    version: {{ version }}
+
+source:
+    fn: gnureadline-{{ version }}.tar.gz
+    url: https://pypi.io/packages/source/g/gnureadline/gnureadline-{{ version }}.tar.gz
+    md5: c4af83c9a3fbeac8f2da9b5a7c60e51c
+
+build:
+    number: 0
+    skip: True  # [not osx]
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+  imports:
+      - gnureadline
+
+about:
+    home: http://github.com/ludwigschwardt/python-gnureadline
+    license: GPL-3.0
+    summary: The standard Python readline extension statically linked against the GNU readline library
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
It look like `metakernel` needs this library to work on OS X. See https://travis-ci.org/conda-forge/metakernel-feedstock/jobs/128333638