### PR TITLE
Add python recipe in debug mode

### DIFF
--- a/recipes/python-dbg/README.md
+++ b/recipes/python-dbg/README.md
@@ -1,0 +1,7 @@
+This is exactly the same recipe as:
+    https://github.com/conda-forge/python-feedstock/commit/bbc8ed6f1a3d8d641f9c2d887afbcb81d5ff2a61
+
+except that:
+    - in `build.sh`, `./configure` is passed `--with-pydebug`.
+    - in `bld.bat`, `build.bat` is passed `-d`.
+    - in `meta.yaml`, `debug` feature is added.

--- a/recipes/python-dbg/bld.bat
+++ b/recipes/python-dbg/bld.bat
@@ -1,0 +1,146 @@
+REM brand Python with conda-forge startup message
+python %RECIPE_DIR%\brand_python.py
+if errorlevel 1 exit 1
+
+
+REM Compile python, extensions and external libraries
+if "%ARCH%"=="64" (
+   set PLATFORM=x64
+   set VC_PATH=x64
+   set BUILD_PATH=amd64
+) else (
+   set PLATFORM=Win32
+   set VC_PATH=x86
+   set BUILD_PATH=win32
+)
+
+cd PCbuild
+call build.bat -e -p %PLATFORM% -d
+if errorlevel 1 exit 1
+cd ..
+
+
+REM Populate the root package directory
+for %%x in (python35.dll python.exe pythonw.exe) do (
+    copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x %PREFIX%
+    if errorlevel 1 exit 1
+)
+
+for %%x in (python.pdb python35.pdb pythonw.pdb) do (
+    copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\%%x %PREFIX%
+    if errorlevel 1 exit 1
+)
+
+copy %SRC_DIR%\LICENSE %PREFIX%\LICENSE_PYTHON.txt
+if errorlevel 1 exit 1
+
+
+REM Populate the DLLs directory
+mkdir %PREFIX%\DLLs
+xcopy /s /y %SRC_DIR%\PCBuild\%BUILD_PATH%\*.pyd %PREFIX%\DLLs\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\sqlite3.dll %PREFIX%\DLLs\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tcl86t.dll %PREFIX%\DLLs\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\tk86t.dll %PREFIX%\DLLs\
+if errorlevel 1 exit 1
+
+copy /Y %SRC_DIR%\PC\py.ico %PREFIX%\DLLs\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PC\pyc.ico %PREFIX%\DLLs\
+if errorlevel 1 exit 1
+
+
+REM Populate the Tools directory
+mkdir %PREFIX%\Tools
+xcopy /s /y /i %SRC_DIR%\Tools\demo %PREFIX%\Tools\demo
+if errorlevel 1 exit 1
+xcopy /s /y /i %SRC_DIR%\Tools\i18n %PREFIX%\Tools\i18n
+if errorlevel 1 exit 1
+xcopy /s /y /i %SRC_DIR%\Tools\parser %PREFIX%\Tools\parser
+if errorlevel 1 exit 1
+xcopy /s /y /i %SRC_DIR%\Tools\pynche %PREFIX%\Tools\pynche
+if errorlevel 1 exit 1
+xcopy /s /y /i %SRC_DIR%\Tools\scripts %PREFIX%\Tools\scripts
+if errorlevel 1 exit 1
+
+del %PREFIX%\Tools\demo\README
+if errorlevel 1 exit 1
+del %PREFIX%\Tools\pynche\README
+if errorlevel 1 exit 1
+del %PREFIX%\Tools\pynche\pynche
+if errorlevel 1 exit 1
+del %PREFIX%\Tools\scripts\README
+if errorlevel 1 exit 1
+del %PREFIX%\Tools\scripts\dutree.doc
+if errorlevel 1 exit 1
+del %PREFIX%\Tools\scripts\idle3
+if errorlevel 1 exit 1
+
+move /y %PREFIX%\Tools\scripts\2to3 %PREFIX%\Tools\scripts\2to3.py
+if errorlevel 1 exit 1
+move /y %PREFIX%\Tools\scripts\pydoc3 %PREFIX%\Tools\scripts\pydoc3.py
+if errorlevel 1 exit 1
+move /y %PREFIX%\Tools\scripts\pyvenv %PREFIX%\Tools\scripts\pyvenv.py
+if errorlevel 1 exit 1
+
+
+REM Populate the tcl directory
+if "%ARCH%"=="64" (
+   xcopy /s /y /i %SRC_DIR%\externals\tcltk64\lib %PREFIX%\tcl
+   if errorlevel 1 exit 1
+) else (
+   xcopy /s /y /i %SRC_DIR%\externals\tcltk\lib %PREFIX%\tcl
+   if errorlevel 1 exit 1
+)
+
+
+REM Populate the include directory
+xcopy /s /y %SRC_DIR%\Include %PREFIX%\include\
+if errorlevel 1 exit 1
+
+copy /Y %SRC_DIR%\PC\pyconfig.h %PREFIX%\include\
+if errorlevel 1 exit 1
+
+
+REM Populate the Scripts directory
+IF NOT exist %SCRIPTS% (mkdir %SCRIPTS%)
+if errorlevel 1 exit 1
+
+for %%x in (idle pydoc) do (
+    copy /Y %SRC_DIR%\Tools\scripts\%%x3 %SCRIPTS%\%%x
+    if errorlevel 1 exit 1
+)
+
+copy /Y %SRC_DIR%\Tools\scripts\2to3 %SCRIPTS%
+if errorlevel 1 exit 1
+
+
+REM Populate the libs directory
+mkdir %PREFIX%\libs
+copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\python35.lib %PREFIX%\libs\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\python3.lib %PREFIX%\libs\
+if errorlevel 1 exit 1
+copy /Y %SRC_DIR%\PCbuild\%BUILD_PATH%\_tkinter.lib %PREFIX%\libs\
+if errorlevel 1 exit 1
+
+
+REM Populate the Lib directory
+del %PREFIX%\libs\libpython*.a
+xcopy /s /y %SRC_DIR%\Lib %PREFIX%\Lib\
+if errorlevel 1 exit 1
+
+
+REM bytecode compile the standard library
+
+rd /s /q %STDLIB_DIR%\lib2to3\tests\
+if errorlevel 1 exit 1
+
+%PYTHON% -Wi %STDLIB_DIR%\compileall.py -f -q -x "bad_coding|badsyntax|py2_" %STDLIB_DIR%
+if errorlevel 1 exit 1
+
+
+REM Pickle lib2to3 Grammar
+%PYTHON% -m lib2to3 --help

--- a/recipes/python-dbg/brand_python.py
+++ b/recipes/python-dbg/brand_python.py
@@ -1,0 +1,41 @@
+import argparse
+import os
+import re
+
+
+platform_file = os.path.join('Lib', 'platform.py')
+get_version_file = os.path.join('Python', 'getversion.c')
+
+
+def patch_platform(msg):
+    with open(platform_file, 'r') as fh:
+        lines = list(fh)
+
+    lines_it = iter(lines)
+    with open(platform_file, 'w') as fh:
+        for line in lines_it:
+            fh.write(line)
+            if line.startswith('_sys_version_parser'):
+                next_line = next(lines_it)
+                fh.write("    r'([\w.+]+)\s*" + re.escape(' ' + msg) + "\s*'\n")
+
+def patch_get_version(msg):
+    with open(get_version_file, 'r') as fh:
+        content = list(fh)
+
+    lines = iter(content)
+    with open(get_version_file, 'w') as fh:
+        for line in lines:
+            if line.strip().startswith('PyOS_snprintf(version, sizeof(version)'):
+                fh.write('    PyOS_snprintf(version, sizeof(version),\n')
+                fh.write('        "%.80s ' + msg.replace('"', '\\"') + ' (%.80s) %.80s",\n')
+            else:
+                fh.write(line)
+
+
+msg = os.environ.get('python_branding', '<undefined>')
+if msg == '<undefined>':
+    msg = "| packaged by conda-forge |" 
+
+patch_platform(msg)
+patch_get_version(msg)

--- a/recipes/python-dbg/build.sh
+++ b/recipes/python-dbg/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+python ${RECIPE_DIR}/brand_python.py
+
+if [ `uname` == Darwin ]; then
+    export CFLAGS="-I$PREFIX/include $CFLAGS"
+    export LDFLAGS="-Wl,-rpath,$PREFIX/lib -L$PREFIX/lib -headerpad_max_install_names $LDFLAGS"
+    sed -i -e "s/@OSX_ARCH@/$ARCH/g" Lib/distutils/unixccompiler.py
+    ./configure \
+        --enable-ipv6 \
+        --enable-shared \
+        --prefix=$PREFIX \
+        --with-ensurepip=no \
+        --with-tcltk-includes="-I$PREFIX/include" \
+        --with-tcltk-libs="-L$PREFIX/lib -ltcl8.5 -ltk8.5" \
+        --with-pydebug
+fi
+if [ `uname` == Linux ]; then
+    ./configure --enable-shared --enable-ipv6 --with-ensurepip=no \
+        --prefix=$PREFIX \
+        --with-tcltk-includes="-I$PREFIX/include" \
+        --with-tcltk-libs="-L$PREFIX/lib -ltcl8.5 -ltk8.5" \
+        --with-pydebug \
+        CPPFLAGS="-I$PREFIX/include" \
+        LDFLAGS="-L$PREFIX/lib -Wl,-rpath=$PREFIX/lib,--no-as-needed"
+fi
+
+make
+make install
+ln -s $PREFIX/bin/python3.5 $PREFIX/bin/python
+ln -s $PREFIX/bin/pydoc3.5 $PREFIX/bin/pydoc

--- a/recipes/python-dbg/meta.yaml
+++ b/recipes/python-dbg/meta.yaml
@@ -1,0 +1,58 @@
+package:
+  name: python
+  version: 3.5.2
+
+source:
+  fn: Python-3.5.2.tgz
+  url: https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz
+  sha256: 1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0
+  patches:
+      - omit-local-site-packages.patch  # [osx]
+
+build:
+  number: 0
+  # Windows has issues updating python if conda is using files itself.
+  # Copy rather than link.
+  no_link:
+    - DLLs/_ctypes.py   # [win]
+    - bin/python
+  track_features:
+    - vc14              # [win]
+  features: 
+    - debug
+
+requirements:
+  build:
+    - bzip2 1.0.*       # [unix]
+    - openssl 1.0.*     # [unix]
+    - readline 6.2*     # [unix]
+    - sqlite 3.9.*      # [unix]
+    - tk 8.5.*          # [unix]
+    - xz 5.0.*          # [unix]
+    - zlib 1.2.*        # [unix]
+    - ncurses 5.9*      # [linux]
+  run:
+    - openssl 1.0.*     # [unix]
+    - readline 6.2*     # [unix]
+    - sqlite 3.9.*      # [unix]
+    - tk 8.5.*          # [unix]
+    - xz 5.0.*          # [unix]
+    - zlib 1.2.*        # [unix]
+    - ncurses 5.9*      # [linux]
+
+test:
+  commands:
+    - python -V
+    - python3 -V            # [unix]
+    - 2to3 -h
+    - pydoc -h
+    - python3-config --help  # [unix]
+
+about:
+  home: http://www.python.org/
+  license: PSF
+  summary: General purpose programming language
+      
+extra:
+  recipe-maintainers:
+    - dfroger

--- a/recipes/python-dbg/omit-local-site-packages.patch
+++ b/recipes/python-dbg/omit-local-site-packages.patch
@@ -1,0 +1,20 @@
+Index: Lib/site.py
+===================================================================
+--- Lib/site.py.orig
++++ Lib/site.py
+@@ -311,15 +311,6 @@ def getsitepackages(prefixes=None):
+         else:
+             sitepackages.append(prefix)
+             sitepackages.append(os.path.join(prefix, "lib", "site-packages"))
+-        if sys.platform == "darwin":
+-            # for framework builds *only* we add the standard Apple
+-            # locations.
+-            from sysconfig import get_config_var
+-            framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
+-                sitepackages.append(
+-                        os.path.join("/Library", framework,
+-                            sys.version[:3], "site-packages"))
+     return sitepackages
+ 
+ def addsitepackages(known_paths, prefixes=None):

--- a/recipes/python-dbg/recipe-license.txt
+++ b/recipes/python-dbg/recipe-license.txt
@@ -1,0 +1,28 @@
+This recipe is based upon the python-3.5 recipe from 
+https://github.com/ContinuumIO/anaconda-recipes
+which is released under the following BSD license:
+
+(c) 2016 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/python-dbg/run_test.py
+++ b/recipes/python-dbg/run_test.py
@@ -1,0 +1,106 @@
+import platform
+import sys
+import subprocess
+
+armv6l = bool(platform.machine() == 'armv6l')
+armv7l = bool(platform.machine() == 'armv7l')
+ppc64le = bool(platform.machine() == 'ppc64le')
+if sys.platform == 'darwin':
+    osx105 = b'10.5.' in subprocess.check_output('sw_vers')
+else:
+    osx105 = False
+
+print('sys.version:', sys.version)
+print('sys.platform:', sys.platform)
+print('tuple.__itemsize__:', tuple.__itemsize__)
+if sys.platform == 'win32':
+    assert 'MSC v.1900' in sys.version
+print('sys.maxunicode:', sys.maxunicode)
+print('platform.architecture:', platform.architecture())
+print('platform.python_version:', platform.python_version())
+
+import _bisect
+import _codecs_cn
+import _codecs_hk
+import _codecs_iso2022
+import _codecs_jp
+import _codecs_kr
+import _codecs_tw
+import _collections
+import _csv
+import _ctypes
+import _ctypes_test
+import _decimal
+import _elementtree
+import _functools
+import _hashlib
+import _heapq
+import _io
+import _json
+import _locale
+import _lsprof
+import _lzma
+import _multibytecodec
+import _multiprocessing
+import _random
+import _socket
+import _sqlite3
+import _ssl
+import _struct
+import _testcapi
+import array
+import audioop
+import binascii
+import bz2
+import cmath
+import datetime
+import itertools
+import lzma
+import math
+import mmap
+import operator
+import parser
+import pyexpat
+import select
+import time
+import unicodedata
+import zlib
+from os import urandom
+
+t = 100 * b'Foo '
+assert lzma.decompress(lzma.compress(t)) == t
+
+if sys.platform != 'win32':
+    if not (ppc64le or armv7l):
+        import _curses
+        import _curses_panel
+    import crypt
+    import fcntl
+    import grp
+    import nis
+    import readline
+    import resource
+    import syslog
+    import termios
+
+    from distutils import sysconfig
+    for var_name in 'LDSHARED', 'CC':
+        value = sysconfig.get_config_var(var_name)
+        assert value.split()[0] == 'gcc', value
+    for var_name in 'LDCXXSHARED', 'CXX':
+        value = sysconfig.get_config_var(var_name)
+        assert value.split()[0] == 'g++', value
+
+if not (armv6l or armv7l or ppc64le or osx105):
+    import tkinter
+    import turtle
+    import _tkinter
+    print('TK_VERSION: %s' % _tkinter.TK_VERSION)
+    print('TCL_VERSION: %s' % _tkinter.TCL_VERSION)
+    TCLTK_VER = '8.6' if sys.platform == 'win32' else '8.5'
+    assert _tkinter.TK_VERSION == _tkinter.TCL_VERSION == TCLTK_VER
+
+import ssl
+print('OPENSSL_VERSION:', ssl.OPENSSL_VERSION)
+if sys.platform != 'win32':
+    assert '1.0.2h' in ssl.OPENSSL_VERSION


### PR DESCRIPTION
Hello,

I would like to add a package for Python built in debug mode.

My use case in the [cython debugger](http://docs.cython.org/src/userguide/debugging.html#running-the-debugger), but it should be usefull in other situations.

This is exactly the same recipe as the [Python recipe](https://github.com/conda-forge/python-feedstock/tree/bbc8ed6f1a3d8d641f9c2d887afbcb81d5ff2a61/recipe) except that:
- in `build.sh`, `./configure` is passed `--with-pydebug`.
- in `bld.bat`, `build.bat` is passed `-d`.
- in `meta.yaml`, `debug` feature is added.
