### PR TITLE
adding deap

### DIFF
--- a/recipes/deap/meta.yaml
+++ b/recipes/deap/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.0.2.post2" %}
+{% set gh_org = "DEAP" %}
+{% set gh_repo = "deap" %}
+{% set pkg_name = "DEAP" %}
+{% set commit = "a4dc75208662ce40158ba0c9eb0045d0bcc66d70" %}
+
+package:
+  name: {{ gh_repo }}
+  version: {{ version }}
+
+source:
+  fn: {{ gh_repo }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ gh_repo[0] }}/{{ gh_repo }}/{{ gh_repo }}-{{ version }}.tar.gz
+  sha256: c52bd32b8f0143db3a0b90f2b976c920b588638d6999ca0d038d8b1c07f7950b
+
+build:
+  number: 0
+  script:
+    - python setup.py install
+
+requirements:
+  build:
+    - numpy
+    - pypandoc
+    - python
+
+  run:
+    - python
+    - numpy
+
+test:
+  requires:
+    - numpy
+    - python
+  imports:
+    - deap
+
+about:
+  home: https://github.com/{{ gh_org }}/{{ gh_repo }}
+  license: LGPL
+  summary: Distributed Evolutionary Algorithms in Python
+
+extra:
+  recipe-maintainers:
+    - bollwyvl
+    - rhiever
+    - tonyfast

--- a/recipes/deap/meta.yaml
+++ b/recipes/deap/meta.yaml
@@ -37,7 +37,7 @@ test:
 
 about:
   home: https://github.com/{{ gh_org }}/{{ gh_repo }}
-  license: LGPL
+  license: LGPL-3.0
   summary: Distributed Evolutionary Algorithms in Python
 
 extra:


### PR DESCRIPTION
This adds deap 1.0.2.

The tests are basically broken, so I'm not running them... I have built against master, but 1.0.2.post2 is what people have been using for a while so i guess we can wait: when 2.0 comes along (soon, perhaps?) there will be more build-chain, the tests will work, and maybe not use 2to3!