### PR TITLE
Added recipe for inflection

### DIFF
--- a/recipes/inflection/meta.yaml
+++ b/recipes/inflection/meta.yaml
@@ -1,0 +1,38 @@
+{%set name = "inflection" %}
+{%set version = "0.3.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: http://github.com/jpvanhal/inflection
+  license: MIT
+  summary: 'A port of Ruby on Rails inflector to Python'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @jpvanhal in case they'd like to be added as a maintainer to the `inflection` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/inflection-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.