### PR TITLE
Revert `conda-build` 1.20.0 downgrade to Python 3.4 64-bit AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,9 +76,6 @@ install:
     - cmd: conda config --add channels conda-forge
     - cmd: conda install --yes --quiet obvious-ci conda-build-all
     - cmd: obvci_install_conda_build_tools.py
-    # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: remove this once a new conda-build is released!
-    - cmd: conda install --yes conda-build=1.20.0
     - cmd: conda info
 
 # Skip .NET project specific build phase.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,9 +77,8 @@ install:
     - cmd: conda install --yes --quiet obvious-ci conda-build-all
     - cmd: obvci_install_conda_build_tools.py
     # Workaround for Python 3.4 and x64 bug in latest conda-build.
-    # FIXME: Remove once there is a release that fixes the upstream issue
-    # ( https://github.com/conda/conda-build/issues/895 ).
-    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
+    # FIXME: remove this once a new conda-build is released!
+    - cmd: conda install --yes conda-build=1.20.0
     - cmd: conda info
 
 # Skip .NET project specific build phase.


### PR DESCRIPTION
Reverts this PR ( https://github.com/conda-forge/staged-recipes/pull/455 ) and this PR ( https://github.com/conda-forge/staged-recipes/pull/452 ) that came before it.

This was a workaround for `conda-build` 1.20.1 on AppVeyor Python 3.4 64-bit builds due to this issue ( https://github.com/conda/conda-build/issues/895 ), which was discussed in this issue ( https://github.com/conda-forge/staged-recipes/issues/448 ) at some length by various affected parties. This is believed to be fixed in `conda-build` 1.20.2; so, we are unpinning it here. A similar change has been proposed to `conda-smithy` ( https://github.com/conda-forge/conda-smithy/pull/170 ).