### PR TITLE
Added recipe for stevedore

### DIFF
--- a/recipes/stevedore/meta.yaml
+++ b/recipes/stevedore/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: http://docs.openstack.org/developer/stevedore/
-  license: Apache Software License Version 2.0
+  license: Apache 2.0
   summary: 'Manage dynamic plugins for Python applications'
 
 extra:

--- a/recipes/stevedore/meta.yaml
+++ b/recipes/stevedore/meta.yaml
@@ -1,0 +1,47 @@
+{%set version = "1.15.0" %}
+{%set name = "stevedore" %}
+
+package:
+  name: stevedore
+  version: {{ version }}
+
+source:
+  fn: stevedore-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b048b7976754ad55d7cbc7407b17cbfd945dbb4c5ecc333d3c2142d506fc90e1
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=1.8
+
+  run:
+    - python
+    - six >=1.9.0
+    - pbr >=1.6
+
+test:
+  imports:
+    - stevedore
+    - stevedore.named
+    - stevedore.driver
+    - stevedore.hook
+    - stevedore.extension
+    - stevedore.enabled
+    - stevedore.dispatch
+    - stevedore.tests
+
+about:
+  home: http://docs.openstack.org/developer/stevedore/
+  license: Apache Software License Version 2.0
+  summary: 'Manage dynamic plugins for Python applications'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
[`stevedore`](http://docs.openstack.org/developer/stevedore/) is a python module connected to the [openstack project](http://www.openstack.org); it provides manager classes for implementing common patterns for using dynamically loaded extensions, and various openstack python-based CLI tools use stevedore as a component. This is a jumping-off point for adding new openstack modules to conda-forge.

Pinging @dhellmann in case he would like to be added as a maintainer to the `stevedore` builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/stevedore-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.