### PR TITLE
Add recipe for pyDOE

### DIFF
--- a/recipes/pydoe/meta.yaml
+++ b/recipes/pydoe/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "0.3.8" %}
+
+package:
+  name: pydoe
+  version: {{ version }}
+
+source:
+    fn: pyDOE-afc5949f01c010a26764adba9624871d51797270.tar.gz
+    url: https://github.com/tisimst/pyDOE/archive/afc5949f01c010a26764adba9624871d51797270.tar.gz
+    sha1: 54f87d106c3f49e1b4cff17a31ef8a9e0142ec5b
+
+build:
+  script: python setup.py install
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - scipy
+
+  run:
+    - python
+    - scipy >=0.13
+    - numpy >=1.8
+
+test:
+  imports:
+    - pyDOE
+
+about:
+  home: https://github.com/tisimst/pyDOE
+  license: BSD License (3-clause)
+
+extra:
+  recipe-maintainers:
+    - melund

--- a/recipes/pydoe/meta.yaml
+++ b/recipes/pydoe/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: https://github.com/tisimst/pyDOE
   license: BSD License (3-clause)
+  summary: The pyDOE package is designed to help the scientist, engineer, statistician, etc., to construct appropriate experimental designs.
 
 extra:
   recipe-maintainers:

--- a/recipes/pydoe/meta.yaml
+++ b/recipes/pydoe/meta.yaml
@@ -10,14 +10,13 @@ source:
     sha1: 54f87d106c3f49e1b4cff17a31ef8a9e0142ec5b
 
 build:
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record=record.txt
   number: 0
 
 requirements:
   build:
     - python
     - setuptools
-    - scipy
 
   run:
     - python
@@ -30,8 +29,9 @@ test:
 
 about:
   home: https://github.com/tisimst/pyDOE
-  license: BSD License (3-clause)
-  summary: The pyDOE package is designed to help the scientist, engineer, statistician, etc., to construct appropriate experimental designs.
+  license: BSD 3-Clause
+  summary: Design of experiments for Python
+  description: The pyDOE package is designed to help the scientist, engineer, statistician, etc., to construct appropriate experimental designs.
 
 extra:
   recipe-maintainers:

--- a/recipes/pydoe/meta.yaml
+++ b/recipes/pydoe/meta.yaml
@@ -5,9 +5,9 @@ package:
   version: {{ version }}
 
 source:
-    fn: pyDOE-afc5949f01c010a26764adba9624871d51797270.tar.gz
-    url: https://github.com/tisimst/pyDOE/archive/afc5949f01c010a26764adba9624871d51797270.tar.gz
-    sha1: 54f87d106c3f49e1b4cff17a31ef8a9e0142ec5b
+    fn: pyDOE-{{ version }}.zip
+    url: https://pypi.io/packages/source/p/pyDOE/pyDOE-{{ version }}.zip
+    sha1: 211c4d74a74109ac134dff31ed20c33141b48dbe
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
pyDOE is a package for 'Design of experiments'. It is an optional dependency in one of my own libraries so I will be happy to maintain this recipe. 

Snippet from https://pythonhosted.org/pyDOE/ :
The pyDOE package is designed to help the scientist, engineer, statistician, etc., to construct appropriate experimental designs.

