### PR TITLE
Add singledispatch

### DIFF
--- a/recipes/singledispatch/meta.yaml
+++ b/recipes/singledispatch/meta.yaml
@@ -1,0 +1,37 @@
+{% set version="3.4.0.3" %}
+
+package:
+  name: singledispatch
+  version: {{ version }}
+
+source:
+  fn: singledispatch-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/singledispatch/singledispatch-{{ version }}.tar.gz
+  md5: af2fc6a3d6cc5a02d0bf54d909785fcb
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - singledispatch
+
+about:
+  home: http://docs.python.org/3/library/functools.html#functools.singledispatch
+  license: MIT
+  summary: This library brings functools.singledispatch from Python 3.4 to Python 2.6-3.3.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for `singledispatch`, which is a backport of `functools.singledispatch`. Generated the recipe using `conda skeleton pypi` and cleaned up afterwards to fit our standards.