### PR TITLE
Added recipe for cmd2

### DIFF
--- a/recipes/cmd2/meta.yaml
+++ b/recipes/cmd2/meta.yaml
@@ -1,0 +1,41 @@
+{%set name = "cmd2" %}
+{%set version = "0.6.8" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "ac780d8c31fc107bf6b4edcbcea711de4ff776d59d89bb167f8819d2d83764a8" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  skip: True  # [py3k]
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pyparsing >=2.0.1
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: http://packages.python.org/cmd2/
+  license: MIT License
+  summary: "Extra features for standard library's cmd module"
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/cmd2/meta.yaml
+++ b/recipes/cmd2/meta.yaml
@@ -11,9 +11,11 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   {{ hash_type }}: {{ hash_val }}
+  # patches:
+  #   - python35-compat.patch  # [py35]
 
 build:
-  skip: True  # [py3k]
+  skip: True  # [py35]
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 


### PR DESCRIPTION
[`cmd2`](https://pypi.python.org/pypi/cmd2) expands the functions of the standard library's `cmd module.  Various openstack python-based CLI tools use `cmd2` as a component; this is a jumping-off point for adding new openstack modules to conda-forge.

Pinging @catherinedevlin in case she would like to be added as a maintainer to the `cmd2` builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/cmd2-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.