### PR TITLE
Add backports_abc

### DIFF
--- a/recipes/backports_abc/meta.yaml
+++ b/recipes/backports_abc/meta.yaml
@@ -1,0 +1,35 @@
+{% set version="0.4" %}
+
+package:
+  name: backports_abc
+  version: {{ version }}
+
+source:
+  fn: backports_abc-0.4.tar.gz
+  url: https://pypi.io/packages/source/b/backports_abc/backports_abc-{{ version }}.tar.gz
+  md5: 0b65a216ce9dc9c1a7e20a729dd7c05b
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - backports_abc
+
+about:
+  home: https://github.com/cython/backports_abc
+  license: PSF 2
+  summary: A backport of recent additions to the `collections.abc` module.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for `backports_abc`. Generated the recipe using `conda skeleton pypi` and then cleaned up a bit. This is a dependency of `cython` and (indirectly) the `notebook`.