### PR TITLE
Added recipe for docker-py

### DIFF
--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - six >=1.4.0
     - websocket-client >=0.32.0
     - ssl_match_hostname >=3.5  # [not py35]
-    - ipaddress ==1.0.16  # [<py33]
+    - ipaddress ==1.0.16  # [py2k or py31 or py32]
 
 test:
   imports:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - six >=1.4.0
     - websocket-client >=0.32.0
     - ssl_match_hostname >=3.5  # [not py35]
-    - ipaddress ==1.0.16  # [py2k]
+    - ipaddress ==1.0.16  # [<py33]
 
 test:
   imports:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - requests >=2.5.2
     - six >=1.4.0
     - websocket-client >=0.32.0
-    - pypiwin32 >= 219  # [win32]
+    - pypiwin32 >=219  # [win32]
     - ssl_match_hostname >=3.5  # [py<35]
     - ipaddress >=1.0.16  # [py<33]
 

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - requests >=2.5.2
     - six >=1.4.0
     - websocket-client >=0.32.0
-    - backports.ssl_match_hostname >=3.5  # [not py35]
+    - ssl_match_hostname >=3.5  # [not py35]
     - ipaddress ==1.0.16  # [py2k]
 
 test:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - requests >=2.5.2
     - six >=1.4.0
     - websocket-client >=0.32.0
+    - backports.ssl_match_hostname >=3.5  # [not py35]
+    - ipaddress ==1.0.16  # [not py33 and not py34 and not py35]
 
 test:
   imports:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -1,0 +1,58 @@
+{%set name = "docker-py" %}
+{%set version = "1.8.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests >=2.5.2
+    - six >=1.4.0
+    - websocket-client >=0.32.0
+
+  run:
+    - python
+    - requests >=2.5.2
+    - six >=1.4.0
+    - websocket-client >=0.32.0
+
+test:
+  # Python imports
+  imports:
+    - docker
+    - docker.api
+    - docker.auth
+    - docker.ssladapter
+    - docker.unixconn
+    - docker.utils
+    - docker.utils.ports
+
+  requires:
+    - coverage ==3.7.1
+    - flake8 ==2.4.1
+    - mock ==1.0.1
+    - pytest ==2.7.2
+    - pytest-cov ==2.1.0
+
+about:
+  home: https://github.com/docker/docker-py/
+  license: Apache 2.0
+  summary: 'Python client for Docker.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -27,8 +27,9 @@ requirements:
     - requests >=2.5.2
     - six >=1.4.0
     - websocket-client >=0.32.0
+    - pypiwin32 >= 219  # [win32]
     - ssl_match_hostname >=3.5  # [py<35]
-    - ipaddress ==1.0.16  # [py<33]
+    - ipaddress >=1.0.16  # [py<33]
 
 test:
   imports:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -1,7 +1,7 @@
 {%set name = "docker-py" %}
 {%set version = "1.8.1" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "" %}
+{%set hash_val = "4f47a05e677472b5e022be1ab1dfd91b473ab3fc14a6b71337042ac2caaafa0b" %}
 
 package:
   name: {{ name }}
@@ -20,9 +20,6 @@ requirements:
   build:
     - python
     - setuptools
-    - requests >=2.5.2
-    - six >=1.4.0
-    - websocket-client >=0.32.0
 
   run:
     - python
@@ -31,7 +28,6 @@ requirements:
     - websocket-client >=0.32.0
 
 test:
-  # Python imports
   imports:
     - docker
     - docker.api
@@ -40,13 +36,6 @@ test:
     - docker.unixconn
     - docker.utils
     - docker.utils.ports
-
-  requires:
-    - coverage ==3.7.1
-    - flake8 ==2.4.1
-    - mock ==1.0.1
-    - pytest ==2.7.2
-    - pytest-cov ==2.1.0
 
 about:
   home: https://github.com/docker/docker-py/

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   build:
     - python
     - setuptools
+    - toolchain
 
   run:
     - python

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -26,8 +26,8 @@ requirements:
     - requests >=2.5.2
     - six >=1.4.0
     - websocket-client >=0.32.0
-    - ssl_match_hostname >=3.5  # [not py35]
-    - ipaddress ==1.0.16  # [py2k or py31 or py32]
+    - ssl_match_hostname >=3.5  # [py<35]
+    - ipaddress ==1.0.16  # [py<33]
 
 test:
   imports:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - six >=1.4.0
     - websocket-client >=0.32.0
     - backports.ssl_match_hostname >=3.5  # [not py35]
-    - ipaddress ==1.0.16  # [not py33 and not py34 and not py35]
+    - ipaddress ==1.0.16  # [py2k]
 
 test:
   imports:

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -13,6 +13,8 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
+  skip: True  # [win32]
+  # win32 requires pypiwin32, which we don't have a build of.
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
@@ -27,7 +29,6 @@ requirements:
     - requests >=2.5.2
     - six >=1.4.0
     - websocket-client >=0.32.0
-    - pypiwin32 >=219  # [win32]
     - ssl_match_hostname >=3.5  # [py<35]
     - ipaddress >=1.0.16  # [py<33]
 

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -22,7 +22,6 @@ requirements:
   build:
     - python
     - setuptools
-    - toolchain
 
   run:
     - python


### PR DESCRIPTION
Pinging @shin- and @aanand in case they'd like to be added as maintainers to the `docker-py` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/docker-py-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
