### PR TITLE
Activate conda environment on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,21 +14,27 @@ environment:
     - TARGET_ARCH: "x86"
       CONDA_PY: "27"
       PY_CONDITION: "python >=2.7,<3"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda"
     - TARGET_ARCH: "x86"
       CONDA_PY: "34"
       PY_CONDITION: "python >=3.4,<3.5"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda3"
     - TARGET_ARCH: "x86"
       CONDA_PY: "35"
       PY_CONDITION: "python >=3.5"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda35"
     - TARGET_ARCH: "x64"
       CONDA_PY: "27"
       PY_CONDITION: "python >=2.7,<3"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
     - TARGET_ARCH: "x64"
       CONDA_PY: "34"
       PY_CONDITION: "python >=3.4,<3.5"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
     - TARGET_ARCH: "x64"
       CONDA_PY: "35"
       PY_CONDITION: "python >=3.5"
+      CONDA_INSTALL_LOCN: "C:\\Miniconda35-x64"
 
 artifacts:
     # Store built conda packages as artifacts
@@ -64,11 +70,17 @@ install:
     - cmd: rmdir C:\cygwin /s /q
 
     # Use the pre-installed Miniconda for the desired arch
-    - ps: if($env:TARGET_ARCH -eq 'x86')
-            {$root = "C:\Miniconda"}
-          else
-            {$root = "C:\Miniconda-x64"}
-          $env:path="$root;$root\Scripts;$root\Library\bin;$($env:path)"
+    #
+    # However, it is really old. So, we need to update some
+    # things before we proceed. That seems to require it being
+    # on the path. So, we temporarily put conda on the path
+    # so that we can update it. Then we remove it so that
+    # we can do a proper activation.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda update --yes --quiet conda
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda config --add channels conda-forge
     - cmd: conda config --set show_channel_urls true
     - cmd: conda update --yes --quiet conda


### PR DESCRIPTION
Tries to properly activate the `root` environment of `conda` on AppVeyor. Previously this was done by messing with the path. This change avoids that entirely. Based loosely off this PR ( https://github.com/bollwyvl/nb_conda_kernels-feedstock/pull/1 ) by @msarahan, the info found in [here]( https://github.com/matplotlib/matplotlib/blob/61bdf00085748d90df2a889bd85672a8c80f2a61/appveyor.yml ), and this [list]( https://github.com/appveyor/ci/issues/359#issue-100615041 ). Similar change proposed for `conda-smithy` in PR ( https://github.com/conda-forge/conda-smithy/pull/221 ). @msarahan, would you please check to see if this is correct?