### PR TITLE
WIP: Add libgfortran

### DIFF
--- a/recipes/libgfortran-abi/meta.yaml
+++ b/recipes/libgfortran-abi/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "1.5.0" %}
+
+package:
+  name: libgfortran-abi
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+
+requirements:
+  run:
+    - libgfortran 3.0.0
+
+test:
+  commands:
+    - true
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson

--- a/recipes/libgfortran/meta.yaml
+++ b/recipes/libgfortran/meta.yaml
@@ -1,0 +1,78 @@
+{% set libgfortran_version = [3, 0, 0] %}
+{% set libquadmath_version = [0, 0, 0] %}
+{% set libgcc_s_version = [1, 0, 0] %}
+
+
+package:
+  name: libgfortran
+  version: {{ libgfortran_version|join('.') }}
+
+build:
+  number: 0
+  skip: true                    # [win]
+  always_include_files:
+    - lib/libgfortran.dylib                                   # [osx]
+    - lib/libgfortran.{{ libgfortran_version[0] }}.dylib      # [osx]
+    - lib/libgfortran.so                                      # [linux]
+    - lib/libgfortran.so.{{ libgfortran_version[0] }}         # [linux]
+    - lib/libgfortran.so.{{ libgfortran_version|join('.') }}  # [linux]
+
+    # Including libquadmath for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - lib/libquadmath.dylib                                   # [osx]
+    - lib/libquadmath.{{ libquadmath_version[0] }}.dylib      # [osx]
+    - lib/libquadmath.so                                      # [linux]
+    - lib/libquadmath.so.{{ libquadmath_version[0] }}         # [linux]
+    - lib/libquadmath.so.{{ libquadmath_version|join('.') }}  # [linux]
+
+    # Including libgcc_s for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - lib/libgcc_s.{{ libgcc_s_version[0] }}.dylib         # [osx]
+    - lib/libgcc_s_ppc64.{{ libgcc_s_version[0] }}.dylib   # [osx]
+    - lib/libgcc_s_x86_64.{{ libgcc_s_version[0] }}.dylib  # [osx]
+    - lib/libgcc_s.so                                      # [linux]
+    - lib/libgcc_s.so.{{ libgcc_s_version[0] }}            # [linux]
+
+requirements:
+  build:
+    - gcc 4.8.5
+    - cloog 0.18.0 10
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libgfortran.dylib"                                   # [osx]
+    - test -f "${PREFIX}/lib/libgfortran.{{ libgfortran_version[0] }}.dylib"      # [osx]
+    - test -f "${PREFIX}/lib/libgfortran.so"                                      # [linux]
+    - test -f "${PREFIX}/lib/libgfortran.so.{{ libgfortran_version[0] }}"         # [linux]
+    - test -f "${PREFIX}/lib/libgfortran.so.{{ libgfortran_version|join('.') }}"  # [linux]
+
+    # Including libquadmath for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - test -f "${PREFIX}/lib/libquadmath.dylib"                                   # [osx]
+    - test -f "${PREFIX}/lib/libquadmath.{{ libquadmath_version[0] }}.dylib"      # [osx]
+    - test -f "${PREFIX}/lib/libquadmath.so"                                      # [linux]
+    - test -f "${PREFIX}/lib/libquadmath.so.{{ libquadmath_version[0] }}"         # [linux]
+    - test -f "${PREFIX}/lib/libquadmath.so.{{ libquadmath_version|join('.') }}"  # [linux]
+
+    # Including libgcc_s for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - test -f "${PREFIX}/lib/libgcc_s.{{ libgcc_s_version[0] }}.dylib"         # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s_ppc64.{{ libgcc_s_version[0] }}.dylib"   # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s_x86_64.{{ libgcc_s_version[0] }}.dylib"  # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s.so"                                      # [linux]
+    - test -f "${PREFIX}/lib/libgcc_s.so.{{ libgcc_s_version[0] }}"            # [linux]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson


### PR DESCRIPTION
This simply breaks out `libgfortran` and bundles `libquadmath` from PR ( https://github.com/conda-forge/staged-recipes/pull/855 ) based on this [suggestion]( https://github.com/conda-forge/staged-recipes/pull/855#issuecomment-228126410 ).

The versioning should probably be changed somehow and I welcome feedback on this point. This issue ( https://github.com/ContinuumIO/anaconda-issues/issues/843 ) may be relevant for addressing the versioning.

cc @pelson @ocefpaf @msarahan @gillins @patricksnape @jjhelmus