### PR TITLE
Added recipe for jsonpointer

### DIFF
--- a/recipes/jsonpointer/meta.yaml
+++ b/recipes/jsonpointer/meta.yaml
@@ -1,0 +1,38 @@
+{%set name = "jsonpointer" %}
+{%set version = "1.10" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "9fa5dcac35eefd53e25d6cd4c310d963c9f0b897641772cd6e5e7b89df7ee0b1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/stefankoegl/python-json-pointer
+  license: BSD 3-Clause
+  summary: 'Identify specific nodes in a JSON document (RFC 6901)'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @stefankoegl in case he would like to be added as a maintainer to the `jsonpointer` builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/jsonpointer-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.