### PR TITLE
WIP: Add libgfortran for OS X

### DIFF
--- a/recipes/libgfortran/meta.yaml
+++ b/recipes/libgfortran/meta.yaml
@@ -1,0 +1,61 @@
+{% set libgfortran_version = [3, 0, 0] %}
+{% set libquadmath_version = [0, 0, 0] %}
+{% set libgcc_s_version = [1, 0, 0] %}
+
+
+package:
+  name: libgfortran
+  version: {{ libgfortran_version|join('.') }}
+
+build:
+  number: 0
+  skip: true                                                  # [not osx]
+  always_include_files:
+    - lib/libgfortran.dylib                                   # [osx]
+    - lib/libgfortran.{{ libgfortran_version[0] }}.dylib      # [osx]
+
+    # Including libquadmath for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - lib/libquadmath.dylib                                   # [osx]
+    - lib/libquadmath.{{ libquadmath_version[0] }}.dylib      # [osx]
+
+    # Including libgcc_s for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - lib/libgcc_s.{{ libgcc_s_version[0] }}.dylib         # [osx]
+    - lib/libgcc_s_ppc64.{{ libgcc_s_version[0] }}.dylib   # [osx]
+    - lib/libgcc_s_x86_64.{{ libgcc_s_version[0] }}.dylib  # [osx]
+
+requirements:
+  build:
+    - gcc 4.8.5
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libgfortran.dylib"                                   # [osx]
+    - test -f "${PREFIX}/lib/libgfortran.{{ libgfortran_version[0] }}.dylib"      # [osx]
+
+    # Including libquadmath for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - test -f "${PREFIX}/lib/libquadmath.dylib"                                   # [osx]
+    - test -f "${PREFIX}/lib/libquadmath.{{ libquadmath_version[0] }}.dylib"      # [osx]
+
+    # Including libgcc_s for the time
+    # being. This will need to be broken
+    # out in the long term.
+    - test -f "${PREFIX}/lib/libgcc_s.{{ libgcc_s_version[0] }}.dylib"         # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s_ppc64.{{ libgcc_s_version[0] }}.dylib"   # [osx]
+    - test -f "${PREFIX}/lib/libgcc_s_x86_64.{{ libgcc_s_version[0] }}.dylib"  # [osx]
+
+about:
+  home: http://gcc.gnu.org/
+  summary: Fortran libraries from the GNU Compiler Collection
+  license: GPL 3 (with GCC Runtime Library Exception 3.1)
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - msarahan
+    - pelson


### PR DESCRIPTION
This is a significantly pared down version of PR ( https://github.com/conda-forge/staged-recipes/pull/861 ), which in turn is a pared down version of PR ( https://github.com/conda-forge/staged-recipes/pull/855 ). The sole purpose of this is to have a `libgfortran` package that comes from the `gcc` compiler on Mac. Think of it as the KISS PR for adding `libgfortran`. We can certainly add to this in the future, but right now having this simplest working thing should vastly improve our current situation. So, please keep that in mind when responding.

cc @msarahan @ocefpaf @pelson