### PR TITLE
Added recipe for ua-parser

### DIFF
--- a/recipes/ua-parser/meta.yaml
+++ b/recipes/ua-parser/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "ua-parser" %}
+{%set version = "0.7.1" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "e1f7cb16ccb68d6c93b19348e678500bec8cd1f692e49214dd38ca2d100ada9b" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pyyaml
+
+  run:
+    - python
+
+test:
+  imports:
+    - ua_parser
+
+about:
+  home: https://github.com/ua-parser/uap-python
+  license: Apache 2.0
+  summary: "Python port of Browserscope's user agent parser"
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Pinging @mattrobenolt in case they'd like to be added as a maintainer to the `ua-parser` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/ua-parser-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.
