### PR TITLE
Add recipe for pybind11

### DIFF
--- a/recipes/pybind11/meta.yaml
+++ b/recipes/pybind11/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "1.7" %}
+
+package:
+    name: pybind11
+    version: {{ version }}
+
+source:
+    fn: pybind11-{{ version }}.tar.gz
+    url: https://pypi.io/packages/source/p/pybind11/pybind11-{{ version }}.tar.gz
+    md5: c73683af384d6494ece41dbb71651c9a
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - pybind11
+
+about:
+    home: https://github.com/pybind/pybind11/
+    license: BSD 3-Clause
+    summary: Seamless operability between C++11 and Python
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - wjakob


### PR DESCRIPTION
Eventually, pybind11 could probably become a noarch package, as per https://github.com/conda/conda/issues/2456.