### PR TITLE
Build recipe for Linux / OS X for Thrift C++ libraries and compiler

### DIFF
--- a/recipes/thrift-cpp/build.sh
+++ b/recipes/thrift-cpp/build.sh
@@ -21,6 +21,7 @@ if [ "$(uname)" == "Darwin" ]; then
 fi
 
 cmake \
+	-DCMAKE_INSTALL_PREFIX=$PREFIX \
 	-DBUILD_PYTHON=off \
 	-DBUILD_JAVA=off \
 	-DBUILD_C_GLIB=off \

--- a/recipes/thrift-cpp/build.sh
+++ b/recipes/thrift-cpp/build.sh
@@ -27,5 +27,8 @@ cmake \
 	.
 
 make
-make check
+
+# TODO(wesm): The unit tests do not run in CircleCI at the moment
+# make check
+
 make install

--- a/recipes/thrift-cpp/build.sh
+++ b/recipes/thrift-cpp/build.sh
@@ -17,6 +17,7 @@ if [ "$(uname)" == "Darwin" ]; then
   export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
   export LDFLAGS="${LDFLAGS} -stdlib=libc++ -std=c++11"
   export LINKFLAGS="${LDFLAGS}"
+  export MACOSX_DEPLOYMENT_TARGET=10.7
 fi
 
 cmake \

--- a/recipes/thrift-cpp/build.sh
+++ b/recipes/thrift-cpp/build.sh
@@ -1,0 +1,30 @@
+#!/bin/env bash
+
+BOOST_ROOT=$PREFIX
+ZLIB_ROOT=$PREFIX
+LIBEVENT_ROOT=$PREFIX
+
+export OPENSSL_ROOT=$PREFIX
+export OPENSSL_ROOT_DIR=$PREFIX
+
+if [ "$(uname)" == "Darwin" ]; then
+  # C++11 finagling for Mac OSX
+  export CC=clang
+  export CXX=clang++
+  export MACOSX_VERSION_MIN="10.7"
+  export CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+  export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+  export LDFLAGS="${LDFLAGS} -mmacosx-version-min=${MACOSX_VERSION_MIN}"
+  export LDFLAGS="${LDFLAGS} -stdlib=libc++ -std=c++11"
+  export LINKFLAGS="${LDFLAGS}"
+fi
+
+cmake \
+	-DBUILD_PYTHON=off \
+	-DBUILD_JAVA=off \
+	-DBUILD_C_GLIB=off \
+	.
+
+make
+make check
+make install

--- a/recipes/thrift-cpp/meta.yaml
+++ b/recipes/thrift-cpp/meta.yaml
@@ -17,6 +17,7 @@ requirements:
     - autoconf
     - automake
     - cmake
+    - gcc
     - libtool
     - openssl
     - bison
@@ -25,6 +26,7 @@ requirements:
     - zlib 1.2*
 
   run:
+    - libgcc
     - zlib 1.2*
 
 test:

--- a/recipes/thrift-cpp/meta.yaml
+++ b/recipes/thrift-cpp/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - boost
     - autoconf
     - automake
+    - cmake
     - libtool
     - openssl
     - bison

--- a/recipes/thrift-cpp/meta.yaml
+++ b/recipes/thrift-cpp/meta.yaml
@@ -27,6 +27,7 @@ requirements:
 
   run:
     - libgcc
+    - openssl
     - zlib 1.2*
 
 test:

--- a/recipes/thrift-cpp/meta.yaml
+++ b/recipes/thrift-cpp/meta.yaml
@@ -22,10 +22,10 @@ requirements:
     - bison
     - flex
     - pkg-config
-    - zlib
+    - zlib 1.2*
 
   run:
-    - zlib
+    - zlib 1.2*
 
 test:
   commands:
@@ -41,3 +41,5 @@ about:
 extra:
   recipe-maintainers:
     - wesm
+    - msarahan
+    - jakirkham

--- a/recipes/thrift-cpp/meta.yaml
+++ b/recipes/thrift-cpp/meta.yaml
@@ -1,0 +1,42 @@
+package:
+  name: thrift-cpp
+  version: "0.9.3"
+
+source:
+  fn: thrift-0.9.3.tar.gz
+  url: http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
+  md5: 88d667a8ae870d5adeca8cb7d6795442
+
+build:
+  skip: true  # [win]
+  number: 0
+
+requirements:
+  build:
+    - boost
+    - autoconf
+    - automake
+    - libtool
+    - openssl
+    - bison
+    - flex
+    - pkg-config
+    - zlib
+
+  run:
+    - zlib
+
+test:
+  commands:
+    - test -f $PREFIX/bin/thrift
+    - test -f $PREFIX/lib/libthrift.a
+    - test -f $PREFIX/include/thrift/Thrift.h
+
+about:
+  home: http://thrift.apache.org
+  license: Apache 2.0
+  summary: 'Compiler and C++ libraries and headers for the Apache Thrift RPC system'
+
+extra:
+  recipe-maintainers:
+    - wesm


### PR DESCRIPTION
There's a bit of cruft here from github.com/cloudera/native-toolchain, and I'm unable to work on the Windows build if someone can help with that. There are a number of projects out there that depend on the Thrift C++ API (e.g. https://github.com/apache/parquet-cpp) that will depend on this