### PR TITLE
Added recipe for rsa

### DIFF
--- a/recipes/rsa/meta.yaml
+++ b/recipes/rsa/meta.yaml
@@ -1,0 +1,60 @@
+{%set name = "rsa" %}
+{%set version = "3.4.2" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  entry_points:
+    - pyrsa-priv2pub = rsa.util:private_to_public
+    - pyrsa-keygen = rsa.cli:keygen
+    - pyrsa-encrypt = rsa.cli:encrypt
+    - pyrsa-decrypt = rsa.cli:decrypt
+    - pyrsa-sign = rsa.cli:sign
+    - pyrsa-verify = rsa.cli:verify
+    - pyrsa-encrypt-bigfile = rsa.cli:encrypt_bigfile
+    - pyrsa-decrypt-bigfile = rsa.cli:decrypt_bigfile
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyasn1 >=0.1.3
+
+  run:
+    - python
+    - pyasn1 >=0.1.3
+
+test:
+  imports:
+    - rsa
+
+  commands:
+    - pyrsa-priv2pub --help
+    - pyrsa-keygen --help
+    - pyrsa-encrypt --help
+    - pyrsa-decrypt --help
+    - pyrsa-sign --help
+    - pyrsa-verify --help
+    - pyrsa-encrypt-bigfile --help
+    - pyrsa-decrypt-bigfile --help
+
+about:
+  home: https://stuvel.eu/rsa
+  license: Apache 2.0
+  summary: 'Pure-Python RSA implementation'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @sybrenstuvel in case they'd like to be added as a maintainer to the `rsa` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/rsa-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.