### PR TITLE
GitHub API Rate Limit Info

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from conda_build.metadata import MetaData
 from conda_smithy.github import gh_token
 from contextlib import contextmanager
+from datetime import datetime
 from github import Github, GithubException, Team
 import os.path
 from random import choice
@@ -145,6 +146,28 @@ if __name__ == '__main__':
         teams = None
         if 'GH_TOKEN' in os.environ:
             gh = Github(os.environ['GH_TOKEN'])
+
+            # Compute some info about our GitHub API Rate Limit.
+            # Note that it doesn't count against our limit to
+            # get this info. So, we should be doing this regularly
+            # to better know when it is going to run out. Also,
+            # this will help us better understand where we are
+            # spending it and how to better optimize it.
+
+            # Get GitHub API Rate Limit usage and total
+            gh_api_used, gh_api_total = gh.rate_limiting()
+
+            # Compute time until GitHub API Rate Limit reset
+            gh_api_reset_time = gh.rate_limiting_resettime()
+            gh_api_reset_time = datetime.datetime.utcfromtimestamp(gh_api_reset_time)
+            gh_api_reset_time -= datetime.datetime.utcnow()
+
+            print("")
+            print("GitHub API Rate Limit Info:")
+            print("---------------------------")
+            print("Currently used {used} out of {total}.".format(gh_api_used, gh_api_total))
+            print("Will reset in {time}.".format(gh_api_reset_time))
+            print("")
 
             # Only get the org and teams if there is stuff to add.
             if feedstock_dirs:

--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -145,8 +145,11 @@ if __name__ == '__main__':
         teams = None
         if 'GH_TOKEN' in os.environ:
             gh = Github(os.environ['GH_TOKEN'])
-            conda_forge = gh.get_organization('conda-forge')
-            teams = {team.name: team for team in conda_forge.get_teams()}
+
+            # Only get the org and teams if there is stuff to add.
+            if feedstock_dirs:
+                conda_forge = gh.get_organization('conda-forge')
+                teams = {team.name: team for team in conda_forge.get_teams()}
 
         # Break the previous loop to allow the TravisCI registering to take place only once per function call.
         # Without this, intermittent failiures to synch the TravisCI repos ensue.


### PR DESCRIPTION
This adds the GitHub API Rate Limit Info to the log so that we can see how much we have used and what our limit is. Also, this will provide info about when our GitHub API Rate Limit will be reset. As this info does not count against our GitHub API Rate Limit, we should not worry about getting this info. Hopefully, this will give us a better idea of how this is being used and what we can do to better optimize it here.

Also, tacked on a minor tweak to our GitHub API usage. When merging a PR that doesn't have stuff to convert to feedstocks, don't bother getting the organization or teams from the GitHub API as there is no need for them. While this doesn't matter for most merges here, it should make the cost of merging maintenance PRs negligible.