### PR TITLE
Add the conda-team channel

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -10,6 +10,9 @@ if [ -z "$GH_TOKEN" ]; then
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
+    conda config --add channels conda-team
+    conda config --add channels conda-team/label/dev
+    conda update --all --yes
     conda install --yes --quiet conda-build-all
     conda install --yes --quiet conda-build=1.20.0 jinja2 anaconda-client setuptools
 

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -14,7 +14,7 @@ if [ -z "$GH_TOKEN" ]; then
     conda config --add channels conda-team/label/dev
     conda update --all --yes
     conda install --yes --quiet conda-build-all
-    conda install --yes --quiet conda-build=1.20.0 jinja2 anaconda-client setuptools
+    conda install --yes --quiet conda-build jinja2 anaconda-client setuptools
 
     # We don't need to build the example recipe.
     rm -rf ./recipes/example

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,10 +78,6 @@ install:
     - cmd: conda config --add channels conda-forge
     - cmd: conda install --yes --quiet obvious-ci conda-build-all
     - cmd: obvci_install_conda_build_tools.py
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
     - cmd: conda info
 
 # Skip .NET project specific build phase.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,9 @@ install:
             {$root = "C:\Miniconda-x64"}
           $env:path="$root;$root\Scripts;$root\Library\bin;$($env:path)"
     - cmd: conda config --set show_channel_urls true
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda config --add channels conda-team
+    - cmd: conda config --add channels conda-team/label/dev
+    - cmd: conda update --yes --quiet --all
     - cmd: set PYTHONUNBUFFERED=1
 
     - cmd: conda config --add channels conda-forge

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -9,6 +9,8 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
+ - conda-team
+ - conda-team/label/dev
  - defaults
 
 show_channel_urls: true
@@ -35,7 +37,7 @@ echo "$config" > ~/.condarc
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artefacts.
 conda clean --lock
 
-conda update --yes conda conda-build
+conda update --yes --all
 conda install --yes anaconda-client conda-build-all
 conda info
 


### PR DESCRIPTION
The conda-team channel is where development builds of `conda-build` are being placed. By adding it to our channels, this will give us a better chance at trying out new features or bug fixes in `conda-build` that are not official released. Hopefully by doing this, we can work with Continuum to iron out any issues before an official release. Also, this should help us try out things that believe are potential fixes.

In addition, this reverts the `conda-build` 1.20.0 pinning on AppVeyor that was added by these two PRs ( https://github.com/conda-forge/staged-recipes/pull/452 ) ( https://github.com/conda-forge/staged-recipes/pull/455 ) as this issue should be resolved in the latest development release by this PR ( https://github.com/conda/conda-build/pull/900 ) ( thanks to the hard work of @msarahan and @mingwandroid 🎉 ). It also reverts the `conda-build` 1.20.0 pinning on Travis CI introduced by this PR ( https://github.com/conda-forge/staged-recipes/pull/488 ) as it should be fixed by this PR ( https://github.com/conda/conda-build/pull/892 ).

cc @msarahan @pelson @ocefpaf

xref: [Gitter message]( https://gitter.im/conda-forge/conda-forge.github.io?at=572d33f53170252648f4b871 )
xref: https://github.com/conda-forge/conda-smithy/pull/156