### PR TITLE
Added recipe for openstacksdk

### DIFF
--- a/recipes/openstacksdk/meta.yaml
+++ b/recipes/openstacksdk/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 
   run:
     - python
-    - pbr >=1.6
+    - pbr >=1.8
     - six >=1.9.0
     - stevedore >=1.10.0
     - os-client-config >=1.13.1

--- a/recipes/openstacksdk/meta.yaml
+++ b/recipes/openstacksdk/meta.yaml
@@ -1,0 +1,44 @@
+{%set name = "openstacksdk" %}
+{%set version = "0.8.6" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "ce336129b3929336093f01b5b54a25725b1e0b3d919c931c62b28193119442e2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=1.8
+
+  run:
+    - python
+    - pbr >=1.6
+    - six >=1.9.0
+    - stevedore >=1.10.0
+    - os-client-config >=1.13.1
+    - keystoneauth1 >=2.7.0
+
+test:
+  imports:
+    - openstack
+
+about:
+  home: http://developer.openstack.org/sdks/python/openstacksdk/
+  license: Apache 2.0
+  summary: 'Collection of libraries for building applications to work with OpenStack clouds. '
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
The [`python-openstacksdk`](https://github.com/openstack/python-openstacksdk) is a collection of libraries for building applications to work with OpenStack clouds. Despite the `python-` prefix, it's tracked in pypi as [`openstacksdk`](https://pypi.python.org/pypi/openstacksdk)