### PR TITLE
Try to fix travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,6 +77,7 @@ install:
     - cmd: obvci_install_conda_build_tools.py
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
+    - cmd: conda install --yes --quiet conda-build=1.20.0
 
 # Skip .NET project specific build phase.
 build: off

--- a/recipes/python-eccodes/meta.yaml
+++ b/recipes/python-eccodes/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or py3k]
+  skip: True  # [win]
+  skip: True  # [py3k]
   detect_binary_files_with_prefix: true
 
 requirements:


### PR DESCRIPTION
Not sure what is going on but Travis-CI is trying to build `python-eccodes` on Windows even with the `skip` flag.

```shell
conda.resolve.NoPackagesFound:  Packages missing in current win-32 channels: 
  - jasper
  - eccodes 0.13.0
```

Maybe I am missing something obvious. Let's see if this PR fixes it: