### PR TITLE
add NFFT and pyNFFT

### DIFF
--- a/recipes/cunit/build.sh
+++ b/recipes/cunit/build.sh
@@ -1,13 +1,5 @@
-./bootstrap $PREFIX
 
-# ./configure --srcdir=`pwd` \
-#             --prefix=$PREFIX \
-#             --enable-debug \
-#             --enable-automated \
-#             --enable-basic \
-#             --enable-console \
-#             --enable-examples \
-#             --enable-test
+./bootstrap $PREFIX
 
 make
 make check

--- a/recipes/cunit/build.sh
+++ b/recipes/cunit/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 ./bootstrap $PREFIX
 

--- a/recipes/cunit/build.sh
+++ b/recipes/cunit/build.sh
@@ -1,0 +1,14 @@
+./bootstrap $PREFIX
+
+# ./configure --srcdir=`pwd` \
+#             --prefix=$PREFIX \
+#             --enable-debug \
+#             --enable-automated \
+#             --enable-basic \
+#             --enable-console \
+#             --enable-examples \
+#             --enable-test
+
+make
+make check
+make install

--- a/recipes/cunit/meta.yaml
+++ b/recipes/cunit/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "2.1.3" %}
+{% set version_url = "2.1-3" %}
+
+package:
+  name: cunit
+  version: {{ version }}
+
+source:
+  fn: CUnit-{{ version }}.tar.gz
+  url: https://sourceforge.net/projects/cunit/files/CUnit/{{ version_url }}/CUnit-{{ version_url }}.tar.bz2
+  md5: b5f1a9f6093869c070c6e4a9450cc10c
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+  run:
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libcunit.a
+    - test -f ${PREFIX}/lib/libcunit.so  # [linux]
+    - test -f ${PREFIX}/lib/libcunit.dyld  # [osx]
+
+about:
+  home: http://sourceforge.net/projects/cunit/
+  license: LGPL v2
+  summary: A Unit Testing Framework for C
+
+extra:
+    recipe-maintainers:
+      - grlee77

--- a/recipes/cunit/meta.yaml
+++ b/recipes/cunit/meta.yaml
@@ -16,9 +16,9 @@ build:
 
 requirements:
   build:
-    - libtool  # [unix]
-    - autoconf  # [unix]
-    - automake  # [unix]
+    - libtool
+    - autoconf
+    - automake
   run:
 
 test:

--- a/recipes/cunit/meta.yaml
+++ b/recipes/cunit/meta.yaml
@@ -16,13 +16,16 @@ build:
 
 requirements:
   build:
+    - libtool  # [unix]
+    - autoconf  # [unix]
+    - automake  # [unix]
   run:
 
 test:
   commands:
     - test -f ${PREFIX}/lib/libcunit.a
     - test -f ${PREFIX}/lib/libcunit.so  # [linux]
-    - test -f ${PREFIX}/lib/libcunit.dyld  # [osx]
+    - test -f ${PREFIX}/lib/libcunit.dylib  # [osx]
 
 about:
   home: http://sourceforge.net/projects/cunit/

--- a/recipes/nfft/build.sh
+++ b/recipes/nfft/build.sh
@@ -8,9 +8,7 @@
             --with-fftw3-libdir=$PREFIX/lib \
             --with-fftw3-includedir=$PREFIX/include \
             --with-window=kaiserbessel
-# --with-gcc-arch=
-# --with-apple-gcc-arch=
 
 make
-# make check
+make check
 make install

--- a/recipes/nfft/build.sh
+++ b/recipes/nfft/build.sh
@@ -12,5 +12,5 @@
 # --with-apple-gcc-arch=
 
 make
-make check
+# make check
 make install

--- a/recipes/nfft/build.sh
+++ b/recipes/nfft/build.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 ./bootstrap.sh
 

--- a/recipes/nfft/build.sh
+++ b/recipes/nfft/build.sh
@@ -1,0 +1,16 @@
+
+./bootstrap.sh
+
+./configure --prefix=$PREFIX \
+            --enable-applications \
+            --enable-all \
+            --enable-openmp \
+            --with-fftw3-libdir=$PREFIX/lib \
+            --with-fftw3-includedir=$PREFIX/include \
+            --with-window=kaiserbessel
+# --with-gcc-arch=
+# --with-apple-gcc-arch=
+
+make
+make check
+make install

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - gcc  # [osx]
   run:
     - fftw
-
+    - libgcc  # [osx]
 
 test:
   commands:

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   build:
     - fftw
-    - gcc  # [osx]
+    - gcc
     - libtool
     - autoconf
     - automake
@@ -28,7 +28,7 @@ requirements:
 
   run:
     - fftw
-    - libgcc  # [osx]
+    - libgcc
 
 test:
   commands:

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "3.3.1" %}
+#{% set version = "3.3.1" %}
+{% set version = "3.2.4" %}
 
 package:
   name: nfft
@@ -6,8 +7,10 @@ package:
 
 source:
   fn: nfft-{{ version }}.tar.gz
-  url: https://github.com/NFFT/nfft/releases/download/{{ version }}/nfft-{{ version }}.tar.gz
-  md5: 8c0516e3252ff39a245e62f1a59d0165
+  # url: https://github.com/NFFT/nfft/releases/download/{{ version }}/nfft-{{ version }}.tar.gz
+  # md5: 8c0516e3252ff39a245e62f1a59d0165
+  url: https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-{{ version }}.tar.gz
+  md5: 8d9b1b708236297397ed1b70cace8b7b
 
 build:
   number: 0

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -1,4 +1,3 @@
-#{% set version = "3.3.1" %}
 {% set version = "3.2.4" %}
 
 package:
@@ -7,8 +6,6 @@ package:
 
 source:
   fn: nfft-{{ version }}.tar.gz
-  # url: https://github.com/NFFT/nfft/releases/download/{{ version }}/nfft-{{ version }}.tar.gz
-  # md5: 8c0516e3252ff39a245e62f1a59d0165
   url: https://www-user.tu-chemnitz.de/~potts/nfft/download/nfft-{{ version }}.tar.gz
   md5: 8d9b1b708236297397ed1b70cace8b7b
 
@@ -23,9 +20,6 @@ requirements:
     - libtool
     - autoconf
     - automake
-# CUnit needed for "make check" in pyNFFT 3.3.x, but not for 3.2.x
-#     - cunit
-
   run:
     - fftw
     - libgcc

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -20,9 +20,9 @@ requirements:
   build:
     - fftw
     - gcc  # [osx]
-    - libtool  # [unix]
-    - autoconf  # [unix]
-    - automake  # [unix]
+    - libtool
+    - autoconf
+    - automake
 # CUnit needed for "make check" in pyNFFT 3.3.x, but not for 3.2.x
 #     - cunit
 

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -19,8 +19,13 @@ build:
 requirements:
   build:
     - fftw
-    - cunit
     - gcc  # [osx]
+    - libtool  # [unix]
+    - autoconf  # [unix]
+    - automake  # [unix]
+# CUnit needed for "make check" in pyNFFT 3.3.x, but not for 3.2.x
+#     - cunit
+
   run:
     - fftw
     - libgcc  # [osx]
@@ -29,10 +34,10 @@ test:
   commands:
     - test -f ${PREFIX}/lib/libnfft3.a
     - test -f ${PREFIX}/lib/libnfft3.so  # [linux]
-    - test -f ${PREFIX}/lib/libnfft3.dyld  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3.dylib  # [osx]
     - test -f ${PREFIX}/lib/libnfft3_threads.a
     - test -f ${PREFIX}/lib/libnfft3_threads.so  # [linux]
-    - test -f ${PREFIX}/lib/libnfft3_threads.dyld  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3_threads.dylib  # [osx]
 
 about:
   home: http://www.nfft.org/

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "3.3.1" %}
+
+package:
+  name: nfft
+  version: {{ version }}
+
+source:
+  fn: nfft-{{ version }}.tar.gz
+  url: https://github.com/NFFT/nfft/releases/download/{{ version }}/nfft-{{ version }}.tar.gz
+  md5: 8c0516e3252ff39a245e62f1a59d0165
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - fftw
+    - cunit
+    - gcc  # [osx]
+  run:
+    - fftw
+
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libnfft3.a
+    - test -f ${PREFIX}/lib/libnfft3.so  # [linux]
+    - test -f ${PREFIX}/lib/libnfft3.dyld  # [osx]
+    - test -f ${PREFIX}/lib/libnfft3_threads.a
+    - test -f ${PREFIX}/lib/libnfft3_threads.so  # [linux]
+    - test -f ${PREFIX}/lib/libnfft3_threads.dyld  # [osx]
+
+about:
+  home: http://www.nfft.org/
+  license: GPLv2
+  summary: Non-equispaced fast Fourier transform (NFFT) library
+
+extra:
+    recipe-maintainers:
+      - grlee77

--- a/recipes/nfft/meta.yaml
+++ b/recipes/nfft/meta.yaml
@@ -40,4 +40,5 @@ about:
 
 extra:
     recipe-maintainers:
+      - ghisvail
       - grlee77

--- a/recipes/pynfft/build.sh
+++ b/recipes/pynfft/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# have to include the path to nfft.h
+echo "[build_ext]" > setup.cfg
+echo "include-dirs=$PREFIX/include/" >> setup.cfg
+
+python setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/pynfft/meta.yaml
+++ b/recipes/pynfft/meta.yaml
@@ -16,14 +16,14 @@ build:
 requirements:
   build:
     - numpy x.x
-    - python >=2.7
+    - python
     - setuptools
     - nfft >=3.2,<3.3
     - gcc
     - cython
   run:
     - numpy x.x
-    - python >=2.7
+    - python
     - nfft >=3.2,<3.3
     - libgcc
 

--- a/recipes/pynfft/meta.yaml
+++ b/recipes/pynfft/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [win]
-  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
@@ -20,10 +19,13 @@ requirements:
     - python >=2.7
     - setuptools
     - nfft >=3.2,<3.3
+    - gcc
+    - cython
   run:
     - numpy >=1.6
     - python >=2.7
     - nfft >=3.2,<3.3
+    - libgcc
 
 test:
   imports:

--- a/recipes/pynfft/meta.yaml
+++ b/recipes/pynfft/meta.yaml
@@ -15,14 +15,14 @@ build:
 
 requirements:
   build:
-    - numpy >=1.6
+    - numpy x.x
     - python >=2.7
     - setuptools
     - nfft >=3.2,<3.3
     - gcc
     - cython
   run:
-    - numpy >=1.6
+    - numpy x.x
     - python >=2.7
     - nfft >=3.2,<3.3
     - libgcc

--- a/recipes/pynfft/meta.yaml
+++ b/recipes/pynfft/meta.yaml
@@ -40,4 +40,5 @@ about:
 
 extra:
     recipe-maintainers:
+      - ghisvail
       - grlee77

--- a/recipes/pynfft/meta.yaml
+++ b/recipes/pynfft/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "1.3.2" %}
+
+package:
+  name: pynfft
+  version: {{ version }}
+
+source:
+  fn: pyNFFT-{{ version }}.tar.bz2
+  url: https://pypi.io/packages/source/p/pyNFFT/pyNFFT-{{ version }}.tar.gz
+  md5: d2457a3f43839a8acce3295c60d5e692
+
+build:
+  number: 0
+  skip: True  # [win]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - numpy >=1.6
+    - python >=2.7
+    - setuptools
+    - nfft >=3.2,<3.3
+  run:
+    - numpy >=1.6
+    - python >=2.7
+    - nfft >=3.2,<3.3
+
+test:
+  imports:
+    - pynfft
+  commands:
+    - python -c "from pynfft.nfft import NFFT; plan = NFFT(8, 8)"
+
+about:
+  home: https://github.com/ghisvail/pyNFFT.git
+  license: GPLv3
+  summary: Pythonic bindings around the NFFT library
+
+extra:
+    recipe-maintainers:
+      - grlee77


### PR DESCRIPTION
This PR adds the Non-equispaced fast Fourier transform (NFFT) library and its Python wrappers pyNFFT (similar to pyFFTW for FFTW).

A few notes:
- I have only implemented builds for linux and osx here.  It is possible to build NFFT for Windows, but this seems to require msys2 and MinGW-w64:  https://www-user.tu-chemnitz.de/~potts/nfft/faq.php

- gcc/libgcc on osx are for OpenMP support, which is assumed by the pyNFFT wrappers.

- pyNFFT only supports NFFT 3.2.x, but the most recent version of NFFT is 3.3.1.  Is there a way to make both 3.2.x and 3.3.x versions of NFFT available?  If not, I would prefer to stay at 3.2.4 for pyNFFT compatibility.

- The CUnit package is needed for `make check` with NFFT v3.3.x, but is not used by 3.2.4 so it is currently commented out in the build requirements for NFFT's meta.yaml.  Building CUnit for Windows is supported via `jam` (https://www.freetype.org/jam/), but I haven't attempted to implement that here.
