### PR TITLE
Added recipe for pydruid

### DIFF
--- a/recipes/pydruid/meta.yaml
+++ b/recipes/pydruid/meta.yaml
@@ -1,0 +1,41 @@
+{%set name = "pydruid" %}
+{%set version = "0.3.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "10039652c02e68b9024e3925ee68e45b33b27f2d9d9c7fccdad996259cc8a537" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six >=1.9.0
+
+  run:
+    - python
+    - six >=1.9.0
+
+test:
+  imports:
+    - pydruid
+    - pydruid.utils
+
+about:
+  home: http://pypi.python.org/pypi/pydruid/
+  license: Apache 2.0
+  summary: 'A Python connector for Druid.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @se7entyse7en in case they'd like to be added as a maintainer to the `pydruid` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/pydruid-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.