### PR TITLE
Add conda dependencies

### DIFF
--- a/recipes/pycosat/meta.yaml
+++ b/recipes/pycosat/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.6.1" %}
+
+package:
+  name: pycosat
+  version: {{ version }}
+
+source:
+  fn: pycosat-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pycosat/pycosat-{{ version }}.tar.gz
+  md5: c1fc35b17865f5f992595ae0362f9f9f
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - pycosat
+
+about:
+  home: https://github.com/ContinuumIO/pycosat
+  license: MIT
+  summary: Bindings to picosat (a SAT solver)
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - kalefranz
+    - mcg1969
+    - msarahan
+    - pelson

--- a/recipes/pycosat/run_test.py
+++ b/recipes/pycosat/run_test.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import sys
+
+
+os.chdir(os.environ["SRC_DIR"])
+subprocess.check_call([sys.executable, "test_pycosat.py"])

--- a/recipes/requests/meta.yaml
+++ b/recipes/requests/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "2.9.2" %}
+
+package:
+  name: requests
+  version: {{ version }}
+
+source:
+  fn: requests-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/r/requests/requests-{{ version }}.tar.gz
+  md5: 18d0e51cd5e84c7d8b6dcbdd51551984
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - requests
+
+about:
+  home: http://python-requests.org
+  license: Apache 2.0
+  summary: Python HTTP for Humans.
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - kalefranz
+    - mcg1969
+    - msarahan
+    - pelson


### PR DESCRIPTION
Broken out from PR ( https://github.com/conda-forge/staged-recipes/pull/656 ).

Adds recipes that either I wrote or used `conda skeleton pypi` to generate and then modified. Having some issue getting the `conda` recipe to build. The rest seem to be doing ok. Maybe we can break out the working ones and merge them first.

@msarahan, I have added you and myself as maintainers on all of these. Please let me know if that is ok. I don't feel a strong need to be a maintainer here, but I thought my handle should be on them as I wrote them.