### PR TITLE
Added recipe for jira

### DIFF
--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -1,0 +1,50 @@
+{%set name = "jira" %}
+{%set version = "1.0.7.dev20160607111203" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "df164507c68a85d05b7d498342c7166b0095273c34f94c8bde02c2746c13bd89" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests >=2.10.0
+    - requests-oauthlib >=0.6.1
+    - tlslite >=0.4.4
+    - six >=1.10.0
+    - setuptools >=20.10.1
+    - requests_toolbelt
+
+  run:
+    - python
+    - requests >=2.10.0
+    - requests-oauthlib >=0.6.1
+    - tlslite >=0.4.4
+    - six >=1.10.0
+    - setuptools >=20.10.1
+    - requests_toolbelt
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/pycontribs/jira
+  license: BSD 2-Clause
+  summary: 'The easiest way to automate JIRA'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -24,10 +24,7 @@ requirements:
     - python
     - setuptools >=20.10.1
     - requests >=2.10.0
-    - requests-oauthlib >=0.6.1
-    - tlslite >=0.4.4
     - six >=1.10.0
-    - requests-toolbelt
 
   run:
     - python

--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - tlslite >=0.4.4
     - six >=1.10.0
     - setuptools >=20.10.1
-    - requests_toolbelt
+    - requests-toolbelt
 
   run:
     - python
@@ -34,7 +34,7 @@ requirements:
     - tlslite >=0.4.4
     - six >=1.10.0
     - setuptools >=20.10.1
-    - requests_toolbelt
+    - requests-toolbelt
 
 test:
   imports:

--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -19,12 +19,11 @@ build:
 requirements:
   build:
     - python
-    - setuptools
+    - setuptools >=20.10.1
     - requests >=2.10.0
     - requests-oauthlib >=0.6.1
     - tlslite >=0.4.4
     - six >=1.10.0
-    - setuptools >=20.10.1
     - requests-toolbelt
 
   run:

--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -41,6 +41,9 @@ test:
   imports:
     - {{ name }}
 
+  commands:
+    - jirashell
+
 about:
   home: https://github.com/pycontribs/jira
   license: BSD 2-Clause

--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -13,6 +13,9 @@ source:
   {{ hash_type }}: {{ hash_val }}
 
 build:
+  entry_points:
+    - jirashell = jira.jirashell:main
+
   number: 0
   script: python setup.py install --single-version-externally-managed --record=record.txt
 

--- a/recipes/jira/meta.yaml
+++ b/recipes/jira/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - six >=1.10.0
     - setuptools >=20.10.1
     - requests-toolbelt
+    - filemagic >=1.6
+    - ipython >=0.13
 
 test:
   imports:


### PR DESCRIPTION
Pinging @ssbarnea in case they'd like to be added as a maintainer to the `jira` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/jira-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
