### PR TITLE
alternative Suitesparse recipe

### DIFF
--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -5,7 +5,7 @@ if [ "$(uname)" == "Linux" ]; then
 
   # build using OpenBLAS
   BLAS='BLAS=-lopenblas'
-  LAPACK='LAPACK=-lopenblas'  # llapack'
+  LAPACK='LAPACK=-lopenblas' # llapack'
 fi
 
 if [ "$(uname)" == "Darwin" ]; then
@@ -32,11 +32,13 @@ fi
 # (optional) write out various make variable settings for debugging purposes
 make config \
     $BLAS \
+    $LAPACK \
     CUDA=no \
     TBB=-ltbb 2>&1 | tee make_config.txt
 
 # enable TBB, disable CUDA
 make $BLAS \
+     $LAPACK \
      CUDA=no \
      TBB=-ltbb
 

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -5,15 +5,15 @@ if [ "$(uname)" == "Linux" ]; then
 
   # build using OpenBLAS
   BLAS='BLAS=-lopenblas'
-  BLAS='LAPACK=-llapack'
+  LAPACK='LAPACK=-llapack'
 fi
 
 if [ "$(uname)" == "Darwin" ]; then
   DYNAMIC_EXT=".dylib"
 
   # if unspecified on OSX BLAS & LAPACK will be get to "-framework Accelerate"
-  BLAS='BLAS=-lopenblas'
-  LAPACK='LAPACK=-llapack'
+  BLAS='' # 'BLAS=-lopenblas'
+  LAPACK='' # 'LAPACK=-llapack'
 fi
 
 # This recipe is currently building the version of METIS included with

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -5,13 +5,15 @@ if [ "$(uname)" == "Linux" ]; then
 
   # build using OpenBLAS
   BLAS='BLAS=-lopenblas'
+  BLAS='LAPACK=-llapack'
 fi
 
 if [ "$(uname)" == "Darwin" ]; then
   DYNAMIC_EXT=".dylib"
 
-  # On OSX BLAS & LAPACK will be set to "-framework Accelerate" instead
-  BLAS=""
+  # if unspecified on OSX BLAS & LAPACK will be get to "-framework Accelerate"
+  BLAS='BLAS=-lopenblas'
+  LAPACK='LAPACK=-llapack'
 fi
 
 # This recipe is currently building the version of METIS included with

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if [ "$(uname)" == "Linux" ]; then
+  DYNAMIC_EXT=".so"
+
+  # build using OpenBLAS
+  BLAS='BLAS=-lopenblas'
+fi
+
+if [ "$(uname)" == "Darwin" ]; then
+  DYNAMIC_EXT=".dylib"
+
+  # On OSX BLAS & LAPACK will be set to "-framework Accelerate" instead
+  BLAS=""
+fi
+
+# This recipe is currently building the version of METIS included with
+# SuiteSparse.  An external METIS library can be used, but only the version
+# included with SuiteSparse will work with the Matlab interface to METIS.
+# (See the SuiteSparse README for more information)
+
+# Notes:
+#    For MKL, set MKLROOT=
+#    To specify a fortran compiler, set F77=
+#    To use external METIS lib, set MY_METIS_LIB=,  MY_METIS_INC=
+
+# (optional) write out various make variable settings for debugging purposes
+make config \
+    $BLAS \
+    CUDA=no \
+    TBB=-ltbb 2>&1 | tee make_config.txt
+
+# enable TBB, disable CUDA
+make $BLAS \
+     CUDA=no \
+     TBB=-ltbb
+
+# make install below fails to link libmetis unless it is copied to $PREFIX/lib
+cp $SRC_DIR/lib/libmetis$DYNAMIC_EXT $PREFIX/lib
+
+# have to specify CUDA=no to avoid attempts to link to libcudart, etc.
+make install metis INSTALL_LIB=$PREFIX/lib \
+             INSTALL_INCLUDE=$PREFIX/include \
+             INSTALL_DOC=$PREFIX/suitesparse_docs \
+             CUDA=no
+
+# remove docs
+rm -rf $PREFIX/suitesparse_docs

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -5,7 +5,7 @@ if [ "$(uname)" == "Linux" ]; then
 
   # build using OpenBLAS
   BLAS='BLAS=-lopenblas'
-  LAPACK='LAPACK=-llapack'
+  LAPACK='LAPACK=-lopenblas'  # llapack'
 fi
 
 if [ "$(uname)" == "Darwin" ]; then

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -14,6 +14,9 @@ if [ "$(uname)" == "Darwin" ]; then
   # if unspecified on OSX BLAS & LAPACK will be get to "-framework Accelerate"
   BLAS='' # 'BLAS=-lopenblas'
   LAPACK='' # 'LAPACK=-llapack'
+
+  # some tests fail to link TBB unless $PREFIX/lib is added to rpath
+  LDFLAGS="$LDFLAGS -Wl,-rpath,${PREFIX}/lib"
 fi
 
 # This recipe is currently building the version of METIS included with

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -46,5 +46,11 @@ make install metis INSTALL_LIB=$PREFIX/lib \
              INSTALL_DOC=$PREFIX/suitesparse_docs \
              CUDA=no
 
+if [ "$(uname)" == "Darwin" ]; then
+
+  install_name_tool -change $SRC_DIR/lib/libmetis.dylib @rpath/libmetis.dylib $PREFIX/lib/libcholmod.dylib
+
+fi
+
 # remove docs
 rm -rf $PREFIX/suitesparse_docs

--- a/recipes/suitesparse/build.sh
+++ b/recipes/suitesparse/build.sh
@@ -4,7 +4,7 @@ if [ "$(uname)" == "Linux" ]; then
   DYNAMIC_EXT=".so"
 
   # build using OpenBLAS
-  BLAS='BLAS=-lopenblas'
+  BLAS='BLAS=-lopenblas -lgfortran'
   LAPACK='LAPACK=-lopenblas' # llapack'
 fi
 

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - tbb
     - blas 1.1 {{ variant }}  # [linux]
     - openblas 0.2.18*  # [linux]
+    # the included METIS package uses cmake
+    - cmake
   run:
     - libgcc
     - tbb

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - openblas 0.2.18*  # [linux]
     # the included METIS package uses cmake
     - cmake
-    # - lapack
+    - lapack
   run:
     - libgcc
     - tbb

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -19,6 +19,7 @@ source:
 
 build:
   number: 0
+  detect_binary_files_with_prefix: True
   skip: True  # [win]
   features:
     - blas_{{ variant }}  # [linux]

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - openblas 0.2.18*  # [linux]
     # the included METIS package uses cmake
     - cmake
+    - lapack
   run:
     - libgcc
     - tbb

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - openblas 0.2.18*  # [linux]
     # the included METIS package uses cmake
     - cmake
-    - lapack
+    # - lapack
   run:
     - libgcc
     - tbb

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -61,7 +61,7 @@ test:
 
 about:
   home: http://faculty.cse.tamu.edu/davis/suitesparse.html
-  license: GPLv3
+  license: LGPL v2 (AMD, BTF, etc), BSD 3-clause (UFget), GPL v2 (UMFPACK, RBIO, SPQR, GPUQRENGINE), Apache 2.0 (Metis)
   summary: SuiteSparse is a suite of sparse matrix algorithms.
 
 extra:

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -1,5 +1,7 @@
 {% set version = "4.5.2" %}
 
+{% set variant = "openblas" %}
+
 # Note: The following fork has a CMAKE build system suitable for windows.
 # https://github.com/jlblancoc/suitesparse-metis-for-windows
 # A conda recipe based on this fork is available at:
@@ -17,16 +19,20 @@ source:
 build:
   number: 0
   skip: True  # [win]
+  features:
+    - blas_{{ variant }}
 
 requirements:
   build:
-    - openblas  # [linux]
     - gcc
     - tbb
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.18*
   run:
-    - openblas  # [linux]
     - libgcc
     - tbb
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.18*
 
 test:
   commands:

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -1,6 +1,7 @@
 {% set version = "4.5.3" %}
 
-{% set variant = "openblas" %}
+{% set variant = "openblas" %}  # [linux]
+{% set variant = "accelerate" %}  # [osx]
 
 # Note: The following fork has a CMAKE build system suitable for windows.
 # https://github.com/jlblancoc/suitesparse-metis-for-windows
@@ -20,19 +21,19 @@ build:
   number: 0
   skip: True  # [win]
   features:
-    - blas_{{ variant }}
+    - blas_{{ variant }}  # [linux]
 
 requirements:
   build:
     - gcc
     - tbb
-    - blas 1.1 {{ variant }}
-    - openblas 0.2.18*
+    - blas 1.1 {{ variant }}  # [linux]
+    - openblas 0.2.18*  # [linux]
   run:
     - libgcc
     - tbb
-    - blas 1.1 {{ variant }}
-    - openblas 0.2.18*
+    - blas 1.1 {{ variant }}  # [linux]
+    - openblas 0.2.18*  # [linux]
 
 test:
   commands:

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.5.2" %}
+{% set version = "4.5.3" %}
 
 {% set variant = "openblas" %}
 
@@ -14,7 +14,7 @@ package:
 source:
   fn: SuiteSparse-{{ version }}.tar.gz
   url: http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-{{ version }}.tar.gz
-  md5: fb582852443ff22b23949d500b3e86e6
+  sha256: 6199a3a35fbce82b155fd2349cf81d2b7cddaf0dac218c08cb172f9bc143f37a
 
 build:
   number: 0

--- a/recipes/suitesparse/meta.yaml
+++ b/recipes/suitesparse/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = "4.5.2" %}
+
+# Note: The following fork has a CMAKE build system suitable for windows.
+# https://github.com/jlblancoc/suitesparse-metis-for-windows
+# A conda recipe based on this fork is available at:
+# https://github.com/menpo/conda-suitesparse
+
+package:
+  name: suitesparse
+  version: {{ version }}
+
+source:
+  fn: SuiteSparse-{{ version }}.tar.gz
+  url: http://faculty.cse.tamu.edu/davis/SuiteSparse/SuiteSparse-{{ version }}.tar.gz
+  md5: fb582852443ff22b23949d500b3e86e6
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - openblas  # [linux]
+    - gcc
+    - tbb
+  run:
+    - openblas  # [linux]
+    - libgcc
+    - tbb
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libamd.so  # [linux]
+    - test -f ${PREFIX}/lib/libamd.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libbtf.so  # [linux]
+    - test -f ${PREFIX}/lib/libbtf.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libcamd.so  # [linux]
+    - test -f ${PREFIX}/lib/libcamd.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libccolamd.so  # [linux]
+    - test -f ${PREFIX}/lib/libccolamd.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libcholmod.so  # [linux]
+    - test -f ${PREFIX}/lib/libcholmod.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libcolamd.so  # [linux]
+    - test -f ${PREFIX}/lib/libcolamd.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libcxsparse.so  # [linux]
+    - test -f ${PREFIX}/lib/libcxsparse.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libklu.so  # [linux]
+    - test -f ${PREFIX}/lib/libklu.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libldl.so  # [linux]
+    - test -f ${PREFIX}/lib/libldl.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libmetis.so  # [linux]
+    - test -f ${PREFIX}/lib/libmetis.dylib  # [osx]
+    - test -f ${PREFIX}/lib/librbio.so  # [linux]
+    - test -f ${PREFIX}/lib/librbio.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libspqr.so  # [linux]
+    - test -f ${PREFIX}/lib/libspqr.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libsuitesparseconfig.so  # [linux]
+    - test -f ${PREFIX}/lib/libsuitesparseconfig.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libumfpack.so  # [linux]
+    - test -f ${PREFIX}/lib/libumfpack.dylib  # [osx]
+
+about:
+  home: http://faculty.cse.tamu.edu/davis/suitesparse.html
+  license: GPLv3
+  summary: SuiteSparse is a suite of sparse matrix algorithms.
+
+extra:
+    recipe-maintainers:
+      - grlee77


### PR DESCRIPTION
I realize there is already a Suitesparse PR in #655, but this is a bit simpler in implementation and is using the most recent release.  This recipe builds shared as opposed to static libraries and I tested that it works with scikit-umfpack (which I can submit a separate PR for).  

I have used both OpenMP and TBB in the builds, but this is optional.  I had problems with openblas on OS X, so I have disabled the BLAS feature on OS X for now.  The build seemed to always want to set "-framework Accelerate" when on mac even when BLAS=-lopenblas was specified.

There is no windows build here, but I found that the menpo channel has such a [recipe](https://github.com/menpo/conda-suitesparse).  They were able to achieve this by basing off of a Suitesparse fork where the build system was changed to cmake.