### PR TITLE
New recipe for autopep8

### DIFF
--- a/recipes/autopep8/meta.yaml
+++ b/recipes/autopep8/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "1.2.4" %}
+package:
+  name: autopep8
+  version: {{ version }}
+
+source:
+  fn: autopep8-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/a/autopep8/autopep8-1.2.4.tar.gz
+  md5: fcea19c0c5e505b425e2a78afb771f5c
+
+build:
+  entry_points:
+    - autopep8 = autopep8:main
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pep8 >=1.5.7
+
+  run:
+    - python
+    - pep8 >=1.5.7
+
+test:
+  commands:
+    - autopep8 --help
+    - autopep8 --version
+
+about:
+  home: https://github.com/hhatto/autopep8
+  license: MIT License
+  summary: 'A tool that automatically formats Python code to conform to the PEP 8 style guide'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/autopep8/meta.yaml
+++ b/recipes/autopep8/meta.yaml
@@ -19,11 +19,11 @@ requirements:
   build:
     - python
     - setuptools
-    - pep8 >=1.5.7
+    - pycodestyle >=2.0
 
   run:
     - python
-    - pep8 >=1.5.7
+    - pycodestyle >=2.0
 
 test:
   commands:

--- a/recipes/autopep8/meta.yaml
+++ b/recipes/autopep8/meta.yaml
@@ -19,11 +19,11 @@ requirements:
   build:
     - python
     - setuptools
-    - pycodestyle >=2.0
+    - pep8 >=1.5.7
 
   run:
     - python
-    - pycodestyle >=2.0
+    - pep8 >=1.5.7
 
 test:
   commands:


### PR DESCRIPTION
New recipe for `autopep8`, based on a new fork of staged-recipes. (Rebasing is no fun.) Swapped out the pep8 requirements for a `pycodestyle` requirement, which matches the current state of the `autopep8` repo on github. (Not sure that it squares with pypi.)