### PR TITLE
Added recipe for pytrie

### DIFF
--- a/recipes/pytrie/meta.yaml
+++ b/recipes/pytrie/meta.yaml
@@ -1,0 +1,37 @@
+{%set name = "pytrie" %}
+{%set camelName = "PyTrie" %}
+{%set version = "0.2" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "b272021351efadc6757591aac03ed4794bdfd091122204a4673e94bfb66cc500" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+about:
+  home: http://bitbucket.org/gsakkis/pytrie/
+  license: BSD 3-Clause
+  summary: 'A pure Python implementation of the trie data structure.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @gsakkis in case they'd like to be added as a maintainer to the `pytrie` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/pytrie-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
