### PR TITLE
Added recipe for warlock

### DIFF
--- a/recipes/warlock/meta.yaml
+++ b/recipes/warlock/meta.yaml
@@ -1,0 +1,41 @@
+{%set name = "warlock" %}
+{%set version = "1.3.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "d7403f728fce67ee2f22f3d7fa09c9de0bc95c3e7bcf6005b9c1962b77976a06" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - jsonschema >=0.7,<3
+    - jsonpatch >=0.10,<2
+    - six
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: http://github.com/bcwaldon/warlock
+  license: Apache 2.0
+  summary: 'Python object model built on JSON schema and JSON patch.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @bcwaldon in case he'd like to be added as a maintainer to the `warlock` builder on conda-forge, a library of community-build `conda` packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/warlock-feedstock shortly after this PR is finished and merged. If you're not interested in helping maintain the build, that's entirely fine too.