### PR TITLE
Add funcsigs

### DIFF
--- a/recipes/funcsigs/meta.yaml
+++ b/recipes/funcsigs/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "funcsigs" %}
+{% set version = "1.0.2" %}
+{% set checksum = "a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ checksum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: http://funcsigs.readthedocs.org
+  license: Apache 2.0
+  summary: Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for `funcsigs`, which is a backport of [PEP 362]( https://www.python.org/dev/peps/pep-0362/ ). Generated the recipe with `conda skeleton pypi` and tweaked to fit our standards here.