### PR TITLE
Add packaging

### DIFF
--- a/recipes/packaging/meta.yaml
+++ b/recipes/packaging/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "packaging" %}
+{% set version = "16.7" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: 5bfeb52de8dee2fcc95a003b0ebe9011
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyparsing
+    - six
+
+  run:
+    - python
+    - pyparsing
+    - six
+
+test:
+  imports:
+    - packaging
+
+about:
+  home: https://github.com/pypa/packaging
+  license: Apache 2.0 or BSD 2-Clause
+  summary: Core utilities for Python packages
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds `packaging`. Generated with `conda skeleton pypi` and tweaked.

This used by `setuptools` in some cases. It doesn't strictly require `setuptools` for install. However, we are temporarily using it as the feedstocks do install `setuptools` by default. Once that changes, we may switch this to `distutils`.