### PR TITLE
Added recipe for mysqlclient

### DIFF
--- a/recipes/mysqlclient/meta.yaml
+++ b/recipes/mysqlclient/meta.yaml
@@ -1,0 +1,40 @@
+{%set name = "mysqlclient" %}
+{%set version = "1.3.7" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "c74a83b4cb2933d0e43370117eeebdfa03077ae72686d2df43d31879267f1f1b" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - MySQLdb
+    - MySQLdb.constants
+    - MySQLdb.cursors
+
+about:
+  home: https://github.com/PyMySQL/mysqlclient-python
+  license: GPL 2.0
+  summary: 'Python interface to MySQL'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @methane in case they'd like to be added as a maintainer to the `mysqlclient` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/mysqlclient-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
