### PR TITLE
Added recipe for oauth2client

### DIFF
--- a/recipes/oauth2client/meta.yaml
+++ b/recipes/oauth2client/meta.yaml
@@ -1,0 +1,50 @@
+{%set name = "oauth2client" %}
+{%set version = "2.2.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "53d40b5a2d7fc5d36289f4848a0d763df479ac50ba5fac05424903b9e4caac26" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    # - httplib2 >=0.9.1
+    # - pyasn1 >=0.1.7
+    # - pyasn1-modules >=0.0.5
+    - rsa >=3.1.4
+    - six >=1.6.1
+
+  run:
+    - python
+    - httplib2 >=0.9.1
+    - pyasn1 >=0.1.7
+    - pyasn1-modules >=0.0.5
+    - rsa >=3.1.4
+    - six >=1.6.1
+
+test:
+  imports:
+    - oauth2client
+    - oauth2client.contrib
+    - oauth2client.contrib.django_util
+
+about:
+  home: http://github.com/google/oauth2client/
+  license: Apache 2.0 and MIT
+  summary: 'OAuth 2.0 client library'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/oauth2client/meta.yaml
+++ b/recipes/oauth2client/meta.yaml
@@ -38,7 +38,6 @@ test:
   imports:
     - oauth2client
     - oauth2client.contrib
-    - oauth2client.contrib.django_util
 
 about:
   home: http://github.com/google/oauth2client/

--- a/recipes/oauth2client/meta.yaml
+++ b/recipes/oauth2client/meta.yaml
@@ -20,9 +20,6 @@ requirements:
   build:
     - python
     - setuptools
-    # - httplib2 >=0.9.1
-    # - pyasn1 >=0.1.7
-    # - pyasn1-modules >=0.0.5
     - rsa >=3.1.4
     - six >=1.6.1
 


### PR DESCRIPTION
I've omitted the test import of `oauth2client.contrib.django_util` because it requires both `django` and a bunch of outside configuration. 