### PR TITLE
Added recipe for setuptools-git

### DIFF
--- a/recipes/setuptools-git/meta.yaml
+++ b/recipes/setuptools-git/meta.yaml
@@ -32,7 +32,7 @@ test:
     - setuptools_git
 
 about:
-  home: https://github.com/wichert/setuptools-git
+  home: https://github.com/msabramo/setuptools-git
   license: BSD 3-Clause
   summary: 'Setuptools revision control system plugin for Git'
 

--- a/recipes/setuptools-git/meta.yaml
+++ b/recipes/setuptools-git/meta.yaml
@@ -1,0 +1,41 @@
+{%set name = "setuptools-git" %}
+{%set version = "1.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "047d7595546635edebef226bc566579d422ccc48a8a91c7d32d8bd174f68f831" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  preserve_egg_dir: True
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - setuptools_git
+
+about:
+  home: https://github.com/wichert/setuptools-git
+  license: BSD 3-Clause
+  summary: 'Setuptools revision control system plugin for Git'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @wichert in case they'd like to be added as a maintainer to the `setuptools-git` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/setuptools-git-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.