### PR TITLE
WIP: Trigger docs

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -11,4 +11,8 @@ if [ -n "$GH_TOKEN" ]; then
     conda install --yes --quiet conda-smithy
 
     python .CI/create_feedstocks.py
+
+    # If we have got this far and we have a GH_TOKEN, trigger the conda-forge.github.io
+    # travis suite to run (this builds docs etc.)
+    python .CI/trigger_travis_conda-forge.github.io.py
 fi

--- a/.CI/trigger_travis_conda-forge.github.io.py
+++ b/.CI/trigger_travis_conda-forge.github.io.py
@@ -1,0 +1,39 @@
+"""
+Trigger the conda-forge.github.io Travis job to restart.
+
+"""
+import requests
+import six
+
+import conda_smithy.ci_register
+from conda_smithy.github import gh_token
+
+
+def rebuild_travis(gh_token, repo_slug):
+    headers = {
+               # If the user-agent isn't defined correctly, we will recieve a 403.
+               'User-Agent': 'MyClient/1.0.0',
+               'Accept': 'application/vnd.travis-ci.2+json',
+               }
+    url = 'https://api.travis-ci.org/auth/github'
+    data = {"github_token": gh_token}
+    response = requests.post(url, json=data, headers=headers)
+    if response.status_code != 201:
+        response.raise_for_status()
+    
+    token = response.json()['access_token']
+    headers['Authorization'] = 'token {}'.format(token)
+
+    # If we don't specify API the version, we get a 404.
+    headers.update({'Travis-API-Version': '3'})
+    
+    encoded_slug = six.moves.urllib.parse.quote(repo_slug, safe='')
+    url = 'https://api.travis-ci.org/repo/{}/requests'.format(encoded_slug)
+    response = requests.post(url, json={"request": {"branch": "master"}},
+                             headers=headers)
+    if response.status_code != 201:
+        response.raise_for_status()
+
+
+if __name__ == '__main__':
+    rebuild_travis(gh_token(), 'conda-forge/conda-forge.github.io')

--- a/.CI/trigger_travis_conda-forge.github.io.py
+++ b/.CI/trigger_travis_conda-forge.github.io.py
@@ -29,8 +29,20 @@ def rebuild_travis(gh_token, repo_slug):
     
     encoded_slug = six.moves.urllib.parse.quote(repo_slug, safe='')
     url = 'https://api.travis-ci.org/repo/{}/requests'.format(encoded_slug)
-    response = requests.post(url, json={"request": {"branch": "master"}},
-                             headers=headers)
+    response = requests.post(
+        url,
+        json={
+            "request": {
+                "branch": "master",
+                "config": {
+                    "env": {
+                        "matrix": ['ACTION="update_docs"']
+                    }
+                }
+            }
+        },
+        headers=headers
+    )
     if response.status_code != 201:
         response.raise_for_status()
 


### PR DESCRIPTION
This reverts commit ( https://github.com/conda-forge/staged-recipes/commit/0105f74fbec1ad28ddbd9c9e7b57f8905a4c3fd7 ) thus bringing back the Travis CI trigger script. It also changes the script so that it only triggers the doc portion of the build only. The change is inspired by the [docs]( https://docs.travis-ci.com/user/triggering-builds ) showing a similar use-case. While I expect this *should* work, it is in need of review.

cc @pelson