### PR TITLE
Added python-decorator

### DIFF
--- a/recipes/decorator/meta.yaml
+++ b/recipes/decorator/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "4.0.9" %}
+
+package:
+  name: python-decorator
+  version: {{ version }}
+
+source:
+  fn: decorator-{{ version }}.tar.gz
+  url: https://github.com/micheles/decorator/archive/{{ version }}.tar.gz
+  md5: 53068c3794e500b4832e71ea4c68a8fc
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - decorator
+
+about:
+  home: https://github.com/micheles/decorator
+  license: BSD 3-Clause
+  license_file: LICENSE.txt 
+  summary: Better living through Python with decorators
+
+extra:
+  recipe-maintainers:
+    - msarahan
+    - pelson


### PR DESCRIPTION
Again, the decorator name is a little overloaded when it is Googled (obviously), and have used `python-decorator` rather than the more general `decorator`.

(FWIW https://www.npmjs.com/package/decorator exists)