### PR TITLE
Added recipe for croniter

### DIFF
--- a/recipes/croniter/meta.yaml
+++ b/recipes/croniter/meta.yaml
@@ -1,0 +1,42 @@
+{%set name = "croniter" %}
+{%set version = "0.3.12" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  preserve_egg_dir: True
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - python-dateutil
+
+  run:
+    - python
+    - python-dateutil
+
+test:
+  imports:
+    - croniter
+    - croniter.tests
+
+about:
+  home: http://github.com/kiorky/croniter
+  license: MIT License
+  summary: 'croniter provides iteration for datetime object with cron like format'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/croniter/meta.yaml
+++ b/recipes/croniter/meta.yaml
@@ -1,7 +1,7 @@
 {%set name = "croniter" %}
 {%set version = "0.3.12" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "" %}
+{%set hash_val = "445cb26bc2f3cff25a7b06575caf98312b552affffeee0437f26d416c6e3c895" %}
 
 package:
   name: {{ name }}

--- a/recipes/croniter/meta.yaml
+++ b/recipes/croniter/meta.yaml
@@ -34,7 +34,7 @@ test:
 
 about:
   home: http://github.com/kiorky/croniter
-  license: MIT License
+  license: MIT
   summary: 'croniter provides iteration for datetime object with cron like format'
 
 extra:


### PR DESCRIPTION
(Pinging @taichino in case they'd like to be added as a maintainer to the `croniter` builder on conda-forge, a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/croniter-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.)