### PR TITLE
Add gevent-socketio development version

### DIFF
--- a/recipes/gevent-socketio/meta.yaml
+++ b/recipes/gevent-socketio/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.3.6.dev0" %}
+
+package:
+    name: gevent-socketio
+    version: {{ version }}
+
+source:
+    git_url: https://github.com/abourget/gevent-socketio
+    git_tag: 8971328ab467adc49bec98bc9eb7d13c89d9dac6
+    patches:
+        - remove-versiontools.patch
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - gevent >=1.1rc5
+        - gevent-websocket
+        - six
+    run:
+        - python
+        - gevent >=1.1rc5
+        - gevent-websocket
+        - six
+
+test:
+    imports:
+        - socketio
+
+about:
+    home: https://github.com/abourget/gevent-socketio
+    license: BSD
+    summary: 'SocketIO server based on the Gevent pywsgi server, a Python network library'
+
+extra:
+    recipe-maintainers:
+        - daf

--- a/recipes/gevent-socketio/remove-versiontools.patch
+++ b/recipes/gevent-socketio/remove-versiontools.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index c8debdc..fc21def 100644
+--- a/setup.py
++++ b/setup.py
+@@ -41,7 +41,6 @@ setup(
+     url="https://github.com/abourget/gevent-socketio",
+     download_url="https://github.com/abourget/gevent-socketio",
+     install_requires=get_reqs('pip-requirements.txt'),
+-    setup_requires=('versiontools >= 1.7'),
+     cmdclass = {'test': PyTest},
+     tests_require=get_reqs('pip-requirements-test.txt'),
+     packages=find_packages(exclude=["examples", "tests"]),


### PR DESCRIPTION
`gevent-socketio` is a dependency for a project I work with, but unfortunately is [maintainer-less](https://github.com/abourget/gevent-socketio#community-rise-up) and [hasn't been released since 2014](https://pypi.python.org/pypi/gevent-socketio/0.3.6#downloads).  The project I use it with trips a bug that's corrected in a commit in github since the release, so I built a package around it.

I'm not sure as to conda-forge's stance on "in development" or "prerelease" software - if allowed, I expect a bit of iteration on this recipe.
- Uses `.dev0` suffix on version number a la an @ocefpaf [recipe from IOOS conda-recipes](https://github.com/ioos/conda-recipes/blob/854606b13bf68be7c57e4536c7a5fa411d70be8e/recipes/basemap-data-hires/meta.yaml#L3)
- Patches out the `setup_requires=('versiontools >= 1.7')` line of `setup.py` as it doesn't actually require it (it was only part of development between 0.2.1 and 0.2.2)
