### PR TITLE
Added recipe for uritemplate

### DIFF
--- a/recipes/uritemplate/meta.yaml
+++ b/recipes/uritemplate/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "uritemplate" %}
+{%set version = "0.6" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "a30e230aeb7ebedbcb5da9999a17fa8a30e512e6d5b06f73d47c6e03c8e357fd" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - simplejson >=2.5.0
+
+  run:
+    - python
+    - simplejson >=2.5.0
+
+test:
+  imports:
+    - uritemplate
+
+about:
+  home: http://github.com/uri-templates/uritemplate-py/
+  license: Apache 2.0
+  summary: 'URI Templates'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @mnot in case they'd like to be added as a maintainer to the `uritemplate` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/uritemplate-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.