### PR TITLE
Added recipe for Flask-BabelEx

### DIFF
--- a/recipes/flask-babelex/meta.yaml
+++ b/recipes/flask-babelex/meta.yaml
@@ -1,8 +1,8 @@
-
 {% set name = "flask-babelex" %}
 {% set camelName = "Flask-BabelEx" %}
 {% set version = "0.9.3" %}
-
+{%set hash_type = "sha256" %}
+{% set hash_val = "cf79cdedb5ce860166120136b0e059e9d97b8df07a3bc2411f6243de04b754b4" %}
 package:
   name: {{ name }}
   version: {{ version }}
@@ -10,10 +10,9 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
-  md5: 59a0fdc99be059365fd5aa673a429189
+  {{ hash_type }}: {{ hash_val }}
 
 build:
-  skip: True  # [py3k]
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 

--- a/recipes/flask-babelex/meta.yaml
+++ b/recipes/flask-babelex/meta.yaml
@@ -1,0 +1,47 @@
+
+{% set name = "flask-babelex" %}
+{% set camelName = "Flask-BabelEx" %}
+{% set version = "0.9.3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  md5: 59a0fdc99be059365fd5aa673a429189
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    # - flask
+    # - babel >=1.0
+    # - speaklater >=1.2
+    # - jinja2 >=2.5
+
+  run:
+    - python
+    - flask
+    - babel >=1.0
+    - speaklater >=1.2
+    - jinja2 >=2.5
+
+test:
+  imports:
+    - flask_babelex
+
+about:
+  home: http://github.com/mrjoes/flask-babelex
+  license: BSD 3-Clause
+  summary: 'Adds i18n/l10n support to Flask applications'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/flask-babelex/meta.yaml
+++ b/recipes/flask-babelex/meta.yaml
@@ -21,10 +21,6 @@ requirements:
   build:
     - python
     - setuptools
-    # - flask
-    # - babel >=1.0
-    # - speaklater >=1.2
-    # - jinja2 >=2.5
 
   run:
     - python

--- a/recipes/flask-babelex/meta.yaml
+++ b/recipes/flask-babelex/meta.yaml
@@ -13,7 +13,7 @@ source:
   md5: 59a0fdc99be059365fd5aa673a429189
 
 build:
-
+  skip: True  # [py3k]
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 


### PR DESCRIPTION
Pinging @mrjoes in case he'd like to be added as a maintainer to the `flask-babelex` builder on [conda-forge](http://conda-forge.github.io)), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/flask-babelex-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.