### PR TITLE
Added recipe for extras

### DIFF
--- a/recipes/extras/meta.yaml
+++ b/recipes/extras/meta.yaml
@@ -1,7 +1,7 @@
 {%set name = "extras" %}
 {%set version = "1.0.0" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "" %}
+{%set hash_val = "132e36de10b9c91d5d4cc620160a476e0468a88f16c9431817a6729611a81b4e" %}
 
 package:
   name: {{ name }}

--- a/recipes/extras/meta.yaml
+++ b/recipes/extras/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "extras" %}
+{%set version = "1.0.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - extras
+    - extras.tests
+
+about:
+  home: https://github.com/testing-cabal/extras
+  license: MIT License
+  summary: 'Useful extra bits for Python - things that shold be in the standard library'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @rbtcollins in case he would like to be added as a maintainer to the `extras` builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/extras-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.