### PR TITLE
Added recipe for tangelo

### DIFF
--- a/recipes/tangelo/meta.yaml
+++ b/recipes/tangelo/meta.yaml
@@ -1,0 +1,49 @@
+{%set version = "0.10.0" %}
+
+package:
+  name: tangelo
+  version: {{ version }}
+
+source:
+  fn: tangelo-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/tangelo/tangelo-{{ version }}.tar.gz
+  sha256: ea5111ba637cdbcbeebe834fff2c530aa18c29f7213e8a9a0e1b708af51426c0
+
+build:
+  skip: True  # [py3k]
+  entry_points:
+    - tangelo = tangelo.__main__:main
+    - tangelo-passwd = tangelo.__main__:tangelo_passwd
+    - tangelo-pkgdata = tangelo.__main__:tangelo_pkgdata
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - cherrypy >=3.2,<4.0
+    - pyyaml ==3.11
+    - ws4py ==0.3.2
+
+test:
+  imports:
+    - tangelo
+
+  commands:
+    - tangelo --help
+    - tangelo-passwd --help
+    - tangelo-pkgdata --help
+
+about:
+  home: http://kitware.github.io/tangelo
+  license: Apache License Version 2.0
+  summary: 'Tangelo Web Framework'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @ronichoudhury in case he'd like to be added as a maintainer to the [`tangelo`](https://tangelo.readthedocs.io/en/v0.10/) builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/tangelo-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.