### PR TITLE
Unpin `conda-build` on Travis CI

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -11,7 +11,7 @@ if [ -z "$GH_TOKEN" ]; then
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
     conda install --yes --quiet conda-build-all
-    conda install --yes --quiet conda-build=1.20.0 jinja2 anaconda-client setuptools
+    conda install --yes --quiet conda-build jinja2 anaconda-client setuptools
 
     # We don't need to build the example recipe.
     rm -rf ./recipes/example


### PR DESCRIPTION
Reverts https://github.com/conda-forge/staged-recipes/pull/488

Reverts the pinning introduced in this PR ( https://github.com/conda-forge/staged-recipes/pull/488 ). As 1.20.2 is out soon and it should fix a shebang bug ( https://github.com/conda/conda-build/issues/889 ) we were running into on Travis CI, we should upgrade to it. Corresponding change proposed to `conda-smithy` in this PR ( https://github.com/conda-forge/conda-smithy/pull/173 ).