### PR TITLE
Added recipe for Flask-WTF

### DIFF
--- a/recipes/flask-wtf/meta.yaml
+++ b/recipes/flask-wtf/meta.yaml
@@ -1,5 +1,5 @@
 {%set name = "flask-wtf" %}
-{%set camelName = "flask-WTF" %}
+{%set camelName = "Flask-WTF" %}
 {%set version = "0.12" %}
 {%set hash_type = "sha256" %}
 {%set hash_val = "bd99316c97ed1d1cb90b8f0c242c86420a891a6a2058f20717e424bf5b0bb80e" %}
@@ -21,9 +21,6 @@ requirements:
   build:
     - python
     - setuptools
-    - flask
-    - werkzeug
-    - wtforms
 
   run:
     - python
@@ -35,10 +32,6 @@ test:
   imports:
     - flask_wtf
     - flask_wtf.recaptcha
-
-  requires:
-    - flask-babel
-    - nose
 
 about:
   home: http://github.com/lepture/flask-wtf

--- a/recipes/flask-wtf/meta.yaml
+++ b/recipes/flask-wtf/meta.yaml
@@ -1,0 +1,50 @@
+{%set name = "flask-wtf" %}
+{%set camelName = "flask-WTF" %}
+{%set version = "0.12" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "bd99316c97ed1d1cb90b8f0c242c86420a891a6a2058f20717e424bf5b0bb80e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - flask
+    - werkzeug
+    - wtforms
+
+  run:
+    - python
+    - flask
+    - werkzeug
+    - wtforms
+
+test:
+  imports:
+    - flask_wtf
+    - flask_wtf.recaptcha
+
+  requires:
+    - flask-babel
+    - nose
+
+about:
+  home: http://github.com/lepture/flask-wtf
+  license: BSD 3-Clause
+  summary: 'Simple integration of Flask and WTForms'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @lepture in case he'd like to be added as a maintainer to the `flask-wtf` builder on [conda-forge](http://conda-forge.github.io), a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/flask-wtf-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
