### PR TITLE
Re-add erlang

### DIFF
--- a/recipes/erlang/build.sh
+++ b/recipes/erlang/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+export LIBRARY_PATH="${PREFIX}/lib:${LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}"
+export ERL_TOP="$(pwd)"
+./configure --with-ssl="${PREFIX}" --prefix="${PREFIX}" --without-javac \
+  --with-libatomic_ops="${PREFIX}" --enable-m${ARCH}-build
+make
+make release_tests
+cd "${ERL_TOP}/release/tests/test_server"
+${ERL_TOP}/bin/erl -s ts install -s ts smoke_test batch -s init stop
+cd ${ERL_TOP}
+make install

--- a/recipes/erlang/meta.yaml
+++ b/recipes/erlang/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "18.3" %}
+
+package:
+  name: erlang
+  version: {{ version }}
+
+source:
+  fn: otp_src_{{ version }}.tar.gz
+  url: http://erlang.org/download/otp_src_{{ version }}.tar.gz
+  sha256: "fdab8129a1cb935db09f1832e3a7d511a4aeb2b9bb3602ca6a7ccb9730d5c9c3"
+
+build:
+  number: 1
+  skip: true  # [win]
+
+requirements:
+  build:
+    - m4
+    - perl
+    - readline 6.2*
+    - openssl 1.0.*
+    - ncurses
+    - zlib 1.2*
+    - libatomic_ops
+  run:
+    - readline 6.2*
+    - openssl 1.0.*
+    - ncurses
+    - zlib 1.2*
+    - libatomic_ops
+
+test:
+  commands:
+    - erl -version
+
+about:
+  home: http://www.erlang.org/
+  license: Apache 2.0
+  summary: "A programming language used to build massively scalable soft real-time systems with requirements on high availability."
+
+extra:
+  recipe-maintainers:
+    - scopatz
+    - jakirkham


### PR DESCRIPTION
Re-add `erlang` exactly as it is in the feedstock [currently]( https://github.com/conda-forge/erlang-feedstock/tree/1ad0972693514d58d47f8c8a5eb0bd5bb8241366/recipe ). Literally drag-n-dropped it here.

The hope is this will reconfigure CircleCI when merged and thus solve this issue ( https://github.com/conda-forge/erlang-feedstock/issues/1 ). Will give this a try. If it doesn't work, we are no worse off. If it does work, we have solved the issue and can move on to other issues. 🚶

xref: https://github.com/conda-forge/staged-recipes/pull/473

cc @pelson @scopatz 