### PR TITLE
Add pytest package

### DIFF
--- a/recipes/pytest/meta.yaml
+++ b/recipes/pytest/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "2.9.2" %}
+{% set hash_type = "md5" %}
+{% set hash = "b65c2944dfaa0efb62c0239afb424f5b" %}
+
+package:
+  name: pytest
+  version: {{ version }}
+
+source:
+  fn: pytest-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pytest/pytest-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  entry_points:
+    - py.test = py.test:main
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 0
+
+requirements:
+  build:
+    - python
+    - py
+    - setuptools
+    - argparse  # [py26]
+    - colorama  # [win]
+  run:
+    - python
+    - py >=1.4.29
+    - argparse  # [py26]
+    - colorama  # [win]
+
+test:
+  commands:
+    - py.test -h
+  imports:
+    - pytest
+
+about:
+  home: http://pytest.org/
+  license: MIT
+  license_file: LICENSE
+  summary: Simple and powerful testing with Python
+  description: |
+    The pytest framework makes it easy to write small tests, yet scales to
+    support complex functional testing for applications and libraries.
+  doc_url: http://pytest.org/latest/contents.html
+  dev_url: https://github.com/pytest-dev/pytest/
+
+extra:
+  recipe-maintainers:
+    - goanpeca


### PR DESCRIPTION
Pinging @nicoddemus, @flub, @pfctdayelise, @The-Compiler in case they'd like to be added as a maintainers to the pytest package on conda-forge, a library of community-build conda packages.

The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/pytest-feedstock shortly after this PR is finished and merged.

