### PR TITLE
Added recipe for pyaml

### DIFF
--- a/recipes/pyaml/meta.yaml
+++ b/recipes/pyaml/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "15.8.2" %}
+
+package:
+  name: pyaml
+  version: {{ version }}
+
+source:
+  fn: pyaml-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pyaml/pyaml-{{ version }}.tar.gz
+  md5: e3a39e02dffaf5f6efa8ccdd22745739
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pyyaml
+
+test:
+  imports:
+    - pyaml
+    - pyaml.tests
+
+about:
+  home: https://github.com/mk-fg/pretty-yaml
+  license: WTFPL
+  summary: 'PyYAML-based module to produce pretty and readable YAML-serialized data'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Added a recipe for [pyaml](https://pypi.python.org/pypi/pyaml), which improves [PyYAML](https://pypi.python.org/pypi/PyYAML). Also pinging @mk-fg in case he's interested in being a maintainer to help make sure that future versions of the package are rapidly built for conda-forge.