### PR TITLE
WIP*2: Add trollius

### DIFF
--- a/trollius/bld.bat
+++ b/trollius/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/trollius/build.sh
+++ b/trollius/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/trollius/meta.yaml
+++ b/trollius/meta.yaml
@@ -1,0 +1,65 @@
+package:
+  name: trollius
+  version: "2.1"
+
+source:
+  fn: trollius-2.1.tar.gz
+  url: https://pypi.python.org/packages/6e/72/5940cfb765488cfe1b62883a0d0e5438f4fc17cfefd4fb4654a5982be852/trollius-2.1.tar.gz
+  md5: 0b36ff1057cb5a93befe7d8ef0edcbf8
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - trollius = trollius:main
+    #
+    # Would create an entry point called trollius that calls trollius.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+    - futures
+
+  run:
+    - python
+    - six
+    - futures
+
+test:
+  # Python imports
+  imports:
+    - trollius
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/haypo/trollius
+  license: Apache Software License
+  summary: 'Port of the Tulip project (asyncio module, PEP 3156) on Python 2'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Adds a recipe to build `trollius`. This is the Python 2 backport of `asyncio`. It is still compatible with Python 3, as well. However, it is minimal maintenance support at this point. So, might not be an ideal dependency.
