### PR TITLE
Added recipe for backports.ssl_match_hostname

### DIFF
--- a/recipes/backports.ssl_match_hostname/meta.yaml
+++ b/recipes/backports.ssl_match_hostname/meta.yaml
@@ -1,0 +1,38 @@
+{%set name = "backports.ssl_match_hostname" %}
+{%set version = "3.5.0.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - backports
+    - backports.ssl_match_hostname
+
+about:
+  home: http://bitbucket.org/brandon/backports.ssl_match_hostname
+  license: PSL 2.0
+  summary: 'The ssl.match_hostname() function from Python 3.5'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Missing requirement for #1010 and likely future builds...
