### PR TITLE
Added recipe for positional

### DIFF
--- a/recipes/positional/meta.yaml
+++ b/recipes/positional/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
   run:
     - python
-    - pbr >=1.6
+    - pbr >=1.8
     - wrapt
 
 test:

--- a/recipes/positional/meta.yaml
+++ b/recipes/positional/meta.yaml
@@ -40,3 +40,4 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
+    - morganfainberg

--- a/recipes/positional/meta.yaml
+++ b/recipes/positional/meta.yaml
@@ -1,0 +1,42 @@
+{%set name = "positional" %}
+{%set version = "1.1.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "e2d1e3a6a2abbc1820c5dfa72f0c8fc4b56eebbb6ccd7ee25b626c34b902c144" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=1.8
+
+  run:
+    - python
+    - pbr >=1.6
+    - wrapt
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/morganfainberg/positional
+  license: Apache Software License Version 2.0
+  summary: 'Library to enforce positional or key-word arguments'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @morganfainberg in case he would like to be added as a maintainer to the `positional` builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/positional-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.