### PR TITLE
Added recipe for snakefood

### DIFF
--- a/recipes/snakefood/meta.yaml
+++ b/recipes/snakefood/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "snakefood" %}
+{%set version = "1.4" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "295784668032254e7391ca99ba7060edd3ae4eca1a330ac11627b18ab5923b77" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  skip: True  # [py3k]
+  number: 0
+  script: python setup.py install --record=record.txt
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - snakefood
+    - snakefood.fallback
+
+about:
+  home: http://furius.ca/snakefood
+  license: GPL 2.0
+  summary: 'Dependency Graphing for Python'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
There are some patch files out there making `snakefood` work with py3k, but they entail some pretty significant changes so I'm choosing to just skip those builds.

(Pinging @blais in case they'd like to be added as a maintainer to the `snakefood` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/snakefood-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.)