### PR TITLE
Added recipe for PyJWT

### DIFF
--- a/recipes/pyjwt/meta.yaml
+++ b/recipes/pyjwt/meta.yaml
@@ -1,0 +1,48 @@
+{%set name = "pyjwt" %}
+{%set camelName = "PyJWT" %}
+{%set version = "1.4.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "e1b2386cfad541445b1d43e480b02ca37ec57259fd1a23e79415b57ba5d8a694" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  entry_points:
+    - jwt = jwt.__main__:main
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pytest-runner
+
+  run:
+    - python
+
+test:
+  imports:
+    - jwt
+    - jwt.contrib
+    - jwt.contrib.algorithms
+
+  commands:
+    - jwt --help
+
+about:
+  home: http://github.com/jpadilla/pyjwt
+  license: MIT
+  summary: 'JSON Web Token implementation in Python'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @jpadilla in case they'd like to be added as a maintainer to the `pyjwt` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/pyjwt-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
