### PR TITLE
Add conda 4.1.0 workaround

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -14,8 +14,8 @@ if [ -z "$GH_TOKEN" ]; then
     # Install and configure conda environment.
     curl -L -O https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
     python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
-    conda config --set show_channel_urls true
     conda config --add channels conda-forge
+    conda config --set show_channel_urls true
     conda install --yes --quiet conda-build-all
     conda install --yes --quiet conda-forge-build-setup
     source run_conda_forge_build_setup

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,10 +69,10 @@ install:
           else
             {$root = "C:\Miniconda-x64"}
           $env:path="$root;$root\Scripts;$root\Library\bin;$($env:path)"
+    - cmd: conda config --add channels conda-forge
     - cmd: conda config --set show_channel_urls true
     - cmd: conda update --yes --quiet conda
 
-    - cmd: conda config --add channels conda-forge
     - cmd: conda install --yes --quiet obvious-ci conda-build-all
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup


### PR DESCRIPTION
Based on some great detective work, we have determined that we need to set our channels before enabling their visibility. Otherwise the `defaults` channel drops out. See this [comment]( https://github.com/Anaconda-Platform/support/issues/45#issuecomment-226036443 ).

@jjhelmus, could you please review this and merge if it is ok. If not, please let me know what needs to be fixed.