### PR TITLE
NO MRG: CheMPS2

### DIFF
--- a/recipes/chemps2/build.sh
+++ b/recipes/chemps2/build.sh
@@ -1,0 +1,36 @@
+mkdir build
+cd build
+
+if [ "$(uname)" == "Darwin" ]; then
+
+    HDF5_INTERJECT="-L${PREFIX}/lib;-lhdf5;-lhdf5_hl;-lhdf5;-lpthread;-lz;-ldl;-lm"
+
+    # configure
+    cmake \
+        -DCMAKE_CXX_COMPILER="${PREFIX}/bin/g++" \
+        -DCMAKE_C_COMPILER="${PREFIX}/bin/gcc" \
+        -DEXTRA_C_FLAGS="''" \
+        -DEXTRA_CXX_FLAGS="''" \
+        -DSHARED_ONLY=ON \
+        -DENABLE_GENERIC=OFF \
+        -DMKL=OFF \
+        -DBUILD_DOXYGEN=OFF \
+        -DBUILD_SPHINX=OFF \
+        -DENABLE_TESTS=OFF \
+        -DHDF5_LIBRARIES="${HDF5_INTERJECT}" \
+        -DHDF5_INCLUDE_DIRS="${PREFIX}/include" \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        ${SRC_DIR}
+
+fi
+
+# build
+make -j${CPU_COUNT}
+
+# install
+make install
+
+# test
+# tests just segfault
+

--- a/recipes/chemps2/meta.yaml
+++ b/recipes/chemps2/meta.yaml
@@ -35,7 +35,7 @@ test:
 about:
   home: http://sebwouters.github.io/CheMPS2
   license: GNU General Public License v2 or later (GPLv2+)
-  license_family: GNU
+  license_family: GPL2
   license_file: LICENSE
   summary: "S. Wouters' spin-adapted implementation of DMRG for ab initio quantum chemistry"
 

--- a/recipes/chemps2/meta.yaml
+++ b/recipes/chemps2/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 5
   binary_relocation: true
-  skip: true  # [win and linux]
+  skip: true  # [win or linux]
 
 requirements:
   build:

--- a/recipes/chemps2/meta.yaml
+++ b/recipes/chemps2/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "1.7.1" %}
+
+package:
+  name: chemps2
+  version: {{ version }}
+
+source:
+  fn: CheMPS2-v{{ version }}.tar.gz
+  url: https://github.com/SebWouters/CheMPS2/archive/v{{ version }}.tar.gz
+  sha256: 16894a0ade6b5f1d3cf06b95723567558bdddf43ad25eca067bced5ab35b3a5e
+
+build:
+  number: 5
+  binary_relocation: true
+  skip: true  # [win and linux]
+
+requirements:
+  build:
+    - cmake >=2.8.11
+    - gcc  # [osx]
+    - hdf5 1.8.17|1.8.17.*
+    - zlib 1.2.*
+  run:
+    - hdf5 1.8.17|1.8.17.*
+    - libgcc  # [osx]
+    - zlib 1.2.*
+
+test:
+  commands:
+    # Verify libraries and executable.
+    - test -f $PREFIX/lib/libchemps2.so  # [linux]
+    - test -f $PREFIX/lib/libchemps2.dylib  # [osx]
+    - test -f $PREFIX/bin/chemps2
+
+about:
+  home: http://sebwouters.github.io/CheMPS2
+  license: GNU General Public License v2 or later (GPLv2+)
+  license_family: GNU
+  license_file: LICENSE
+  summary: "S. Wouters' spin-adapted implementation of DMRG for ab initio quantum chemistry"
+
+extra:
+  recipe-maintainers:
+    - loriab
+

--- a/recipes/chemps2/post-link.sh
+++ b/recipes/chemps2/post-link.sh
@@ -1,0 +1,12 @@
+set +x
+
+echo "" >> .messages.txt
+echo "  Thank you for installing CheMPS2." >> .messages.txt
+echo "    Manual:  sebwouters.github.io/CheMPS2" >> .messages.txt
+echo "    GitHub:  github.com/SebWouters/CheMPS2" >> .messages.txt
+#echo "    Binary:  anaconda.org/psi4/chemps2" >> .messages.txt
+#echo "    Inputs:  ${PREFIX}/share/psi4/samples/dmrg" >> .messages.txt
+#echo "    Test (after first activating conda installation or environment):" >> .messages.txt
+#echo "      psi4 \"\$(dirname \$(which psi4))\"/../share/psi4/samples/dmrg/ci-h2o/test.in" >> .messages.txt
+echo "" >> .messages.txt
+


### PR DESCRIPTION
This is a conda-forge translation of a recipe for CheMPS2 (http://sebwouters.github.io/CheMPS2/index.html). I've a number of macOS and linux recipes (ambit, chemps2, pychemps2, dftd3, pcmsolver, psi4 at https://github.com/psi4/psi4meta/tree/master/conda-recipes hosted at https://anaconda.org/psi4). conda-forge isn't really suitable for the linux recipes because we like special compilers, but I thought it might be useful for the macOS ones.

These recipes are combinations of python, c++, and fortran. Some special considerations are:
- we like building with gcc over clang for parallelism
- there's fortran involved, so we need gfortran
- we've hit serious issues upon mixed linking against `libstdc++` and `libc++` 

Upon advice, while _this_ package might be suitable for conda-forge, I don't know if it'll be suitable for all the psi4 ecosystem packages.
