### PR TITLE
WIP: Add python-toolchain

### DIFF
--- a/recipes/python-toolchain/activate.bat
+++ b/recipes/python-toolchain/activate.bat
@@ -1,0 +1,2 @@
+:: handle conda...      >=4.1.3        <= 4.1.2
+set "PIP_CONFIG_FILE=%CONDA_PREFIX%%CONDA_ENV_PATH%\etc\pip.conf"

--- a/recipes/python-toolchain/activate.sh
+++ b/recipes/python-toolchain/activate.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# handle conda...           >=4.1.3         <= 4.1.2
+export PIP_CONFIG_FILE="${CONDA_PREFIX}${CONDA_ENV_PATH}/etc/pip.conf"

--- a/recipes/python-toolchain/bld.bat
+++ b/recipes/python-toolchain/bld.bat
@@ -11,3 +11,12 @@ IF NOT EXIST "%LIBRARY_PREFIX%\etc" mkdir "%LIBRARY_PREFIX%\etc"
 if errorlevel 1 exit 1
 copy "%RECIPE_DIR%\pip.conf" "%LIBRARY_PREFIX%\etc\pip.conf"
 if errorlevel 1 exit 1
+
+:: Copy the [de]activate scripts to %PREFIX%\etc\conda\[de]activate.d.
+:: This will allow them to be run on environment activation.
+FOR %%F IN (activate deactivate) DO (
+    IF NOT EXIST "%PREFIX%\etc\conda\%%F.d" MKDIR "%PREFIX%\etc\conda\%%F.d"
+    if errorlevel 1 exit 1
+    COPY "%RECIPE_DIR%\%%F.bat" "%PREFIX%\etc\conda\%%F.d\python-toolchain_%%F.bat"
+    if errorlevel 1 exit 1
+)

--- a/recipes/python-toolchain/bld.bat
+++ b/recipes/python-toolchain/bld.bat
@@ -1,0 +1,13 @@
+:: Print all of the commands run.
+echo on
+
+:: This works for `setuptools`, but breaks `distutils`.
+:: Will need to figure out a better long term strategy.
+copy "%RECIPE_DIR%\distutils.cfg" "%STDLIB_DIR%\distutils\distutils.cfg"
+if errorlevel 1 exit 1
+
+:: Configure `pip`.
+IF NOT EXIST "%LIBRARY_PREFIX%\etc" mkdir "%LIBRARY_PREFIX%\etc"
+if errorlevel 1 exit 1
+copy "%RECIPE_DIR%\pip.conf" "%LIBRARY_PREFIX%\etc\pip.conf"
+if errorlevel 1 exit 1

--- a/recipes/python-toolchain/build.sh
+++ b/recipes/python-toolchain/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+
+# This works for `setuptools`, but breaks `distutils`.
+# Will need to figure out a better long term strategy.
+cp "${RECIPE_DIR}/distutils.cfg" "${STDLIB_DIR}/distutils/distutils.cfg"
+
+# Configure `pip`.
+mkdir -p "${PREFIX}/etc"
+cp "${RECIPE_DIR}/pip.conf" "${PREFIX}/etc/pip.conf"

--- a/recipes/python-toolchain/build.sh
+++ b/recipes/python-toolchain/build.sh
@@ -8,3 +8,11 @@ cp "${RECIPE_DIR}/distutils.cfg" "${STDLIB_DIR}/distutils/distutils.cfg"
 # Configure `pip`.
 mkdir -p "${PREFIX}/etc"
 cp "${RECIPE_DIR}/pip.conf" "${PREFIX}/etc/pip.conf"
+
+# Copy the [de]activate scripts to $PREFIX/etc/conda/[de]activate.d.
+# This will allow them to be run on environment activation.
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/python-toolchain_${CHANGE}.sh"
+done

--- a/recipes/python-toolchain/deactivate.bat
+++ b/recipes/python-toolchain/deactivate.bat
@@ -1,0 +1,1 @@
+set "PIP_CONFIG_FILE="

--- a/recipes/python-toolchain/deactivate.sh
+++ b/recipes/python-toolchain/deactivate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+unset PIP_CONFIG_FILE

--- a/recipes/python-toolchain/distutils.cfg
+++ b/recipes/python-toolchain/distutils.cfg
@@ -1,0 +1,3 @@
+[install]
+single-version-externally-managed = true
+record = record.txt

--- a/recipes/python-toolchain/meta.yaml
+++ b/recipes/python-toolchain/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: python-toolchain
+  version: 1.0.0
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  commands:
+    # Configure `STDLIB_DIR` location.
+    - python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())' > temp.txt
+    - export STDLIB_DIR="$(cat temp.txt)"                                  # [unix]
+    - set /p STDLIB_DIR=<temp.txt                                          # [win]
+
+    # Test configuration files are in place.
+    - test -f "${PREFIX}/etc/pip.conf"                                     # [unix]
+    - test -f "${STDLIB_DIR}/../distutils/distutils.cfg"                   # [unix]
+    - if not exist "%LIBRARY_PREFIX%\\etc\\pip.conf" exit 1                # [win]
+    - if not exist "%STDLIB_DIR%\\..\\distutils\\distutils.cfg" exit 1     # [win]
+
+about:
+  home: https://github.com/conda-forge/python-toolchain-feedstock
+  license: BSD 3-Clause
+  summary: A meta-package to enable the right python-toolchain.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/python-toolchain/meta.yaml
+++ b/recipes/python-toolchain/meta.yaml
@@ -25,6 +25,12 @@ test:
     - if not exist "%LIBRARY_PREFIX%\\etc\\pip.conf" exit 1                # [win]
     - if not exist "%STDLIB_DIR%\\..\\distutils\\distutils.cfg" exit 1     # [win]
 
+    # Verify the scripts are in-place.
+    {% for state in ["activate", "deactivate"] %}
+    - test -f "${PREFIX}/etc/conda/{{ state }}.d/python-toolchain_{{ state }}.sh"                        # [unix]
+    - if not exist %PREFIX%\\etc\\conda\\{{ state }}.d\\python-toolchain_{{ state }}.bat exit 1  # [win]
+    {% endfor %}
+
 about:
   home: https://github.com/conda-forge/python-toolchain-feedstock
   license: BSD 3-Clause

--- a/recipes/python-toolchain/meta.yaml
+++ b/recipes/python-toolchain/meta.yaml
@@ -11,6 +11,8 @@ requirements:
 
   run:
     - python
+    - setuptools
+    - pip
 
 test:
   commands:

--- a/recipes/python-toolchain/pip.conf
+++ b/recipes/python-toolchain/pip.conf
@@ -1,0 +1,4 @@
+[install]
+ignore-installed = true
+no-dependencies = true
+use-wheel = false


### PR DESCRIPTION
Partially resolves: https://github.com/conda-forge/staged-recipes/issues/528

This is a "toolchain" for configuring our Python installs. This PR includes a few pieces that still need a bit more polishing.

As a note, this package is designed intentionally to not overlap with the `toolchain` package. The reason is the `toolchain` package implies compilation happens, which is an important piece of information to make clear and distinct. By keeping the `toolchain` package for compiling, it makes it easy for someone to know if compilation is done in a recipe. We do not want to mix this up with Python packages and lose this very important piece of information. This package provided here is only useful for Python builds and does not configure compilers. Though the two could be combined together when both are needed.

The first piece added here are default `setuptools` arguments. One only needs to run `python setup.py install` and add `python-toolchain` as a build dependency to make this work. The only subtle point here is the configuration file we add seems to break `distutils`. However, I don't actually see this as a problem. We simply don't use this toolchain with `distutils`. Also, we can find out pretty quickly whether a package uses `setuptools` or not by doing this experiment. This saves us from hunting around in the code for this information. As we are going to disable the inclusion of `pip`, `setuptools`, and `wheel` as `python` dependencies on the VMs, it will be much easier to tell if something is building with `distutils` or not. Basically, people try not using `python-toolchain` (i.e. using `distutils`). When it fails, it will need the `python-toolchain` added too. The rest happens behind the scenes. We have simplified things for that use case by actually making `setuptools` a run dependency of the `python-toolchain` to ensure it gets pulled into so only the `python-toolchain` will be needed as a dependency. 

The second piece basically this implements the same idea that @minrk described in this [comment](https://github.com/conda-forge/staged-recipes/issues/528#issuecomment-216874083). This works by adding a configuration file to `$PREFIX/etc/pip.conf` or `%LIBRARY_PREFIX\etc\pip.conf` on Windows. As `pip` may not know where to find this file and it will not necessarily look in such places we set `PIP_CONFIG_FILE` in activation scripts to make sure it finds this. In the long run, we will want the functionality asked for in this issue ( https://github.com/conda/conda-build/issues/910 ) to make this work smoothly. In the interim, there is a kludgy one line hack that we can use to get by. In any event, this will allow one to do `pip install .` and everything will work correctly behind the scenes. Just as mentioned in the previous case, we made things easier by making `pip` a runtime dependency of the `python-toolchain`. Should add that regardless of whether the package uses `distutils` or `setuptools`, we still find `pip install .` works fine with the `python-toolchain`.

This package (just as the `toolchain` package) was designed so that it could work locally just as well as it does in the CIs. By doing this, we make it easy for people to debug things locally. A feature that remains useful for more complex problems.

Please provide feedback on this. Also, feel free to take it for a test drive. 🚗

cc @msarahan @ocefpaf @pelson @minrk @scopatz @frol
