### PR TITLE
Added recipe for botocore

### DIFF
--- a/recipes/botocore/meta.yaml
+++ b/recipes/botocore/meta.yaml
@@ -23,12 +23,16 @@ requirements:
     - jmespath >=0.7.1,<1.0.0
     - python-dateutil >=2.1,<3.0.0
     - docutils >=0.10
+    - ordereddict ==1.1  # [py26]
+    - simplejson ==3.3.0  # [py26]
 
   run:
     - python
     - jmespath >=0.7.1,<1.0.0
     - python-dateutil >=2.1,<3.0.0
     - docutils >=0.10
+    - ordereddict ==1.1  # [py26]
+    - simplejson ==3.3.0  # [py26]
 
 test:
   # Python imports

--- a/recipes/botocore/meta.yaml
+++ b/recipes/botocore/meta.yaml
@@ -35,7 +35,6 @@ requirements:
     - simplejson ==3.3.0  # [py26]
 
 test:
-  # Python imports
   imports:
     - botocore
     - botocore.docs

--- a/recipes/botocore/meta.yaml
+++ b/recipes/botocore/meta.yaml
@@ -1,0 +1,56 @@
+{%set name = "botocore" %}
+{%set version = "1.4.34" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "a649ab5f9d9ddaa235510f62939e874aa3e37677564319883337ef9e98b7e5a1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - jmespath >=0.7.1,<1.0.0
+    - python-dateutil >=2.1,<3.0.0
+    - docutils >=0.10
+
+  run:
+    - python
+    - jmespath >=0.7.1,<1.0.0
+    - python-dateutil >=2.1,<3.0.0
+    - docutils >=0.10
+
+test:
+  # Python imports
+  imports:
+    - botocore
+    - botocore.docs
+    - botocore.docs.bcdoc
+    - botocore.vendored
+    - botocore.vendored.requests
+    - botocore.vendored.requests.packages
+    - botocore.vendored.requests.packages.chardet
+    - botocore.vendored.requests.packages.urllib3
+    - botocore.vendored.requests.packages.urllib3.contrib
+    - botocore.vendored.requests.packages.urllib3.packages
+    - botocore.vendored.requests.packages.urllib3.packages.ssl_match_hostname
+    - botocore.vendored.requests.packages.urllib3.util
+
+about:
+  home: https://github.com/boto/botocore
+  license: Apache 2.0
+  summary: 'Low-level, data-driven core of boto 3.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Getting a conda-forge build of `awscli` requires a more current build of `botocore` than the main anaconda build.