### PR TITLE
Add a recipe to build scikit-image

### DIFF
--- a/recipes/scikit-image/bld.bat
+++ b/recipes/scikit-image/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/scikit-image/build.sh
+++ b/recipes/scikit-image/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ `uname` == "Darwin" ]
+then
+    export LDFLAGS="-headerpad_max_install_names"
+fi
+
+"${PYTHON}" setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/scikit-image/meta.yaml
+++ b/recipes/scikit-image/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "0.12.3" %}
+
+package:
+  name: scikit-image
+  version: {{ version }}
+
+source:
+  fn: scikit-image-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/scikit-image/scikit-image-{{ version }}.tar.gz
+  md5: 04ea833383e0b6ad5f65da21292c25e1
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - setuptools
+    - cython
+    - python
+    - six
+    - numpy x.x
+    - scipy
+  run:
+    - python
+    - six
+    - numpy x.x
+    - scipy
+    - matplotlib
+    - networkx
+    - pillow
+
+test:
+  imports:
+    - skimage
+
+about:
+  home: http://scikit-image.org/
+  license: BSD 3-Clause
+  summary: Image processing routines for SciPy
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/scikit-image/meta.yaml
+++ b/recipes/scikit-image/meta.yaml
@@ -41,4 +41,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - ivoflipse
     - jakirkham
+    - Korijn
+    - msarahan

--- a/recipes/scikit-image/meta.yaml
+++ b/recipes/scikit-image/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:


### PR DESCRIPTION
This adds a recipe to build scikit-image. It is loosely based off of the one from conda-recipes, but has been modified quite a bit.

Note: `conda skeleton pypi` did not work here and the recipe in conda-recipes is pretty out of date. So, this may need a bit of love.