### PR TITLE
Add isort package

### DIFF
--- a/recipes/isort/meta.yaml
+++ b/recipes/isort/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "4.2.5" %}
+{% set md5 = "71489ebd936429d5bda2af7ae662ed78" %}
+
+package:
+  name: isort
+  version: {{ version }}
+
+source:
+  fn: isort-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/i/isort/isort-{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+build:
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+    number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - isort
+
+about:
+  home: https://github.com/timothycrosley/isort
+  license: MIT License
+  summary: 'A Python utility / library to sort Python imports.'
+  description: |
+    isort is a Python utility / library to sort imports alphabetically, and
+    automatically separated into sections. It provides a command line utility,
+    Python library and plugins for various editors to quickly sort all your
+    imports. It currently cleanly supports Python 2.6 - 3.5 using pies to
+    achieve this without ugly hacks and/or py2to3.
+  doc_url: http://isort.readthedocs.io/en/latest/
+  dev_url: https://github.com/timothycrosley/isort
+
+extra:
+  recipe-maintainers:
+    - goanpeca
+


### PR DESCRIPTION
Hi @timothycrosley, thanks for isort :-).

Are you familiar with conda-forge? Are you ok with being added as maintainer?

---
isort your python imports for you so you don’t have to.

isort is a Python utility / library to sort imports alphabetically, and automatically separated into sections. It provides a command line utility, Python library and plugins for various editors to quickly sort all your imports. It currently cleanly supports Python 2.6 - 3.5 using pies to achieve this without ugly hacks and/or py2to3.