### PR TITLE
Add recipe for parquet-cpp

### DIFF
--- a/recipes/parquet-cpp/build.sh
+++ b/recipes/parquet-cpp/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Build dependencies
+export BOOST_ROOT=$PREFIX
+export ARROW_HOME=$PREFIX
+export SNAPPY_HOME=$PREFIX
+export THRIFT_HOME=$PREFIX
+export ZLIB_HOME=$PREFIX
+
+mkdir build-dir
+cd build-dir
+
+cmake \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DPARQUET_ARROW=on \
+    -DPARQUET_BUILD_BENCHMARKS=off \
+    -DPARQUET_BUILD_TESTS=off \
+    ..
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/parquet-cpp/meta.yaml
+++ b/recipes/parquet-cpp/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.1.pre" %}
+{% set commit = "ac4e80c97ab56483b8adca3a4d7881b6e6e7b0bb" %}
+
+package:
+  name: parquet-cpp
+  version: {{ version }}
+
+source:
+  fn: {{ commit }}.tar.gz
+  url: https://github.com/apache/parquet-cpp/archive/{{ commit }}.tar.gz
+  sha256: aa5eef51113f1f19df780a6238042c5a37ca9fbc74165bb3ad6cc0e592c22793
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - arrow-cpp
+    - boost
+    - cmake
+    - zlib
+    - snappy
+    - thrift-cpp
+
+  run:
+    - arrow-cpp
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libparquet.so  # [linux]
+    - test -f $PREFIX/lib/libparquet_arrow.so  # [linux]
+    - test -f $PREFIX/lib/libparquet.dylib  # [osx]
+    - test -f $PREFIX/lib/libparquet_arrow.dylib  # [osx]
+    - test -f $PREFIX/include/parquet/api/reader.h
+
+about:
+  home: http://github.com/apache/parquet-cpp
+  license: Apache 2.0
+  summary: 'C++ libraries for the Apache Parquet file format'
+
+extra:
+  recipe-maintainers:
+    - wesm
+    - xhochy


### PR DESCRIPTION
This is unreleased software, but while it is in development, having packages in conda-forge will facilitate testing and developer engagement. 