### PR TITLE
add logbook

### DIFF
--- a/recipes/logbook/meta.yaml
+++ b/recipes/logbook/meta.yaml
@@ -1,0 +1,45 @@
+{% set name="logbook" %}
+{% set name_upper=name|title %}
+{% set version="1.0.0" %}
+{% set sha256="87da2515a6b3db866283cb9d4e5a6ec44e52a1d556ebb2ea3b6e7e704b5f1872" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name_upper[0] }}/{{ name_upper }}/{{ name_upper }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - logbook
+
+about:
+  home: http://logbook.pocoo.org/
+  license: BSD 3-clause
+  summary: 'A logging replacement for Python'
+
+extra:
+  recipe-maintainers:
+    - brainstorm
+    - gbrandl
+    - jikamens
+    - mitsuhiko
+    - msarahan
+    - richafrank
+    - scilifelab
+    - vmalloc

--- a/recipes/logbook/meta.yaml
+++ b/recipes/logbook/meta.yaml
@@ -35,11 +35,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - brainstorm
-    - gbrandl
-    - jikamens
-    - mitsuhiko
     - msarahan
     - richafrank
-    - scilifelab
-    - vmalloc


### PR DESCRIPTION
Taken originally from https://github.com/quantopian/zipline/tree/master/conda/logbook

Pinging @mitsuhiko @gbrandl @scilifelab @brainstorm @vmalloc @jikamens @richafrank

Because of your previous maintenance of this package or the original recipe, I have listed you as maintainer for this package on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/logbook-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too - I'm happy to remove you from the list below.
