### PR TITLE
add pytest-timeout

### DIFF
--- a/recipes/pytest-timeout/meta.yaml
+++ b/recipes/pytest-timeout/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
     - pytest >=2.8

--- a/recipes/pytest-timeout/meta.yaml
+++ b/recipes/pytest-timeout/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - setuptools
   run:
     - python
+    - setuptools
     - pytest >=2.8
 
 test:

--- a/recipes/pytest-timeout/meta.yaml
+++ b/recipes/pytest-timeout/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: pytest-timeout
+  version: '{{ version }}'
+
+source:
+  fn: '{{ version }}.tar.gz'
+  url: https://bitbucket.org/pytest-dev/pytest-timeout/get/{{ version }}.tar.gz
+  sha256: 0c69eb6d038ca02445bd83921da148bd274b25c5e9cebcad58860f9f05de9e6f
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - pytest >=2.8
+
+test:
+  requires:
+    - pexpect
+  commands:
+    - 'py.test {{ SRC_DIR }}'
+
+about:
+  home: https://bitbucket.org/pytest-dev/pytest-timeout
+  license: MIT
+  summary: >
+    This plugin allows terminating tests after a specified timeout. When
+    doing so it will show a stack dump of all threads running at the time.
+    This is useful when running tests under a continuous integration server
+    or simply if you don't know why the test suite hangs.
+
+extra:
+  recipe-maintainers:
+    - kalefranz


### PR DESCRIPTION
This is a current test requirement for conda.  We'll be pulling into defaults soon.
