### PR TITLE
Added recipe for python-mimeparse

### DIFF
--- a/recipes/python-mimeparse/meta.yaml
+++ b/recipes/python-mimeparse/meta.yaml
@@ -1,5 +1,5 @@
 {%set name = "python-mimeparse" %}
-{%set version = "1.5.2." %}
+{%set version = "1.5.2" %}
 {%set hash_type = "sha256" %}
 {%set hash_val = "bef134a59598cc6aa598f84553162aa7a0c01f3f431588225bb9a208964b1827" %}
 
@@ -26,7 +26,7 @@ requirements:
 
 test:
   imports:
-    - {{ name }}
+    - mimeparse
 
 about:
   home: https://github.com/dbtsai/python-mimeparse

--- a/recipes/python-mimeparse/meta.yaml
+++ b/recipes/python-mimeparse/meta.yaml
@@ -1,0 +1,38 @@
+{%set name = "python-mimeparse" %}
+{%set version = "1.5.2." %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "bef134a59598cc6aa598f84553162aa7a0c01f3f431588225bb9a208964b1827" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/dbtsai/python-mimeparse
+  license: MIT License
+  summary: 'A module provides basic functions for parsing mime-type names and matching them against a list of media-ranges.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
As I understand it, [`python-mimeparse`]() is a distinct fork of [`mimeparse`](https://pypi.python.org/pypi/mimeparse/0.1.4) that fixes some versioning issues.

Pinging @dbtsai in case he'd like to be added as a maintainer to the `python-mimeparse` builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/python-mimeparse-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.