### PR TITLE
Add jsoncpp

### DIFF
--- a/recipes/jsoncpp/bld.bat
+++ b/recipes/jsoncpp/bld.bat
@@ -1,0 +1,23 @@
+mkdir build
+if errorlevel 1 exit 1
+
+cd build
+if errorlevel 1 exit 1
+
+cmake .. ^
+        -G %CMAKE_GENERATOR% ^
+        -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+        -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+        -DBUILD_STATIC_LIBS=1 ^
+        -DBUILD_SHARED_LIBS=1 ^
+        -DPYTHON_EXECUTABLE="%PYTHON%"
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+ctest
+if errorlevel 1 exit 1

--- a/recipes/jsoncpp/build.sh
+++ b/recipes/jsoncpp/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# FIXME: This is a hack to make sure the environment is activated.
+# The reason this is required is due to the conda-build issue
+# mentioned below.
+#
+# https://github.com/conda/conda-build/issues/910
+#
+source activate "${CONDA_DEFAULT_ENV}"
+
+export CFLAGS="-fPIC ${CFLAGS}"
+export CXXFLAGS="-fPIC ${CXXFLAGS}"
+
+if [ "$(uname)" == "Darwin" ]
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+else
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+mkdir build
+cd build
+cmake ..\
+        -DCMAKE_C_COMPILER="${CC}" \
+        -DCMAKE_CXX_COMPILER="${CXX}" \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DCMAKE_INSTALL_LIBDIR="${PREFIX}/lib" \
+        -DCMAKE_PREFIX_PATH="${PREFIX}" \
+        -DCMAKE_C_FLAGS="${CFLAGS}" \
+        -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+        -DBUILD_STATIC_LIBS=1 \
+        -DBUILD_SHARED_LIBS=1 \
+        -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}" \
+        -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+        -DPYTHON_EXECUTABLE="${PYTHON}"
+
+make
+eval ${LIBRARY_SEARCH_VAR}=$PREFIX/lib make jsoncpp_check
+make install

--- a/recipes/jsoncpp/meta.yaml
+++ b/recipes/jsoncpp/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = "0.10.6" %}
+
+package:
+  name: jsoncpp
+  version: {{ version }}
+
+source:
+  fn: jsoncpp-{{ version }}.tar.gz
+  url: https://github.com/open-source-parsers/jsoncpp/archive/{{ version }}.tar.gz
+  sha256: 7c285fc40ad0c113e436a1271c4e38b5017b5c7782c306e90be9d6b2ffa90212
+
+build:
+  number: 0
+  skip: true  # [win or (unix and not py27)]
+  features:
+    - vc9     # [win and py27]
+    - vc10    # [win and py34]
+    - vc14    # [win and py35]
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - pkg-config  # [unix]
+    - python
+
+test:
+  requires:
+    - python 2.7.*  # [win and py27]
+    - python 3.4.*  # [win and py34]
+    - python 3.5.*  # [win and py35]
+
+  commands:
+    # Verify headers are present.
+    - test -d "${PREFIX}/include/jsoncpp"           # [unix]
+
+    # Verify pkg-config file is present.
+    - test -f "${PREFIX}/lib/pkgconfig/jsoncpp.pc"  # [unix]
+
+    # Verify libraries are present.
+    - test -f "${PREFIX}/lib/libjsoncpp.a"          # [unix]
+    - test -f "${PREFIX}/lib/libjsoncpp.so"         # [linux]
+    - test -f "${PREFIX}/lib/libjsoncpp.dylib"      # [osx]
+
+about:
+  home: https://github.com/open-source-parsers/jsoncpp
+  license: Public Domain/MIT
+  summary: A C++ library for interacting with JSON.
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - stuarteberg


### PR DESCRIPTION
Wrote this from scratch. It appears to work fine. Has some tests.

Only builds for Mac and Linux. Windows support is possible, but not done yet.

1.x versions require C++11. So, starting with 0.x versions, which do not have this requirement. Will add 1.x in the feedstock.