### PR TITLE
Added recipe for alembic

### DIFF
--- a/recipes/alembic/meta.yaml
+++ b/recipes/alembic/meta.yaml
@@ -39,15 +39,10 @@ test:
     - alembic.operations
     - alembic.runtime
     - alembic.script
-    - alembic.testing
-    - alembic.testing.plugin
     - alembic.util
 
   commands:
     - alembic --help
-
-  requires:
-    - nose
 
 about:
   home: http://bitbucket.org/zzzeek/alembic

--- a/recipes/alembic/meta.yaml
+++ b/recipes/alembic/meta.yaml
@@ -1,4 +1,3 @@
-
 {%set name = "alembic" %}
 {%set version = "0.8.6" %}
 {%set hash_type = "sha256" %}

--- a/recipes/alembic/meta.yaml
+++ b/recipes/alembic/meta.yaml
@@ -1,0 +1,61 @@
+
+{%set name = "alembic" %}
+{%set version = "0.8.6" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "53403da066ef90cbc5a3f801f3dd39bbbfbc41b0a84eb8c1c806243b7e2c6466" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  entry_points:
+    - alembic = alembic.config:main
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - python-editor >=0.3
+
+  run:
+    - python
+    - sqlalchemy >=0.7.6
+    - mako
+    - python-editor >=0.3
+
+test:
+  imports:
+    - alembic
+    - alembic.autogenerate
+    - alembic.ddl
+    - alembic.operations
+    - alembic.runtime
+    - alembic.script
+    - alembic.testing
+    - alembic.testing.plugin
+    - alembic.util
+
+  commands:
+    - alembic --help
+
+  requires:
+    - mock
+    - pytest
+
+about:
+  home: http://bitbucket.org/zzzeek/alembic
+  license: MIT
+  summary: 'A database migration tool for SQLAlchemy.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/alembic/meta.yaml
+++ b/recipes/alembic/meta.yaml
@@ -48,8 +48,7 @@ test:
     - alembic --help
 
   requires:
-    - mock
-    - pytest
+    - nose
 
 about:
   home: http://bitbucket.org/zzzeek/alembic


### PR DESCRIPTION
Pinging @zzzeek in case he'd like to be added as a maintainer to the `alembic` builder on conda-forge, a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/alembic-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.