### PR TITLE
Add theano

### DIFF
--- a/recipes/theano/meta.yaml
+++ b/recipes/theano/meta.yaml
@@ -1,0 +1,65 @@
+{% set version = "0.8.2" %}
+
+package:
+  name: theano
+  version: {{ version }}
+
+source:
+  fn: Theano-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/T/Theano/Theano-{{ version }}.tar.gz
+  md5: f2d0dfe7df141115201077cd933b2c52
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six >=1.9.0
+    - numpy >=1.3.0
+    - scipy >=0.7.0
+
+  run:
+    - python
+    - six >=1.9.0
+    - numpy >=1.3.0
+    - scipy >=0.7.0
+
+test:
+  requires:
+    - nose >=1.3.0
+    - nose_parameterized >=0.5.0
+
+  imports:
+    - theano
+    - theano.compile
+    - theano.compile.sandbox
+    - theano.compile.tests
+    - theano.gof
+    - theano.gof.tests
+    - theano.misc
+    - theano.sandbox
+    - theano.sandbox.cuda
+    - theano.sandbox.cuda.tests
+    - theano.scalar
+    - theano.scalar.tests
+    - theano.sparse
+    - theano.sparse.tests
+    - theano.tensor
+    - theano.tensor.nnet
+    - theano.tensor.nnet.tests
+    - theano.tensor.signal
+    - theano.tensor.signal.tests
+    - theano.tensor.tests
+    - theano.tests
+
+about:
+  home: http://deeplearning.net/software/theano/
+  license: BSD 3-Clause
+  summary: Optimizing compiler for evaluating mathematical expressions on CPUs and GPUs.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build `theano`.

Still need to do.

* [x] Remove `nose_parameterized` as it is a feedstock (once packages are built).

~~* [ ] Configure with BLAS~~
~~* [ ] Somehow express it requires a compiler at install time.~~

~~Nice to haves.~~

~~* [ ] CUDA~~
~~* [ ] cuDNN~~