### PR TITLE
Added recipe for fuzzywuzzy

### DIFF
--- a/recipes/fuzzywuzzy/meta.yaml
+++ b/recipes/fuzzywuzzy/meta.yaml
@@ -28,6 +28,7 @@ requirements:
 test:
   imports:
     - fuzzywuzzy
+    - fuzzywuzzy.string_processing
 
 about:
   home: https://github.com/seatgeek/fuzzywuzzy

--- a/recipes/fuzzywuzzy/meta.yaml
+++ b/recipes/fuzzywuzzy/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "fuzzywuzzy" %}
+{%set version = "0.11.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "3d3d961c24aec15d48e9d2a60d7fdffce18d0a168d4e0ca2dd22571d5c53cc80" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - python-levenshtein
+
+test:
+  imports:
+    - fuzzywuzzy
+
+about:
+  home: https://github.com/seatgeek/fuzzywuzzy
+  license: MIT
+  summary: 'Fuzzy string matching in python'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/fuzzywuzzy/meta.yaml
+++ b/recipes/fuzzywuzzy/meta.yaml
@@ -38,3 +38,4 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
+    - josegonzalez


### PR DESCRIPTION
I've added `python-levenshtein` as a runtime dependency because the docs note that it speeds up execution by about 4x. However, it seems entirely optional.

Pinging @josegonzalez in case they'd like to be added as a maintainer to the `fuzzywuzzy` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/fuzzywuzzy-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
