### PR TITLE
Added recipe for brewer2mpl

### DIFF
--- a/recipes/brewer2mpl/meta.yaml
+++ b/recipes/brewer2mpl/meta.yaml
@@ -27,6 +27,9 @@ test:
     - brewer2mpl
     - brewer2mpl.wesanderson
 
+  requires:
+    - setuptools
+
 about:
   home: https://github.com/jiffyclub/brewer2mpl/wiki
   license: MIT License

--- a/recipes/brewer2mpl/meta.yaml
+++ b/recipes/brewer2mpl/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: brewer2mpl-{{ version }}.tar.gz
-  url: https://files.pythonhosted.org/packages/fa/fd/838695792e82978a708fc5ca6ad5d085923d8d76f5e01875078e837827cf/brewer2mpl-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/b/brewer2mpl/brewer2mpl-{{ version }}.tar.gz
   md5: f8cd1fbb9f5d836a3a095b1ca9d58fc2
 
 build:

--- a/recipes/brewer2mpl/meta.yaml
+++ b/recipes/brewer2mpl/meta.yaml
@@ -27,9 +27,6 @@ test:
     - brewer2mpl
     - brewer2mpl.wesanderson
 
-  requires:
-    - setuptools
-
 about:
   home: https://github.com/jiffyclub/brewer2mpl/wiki
   license: MIT

--- a/recipes/brewer2mpl/meta.yaml
+++ b/recipes/brewer2mpl/meta.yaml
@@ -27,6 +27,9 @@ test:
     - brewer2mpl
     - brewer2mpl.wesanderson
 
+  requires:
+    - setuptools
+
 about:
   home: https://github.com/jiffyclub/brewer2mpl/wiki
   license: MIT

--- a/recipes/brewer2mpl/meta.yaml
+++ b/recipes/brewer2mpl/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "1.4.1" %}
+
+package:
+  name: brewer2mpl
+  version: {{ version }}
+
+source:
+  fn: brewer2mpl-{{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/fa/fd/838695792e82978a708fc5ca6ad5d085923d8d76f5e01875078e837827cf/brewer2mpl-{{ version }}.tar.gz
+  md5: f8cd1fbb9f5d836a3a095b1ca9d58fc2
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - brewer2mpl
+    - brewer2mpl.wesanderson
+
+about:
+  home: https://github.com/jiffyclub/brewer2mpl/wiki
+  license: MIT License
+  summary: 'Connect colorbrewer2.org color maps to Python and matplotlib'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/brewer2mpl/meta.yaml
+++ b/recipes/brewer2mpl/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: https://github.com/jiffyclub/brewer2mpl/wiki
-  license: MIT License
+  license: MIT
   summary: 'Connect colorbrewer2.org color maps to Python and matplotlib'
 
 extra:


### PR DESCRIPTION
[brewer2mpl](https://pypi.python.org/pypi/brewer2mpl/1.4.1) has been renamed to [Pallettable,](https://pypi.python.org/pypi/palettable/) but some modules such as [ggplot](https://pypi.python.org/pypi/ggplot) still depend on the original module. 