### PR TITLE
Add pydocstyle package

### DIFF
--- a/recipes/pydocstyle/meta.yaml
+++ b/recipes/pydocstyle/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "1.0.0" %}
+{% set md5 = "74a42c1c8148f80c8f2931b615b54a24" %}
+
+package:
+  name: pydocstyle
+  version: {{ version }}
+
+source:
+  fn: pydocstyle-{{version}}.zip
+  url: https://pypi.io/packages/source/p/pydocstyle/pydocstyle-{{ version }}.zip
+  md5: {{ md5 }}
+
+build:
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+    number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - pydocstyle
+
+about:
+  home: https://github.com/PyCQA/pydocstyle
+  license: MIT License
+  summary: 'Python docstring style checker (formerly pep257)'
+  description: |
+    pydocstyle is a static analysis tool for checking compliance with Python
+    docstring conventions. pydocstyle supports most of PEP 257 out of the box,
+    but it should not be considered a reference implementation.
+    The framework for checking docstring style is flexible, and custom checks
+    can be easily added, for example to cover NumPy docstring conventions.
+    pydocstyle supports Python 2.6, 2.7, 3.3, 3.4, 3.5, pypy and pypy3.
+  doc_url: http://pydocstyle.readthedocs.org
+  dev_url: https://github.com/PyCQA/pydocstyle
+
+extra:
+  recipe-maintainers:
+    - goanpeca
+

--- a/recipes/pydocstyle/meta.yaml
+++ b/recipes/pydocstyle/meta.yaml
@@ -43,4 +43,5 @@ about:
 extra:
   recipe-maintainers:
     - goanpeca
+    - Nurdok
 


### PR DESCRIPTION
Pinging @nurdok in case they'd like to be added as a maintainer to the pydocstyle package on conda-forge, a library of community-build conda packages.

The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/pydocstyle-feedstock shortly after this PR is finished and merged.

If you aren't interested in helping maintain the build, that's entirely fine too.

----

## pydocstyle

Python docstring style checker

(formerly pep257)

pydocstyle is a static analysis tool for checking compliance with Python docstring conventions.

pydocstyle supports most of PEP 257 out of the box, but it should not be considered a reference implementation.

The framework for checking docstring style is flexible, and custom checks can be easily added, for example to cover NumPy docstring conventions.