### PR TITLE
WIP: Pin conda-build-all to version 0.12.0

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -19,6 +19,7 @@ if [ -z "$GH_TOKEN" ]; then
     conda install --yes --quiet conda-build-all=0.12.0
     conda install --yes --quiet conda-forge-build-setup
     source run_conda_forge_build_setup
+    conda install --yes --quiet conda-build=1.20.3
 
     # We don't need to build the example recipe.
     rm -rf ./recipes/example

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -16,7 +16,7 @@ if [ -z "$GH_TOKEN" ]; then
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
-    conda install --yes --quiet conda-build-all
+    conda install --yes --quiet conda-build-all=0.12.0
     conda install --yes --quiet conda-forge-build-setup
     source run_conda_forge_build_setup
 

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -16,9 +16,10 @@ if [ -z "$GH_TOKEN" ]; then
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
-    conda install --yes --quiet conda-build-all=0.12.0
+    conda install --yes --quiet conda-build-all
     conda install --yes --quiet conda-forge-build-setup
     source run_conda_forge_build_setup
+    conda install --yes --quiet conda-build-all=0.12.0
     conda install --yes --quiet conda-build=1.20.3
 
     # We don't need to build the example recipe.

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -11,6 +11,7 @@ if [ -n "$GH_TOKEN" ]; then
     conda install --yes --quiet conda-smithy
     # Temporary workaround b/c conda-build-all 0.13.0 does not work with the latest conda-build.
     conda install -n root --yes --quiet conda-build-all=0.12.0
+    conda install --yes --quiet conda-build=1.20.3
 
     python .CI/create_feedstocks.py
 fi

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -9,8 +9,8 @@ if [ -n "$GH_TOKEN" ]; then
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
     conda install --yes --quiet conda-smithy
-    # Temporary workaround b/c conda-build-all is not ready for the latest conda-build.
-    conda install -n root --yes --quiet conda-build=1.20.1
+    # Temporary workaround b/c conda-build-all 0.13.0 does not work with the latest conda-build.
+    conda install -n root --yes --quiet conda-build-all=0.12.0
 
     python .CI/create_feedstocks.py
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
     - cmd: conda update --yes --quiet conda
 
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install --yes --quiet obvious-ci conda-build-all
+    - cmd: conda install --yes --quiet obvious-ci conda-build-all=0.12.0
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,10 +73,12 @@ install:
     - cmd: conda update --yes --quiet conda
 
     - cmd: conda config --add channels conda-forge
-    - cmd: conda install --yes --quiet obvious-ci conda-build-all=0.12.0
+    - cmd: conda install --yes --quiet obvious-ci conda-build-all
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
+    - cmd: conda install --yes --quiet conda-build-all=0.12.0
     - cmd: conda install --yes --quiet conda-build=1.20.3
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,6 +76,7 @@ install:
     - cmd: conda install --yes --quiet obvious-ci conda-build-all=0.12.0
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
+    - cmd: conda install --yes --quiet conda-build=1.20.3
 
 # Skip .NET project specific build phase.
 build: off

--- a/recipes/python-eccodes/build.sh
+++ b/recipes/python-eccodes/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+if [[ $(uname) == Darwin ]]; then
+  export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [[ $(uname) == Linux ]]; then
+  export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+export PYTHON="$PYTHON"
+export PYTHON_LDFLAGS="$PREFIX/lib"
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
+export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
+
+src_dir="$(pwd)"
+mkdir ../build
+cd ../build
+cmake $src_dir \
+         -DCMAKE_INSTALL_PREFIX=$PREFIX \
+         -DENABLE_JPG=1 \
+         -DENABLE_NETCDF=1 \
+         -DENABLE_PNG=1 \
+         -DENABLE_PYTHON=1 \
+         -DENABLE_FORTRAN=0
+
+make
+make install
+
+if [[ $(uname) == Darwin ]]; then
+  ln -s $SP_DIR/gribapi/_gribapi_swig.dylib $SP_DIR/gribapi/_gribapi_swig.so
+fi

--- a/recipes/python-eccodes/meta.yaml
+++ b/recipes/python-eccodes/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "0.13.0" %}
+
+package:
+  name: python-eccodes
+  version: {{ version }}
+
+source:
+  url: https://software.ecmwf.int/wiki/download/attachments/45757960/eccodes-{{ version }}-Source.tar.gz
+  fn: eccodes-{{ version }}-Source.tar.gz
+  md5: 46a0a520f647cfa2fb5f287f22269603
+
+build:
+  number: 0
+  skip: True  # [win or py3k]
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - cmake
+    - python
+    - numpy x.x
+    - boost 1.61.*
+    - jasper
+    - libpng >=1.6.21,<1.7
+    - libnetcdf 4.4.*
+    - perl >=5.20
+    - eccodes {{ version }}
+  run:
+    - python
+    - numpy x.x
+    - boost 1.61.*
+    - jasper
+    - libpng >=1.6.21,<1.7
+    - libnetcdf 4.4.*
+    - perl >=5.20
+    - eccodes {{ version }}
+
+test:
+  imports:
+    - eccodes
+    - gribapi
+
+about:
+  home: https://software.ecmwf.int/wiki/display/ECC/ecCodes+Home
+  license: Apache License Version 2.0, January 2004
+  summary: ECMWF ecCodes Copyright 2005-2016 ECMWF.
+
+extra:
+  recipe-maintainers:
+    - kmuehlbauer
+    - pelson
+    - ocefpaf

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -36,9 +36,10 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update conda conda-build
-conda install conda-build-all=0.12.0
+conda install conda-build-all
 conda install conda-forge-build-setup
 source run_conda_forge_build_setup
+conda install conda-build-all=0.12.0
 conda install conda-build=1.20.3
 
 # We don't need to build the example recipe.

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -36,7 +36,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update conda conda-build
-conda install conda-build-all
+conda install conda-build-all=0.12.0
 conda install conda-forge-build-setup
 source run_conda_forge_build_setup
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -39,6 +39,7 @@ conda update conda conda-build
 conda install conda-build-all=0.12.0
 conda install conda-forge-build-setup
 source run_conda_forge_build_setup
+conda install conda-build=1.20.3
 
 # We don't need to build the example recipe.
 rm -rf /conda-recipes/example


### PR DESCRIPTION
Appears that `conda-build-all` version `0.13.0` does not work well with `conda-build` version `1.20.3`. It seems to ignore Windows selectors. However, it turns out that `conda-build-all` version `0.12.0` does not suffer from this defect. So, instead of pinning `conda-build` across the entire stack. Let's try pinning `conda-build-all` instead as it only affects staged-recipes and local use leaving feedstocks unaffected.

This worked for me locally. Let's try it out on staged-recipes. 😄 I've re-added `python-eccodes` for testing purposes and have forced `conda-build` to update to version `1.20.3` to make sure we are testing what we want to test. Those commits can be reverted once we demonstrate the fix works.

cc @ocefpaf @kmuehlbauer @msarahan