### PR TITLE
Added recipe for os-client-config

### DIFF
--- a/recipes/os-client-config/meta.yaml
+++ b/recipes/os-client-config/meta.yaml
@@ -1,0 +1,44 @@
+{%set name = "os-client-config" %}
+{%set version = "1.18.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "69f51888730a0e7b860dec2723c5119c7e7aaf60f4935d2c8062f8f812238be0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr
+
+  run:
+    - python
+    - PyYAML >=3.1.0
+    - appdirs >=1.3.0
+    - keystoneauth1 >=2.1.0
+    - requestsexceptions >=1.1.1
+
+test:
+  imports:
+    - os_client_config
+    - os_client_config.tests
+
+about:
+  home: https://github.com/openstack/os-client-config
+  license: Apache 2.0
+  summary: 'OpenStack Client Configuation Library'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/os-client-config/meta.yaml
+++ b/recipes/os-client-config/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python
-    - PyYAML >=3.1.0
+    - pyyaml >=3.1.0
     - appdirs >=1.3.0
     - keystoneauth1 >=2.1.0
     - requestsexceptions >=1.1.1


### PR DESCRIPTION
[`os-client-config`](https://github.com/openstack/os-client-config) is a library for collecting client configuration for using an OpenStack cloud in a consistent and comprehensive manner. It’s another component of the OpenStack Client, and of getting that client building in `conda`.