### PR TITLE
add sortedcontainers

### DIFF
--- a/recipes/sortedcontainers/meta.yaml
+++ b/recipes/sortedcontainers/meta.yaml
@@ -1,0 +1,39 @@
+{% set name="sortedcontainers" %}
+{% set version="1.5.3" %}
+{% set sha256="37190869bdd8405426b72b75a0e3a699b7fd6a7285905892acb49bd905d8625d" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - sortedcontainers
+
+about:
+  home: http://www.grantjenks.com/docs/sortedcontainers/
+  license: Apache 2.0
+  summary: 'Python Sorted Container Types: SortedList, SortedDict, and SortedSet'
+
+extra:
+  recipe-maintainers:
+    - grantjenks
+    - msarahan
+    - richafrank


### PR DESCRIPTION
recipe originally from https://github.com/quantopian/zipline/tree/master/conda/0_sortedcontainers - updated here

ping @grantjenks @richafrank

Because of your previous maintenance of this package or the original recipe, I have listed you as maintainer for this package on conda-forge, a library of community-build conda packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/sortedcontainers-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too - I'm happy to remove you from the list below.