### PR TITLE
Added recipe for prettytable

### DIFF
--- a/recipes/prettytable/meta.yaml
+++ b/recipes/prettytable/meta.yaml
@@ -1,0 +1,40 @@
+{%set name = "prettytable" %}
+{%set version = "0.7.2" %}
+{%set hash_type="sha256" %}
+{%set hash_val = "2d5460dc9db74a32bcc8f9f67de68b2c4f4d2f01fa3bd518764c69156d9cacd9" %}
+
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type}}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: http://code.google.com/p/prettytable
+  license: BSD 3-Clause
+  summary: 'A simple Python library for easily displaying tabular data in a visually appealing ASCII table format'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
`prettytable` is a python module for generating pretty ASCII tables. Additonally, various [openstack](https://www.openstack.org/) python-based CLI tools use stevedore as a component. This is a jumping-off point for adding new openstack modules to conda-forge.

Pinging @flaper87 in case he would like to be added as a maintainer to the `prettytable` builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/prettytable-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.