### PR TITLE
add scikit-sparse

### DIFF
--- a/recipes/scikit-sparse/build.sh
+++ b/recipes/scikit-sparse/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib"
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/scikit-sparse/meta.yaml
+++ b/recipes/scikit-sparse/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - numpy x.x
     - scipy
     - suitesparse
+    - setuptools
 
 test:
   requires:

--- a/recipes/scikit-sparse/meta.yaml
+++ b/recipes/scikit-sparse/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.3" %}
+
+package:
+  name: scikit-sparse
+  version: {{ version }}
+
+source:
+  fn: scikit-sparse--{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/scikit-sparse/scikit-sparse-{{ version }}.tar.gz
+  sha256: 2456be16e65bb8126ea7b9a3b175282b396d07ebeb0b4c5ac85d707bfc977008
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - python
+    - numpy x.x
+    - suitesparse
+    - cython
+    - setuptools
+  run:
+    - python
+    - numpy x.x
+    - scipy
+    - suitesparse
+
+test:
+  requires:
+    - nose
+  imports:
+    - sksparse
+    - sksparse.cholmod
+  commands:
+    - nosetests -sv sksparse
+
+about:
+  home: https://github.com/scikit-sparse/scikit-sparse
+  license: BSD 2-clause
+  summary: A companion to the scipy.sparse library for sparse matrix manipulation in Python.
+
+extra:
+    recipe-maintainers:
+      - grlee77

--- a/recipes/scikit-sparse/meta.yaml
+++ b/recipes/scikit-sparse/meta.yaml
@@ -25,11 +25,11 @@ requirements:
     - numpy x.x
     - scipy
     - suitesparse
-    - setuptools
 
 test:
   requires:
     - nose
+    - setuptools
   imports:
     - sksparse
     - sksparse.cholmod


### PR DESCRIPTION
This python package wraps the CHOLMOD functionality from SuiteSparse and is complementary to scikit-umfpack (#683).

Note that the wrapper code here is BSD 2-clause, but the underlying CHOLMOD library from SuiteSparse is LGPL v2.1 which is perhaps the more relevant constraint for other projects wanting to use this.  Should that be noted in the license section? 

also, any other volunteers for maintaining?