### PR TITLE
Add wincertstore

### DIFF
--- a/recipes/wincertstore/meta.yaml
+++ b/recipes/wincertstore/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "wincertstore" %}
+{% set version = "0.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  md5: ae728f2f007185648d0c7a8679b361e2
+
+build:
+  number: 0
+  skip: true  # [not win]
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://bitbucket.org/tiran/wincertstore
+  license: PSF 2
+  summary: Python module to extract CA and CRL certs from Windows' cert store (ctypes based).
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - patricksnape


### PR DESCRIPTION
Add a recipe to build `wincertstore`. Written from scratch. Feedback welcome.

This is used by `setuptools` and others to make sure there are certificates on Windows that one can use with Python.

cc @msarahan