### PR TITLE
Added recipe for python-editor

### DIFF
--- a/recipes/python-editor/meta.yaml
+++ b/recipes/python-editor/meta.yaml
@@ -1,0 +1,38 @@
+{%set name = "python-editor" %}
+{%set version = "1.0.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "8672e9a44a7957741453dd35e842299f6c29f0a88dc9e4316b0fa5935abb9186" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - editor
+
+about:
+  home: https://github.com/fmoo/python-editor
+  license: Apache 2.0
+  summary: 'Programmatically open an editor, capture the result.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @fmoo in case he'd like to be added as a maintainer to the [`python-editor`](https://github.com/fmoo/python-editor) builder on conda-forge, a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/python-editor-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.