### PR TITLE
Added recipe for nose-xcover

### DIFF
--- a/recipes/nosexcover/meta.yaml
+++ b/recipes/nosexcover/meta.yaml
@@ -1,4 +1,5 @@
 {%set version = "1.0.10" %}
+
 package:
   name: nosexcover
   version: {{ version }}
@@ -30,7 +31,7 @@ test:
 
 about:
   home: http://github.com/cmheisel/nose-xcover/
-  license: BSD 1-Clause
+  license: MIT License
   summary: 'Extends nose.plugins.cover to add Cobertura-style XML reports'
 
 extra:

--- a/recipes/nosexcover/meta.yaml
+++ b/recipes/nosexcover/meta.yaml
@@ -1,0 +1,38 @@
+{%set version = "1.0.10" %}
+package:
+  name: nosexcover
+  version: {{ version }}
+
+source:
+  fn: nosexcover-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/n/nosexcover/nosexcover-{{ version }}.tar.gz
+  md5: 12bf494a801b376debeb6a167c247391
+
+build:
+  preserve_egg_dir: True
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - nose
+    - coverage >=3.4
+
+test:
+  imports:
+    - nosexcover
+
+about:
+  home: http://github.com/cmheisel/nose-xcover/
+  license: BSD 1-Clause
+  summary: 'Extends nose.plugins.cover to add Cobertura-style XML reports'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/nosexcover/meta.yaml
+++ b/recipes/nosexcover/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   preserve_egg_dir: True
+  entry_points:
+    - xcover = nosexcover.nosexcover:XCoverage
 
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
@@ -28,6 +30,7 @@ requirements:
 test:
   imports:
     - nosexcover
+    - nosexcover.nosexcover
 
 about:
   home: http://github.com/cmheisel/nose-xcover/


### PR DESCRIPTION
Adds a recipe for [nose-xcover.](https://pypi.python.org/pypi/nosexcover) Also, pinging @cmheisel in case he would like to be added as a maintainer to the `nosexcover` builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how it is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/nosexcover-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too!