### PR TITLE
CI tweaks

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -6,6 +6,11 @@ export CONDA_NPY=19
 
 # We only build if we aren't a merged PR (that is, only build for PRs).
 if [ -z "$GH_TOKEN" ]; then
+    # Remove homebrew.
+    brew remove --force $(brew list)
+    brew cleanup -s
+    rm -rf $(brew --cache)
+
     # Install and configure conda environment.
     wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
@@ -17,11 +22,6 @@ if [ -z "$GH_TOKEN" ]; then
 
     # We don't need to build the example recipe.
     rm -rf ./recipes/example
-
-    # Remove homebrew.
-    brew remove --force $(brew list)
-    brew cleanup -s
-    rm -rf $(brew --cache)
 
     # We just want to build all of the recipes.
     conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.4"

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -6,6 +6,7 @@ export CONDA_NPY=19
 
 # We only build if we aren't a merged PR (that is, only build for PRs).
 if [ -z "$GH_TOKEN" ]; then
+    # Install and configure conda environment.
     wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     conda config --set show_channel_urls true

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -12,7 +12,7 @@ if [ -z "$GH_TOKEN" ]; then
     conda config --add channels conda-forge
     conda install --yes --quiet conda-build-all
     conda install --yes --quiet conda-forge-build-setup
-    source "`conda info --root`/bin/run_conda_forge_build_setup"
+    source run_conda_forge_build_setup
 
     # We don't need to build the example recipe.
     rm -rf ./recipes/example

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -12,7 +12,7 @@ if [ -z "$GH_TOKEN" ]; then
     rm -rf $(brew --cache)
 
     # Install and configure conda environment.
-    wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+    curl -L -O https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     conda config --set show_channel_urls true
     conda config --add channels conda-forge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,6 @@ install:
 
     - cmd: conda config --add channels conda-forge
     - cmd: conda install --yes --quiet obvious-ci conda-build-all
-    - cmd: obvci_install_conda_build_tools.py
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -38,7 +38,7 @@ conda clean --lock
 conda update conda conda-build
 conda install conda-build-all
 conda install conda-forge-build-setup
-source "\`conda info --root\`/bin/run_conda_forge_build_setup"
+source run_conda_forge_build_setup
 
 # We don't need to build the example recipe.
 rm -rf /conda-recipes/example


### PR DESCRIPTION
Follow-up to https://github.com/conda-forge/staged-recipes/pull/705

Tries to make a few minor tweaks.

* Drop use of `conda info --root`.
* Drop call to `obvci_install_conda_build_tools.py` on AppVeyor as it doesn't do anything.

cc @pelson