### PR TITLE
WIP: Added recipe for python-igraph

### DIFF
--- a/recipes/python-igraph/meta.yaml
+++ b/recipes/python-igraph/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "0.7.1.post6" %}
+
+package:
+  name: python-igraph
+  version: {{ version }}
+
+source:
+  fn: python-igraph-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/python-igraph/python-igraph-{{ version }}.tar.gz
+  md5: a4c0b5960735b36adb5d3a40031cb7c0
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - igraph
+    - igraph.app
+    - igraph.drawing
+    - igraph.remote
+    - igraph.test
+    - igraph.vendor
+
+about:
+  home: http://pypi.python.org/pypi/python-igraph
+  license: GNU General Public License (GPLv2)
+  summary: 'High performance graph data structures and algorithms'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Added basic recipe; the `python-igraph` bindings require that you've already installed an external copy of [igraph,](http://igraph.org/) so I'm not positive how this will mess with the build process. Expecting some failures…