### PR TITLE
Added recipe for chartkick

### DIFF
--- a/recipes/chartkick/meta.yaml
+++ b/recipes/chartkick/meta.yaml
@@ -24,10 +24,6 @@ requirements:
   run:
     - python
 
-package:
-  name: chartkick
-  version: "0.4.2"
-
 test:
   imports:
     - chartkick
@@ -35,7 +31,7 @@ test:
 
 about:
   home: https://github.com/mher/chartkick.py
-  license: MIT License
+  license: MIT
   summary: 'Create beautiful Javascript charts with minimal code'
 
 extra:

--- a/recipes/chartkick/meta.yaml
+++ b/recipes/chartkick/meta.yaml
@@ -1,0 +1,43 @@
+{%set name = "chartkick" %}
+{%set version = "0.4.2" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "298f9555df45e0b8bffc2613b1efd41cd74bf0dfaf850dcedb4d9984af50174f" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+package:
+  name: chartkick
+  version: "0.4.2"
+
+test:
+  imports:
+    - chartkick
+    - chartkick.templatetags
+
+about:
+  home: https://github.com/mher/chartkick.py
+  license: MIT License
+  summary: 'Create beautiful Javascript charts with minimal code'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
I'm pushing a recipe for `0.4.2` instead of `0.5` because [`airflow`](https://pypi.python.org/pypi/airflow) has a pinned dependency that I’d like to get right. Once airflow is building, we should be able to tick the [`chartkick`](https://pypi.python.org/pypi/chartkick/0.4.2) version correspondingly. We can wrangle with `airflow` the next time it updates.

(Pinging @mher in case they'd like to be added as a maintainer to the `chartkick` builder on conda-forge, a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/chartkick-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.)
