### PR TITLE
Added recipe for elasticsearch-dsl

### DIFF
--- a/recipes/elasticsearch-dsl/meta.yaml
+++ b/recipes/elasticsearch-dsl/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "2.0.0" %}
+
+package:
+  name: elasticsearch-dsl
+  version: {{ version }}
+
+source:
+  fn: elasticsearch-dsl-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/e/elasticsearch-dsl/elasticsearch-dsl-{{ version }}.tar.gz
+  md5: 4cdfec81bb35383dd3b7d02d7dc5ee68
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six
+    - python-dateutil
+    - elasticsearch >=2.0.0,<3.0.0
+
+test:
+  imports:
+    - elasticsearch_dsl
+
+about:
+  home: https://github.com/elasticsearch/elasticsearch-dsl-py
+  license: Apache Software License Version 2.0
+  summary: 'Higher-level Python client for Elasticsearch'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/elasticsearch-dsl/meta.yaml
+++ b/recipes/elasticsearch-dsl/meta.yaml
@@ -31,7 +31,7 @@ test:
 
 about:
   home: https://github.com/elasticsearch/elasticsearch-dsl-py
-  license: Apache Software License Version 2.0
+  license: Apache 2.0
   summary: 'Higher-level Python client for Elasticsearch'
 
 extra:

--- a/recipes/elasticsearch-dsl/meta.yaml
+++ b/recipes/elasticsearch-dsl/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: elasticsearch-dsl-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/e/elasticsearch-dsl/elasticsearch-dsl-{{ version }}.tar.gz
-  md5: 4cdfec81bb35383dd3b7d02d7dc5ee68
+  sha256: 9060e4ff9abfc632b78f730b442ad2997f2fb985be9f6e49e3612ce292b5c36a
 
 build:
 


### PR DESCRIPTION
Higher level recipe for querying Elastic - can be added now that we have `elasticsearch`.