### PR TITLE
Added recipe for fake-factory/faker

### DIFF
--- a/recipes/fake-factory/meta.yaml
+++ b/recipes/fake-factory/meta.yaml
@@ -25,15 +25,15 @@ requirements:
     - setuptools
     - python-dateutil >=2.4
     - six
-    - importlib  # [py26 or py30]
-    - ipaddress  # [py26 or py27 or py32]
+    - importlib  # [py26]
+    - ipaddress  # [py26 or py27]
 
   run:
     - python
     - python-dateutil >=2.4
     - six
-    - importlib  # [py26 or py30]
-    - ipaddress  # [py26 or py27 or py32]
+    - importlib  # [py26]
+    - ipaddress  # [py26 or py27]
 
 test:
   imports:

--- a/recipes/fake-factory/meta.yaml
+++ b/recipes/fake-factory/meta.yaml
@@ -231,7 +231,8 @@ test:
     - faker.utils
 
   commands:
-    - faker --help
+    - faker --help  # [not linux]
+    - PYTHONIOENCODING=utf8 faker --help  # [linux]
 
 about:
   home: http://github.com/joke2k/faker

--- a/recipes/fake-factory/meta.yaml
+++ b/recipes/fake-factory/meta.yaml
@@ -1,0 +1,239 @@
+{%set name = "fake-factory" %}
+{%set version = "0.5.8" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "d004b53e9e5340c0879eb59941d6e0edae3a0a840c28b5cc84fd66b2732b218f" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  entry_points:
+    - faker=faker.cli:execute_from_command_line
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - python-dateutil >=2.4
+    - six
+
+  run:
+    - python
+    - python-dateutil >=2.4
+    - six
+
+test:
+  imports:
+    - faker
+    - faker.providers
+    - faker.providers.address
+    - faker.providers.address.cs_CZ
+    - faker.providers.address.de_DE
+    - faker.providers.address.el_GR
+    - faker.providers.address.en
+    - faker.providers.address.en_AU
+    - faker.providers.address.en_CA
+    - faker.providers.address.en_GB
+    - faker.providers.address.en_US
+    - faker.providers.address.es
+    - faker.providers.address.es_ES
+    - faker.providers.address.es_MX
+    - faker.providers.address.fa_IR
+    - faker.providers.address.fi_FI
+    - faker.providers.address.fr_FR
+    - faker.providers.address.hi_IN
+    - faker.providers.address.hr_HR
+    - faker.providers.address.it_IT
+    - faker.providers.address.ja_JP
+    - faker.providers.address.ko_KR
+    - faker.providers.address.ne_NP
+    - faker.providers.address.nl_NL
+    - faker.providers.address.no_NO
+    - faker.providers.address.pl_PL
+    - faker.providers.address.pt_BR
+    - faker.providers.address.pt_PT
+    - faker.providers.address.sk_SK
+    - faker.providers.address.sl_SI
+    - faker.providers.address.sv_SE
+    - faker.providers.address.zh_CN
+    - faker.providers.address.zh_TW
+    - faker.providers.barcode
+    - faker.providers.barcode.en_US
+    - faker.providers.color
+    - faker.providers.color.en_US
+    - faker.providers.company
+    - faker.providers.company.bg_BG
+    - faker.providers.company.cs_CZ
+    - faker.providers.company.de_DE
+    - faker.providers.company.en_US
+    - faker.providers.company.es_MX
+    - faker.providers.company.fa_IR
+    - faker.providers.company.fi_FI
+    - faker.providers.company.fr_FR
+    - faker.providers.company.hr_HR
+    - faker.providers.company.it_IT
+    - faker.providers.company.ja_JP
+    - faker.providers.company.ko_KR
+    - faker.providers.company.no_NO
+    - faker.providers.company.pt_BR
+    - faker.providers.company.pt_PT
+    - faker.providers.company.sk_SK
+    - faker.providers.company.sl_SI
+    - faker.providers.company.sv_SE
+    - faker.providers.company.zh_CN
+    - faker.providers.company.zh_TW
+    - faker.providers.credit_card
+    - faker.providers.credit_card.en_US
+    - faker.providers.currency
+    - faker.providers.currency.en_US
+    - faker.providers.date_time
+    - faker.providers.date_time.en_US
+    - faker.providers.file
+    - faker.providers.file.en_US
+    - faker.providers.internet
+    - faker.providers.internet.bg_BG
+    - faker.providers.internet.bs_BA
+    - faker.providers.internet.cs_CZ
+    - faker.providers.internet.de_AT
+    - faker.providers.internet.de_DE
+    - faker.providers.internet.el_GR
+    - faker.providers.internet.en_AU
+    - faker.providers.internet.en_US
+    - faker.providers.internet.fa_IR
+    - faker.providers.internet.fi_FI
+    - faker.providers.internet.fr_FR
+    - faker.providers.internet.hr_HR
+    - faker.providers.internet.ja_JP
+    - faker.providers.internet.ko_KR
+    - faker.providers.internet.no_NO
+    - faker.providers.internet.pt_BR
+    - faker.providers.internet.pt_PT
+    - faker.providers.internet.sk_SK
+    - faker.providers.internet.sl_SI
+    - faker.providers.internet.sv_SE
+    - faker.providers.job
+    - faker.providers.job.en_US
+    - faker.providers.job.fa_IR
+    - faker.providers.job.fr_FR
+    - faker.providers.job.pl_PL
+    - faker.providers.job.ru_RU
+    - faker.providers.job.uk_UA
+    - faker.providers.job.zh_TW
+    - faker.providers.lorem
+    - faker.providers.lorem.el_GR
+    - faker.providers.lorem.la
+    - faker.providers.lorem.ru_RU
+    - faker.providers.misc
+    - faker.providers.misc.en_US
+    - faker.providers.person
+    - faker.providers.person.bg_BG
+    - faker.providers.person.cs_CZ
+    - faker.providers.person.de_AT
+    - faker.providers.person.de_DE
+    - faker.providers.person.dk_DK
+    - faker.providers.person.el_GR
+    - faker.providers.person.en
+    - faker.providers.person.en_US
+    - faker.providers.person.es_ES
+    - faker.providers.person.es_MX
+    - faker.providers.person.fa_IR
+    - faker.providers.person.fi_FI
+    - faker.providers.person.fr_FR
+    - faker.providers.person.hi_IN
+    - faker.providers.person.hr_HR
+    - faker.providers.person.it_IT
+    - faker.providers.person.ja_JP
+    - faker.providers.person.ko_KR
+    - faker.providers.person.lt_LT
+    - faker.providers.person.lv_LV
+    - faker.providers.person.ne_NP
+    - faker.providers.person.nl_NL
+    - faker.providers.person.no_NO
+    - faker.providers.person.pl_PL
+    - faker.providers.person.pt_BR
+    - faker.providers.person.pt_PT
+    - faker.providers.person.ru_RU
+    - faker.providers.person.sl_SI
+    - faker.providers.person.sv_SE
+    - faker.providers.person.tr_TR
+    - faker.providers.person.uk_UA
+    - faker.providers.person.zh_CN
+    - faker.providers.person.zh_TW
+    - faker.providers.phone_number
+    - faker.providers.phone_number.bg_BG
+    - faker.providers.phone_number.bs_BA
+    - faker.providers.phone_number.cs_CZ
+    - faker.providers.phone_number.de_DE
+    - faker.providers.phone_number.dk_DK
+    - faker.providers.phone_number.el_GR
+    - faker.providers.phone_number.en_AU
+    - faker.providers.phone_number.en_CA
+    - faker.providers.phone_number.en_GB
+    - faker.providers.phone_number.en_US
+    - faker.providers.phone_number.es_ES
+    - faker.providers.phone_number.es_MX
+    - faker.providers.phone_number.fa_IR
+    - faker.providers.phone_number.fi_FI
+    - faker.providers.phone_number.fr_FR
+    - faker.providers.phone_number.hi_IN
+    - faker.providers.phone_number.hr_HR
+    - faker.providers.phone_number.it_IT
+    - faker.providers.phone_number.ja_JP
+    - faker.providers.phone_number.ko_KR
+    - faker.providers.phone_number.lt_LT
+    - faker.providers.phone_number.lv_LV
+    - faker.providers.phone_number.ne_NP
+    - faker.providers.phone_number.nl_NL
+    - faker.providers.phone_number.no_NO
+    - faker.providers.phone_number.pl_PL
+    - faker.providers.phone_number.pt_BR
+    - faker.providers.phone_number.pt_PT
+    - faker.providers.phone_number.ru_RU
+    - faker.providers.phone_number.sk_SK
+    - faker.providers.phone_number.sl_SI
+    - faker.providers.phone_number.sv_SE
+    - faker.providers.phone_number.tr_TR
+    - faker.providers.phone_number.uk_UA
+    - faker.providers.phone_number.zh_CN
+    - faker.providers.phone_number.zh_TW
+    - faker.providers.profile
+    - faker.providers.profile.en_US
+    - faker.providers.python
+    - faker.providers.python.en_US
+    - faker.providers.ssn
+    - faker.providers.ssn.en_CA
+    - faker.providers.ssn.en_US
+    - faker.providers.ssn.fi_FI
+    - faker.providers.ssn.it_IT
+    - faker.providers.ssn.ko_KR
+    - faker.providers.ssn.nl_NL
+    - faker.providers.ssn.pt_BR
+    - faker.providers.ssn.sv_SE
+    - faker.providers.ssn.uk_UA
+    - faker.providers.ssn.zh_CN
+    - faker.providers.ssn.zh_TW
+    - faker.providers.user_agent
+    - faker.providers.user_agent.en_US
+    - faker.shims
+    - faker.utils
+
+  commands:
+    - faker --help
+
+about:
+  home: http://github.com/joke2k/faker
+  license: MIT
+  summary: 'Faker is a Python package that generates fake data for you.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/fake-factory/meta.yaml
+++ b/recipes/fake-factory/meta.yaml
@@ -25,11 +25,15 @@ requirements:
     - setuptools
     - python-dateutil >=2.4
     - six
+    - importlib  # [py26 or py30]
+    - ipaddress  # [py26 or py27 or py32]
 
   run:
     - python
     - python-dateutil >=2.4
     - six
+    - importlib  # [py26 or py30]
+    - ipaddress  # [py26 or py27 or py32]
 
 test:
   imports:


### PR DESCRIPTION
Pinging @joke2k and @fcurella in case they'd like to be added as maintainers to the `fake-factory` builder on [conda-forge](http://conda-forge.github.io), a library of community-build [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/fake-factory-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that is entirely fine too.

NOTE: In September, `fake-factory` will take over the namespace currently occupied by `faker` (no conda-forge feedstock). When that happens we'll need to fork and rename the feedstock.