### PR TITLE
Added recipe for Flask-Cache

### DIFF
--- a/recipes/flask-cache/meta.yaml
+++ b/recipes/flask-cache/meta.yaml
@@ -1,0 +1,41 @@
+{%set name = "flask-cache" %}
+{%set camelName = "Flask-Cache" %}
+{%set version = "0.13.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "90126ca9bc063854ef8ee276e95d38b2b4ec8e45fd77d5751d37971ee27c7ef4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - flask
+
+  run:
+    - python
+    - flask
+
+test:
+  imports:
+    - flask_cache
+
+about:
+  home: http://github.com/thadeusb/flask-cache
+  license: BSD 3-Clause
+  summary: 'Adds cache support to your Flask application'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
(Pinging @thadeusb in case they'd like to be added as a maintainer to the `Flask-Cache` builder on conda-forge, a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/flask-cache-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.)