### PR TITLE
Added recipe for requestsexceptions

### DIFF
--- a/recipes/requestsexceptions/meta.yaml
+++ b/recipes/requestsexceptions/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   build:
     - python
     - setuptools
-    - pbr
+    - pbr >=0.11,<2.0
 
   run:
     - python

--- a/recipes/requestsexceptions/meta.yaml
+++ b/recipes/requestsexceptions/meta.yaml
@@ -33,7 +33,7 @@ test:
 
 about:
   home: https://github.com/openstack-infra/requestsexceptions
-  license: Apache Software License Version 2.0
+  license: Apache 2.0
   summary: 'Import exceptions from potentially bundled packages in requests.'
 
 extra:

--- a/recipes/requestsexceptions/meta.yaml
+++ b/recipes/requestsexceptions/meta.yaml
@@ -1,0 +1,41 @@
+{%set name = "requestsexceptions" %}
+{%set version = "1.1.3" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "d678b872f51f76d875e00e6667f4ddbf013b3a99490ae5fe07cf3e4f846e283e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr
+
+  run:
+    - python
+    - pbr >=0.11,<2.0
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/openstack-infra/requestsexceptions
+  license: Apache Software License Version 2.0
+  summary: 'Import exceptions from potentially bundled packages in requests.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
[`requestsexceptions`](https://github.com/openstack-infra/requestsexceptions) is another component of the openstack python CLIs, and another step towards having working conda-forge builds of them.

Pinging @emonty and @onovy in case they would like to be added as maintainers to the `requestsexceptions` builder on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/requestsexceptions-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.