### PR TITLE
Added recipe for keystoneauth1

### DIFF
--- a/recipes/keystoneauth1/meta.yaml
+++ b/recipes/keystoneauth1/meta.yaml
@@ -24,16 +24,21 @@ requirements:
 
   run:
     - python
-    - pbr >=1.6
+    - pbr >=1.8
     - iso8601 >=0.1.11
     - positional >=1.0.1
     - requests >=2.10.0
     - six >=1.9.0
-    - stevedore>=1.10.0
+    - stevedore >=1.10.0
 
 test:
   imports:
-    - {{ name }}
+    - keystoneauth1
+    - keystoneauth1.identity
+    - keystoneauth1.identity.v2
+    - keystoneauth1.identity.v3
+    - keystoneauth1.identity.generic
+    - keystoneauth1.extras
 
 about:
   home: http://docs.openstack.org/developer/keystoneauth/

--- a/recipes/keystoneauth1/meta.yaml
+++ b/recipes/keystoneauth1/meta.yaml
@@ -1,0 +1,45 @@
+{%set name = "keystoneauth1" %}
+{%set version = "2.8.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "7f92251600b86c368d2201317c60b82e37760e1399c223005710b1ee8a52b03f" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=1.8
+
+  run:
+    - python
+    - pbr >=1.6
+    - iso8601 >=0.1.11
+    - positional >=1.0.1
+    - requests >=2.10.0
+    - six >=1.9.0
+    - stevedore>=1.10.0
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: http://docs.openstack.org/developer/keystoneauth/
+  license: Apache Software License Version 2.0
+  summary: 'Authentication Library for OpenStack Identity'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
(Pinging @morganfainberg in case he'd like to be added as a maintainer to the `keystone1` builder on conda-forge. Incidentally, we see the same `pbr` mismatch here between setup.py and requirements.txt as in the other build.)