### PR TITLE
Added recipe for netifaces

### DIFF
--- a/recipes/netifaces/meta.yaml
+++ b/recipes/netifaces/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "netifaces" %}
+{%set version = "0.10.4" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "9656a169cb83da34d732b0eb72b39373d48774aee009a3d1272b7ea2ce109cde" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://bitbucket.org/al45tair/netifaces
+  license: MIT License
+  summary: 'Portable network interface information.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @al45tair in case he would like to be added as a maintainer to the `netifaces` builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/netifaces-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.