### PR TITLE
Added recipe for Flask-Bcrypt

### DIFF
--- a/recipes/flask-bcrypt/meta.yaml
+++ b/recipes/flask-bcrypt/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "flask-bcrypt" %}
+{% set camelName = "Flask-Bcrypt" %}
+{% set version = "0.7.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  md5: d345c36ac6637d3ca9fa942e238d00ca
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    # - flask
+    # - bcrypt
+
+  run:
+    - python
+    - flask
+    - bcrypt
+
+test:
+  imports:
+    - flask_bcrypt
+
+about:
+  home: https://github.com/maxcountryman/flask-bcrypt
+  license: BSD 3-Clause
+  summary: 'Bcrypt hashing for Flask.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/flask-bcrypt/meta.yaml
+++ b/recipes/flask-bcrypt/meta.yaml
@@ -1,6 +1,8 @@
 {% set name = "flask-bcrypt" %}
 {% set camelName = "Flask-Bcrypt" %}
 {% set version = "0.7.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "d71c8585b2ee1c62024392ebdbc447438564e2c8c02b4e57b56a4cafd8d13c5f" %}
 
 package:
   name: {{ name }}
@@ -9,7 +11,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
-  md5: d345c36ac6637d3ca9fa942e238d00ca
+  {{ hash_type }}: {{ hash_val }}
 
 build:
 
@@ -20,8 +22,6 @@ requirements:
   build:
     - python
     - setuptools
-    # - flask
-    # - bcrypt
 
   run:
     - python


### PR DESCRIPTION
Pinging @maxcountryman in case they'd like to be added as a maintainer to the `flask-bcrypt` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/flask-bcrypt-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.