### PR TITLE
ENH: add subprocess32

### DIFF
--- a/recipes/subprocess32/bld.bat
+++ b/recipes/subprocess32/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/subprocess32/build.sh
+++ b/recipes/subprocess32/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/subprocess32/meta.yaml
+++ b/recipes/subprocess32/meta.yaml
@@ -1,0 +1,63 @@
+# Jinja variables help maintain the recipe as you'll update the version only here.
+{% set version = "3.2.7" %}
+
+package:
+  name: subprocess32
+  version: {{ version }}
+
+source:
+  fn: subprocess32-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/subprocess32/subprocess32-{{ version }}.tar.gz
+  #url: https://files.pythonhosted.org/packages/b8/2f/49e53b0d0e94611a2dc624a1ad24d41b6d94d0f1b0a078443407ea2214c2/subprocess32-3.2.7.tar.gz
+  md5: 824c801e479d3e916879aae3e9c15e16
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - subprocess32 = subprocess32:main
+    #
+    # Would create an entry point called subprocess32 that calls subprocess32.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+# test:
+  # Python imports
+  # imports:
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://github.com/google/python-subprocess32
+  license: Python Software Foundation License
+  summary: 'A backport of the subprocess module from Python 3.2/3.3 for use on 2.x.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/subprocess32/meta.yaml
+++ b/recipes/subprocess32/meta.yaml
@@ -14,7 +14,7 @@ source:
    # List any patch files here
    # - fix.patch
 
- build:
+build:
   # noarch_python: True
   # preserve_egg_dir: True
   # entry_points:

--- a/recipes/subprocess32/meta.yaml
+++ b/recipes/subprocess32/meta.yaml
@@ -1,9 +1,6 @@
 # Jinja variables help maintain the recipe as you'll update the version only here.
 {% set version = "3.2.7" %}
 
-build:
-  skip: True  # [not py2k]
-
 package:
   name: subprocess32
   version: {{ version }}
@@ -32,6 +29,7 @@ source:
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
   number: 0
+  skip: True  # [not py2k]
 
 requirements:
   build:

--- a/recipes/subprocess32/meta.yaml
+++ b/recipes/subprocess32/meta.yaml
@@ -17,7 +17,7 @@ source:
    # List any patch files here
    # - fix.patch
 
-# build:
+ build:
   # noarch_python: True
   # preserve_egg_dir: True
   # entry_points:
@@ -31,7 +31,7 @@ source:
 
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/subprocess32/meta.yaml
+++ b/recipes/subprocess32/meta.yaml
@@ -1,6 +1,9 @@
 # Jinja variables help maintain the recipe as you'll update the version only here.
 {% set version = "3.2.7" %}
 
+build:
+  skip: True  # [not py2k]
+
 package:
   name: subprocess32
   version: {{ version }}
@@ -37,9 +40,10 @@ requirements:
   run:
     - python
 
-# test:
+test:
   # Python imports
-  # imports:
+  imports:
+    - subprocess32
 
   # commands:
     # You can put test commands to be run here.  Use this to test that the
@@ -61,3 +65,9 @@ about:
 # See
 # http://docs.continuum.io/conda/build.html for
 # more information about meta.yaml
+
+extra:
+  recipe-maintainers:
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - tacaswell
+    - mdboom


### PR DESCRIPTION
Tried to use the `--single-version-externally-managed` but got errors like:

```
+ python setup.py install --single-version-externally-managed --record record.txt
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: option --single-version-externally-managed not recognized
```

How do you tell the CI system to only build this for python2 (install fails if in python).