### PR TITLE
Add statuspage

### DIFF
--- a/recipes/statuspage/activate.sh
+++ b/recipes/statuspage/activate.sh
@@ -1,0 +1,3 @@
+# handle conda...      >=4.1.3        <= 4.1.2
+export SSL_CERT_DIR="${CONDA_PREFIX}${CONDA_ENV_PATH}/ssl"
+export SSL_CERT_FILE="${SSL_CERT_DIR}/cacert.pem"

--- a/recipes/statuspage/build.sh
+++ b/recipes/statuspage/build.sh
@@ -1,0 +1,34 @@
+# Info about the PyGithub development version we want to install.
+PYGITHUB_COMMIT="8bb765a2dacfac73e98d09191e1decb2bdbe2584"
+PYGITHUB_CHECKSUM="9d653d58cdacac2161d85788e31f5ddb25d8bbd57361da27810ca2f7accfc0f8"
+
+# Install a development build of PyGithub.
+# This is a workaround for the fact there is no PyGithub release with the changes needed.
+# See PR ( https://github.com/conda-forge/pygithub-feedstock/pull/9 ).
+# Also see PR ( https://github.com/PyGithub/PyGithub/pull/379 ).
+curl -L "https://github.com/PyGithub/PyGithub/archive/${PYGITHUB_COMMIT}.tar.gz" > PyGithub.tar.gz
+openssl sha256 PyGithub.tar.gz | grep "${PYGITHUB_CHECKSUM}"
+mkdir PyGithub
+tar -xzf PyGithub.tar.gz -C PyGithub --strip-components=1
+rm -f PyGithub.tar.gz
+pushd PyGithub
+python setup.py install --single-version-externally-managed --record=record.txt
+popd
+rm -rf PyGithub
+
+# Build and install statuspage as a single binary with PyInstaller.
+pyinstaller -p "${PREFIX}/lib:${SP_DIR}" statuspage/statuspage.spec
+cp dist/statuspage "${PREFIX}/bin/"
+chmod +x "${PREFIX}/bin/statuspage"
+
+# Remove PyGithub development version install.
+rm -rf "${SP_DIR}"
+
+# Install [de]activation scripts for determining where to find the certificates.
+# This is a workaround for the fact that this has not been added to `ca-certificates`.
+# See PR ( https://github.com/conda-forge/ca-certificates-feedstock/pull/4 ).
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
+done

--- a/recipes/statuspage/deactivate.sh
+++ b/recipes/statuspage/deactivate.sh
@@ -1,0 +1,2 @@
+unset SSL_CERT_DIR
+unset SSL_CERT_FILE

--- a/recipes/statuspage/meta.yaml
+++ b/recipes/statuspage/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.3.3" %}
+
+package:
+  name: statuspage
+  version: {{ version }}
+
+source:
+  fn: python-statuspage-{{ version }}.tar.gz
+  url: https://github.com/jayfk/statuspage/archive/{{ version }}.tar.gz
+  sha256: 5c300579f69afcc969c813160147a0478270bad533a6a925df4d624c9501991d
+
+build:
+  number: 0
+  skip: true  # [win or py3k]
+
+requirements:
+  build:
+    - curl
+    - python
+    - openssl
+    - setuptools
+    - packaging
+    - pyinstaller
+    - click
+    - jinja2
+    - tqdm
+    - six
+
+  run:
+    - ca-certificates
+
+test:
+  commands:
+    - statuspage --help
+
+about:
+  home: https://github.com/jayfk/statuspage
+  license: MIT
+  summary: A statuspage generator that lets you host your statuspage for free on Github.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
The purpose here is to package [statuspage]( https://github.com/jayfk/statuspage/ ). However, it became clear that statuspage itself was providing binaries. So, in an attempt to build from source, we ended up with things like waf and PyInstaller. These have all either been written from scratch or added via `conda skeleton pypi` and tweaked.