### PR TITLE
Add uritemplate.py and github3.py

### DIFF
--- a/recipes/github3.py/meta.yaml
+++ b/recipes/github3.py/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "github3.py" %}
+{% set version = "0.9.5" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: a20c3af33337633d60e0e0a0ed10398d
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests >=2.0
+    - uritemplate.py >=0.2.0
+
+  run:
+    - python
+    - requests >=2.0
+    - uritemplate.py >=0.2.0
+
+test:
+  imports:
+    - github3
+    - github3.gists
+    - github3.issues
+    - github3.repos
+    - github3.search
+
+about:
+  home: https://github3py.readthedocs.org
+  license: BSD 3-Clause
+  summary: Python wrapper for the GitHub API (http://developer.github.com/v3)
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - sigmavirus24

--- a/recipes/uritemplate.py/meta.yaml
+++ b/recipes/uritemplate.py/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "uritemplate.py" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: 4dd14904ba502c6ff8d6276e004404de
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - uritemplate
+
+about:
+  home: https://uritemplate.readthedocs.org
+  license: BSD 3-Clause
+  summary: URI templates
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - sigmavirus24


### PR DESCRIPTION
Adds recipes for `uritemplate.py` and `github3.py`. Both generated with `conda skeleton pypi` and tweaked. Please let me know your thoughts.

Made you as a maintainer @sigmavirus24 on both of these too. Please let me know if that is ok. Also, if there is anything missing, please let me know and we can add it.

cc @pelson @sigmavirus24