### PR TITLE
Added recipe for debtcollector

### DIFF
--- a/recipes/debtcollector/meta.yaml
+++ b/recipes/debtcollector/meta.yaml
@@ -1,0 +1,48 @@
+{%set name = "debtcollector" %}
+{%set version = "1.5.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "8eab1fba356cc465c4ab347119e217b045929713e2c543290f7c0571ede417dc" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=1.8
+
+  run:
+    - python
+    - pbr >=1.6
+    - six >=1.9.0
+    - wrapt >=1.7.0
+    - funcsigs >=0.4  # [py26 or py27]
+
+test:
+  imports:
+    - debtcollector
+    - debtcollector.moves
+    - debtcollector.renames
+    - debtcollector.removals
+    - debtcollector.fixtures
+
+about:
+  home: http://docs.openstack.org/developer/debtcollector/
+  license: Apache 2.0
+  summary: 'A collection of Python deprecation patterns and strategies that help you collect your technical debt in a non-destructive manner.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @harlowja in case he would like to be added as a maintainer to the `debtcollector` builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/debtcollector-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.