### PR TITLE
Add pango

### DIFF
--- a/recipes/pango/build.sh
+++ b/recipes/pango/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX --with-xft
+make
+# # FIXME: There is one failure:
+# ========================================
+#    pango 1.40.1: tests/test-suite.log
+# ========================================
+#
+# # TOTAL: 12
+# # PASS:  11
+# # SKIP:  0
+# # XFAIL: 0
+# # FAIL:  1
+# # XPASS: 0
+# # ERROR: 0
+#
+# .. contents:: :depth: 2
+#
+# FAIL: test-layout
+# =================
+#
+# /layout/valid-1.markup:
+# (/opt/conda/conda-bld/work/pango-1.40.1/tests/.libs/lt-test-layout:5078): Pango-CRITICAL **: pango_font_describe: assertion 'font != NULL' failed
+# FAIL test-layout (exit status: 133)
+# make check
+make install
+
+rm -rf $PREFIX/lib/*.la

--- a/recipes/pango/meta.yaml
+++ b/recipes/pango/meta.yaml
@@ -1,0 +1,56 @@
+{% set major = "1.40" %}
+{% set patch = "1" %}
+{% set version = major + "." + patch %}
+
+package:
+    name: pango
+    version: {{ version }}
+
+source:
+    url: http://ftp.gnome.org/pub/GNOME/sources/pango/{{ major }}/pango-{{ version }}.tar.xz
+    fn: pango-{{ version }}.tar.xz
+    sha256: e27af54172c72b3ac6be53c9a4c67053e16c905e02addcf3a603ceb2005c1a40
+
+build:
+    number: 0
+    skip: True  # [win or osx]
+    detect_binary_files_with_prefix: true
+
+requirements:
+    build:
+        - perl
+        - harfbuzz
+        # FIXME: harfbuzz install everything that pango needs, but to avoid issues
+        # with defaults we need to pin against conda-forge versions until
+        # conda-forge packages harfbuzz.
+        - fontconfig 2.11.*
+        - freetype 2.6.*
+        - libpng >=1.6.21,<1.7
+    run:
+        - harfbuzz
+        - fontconfig 2.11.*
+        - freetype 2.6.*
+        - libpng >=1.6.21,<1.7
+test:
+    commands:
+        - pango-view --help
+
+about:
+    home: http://www.pango.org/
+    license: LGPL-2.1
+    license_file: COPYING
+    summary: Text layout and rendering engine
+    description: |
+        Pango is a library for laying out and rendering of text, with an emphasis
+        on internationalization. Pango can be used anywhere that text layout is
+        needed, though most of the work on Pango so far has been done in the
+        context of the GTK+ widget toolkit. Pango forms the core of text and font
+        handling for GTK+-2.x.
+    doc_url: http://www.pango.org/
+    dev_url: https://github.com/phuang/pango
+
+extra:
+    recipe-maintainers:
+        - ocefpaf
+        - ccordoba12
+        - jakirkham


### PR DESCRIPTION
There is one hiccup with the tests, but the works OK on Linux.

This is needed to get `pyferret` on `OS X`.

Ping @karlmsmith 