### PR TITLE
CI: Do not make `pip` and `setuptools` dependencies of `python`

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -9,6 +9,7 @@ if [ -z "$GH_TOKEN" ]; then
     wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     conda config --set show_channel_urls true
+    conda config --set add_pip_as_python_depedency false
     conda config --add channels conda-forge
     conda install --yes --quiet conda-build-all
     conda install --yes --quiet conda-build=1.20.0 jinja2 anaconda-client setuptools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ install:
             {$root = "C:\Miniconda-x64"}
           $env:path="$root;$root\Scripts;$root\Library\bin;$($env:path)"
     - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --set add_pip_as_python_depedency false
     - cmd: conda update --yes --quiet conda
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -13,6 +13,7 @@ channels:
 
 always_yes: true
 show_channel_urls: true
+add_pip_as_python_depedency: false
 
 CONDARC
 )


### PR DESCRIPTION
This disables adding `pip` and `setuptools` as dependencies of `python`. By doing this, it should make it easier for us to figure out if something requires `setuptools` to install as it will error out if `setuptools` is not listed as a build dependency. Similar, nothing will be able to try to use `pip` to install stuff. This will make it easier to figure out what dependencies we are missing on a package. Further, this will be helpful for packaging `pip` ( https://github.com/conda-forge/staged-recipes/pull/552 ) and `setuptools` ( https://github.com/conda-forge/staged-recipes/pull/551 ) too.

Related change proposed to `conda-smithy` in this PR ( https://github.com/conda-forge/conda-smithy/pull/172 ).

cc @pelson @ocefpaf @msarahan @jjhelmus