### PR TITLE
Add libarchive

### DIFF
--- a/recipes/libarchive/build.sh
+++ b/recipes/libarchive/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
+# Needed for the tests.
+export CFLAGS="-std=c99 ${CFLAGS}"
+
+if [ "`uname`" == 'Darwin' ]
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+else
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+
+aclocal
+autoconf
+autoreconf -ivf
+./configure --prefix=${PREFIX} \
+            --with-expat \
+            --without-nettle \
+            --without-lz4 \
+            --without-lzmadec \
+            --without-xml2
+make
+eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
+make install

--- a/recipes/libarchive/meta.yaml
+++ b/recipes/libarchive/meta.yaml
@@ -1,0 +1,65 @@
+{% set version = "3.2.1" %}
+
+package:
+  name: libarchive
+  version: {{ version }}
+
+source:
+  fn: libarchive-{{ version }}.tar.gz
+  url: https://github.com/libarchive/libarchive/archive/v{{ version }}.tar.gz
+  sha256: bcefe75f3f1527656c82e42e7adf1614ae274d005b2583d0ae15f857bfb1ed28
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+    - bzip2 1.0.*
+    - expat
+    - libiconv
+    - openssl 1.0.*
+    - xz 5.0.*
+    - zlib 1.2.*
+
+  run:
+    - bzip2 1.0.*
+    - expat
+    - libiconv
+    - openssl 1.0.*
+    - xz 5.0.*
+    - zlib 1.2.*
+
+test:
+  commands:
+    # Verify pkg-config file is in place.
+    - test -f "${PREFIX}/lib/pkgconfig/libarchive.pc"  # [unix]
+
+    # Verify headers are in place.
+    - test -f "${PREFIX}/include/archive.h"            # [unix]
+    - test -f "${PREFIX}/include/archive_entry.h"      # [unix]
+
+    # Verify libraries are in place.
+    - test -f "${PREFIX}/lib/libarchive.a"             # [unix]
+    - test -f "${PREFIX}/lib/libarchive.so"            # [linux]
+    - test -f "${PREFIX}/lib/libarchive.dylib"         # [osx]
+
+    # Check for commands
+    - bsdcat --version
+    - bsdcpio --version
+    - bsdtar --version
+
+about:
+  home: http://www.libarchive.org/
+  summary: Multi-format archive and compression library
+  license: BSD 2-Clause
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - mingwandroid


### PR DESCRIPTION
This adds a recipe to build `libarchive`. It is loosely based off of the recipe in conda-recipes.

We have tried to support all the possible dependencies that we could build with. However, some things like `nettle` we don't have packages for currently (though [they]( https://github.com/conda/conda-recipes/tree/d34a9a134844f36fff885ce3cf92287efb17222c/nettle) could be added) and so we have ignored/disabled them here.

Currently, we are just building for Mac and Linux, but it should be possible to build for Windows with CMake.

We have noted some test failures on Mac. They seem related to some long UIDs. Maybe the won't cause problems on Travis CI. This seems to be the most relevant thing I can find on this issue ( https://lists.freebsd.org/pipermail/freebsd-hackers/2010-September/033048.html ).

cc @mingwandroid