### PR TITLE
Re-add python-simplegeneric as simplegeneric

### DIFF
--- a/recipes/simplegeneric/meta.yaml
+++ b/recipes/simplegeneric/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.8.1" %}
+
+package:
+  name: simplegeneric
+  version: {{ version }}
+
+source:
+  fn: simplegeneric-{{ version }}.zip
+  url: https://pypi.python.org/packages/source/s/simplegeneric/simplegeneric-{{ version }}.zip
+  md5: f9c1fab00fd981be588fc32759f474e3
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - simplegeneric
+
+about:
+  home: http://cheeseshop.python.org/pypi/simplegeneric
+  license: Zope Public License
+  summary: "Simple generic functions (similar to Python's own len(), pickle.dump(), etc.)"
+
+extra:
+  recipe-maintainers:
+    - minrk
+    - msarahan
+    - pelson
+    - ocefpaf


### PR DESCRIPTION
Not sure were the discussion on this ended, but it is bringing a lot of grieve to our users and I believe we should move forward with the renaming.

If this is merged we should remove https://github.com/conda-forge/python-simplegeneric-feedstock

Ping @minrk, @msaraha, and @pelson.