### PR TITLE
Add qtconsole

### DIFF
--- a/recipes/qtconsole/meta.yaml
+++ b/recipes/qtconsole/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = "4.2.1" %}
+
+package:
+  name: qtconsole
+  version: {{ version }}
+
+source:
+  fn: qtconsole-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/q/qtconsole/qtconsole-{{ version }}.tar.gz
+  md5: c08ebebc7a60629ebadf685361ca0798
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - ipykernel >=4.1
+    - jupyter_client >=4.1
+    - jupyter_core
+    - pygments
+    - pyqt
+    - traitlets
+
+  run:
+    - python
+    - ipykernel >=4.1
+    - jupyter_client >=4.1
+    - jupyter_core
+    - pygments
+    - pyqt
+    - traitlets
+
+test:
+  commands:
+    - jupyter qtconsole --help                                              # [not linux]
+    - DISPLAY=localhost:1.0 xvfb-run -a bash -c 'jupyter qtconsole --help'  # [linux]
+
+  imports:
+    - qtconsole
+    - qtconsole.tests
+
+about:
+  home: http://jupyter.org
+  license: BSD 3-Clause
+  summary: Jupyter Qt console
+
+extra:
+  recipe-maintainers:
+    - Carreau
+    - ccordoba12
+    - jakirkham
+    - minrk
+    - takluyver

--- a/recipes/qtconsole/yum_requirements.txt
+++ b/recipes/qtconsole/yum_requirements.txt
@@ -1,0 +1,1 @@
+xorg-x11-server-Xvfb


### PR DESCRIPTION
Adds Jupyter's qtconsole. Basically generated by using `conda skeleton pypi`, cleaning up a bit, and adding the dependencies that the the `defaults` version had.