### PR TITLE
Ferret datasets

### DIFF
--- a/recipes/ferret_datasets/build.sh
+++ b/recipes/ferret_datasets/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/share/fer_dsets
+cp -r $SRC_DIR/data $PREFIX/share/fer_dsets/data
+cp -r $SRC_DIR/descr $PREFIX/share/fer_dsets/descr
+cp -r $SRC_DIR/grids $PREFIX/share/fer_dsets/grids

--- a/recipes/ferret_datasets/meta.yaml
+++ b/recipes/ferret_datasets/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "7.0.0" %}
+
+package:
+    name: ferret_datasets
+    version: {{ version }}
+
+source:
+    fn: ferret_datasets-{{ version }}.tar.gz
+    url: https://github.com/NOAA-PMEL/PyFerret/releases/download/v{{ version }}-final/FerretDatasets.tar.gz
+    sha256: 3d735fd3e952e01646894beea91b39c2adbfde087bcfec2a78ebef189048213f
+
+build:
+    number: 0
+    skip: True  # [win or py3k or osx]
+
+requirements:
+    build:
+        - python
+        - pyferret
+    run:
+        - python
+        - pyferret
+
+test:
+    imports:
+        - pyferret
+
+about:
+    home: http://ferret.pmel.noaa.gov/Ferret
+    license: MIT
+    summary: 'Data for pyferret examples.'
+
+extra:
+    recipe-maintainers:
+        - eugeneburger
+        - karlmsmith
+        - ocefpaf


### PR DESCRIPTION
@karlmsmith I still need to update the paths in `pyferret`.

Note that people can do `conda install ferret_datasets` and get both `pyferret` and the `datasets`, but `conda install pyferret` does not install the `datasets`.