### PR TITLE
add vs runtime packages

### DIFF
--- a/recipes/vs2008_runtime/bld.bat
+++ b/recipes/vs2008_runtime/bld.bat
@@ -1,0 +1,21 @@
+setlocal enabledelayedexpansion
+set MSC_VER=9
+set VC_PATH=x86
+if "%ARCH%"=="64" (
+   set VC_PATH=amd64
+)
+
+FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\DevDiv\VS\Servicing\%MSC_VER%.0" /v SP`) DO (
+    set SP=%%A
+    )
+
+if not "%SP%" == "0x1" (
+   echo "VS 2008 Service Pack 1 needs to be installed.  Exiting."
+   exit 1
+)
+
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.CRT" "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.CRT" "%PREFIX%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.OpenMP" "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.OpenMP" "%PREFIX%" *.dll /E
+if %ERRORLEVEL% LSS 8 exit 0

--- a/recipes/vs2008_runtime/meta.yaml
+++ b/recipes/vs2008_runtime/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: vs2008_runtime
+  version: "9.00.30729.1"
+
+build:
+  number: 0
+  msvc_compiler: 9.0
+  skip: True  # [not win]
+
+test:
+  commands:
+    - if not exist Library\bin\msvcm90.dll exit 1
+    - if not exist Library\bin\msvcp90.dll exit 1
+    - if not exist Library\bin\msvcr90.dll exit 1
+    - if not exist Library\bin\vcomp90.dll exit 1
+    - if not exist msvcm90.dll exit 1
+    - if not exist msvcp90.dll exit 1
+    - if not exist msvcr90.dll exit 1
+    - if not exist vcomp90.dll exit 1
+
+about:
+  home: http://www.microsoft.com
+  license: Proprietary
+  summary: Bundles of the MSVC 9 (VS 2008) runtime
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - mingwandroid
+    - msarahan
+    - patricksnape

--- a/recipes/vs2010_runtime/bld.bat
+++ b/recipes/vs2010_runtime/bld.bat
@@ -1,0 +1,21 @@
+setlocal enabledelayedexpansion
+set MSC_VER=10
+set VC_PATH=x86
+if "%ARCH%"=="64" (
+   set VC_PATH=x64
+)
+
+FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\Software\WOW6432Node\Microsoft\DevDiv\VS\Servicing\%MSC_VER%.0" /v SP`) DO (
+    set SP=%%A
+    )
+
+if not "%SP%" == "0x1" (
+   echo VS 2010 Service Pack 1 needs to be installed.  Exiting.
+   exit 1
+)
+
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.CRT" "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.CRT" "%PREFIX%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.OpenMP" "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.OpenMP" "%PREFIX%" *.dll /E
+if %ERRORLEVEL% LSS 8 exit 0

--- a/recipes/vs2010_runtime/meta.yaml
+++ b/recipes/vs2010_runtime/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: vs2010_runtime
+  version: "10.00.40219.1"
+
+build:
+  number: 0
+  msvc_compiler: 10.0
+  skip: True  # [not win]
+
+test:
+  commands:
+    - if not exist Library\bin\msvcp100.dll exit 1
+    - if not exist Library\bin\msvcr100.dll exit 1
+    - if not exist Library\bin\vcomp100.dll exit 1
+    - if not exist msvcp100.dll exit 1
+    - if not exist msvcr100.dll exit 1
+    - if not exist vcomp100.dll exit 1
+
+about:
+  home: http://www.microsoft.com
+  license: Proprietary
+  summary: Bundles of the MSVC 10 (VS 2010) runtime
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - mingwandroid
+    - msarahan
+    - patricksnape

--- a/recipes/vs2015_runtime/bld.bat
+++ b/recipes/vs2015_runtime/bld.bat
@@ -1,0 +1,30 @@
+set VC_PATH=x86
+if "%ARCH%"=="64" (
+   set VC_PATH=x64
+)
+
+set MSC_VER=14
+
+:: This should always be present for VC installed with VS.  Not sure about VC installed with Visual C++ Build Tools 2015
+FOR /F "usebackq tokens=3*" %%A IN (`REG QUERY "HKEY_LOCAL_MACHINE\Software\Microsoft\DevDiv\VC\Servicing\14.0\IDE.x64" /v UpdateVersion`) DO (
+    set SP=%%A
+    )
+
+if not "%SP%" == "%PKG_VERSION%" (
+   echo "Version detected from registry: %SP%"
+   echo    "does not match version of package being built (%PKG_VERSION%)"
+   echo "Do you have current updates for VS 2015 installed?"
+   exit 1
+)
+
+
+REM ========== REQUIRES Win 10 SDK be installed, or files otherwise copied to location below!
+robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%"  "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Windows Kits\10\Redist\ucrt\DLLs\%VC_PATH%"  "%PREFIX%" *.dll /E
+if %ERRORLEVEL% GEQ 8 exit 1
+REM ========== This one comes from visual studio 2015
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.CRT" "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.CRT" "%PREFIX%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.OpenMP" "%LIBRARY_BIN%" *.dll /E
+robocopy "C:\Program Files (x86)\Microsoft Visual Studio %MSC_VER%.0\VC\redist\%VC_PATH%\Microsoft.VC%MSC_VER%0.OpenMP" "%PREFIX%" *.dll /E
+if %ERRORLEVEL% LSS 8 exit 0

--- a/recipes/vs2015_runtime/meta.yaml
+++ b/recipes/vs2015_runtime/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: vs2015_runtime
+  # version is the update version reported from the registry
+  version: "14.0.25123"
+
+build:
+  number: 0
+  msvc_compiler: 14.0
+  skip: True  # [not win]
+
+test:
+  commands:
+    # only test one of the api dll's.  We test all the others, but there are lots of these.
+    - if not exist Library\bin\api-ms-win-crt-string-l1-1-0.dll exit 1
+    - if not exist Library\bin\concrt140.dll exit 1
+    - if not exist Library\bin\msvcp140.dll exit 1
+    - if not exist Library\bin\ucrtbase140.dll exit 1
+    - if not exist Library\bin\vccorlib140.dll exit 1
+    - if not exist Library\bin\vcruntime140.dll exit 1
+    - if not exist Library\bin\vcomp140.dll exit 1
+    - if not exist api-ms-win-crt-string-l1-1-0.dll exit 1
+    - if not exist concrt140.dll exit 1
+    - if not exist msvcp140.dll exit 1
+    - if not exist ucrtbase140.dll exit 1
+    - if not exist vccorlib140.dll exit 1
+    - if not exist vcruntime140.dll exit 1
+    - if not exist vcomp140.dll exit 1
+
+about:
+  home: http://www.microsoft.com
+  license: Proprietary
+  summary: Bundles of the MSVC 14 (VS 2015) runtime
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - mingwandroid
+    - msarahan
+    - patricksnape


### PR DESCRIPTION
Based on https://github.com/conda/conda/issues/2727#issuecomment-226605954, it is important that conda-forge maintains its own vs runtimes, and keeps them current with whatever AppVeyor's build environment is.

I have added the usual Windows suspects as maintainers here - @gillins @mingwandroid @patricksnape - please let me know if this is OK.