### PR TITLE
WIP: Add libgcc split

### DIFF
--- a/recipes/libgcc/meta.yaml
+++ b/recipes/libgcc/meta.yaml
@@ -1,0 +1,30 @@
+{% set version = "4.8.5" %}
+
+package:
+  name: libgcc
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+
+requirements:
+  run:
+    - libgcc_s {{ version }}
+    - libgomp {{ version }}
+    - libgfortran {{ version }}
+    - libquadmath {{ version }}
+    - libstdc++ {{ version }}
+
+test:
+  commands:
+    - true
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libgcc_s/meta.yaml
+++ b/recipes/libgcc_s/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "4.8.5" %}
+
+package:
+  name: libgcc_s
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                       # [win]
+  always_include_files:
+    - lib/libgcc_s.1.dylib         # [osx]
+    - lib/libgcc_s_ppc64.1.dylib   # [osx]
+    - lib/libgcc_s_x86_64.1.dylib  # [osx]
+    - lib/libgcc_s.so              # [linux]
+    - lib/libgcc_s.so.1            # [linux]
+
+requirements:
+  build:
+    - gcc {{ version }}
+    - cloog 0.18.0 10
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libgcc_s.1.dylib"         # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s_ppc64.1.dylib"   # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s_x86_64.1.dylib"  # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s.so"              # [linux]
+    - test -f "${PREFIX}/lib/libgcc_s.so.1"            # [linux]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libgfortran/meta.yaml
+++ b/recipes/libgfortran/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "4.8.5" %}
+
+package:
+  name: libgfortran
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+  always_include_files:
+    - lib/libgfortran.dylib     # [osx]
+    - lib/libgfortran.3.dylib   # [osx]
+    - lib/libgfortran.so        # [linux]
+    - lib/libgfortran.so.3      # [linux]
+    - lib/libgfortran.so.3.0.0  # [linux]
+
+requirements:
+  build:
+    - gcc {{ version }}
+    - cloog 0.18.0 10
+
+  run:
+    - libquadmath {{ version }}
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libgfortran.dylib"     # [osx]
+    - test -f "${PREFIX}/lib/libgfortran.3.dylib"   # [osx]
+    - test -f "${PREFIX}/lib/libgfortran.so"        # [linux]
+    - test -f "${PREFIX}/lib/libgfortran.so.3"      # [linux]
+    - test -f "${PREFIX}/lib/libgfortran.so.3.0.0"  # [linux]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libgomp/meta.yaml
+++ b/recipes/libgomp/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "4.8.5" %}
+
+package:
+  name: libgomp
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+  always_include_files:
+    - lib/libgomp.dylib         # [osx]
+    - lib/libgomp.1.dylib       # [osx]
+    - lib/libgomp.so            # [linux]
+    - lib/libgomp.so.1          # [linux]
+    - lib/libgomp.so.1.0.0      # [linux]
+
+requirements:
+  build:
+    - gcc {{ version }}
+    - cloog 0.18.0 10
+  run:
+    - libgcc_s {{ version }}    # [osx]
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libgomp.dylib"     # [osx]
+    - test -f "${PREFIX}/lib/libgomp.1.dylib"   # [osx]
+    - test -f "${PREFIX}/lib/libgomp.so"        # [linux]
+    - test -f "${PREFIX}/lib/libgomp.so.1"      # [linux]
+    - test -f "${PREFIX}/lib/libgomp.so.1.0.0"  # [linux]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libquadmath/meta.yaml
+++ b/recipes/libquadmath/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "4.8.5" %}
+
+package:
+  name: libquadmath
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+  always_include_files:
+    - lib/libquadmath.dylib     # [osx]
+    - lib/libquadmath.0.dylib   # [osx]
+    - lib/libquadmath.so        # [linux]
+    - lib/libquadmath.so.0      # [linux]
+    - lib/libquadmath.so.0.0.0  # [linux]
+
+requirements:
+  build:
+    - gcc {{ version }}
+    - cloog 0.18.0 10
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libquadmath.dylib"     # [osx]
+    - test -f "${PREFIX}/lib/libquadmath.0.dylib"   # [osx]
+    - test -f "${PREFIX}/lib/libquadmath.so"        # [linux]
+    - test -f "${PREFIX}/lib/libquadmath.so.0"      # [linux]
+    - test -f "${PREFIX}/lib/libquadmath.so.0.0.0"  # [linux]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libstdc++/meta.yaml
+++ b/recipes/libstdc++/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "4.8.5" %}
+
+package:
+  name: libstdc++
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+  always_include_files:
+    - lib/libstdc++.dylib       # [osx]
+    - lib/libstdc++.6.dylib     # [osx]
+    - lib/libstdc++.so          # [linux]
+    - lib/libstdc++.so.6        # [linux]
+    - lib/libstdc++.so.6.0.19   # [linux]
+
+requirements:
+  build:
+    - gcc {{ version }}
+    - cloog 0.18.0 10
+  run:
+    - libgcc_s {{ version }}
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libstdc++.dylib"      # [osx]
+    - test -f "${PREFIX}/lib/libstdc++.6.dylib"    # [osx]
+    - test -f "${PREFIX}/lib/libstdc++.so"         # [linux]
+    - test -f "${PREFIX}/lib/libstdc++.so.6"       # [linux]
+    - test -f "${PREFIX}/lib/libstdc++.so.6.0.19"  # [linux]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Here we do something that has long been discussed and people have generally been amenable to. This breaks up the `libgcc` library into a bunch of smaller library packages.

The hope is that people can be more particular with what they pull in dependency wise. For instance, if someone is just using GFortran, they should only need to add the `libgfortran` package. That way `libstdc++` or something else that is unneeded is not included. Same story with using GNU OpenMP, one need only include `libgomp`. However, people that are using `libstdc++` may still present problems. Not sure what more to do about that ATM.

I have decided to version these based on the `gcc` compiler they were pulled from. IMHO this make simple to understand where they came from and makes it easier to stay on top of updating them. Also IMHO `defaults` should follow suit.

cc @pelson @ocefpaf @msarahan @gillins @patricksnape @jjhelmus