### PR TITLE
Added recipe for tangelo (mark 2)

### DIFF
--- a/recipes/tangelo/meta.yaml
+++ b/recipes/tangelo/meta.yaml
@@ -1,4 +1,3 @@
-
 {%set name = "tangelo" %}
 {%set version = "0.10.0" %}
 {%set hash_type = "sha256" %}

--- a/recipes/tangelo/meta.yaml
+++ b/recipes/tangelo/meta.yaml
@@ -41,7 +41,7 @@ test:
 
 about:
   home: http://kitware.github.io/tangelo
-  license: Apache License Version 2.0
+  license: Apache 2.0
   summary: 'Tangelo Web Framework'
 
 extra:

--- a/recipes/tangelo/meta.yaml
+++ b/recipes/tangelo/meta.yaml
@@ -44,9 +44,9 @@ test:
     - tangelo-pkgdata --help
 
 about:
-  home: http://kitware.github.io/tangelo
+  home: https://github.com/Kitware/tangelo
   license: Apache 2.0
-  summary: 'Tangelo Web Framework'
+  summary: 'A Web Application Platform for Python Programmers'
 
 extra:
   recipe-maintainers:

--- a/recipes/tangelo/meta.yaml
+++ b/recipes/tangelo/meta.yaml
@@ -1,0 +1,49 @@
+{%set version = "0.10.0" %}
+
+package:
+  name: tangelo
+  version: {{ version }}
+
+source:
+  fn: tangelo-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/tangelo/tangelo-{{ version }}.tar.gz
+  sha256: ea5111ba637cdbcbeebe834fff2c530aa18c29f7213e8a9a0e1b708af51426c0
+
+build:
+  skip: True  # [py3k]
+  entry_points:
+    - tangelo = tangelo.__main__:main
+    - tangelo-passwd = tangelo.__main__:tangelo_passwd
+    - tangelo-pkgdata = tangelo.__main__:tangelo_pkgdata
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - cherrypy >=3.2,<4.0
+    - pyyaml ==3.11
+    - ws4py ==0.3.2
+
+test:
+  imports:
+    - tangelo
+
+  commands:
+    - tangelo --help
+    - tangelo-passwd --help
+    - tangelo-pkgdata --help
+
+about:
+  home: http://kitware.github.io/tangelo
+  license: Apache License Version 2.0
+  summary: 'Tangelo Web Framework'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/tangelo/meta.yaml
+++ b/recipes/tangelo/meta.yaml
@@ -1,13 +1,17 @@
+
+{%set name = "tangelo" %}
 {%set version = "0.10.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "ea5111ba637cdbcbeebe834fff2c530aa18c29f7213e8a9a0e1b708af51426c0" %}
 
 package:
-  name: tangelo
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: tangelo-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/t/tangelo/tangelo-{{ version }}.tar.gz
-  sha256: ea5111ba637cdbcbeebe834fff2c530aa18c29f7213e8a9a0e1b708af51426c0
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
 
 build:
   skip: True  # [py3k]


### PR DESCRIPTION
Fixed `ws4py` and `cherrypy` at appropriately earlier versions. Let's get this built and added...