### PR TITLE
Add pyferret

### DIFF
--- a/recipes/pyferret/build.sh
+++ b/recipes/pyferret/build.sh
@@ -8,6 +8,9 @@ export FER_DIR=$PREFIX
 export FC="gfortran"
 export LD_X11="-L/usr/lib64 -lX11"
 
+# set in conda_forge_build_setup to `-j2 ${MAKEFLAGS}` and that breaks the build here.
+export MAKEFLAGS=""
+
 make
 # make run_tests  # Image mismatch issues.
 make install

--- a/recipes/pyferret/build.sh
+++ b/recipes/pyferret/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+export LIBZ_DIR=$PREFIX
+export READLINE_DIR=$PREFIX
+export HDF5_DIR=$PREFIX
+export NETCDF4_DIR=$PREFIX
+export FER_DIR=$PREFIX
+export FC="gfortran"
+export LD_X11="-L/usr/lib64 -lX11"
+
+make
+# make run_tests  # Image mismatch issues.
+make install

--- a/recipes/pyferret/meta.yaml
+++ b/recipes/pyferret/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "7.0" %}
+{% set commit = "67aed0fa29f2d3f28e624030d746d23d146fc387" %}
+
+package:
+    name: pyferret
+    version: {{ version }}
+
+source:
+    fn: pyferret-{{ version }}-{{ commit }}.tar.bz2
+    url: https://github.com/NOAA-PMEL/PyFerret/archive/{{ commit }}.tar.gz
+    sha256: f02537b14371a8adcfe02c55701e6c57eb9b4fb0f65f7f2be49e920f707cbf0b
+    patches:
+        - site_specific.patch
+
+build:
+    number: 0
+    skip: True  # [win or py3k or osx]
+
+requirements:
+    build:
+        - python
+        - netcdf-fortran 4.4.*
+        - numpy x.x
+        - cairo
+        - pango
+        - gcc
+    run:
+        - netcdf-fortran 4.4.*
+        - numpy x.x
+        - cairo
+        - pango
+        - libgcc
+
+test:
+    imports:
+        - pyferret
+
+about:
+    home: http://ferret.pmel.noaa.gov/Ferret
+    license: MIT
+    summary: 'An Analysis Tool for Gridded and Non-Gridded Data.'
+
+extra:
+    recipe-maintainers:
+        - eugeneburger
+        - karlmsmith
+        - ocefpaf

--- a/recipes/pyferret/site_specific.patch
+++ b/recipes/pyferret/site_specific.patch
@@ -1,0 +1,199 @@
+diff -Naur PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387.orig/external_functions/ef_utility/platform_specific.mk.x86_64-linux PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387/external_functions/ef_utility/platform_specific.mk.x86_64-linux
+--- external_functions/ef_utility/platform_specific.mk.x86_64-linux	2016-06-29 20:09:51.000000000 -0300
++++ external_functions/ef_utility/platform_specific.mk.x86_64-linux	2016-07-06 14:40:59.260485464 -0300
+@@ -23,8 +23,7 @@
+ LD		= gfortran
+ LD_DYN_FLAGS	= -fPIC -m64 -shared -Wl,--no-undefined
+ SYSLIBS		= ../ef_utility/copy_ferret_ef_mem_subsc.o \
+-		  -L$(INSTALL_FER_DIR)/lib64/$(PYTHON_EXE)/site-packages/pyferret \
+-		  -L$(INSTALL_FER_DIR)/lib/$(PYTHON_EXE)/site-packages/pyferret \
++		  -L$(SP_DIR)/pyferret \
+ 		  -lpyferret
+ 
+ # Directly compile the .F source files to the .o object files
+diff -Naur PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387.orig/external_functions/ef_utility/site_specific.mk PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387/external_functions/ef_utility/site_specific.mk
+--- external_functions/ef_utility/site_specific.mk	2016-06-29 20:09:51.000000000 -0300
++++ external_functions/ef_utility/site_specific.mk	2016-07-06 14:34:56.858490288 -0300
+@@ -9,8 +9,7 @@
+ ##   intel-mac         for Max OSX
+ ## This value is used to determine which platform_specific.mk
+ ## file to include in the Makefiles.
+-BUILDTYPE = $(HOSTTYPE)
+-# BUILDTYPE = x86_64-linux
++BUILDTYPE = x86_64-linux
+ # BUILDTYPE = x86_64-linux-gnu
+ # BUILDTYPE = i386-linux
+ # BUILDTYPE = i386-linux-gnu
+@@ -27,7 +26,7 @@
+ INSTALL_FER_DIR = $(FER_DIR)
+ 
+ ## Python version used by PyFerret, either python2.6 or python2.7
+-PYTHON_EXE = python2.6
++PYTHON_EXE = python$(PY_VER)
+ # PYTHON_EXE = python2.7
+ 
+ ## FER_LOCAL_EXTFCNS is the directory in which to install
+diff -Naur PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387.orig/Makefile PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387/Makefile
+--- Makefile	2016-06-29 20:09:51.000000000 -0300
++++ Makefile	2016-07-06 14:19:20.782502751 -0300
+@@ -54,7 +54,8 @@
+ 	  export PIXMAN_LIBDIR=$(PIXMAN_LIBDIR) ; \
+ 	  export HDF5_LIBDIR=$(HDF5_LIBDIR) ; \
+ 	  export NETCDF4_LIBDIR=$(NETCDF4_LIBDIR) ; \
+-	  $(PYTHON_EXE) setup.py --quiet build )
++	  $(PYTHON_EXE) setup.py --quiet build ; \
++	  $(PYTHON_EXE) setup.py install )
+ 
+ ## The following installs libpyferret.so and optimized 
+ ## versions of all the python scripts into $(DIR_PREFIX)/install.
+@@ -128,7 +129,7 @@
+ 	bin/make_dist_tar . latest local . -y
+ 	mkdir -p $(INSTALL_FER_DIR)
+ 	mv -f pyferret-latest-local.tar.gz $(INSTALL_FER_DIR)
+-	( cd $(INSTALL_FER_DIR) ; tar xz --strip-components=1 -f pyferret-latest-local.tar.gz )
++	( cd $(INSTALL_FER_DIR) ; tar xz --strip-components=1 -f pyferret-latest-local.tar.gz ; rm -f pyferret-latest-local.tar.gz )
+ 
+ ## The following is for installing the updated threddsBrowser.jar, ferret_ef_meme_subsc.so,
+ ## libpyferret.so, and PyFerret python scripts into $(INSTALL_FER_DIR)/lib without having 
+diff -Naur PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387.orig/platform_specific.mk.x86_64-linux PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387/platform_specific.mk.x86_64-linux
+--- platform_specific.mk.x86_64-linux	2016-06-29 20:09:51.000000000 -0300
++++ platform_specific.mk.x86_64-linux	2016-07-06 14:19:38.718502512 -0300
+@@ -17,10 +17,9 @@
+ ifeq ($(strip $(CAIRO_DIR)),)
+ 	CAIRO_LIBDIR	=
+ #	This include is only for code in Pango that did use the proper cairo include
+-	CAIRO_INCLUDE	= -I/usr/include/cairo
++	CAIRO_INCLUDE	= -I$(PREFIX)/include -I$(PREFIX)/include/cairo
+ else
+-#	CAIRO_LIBDIR	= $(CAIRO_DIR)/lib
+-	CAIRO_LIBDIR	= $(CAIRO_DIR)/lib64
++	CAIRO_LIBDIR	= $(CAIRO_DIR)/lib
+ #	The second include is only for code in Pango that did use the proper cairo include
+ 	CAIRO_INCLUDE	= -I$(CAIRO_DIR)/include -I$(CAIRO_DIR)/include/cairo
+ endif
+@@ -29,20 +28,17 @@
+ 	PIXMAN_LIBDIR	=
+ 	PIXMAN_INCLUDE	= 
+ else
+-#	PIXMAN_LIBDIR	= $(PIXMAN_DIR)/lib
+-	PIXMAN_LIBDIR	= $(PIXMAN_DIR)/lib64
++	PIXMAN_LIBDIR	= $(PIXMAN_DIR)/lib
+ 	PIXMAN_INCLUDE	= -I$(PIXMAN_DIR)/include
+ endif
+ 
+ ifeq ($(strip $(HDF5_DIR)),)
+ 	HDF5_LIBDIR	=
+ else
+-#	HDF5_LIBDIR	= $(HDF5_DIR)/lib
+-	HDF5_LIBDIR	= $(HDF5_DIR)/lib64
++	HDF5_LIBDIR	= $(HDF5_DIR)/lib
+ endif
+ 
+-#	NETCDF4_LIBDIR	= $(NETCDF4_DIR)/lib
+-	NETCDF4_LIBDIR	= $(NETCDF4_DIR)/lib64
++	NETCDF4_LIBDIR	= $(NETCDF4_DIR)/lib
+ 
+ #
+ # Local defines
+@@ -59,9 +55,9 @@
+ 			  -I$(DIR_PREFIX)/external_functions/ef_utility \
+ 			  $(CAIRO_INCLUDE) \
+ 			  $(PIXMAN_INCLUDE) \
+-			  -I/usr/include/pango-1.0 \
+-			  -I/usr/include/glib-2.0 \
+-			  -I/usr/lib64/glib-2.0/include \
++			  -I$(PREFIX)/include/pango-1.0 \
++			  -I$(PREFIX)/include/glib-2.0 \
++			  -I$(PREFIX)/lib64/glib-2.0/include \
+ 			  -I$(NETCDF4_DIR)/include
+ 
+ 	MYDEFINES	= -Dcrptd_cat_argument \
+diff -Naur PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387.orig/site_specific.mk PyFerret-67aed0fa29f2d3f28e624030d746d23d146fc387/site_specific.mk
+--- site_specific.mk	2016-06-29 20:09:51.000000000 -0300
++++ site_specific.mk	2016-07-06 14:42:47.234484026 -0300
+@@ -3,7 +3,7 @@
+ 
+ ## Full path name of the directory containing this file (the ferret root directory).
+ ## Do not use $(shell pwd) since this is included in Makefiles in other directories.
+-DIR_PREFIX = $(HOME)/build/pyferret_dev
++DIR_PREFIX = $(SRC_DIR)
+ # DIR_PREFIX = $(HOME)/pyferret_dev
+ 
+ ## Machine type for which to build Ferret/PyFerret
+@@ -12,15 +12,15 @@
+ ##   i386-linux        for 32-bit RHEL
+ ##   i386-linux-gnu    for 32-bit Ubuntu and many "free" Linux systems
+ ##   intel-mac         for Mac OSX
+-BUILDTYPE = $(HOSTTYPE)
+-# BUILDTYPE = x86_64-linux
++# BUILDTYPE = $(HOSTTYPE)
++BUILDTYPE = x86_64-linux
+ # BUILDTYPE = x86_64-linux-gnu
+ # BUILDTYPE = i386-linux
+ # BUILDTYPE = i386-linux-gnu
+ # BUILDTYPE = intel-mac
+ 
+ ## Python 2.x executable to invoke for build and install.
+-PYTHON_EXE = python2.6
++PYTHON_EXE = python$(PY_VER)
+ # PYTHON_EXE = python2.7
+ ## The assignment of PYTHONINCDIR should not need any modifications
+ PYTHONINCDIR := $(shell $(PYTHON_EXE) -c "import distutils.sysconfig; print distutils.sysconfig.get_python_inc()")
+@@ -28,39 +28,31 @@
+ ## Installation directory for built Ferret.  Using the "install"
+ ## Makefile target circumvents the need to create the fer_*.tar.gz
+ ## files just for creating a Ferret installation.
+-INSTALL_FER_DIR = $(HOME)/ferret_distributions/rhel6_64
+-# INSTALL_FER_DIR = $(FER_DIR)
++INSTALL_FER_DIR = $(FER_DIR)
+ 
+ ## Installation directory for cairo v1.12 or later static library 
+ ## (contains include and lib or lib64 subdirectories).  If blank,
+ ## the system's cairo shared library will be used.  Older versions 
+ ## of cairo (v1.8 or later) can be used, but raster images from 
+ ## -nodisplay may look a little fuzzy unless -gif is specified.
+-CAIRO_DIR = /usr/local/cairo-1.14.4
+-# CAIRO_DIR = /usr/local
+-# CAIRO_DIR =
++CAIRO_DIR =
+ 
+ ## Installation directory for pixman-1 static library (contains 
+ ## include and lib or lib64 subdirectories) used by the above cairo 
+ ## library.  If blank, or if CAIRO_DIR is blank, the system's 
+ ## pixman-1 shared library will be used.
+-PIXMAN_DIR = /usr/local/cairo-1.14.4
+-# PIXMAN_DIR = /usr/local
+-# PIXMAN_DIR =
++PIXMAN_DIR =
+ 
+ ## Installation directory for HDF5 static libraries (contains 
+ ## include and lib or lib64 subdirectories).  Do not give a location 
+ ## to link to NetCDF shared-object libraries.
+-HDF5_DIR = /usr/local/hdf5-1.8.16
+-# HDF5_DIR = /usr/local
+-# HDF5_DIR = 
++HDF5_DIR = 
+ 
+ ## Installation directory for NetCDF static or shared object libraries
+ ## (contains include and lib or lib64 subdirectories).  If HDF5_DIR 
+ ## (above) is blank, the netcdf shared-object (.so) libraries will be 
+ ## used;  otherwise the netcdf static (.a) libraries will be used.
+-NETCDF4_DIR = /usr/local/netcdf-4.4.0
+-# NETCDF4_DIR = /usr/local
++NETCDF4_DIR = $(PREFIX)
+ 
+ ## Java home directory - this may be predefined
+ ## from your shell environment.  If JAVA_HOME is defined,
+@@ -68,11 +60,6 @@
+ ## called to build threddsBrowser.jar; otherwise, 
+ ## threddsBrowser.jar is not built and the Ferret command
+ ## SET DATA /BROWSE (or the alias OPEN) will not work.
+-# JAVA_HOME = /usr/java/default
+-# JAVA_HOME = /usr/java/latest
+-# JAVA_HOME = /usr/lib/jvm/default-java
+-# JAVA_HOME = /usr/lib/jvm/java-oracle
+-JAVA_HOME = /usr/lib/jvm/java
+-# JAVA_HOME = /Library/Java/JavaVirtualMachines/jdk1.8.0_60.jdk/Contents/Home
++JAVA_HOME = 
+ 
+ ##


### PR DESCRIPTION
First attempt to build `ferret` from source.

```
Ferret is an interactive computer visualization and analysis environment designed to
meet the needs of oceanographers and meteorologists analyzing large and complex gridded
data sets. It runs on recent Unix and Mac systems, using X windows for display.
PyFerret, introduced in 2012, is a Python module wrapping Ferret. 

The pyferret module provides Python functions so Python users can easily take advantage
of Ferret's abilities to retrieve, manipulate, visualize, and save data. 
```

For more inforation see: http://ferret.pmel.noaa.gov/Ferret/home