### PR TITLE
Add rasterstats

### DIFF
--- a/recipes/rasterstats/meta.yaml
+++ b/recipes/rasterstats/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "0.10.3" %}
+
+package:
+    name: rasterstats
+    version: {{ version }}
+
+source:
+    fn: rasterstats-{{ version }}.tar.gz
+    url: https://pypi.io/packages/source/r/rasterstats/rasterstats-{{ version }}.tar.gz
+    sha256: 7a4a79d71fbfb15812ee40081a8fd321039e9b26f389f7ec456c657c3298a818
+
+build:
+    number: 0
+    preserve_egg_dir: True
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - shapely
+        - numpy >=1.9
+        - rasterio >=0.27
+        - fiona
+        - gdal 2.1.*
+
+test:
+    imports:
+        - rasterstats
+    commands:
+        - rio zonalstats --help
+        - rio pointquery --help
+    requires:
+        - coverage
+        - pyshp >=1.1.4
+        - pytest
+
+about:
+  home: https://github.com/perrygeo/python-raster-stats
+  license: BSD 3-Clause
+  summary: 'Summarize geospatial raster datasets based on vector geometries.'
+
+extra:
+    recipe-maintainers:
+        - perrygeo
+        - ocefpaf


### PR DESCRIPTION
``rasterstats`` is a Python module for summarizing geospatial raster datasets based on vector geometries. It includes functions for **zonal statistics** and interpolated **point queries**. The command-line interface allows for easy interoperability with other GeoJSON tools. 