### PR TITLE
Added recipe for ws4py

### DIFF
--- a/recipes/ws4py/meta.yaml
+++ b/recipes/ws4py/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.3.5" %}
+
+package:
+  name: ws4py
+  version: {{ version }}
+
+source:
+  fn: ws4py-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/w/ws4py/ws4py-{{ version }}.tar.gz
+  sha256: c4cc4a872027f6a6006a6142a38eb6d65c2ece29a4cefac98dd20a48c34ec7a9
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - ws4py
+    - ws4py.client
+    - ws4py.server
+
+about:
+  home: https://github.com/Lawouach/WebSocket-for-Python
+  license: BSD 3-Clause
+  summary: 'WebSocket client and server library for Python 2, 3, and PyPy'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @Lawouach in case he would like to be added as a maintainer to the [`ws4py`](https://pypi.python.org/pypi/ws4py) builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/ws4py-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.