### PR TITLE
Fix python-avro

### DIFF
--- a/recipes/python-avro/meta.yaml
+++ b/recipes/python-avro/meta.yaml
@@ -4,7 +4,7 @@ package:
   name: python-avro
   version: {{ version }}
 
-source:
+source:  # [py27 or py3k]
   # Avro exist as two versions in apache avro for py2 and py3.
   fn: avro-{{ version }}.tar.gz  # [py27]
   url: https://pypi.python.org/packages/source/a/avro/avro-{{ version }}.tar.gz  # [py27]


### PR DESCRIPTION
Sadly, `conda-build` is not very smart in this situation. It seems to think if the selectors are not met that there is an empty string in the `source` section. In reality, that section is just empty. So, this is an ugly hack that must remain for now until `conda-build` improves its handling of this situation. We have had to use it in a few different places for similar reasons and now we have to add it here. See the [log]( https://travis-ci.org/conda-forge/staged-recipes/jobs/141466202#L641-L661 ) for the exception.

cc @msarahan @mariusvniekerk