### PR TITLE
Added recipe for cliff

### DIFF
--- a/recipes/cliff/meta.yaml
+++ b/recipes/cliff/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 0c3d100cbf47d168bdca70acf890f1fc024abdadac13ede1336b0f8075403dea
 
 build:
-  # skip: True  # [py35]
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 

--- a/recipes/cliff/meta.yaml
+++ b/recipes/cliff/meta.yaml
@@ -1,0 +1,53 @@
+{%set version = "2.1.0" %}
+
+package:
+  name: cliff
+  version: {{ version }}
+
+source:
+  fn: cliff-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/c/cliff/cliff-{{ version }}.tar.gz
+  sha256: 0c3d100cbf47d168bdca70acf890f1fc024abdadac13ede1336b0f8075403dea
+
+build:
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=1.6
+
+  run:
+    - python
+    # - cmd2 >=0.6.7
+    # - PrettyTable <0.8,>=0.7
+    # - pyparsing >=2.0.1
+    - six >=1.9.0
+    - stevedore >=1.10.0
+    # - unicodecsv >=0.8.0  # [not py3k]
+    # - PyYAML >=3.1.0
+
+test:
+  imports:
+    - cliff
+    - cliff.app
+    - cliff.app.App
+    - cliff.commandmanager
+    - cliff.commandmanager.CommandManager
+    - cliff.command
+    - cliff.command.Command
+    - cliff.interactive
+    - cliff.interactive.InteractiveApp
+
+about:
+  home: https://github.com/openstack/cliff
+  license: Apache Software License
+  summary: 'Command Line Interface Formulation Framework'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/cliff/meta.yaml
+++ b/recipes/cliff/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/openstack/cliff
-  license: Apache Software License
+  license: Apache 2.0
   summary: 'Command Line Interface Formulation Framework'
 
 extra:

--- a/recipes/cliff/meta.yaml
+++ b/recipes/cliff/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0c3d100cbf47d168bdca70acf890f1fc024abdadac13ede1336b0f8075403dea
 
 build:
-
+  skip: True  # [py35]
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
@@ -23,25 +23,21 @@ requirements:
 
   run:
     - python
-    # - cmd2 >=0.6.7
-    # - PrettyTable <0.8,>=0.7
-    # - pyparsing >=2.0.1
+    - cmd2 >=0.6.7
+    - prettytable <0.8,>=0.7
+    - pyparsing >=2.0.1
     - six >=1.9.0
     - stevedore >=1.10.0
-    # - unicodecsv >=0.8.0  # [not py3k]
-    # - PyYAML >=3.1.0
+    - unicodecsv >=0.8.0  # [not py3k]
+    - pyyaml >=3.1.0
 
 test:
   imports:
     - cliff
     - cliff.app
-    - cliff.app.App
     - cliff.commandmanager
-    - cliff.commandmanager.CommandManager
     - cliff.command
-    - cliff.command.Command
     - cliff.interactive
-    - cliff.interactive.InteractiveApp
 
 about:
   home: https://github.com/openstack/cliff

--- a/recipes/cliff/meta.yaml
+++ b/recipes/cliff/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 0c3d100cbf47d168bdca70acf890f1fc024abdadac13ede1336b0f8075403dea
 
 build:
-  skip: True  # [py35]
+  # skip: True  # [py35]
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 


### PR DESCRIPTION
Getting back on the path of an openstack client build... `cliff` is another component of the system.

Pinging @dhellmann in case he'd like to be added as a maintainer to the `cliff` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages…