### PR TITLE
Add python-neo

### DIFF
--- a/recipes/python-neo/meta.yaml
+++ b/recipes/python-neo/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "neo" %}
+{% set version = "0.3.3" %}
+
+package:
+  name: python-{{ name }}
+  version: {{ version }}
+
+source:
+  fn: python-{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: 98e7e8948158f4492fc94d9d44367c91
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >=1.3.0
+    - quantities >=0.9.0
+
+  run:
+    - python
+    - numpy >=1.3.0
+    - quantities >=0.9.0
+
+test:
+  imports:
+    - neo
+    - neo.core
+    - neo.io
+    - neo.test
+    - neo.test.iotest
+
+about:
+  home: http://neuralensemble.org/neo
+  license: BSD 3-Clause
+  summary: A Python package for representing and reading electrophysiology data.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build `neo`. Prefixed with `python-` due to it being a Python package. Generated with `conda skeleton pypi` and cleaned up for addition.