### PR TITLE
Added recipe for audioread

### DIFF
--- a/recipes/audioread/meta.yaml
+++ b/recipes/audioread/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "2.1.4" %}
+{% set hash_type = "md5" %}
+{% set hash_val = "8151d336c48ee2bc03fbcba5840a3fe4" %}
+
+package:
+  name: audioread
+  version: {{ version }}
+
+source:
+  fn: audioread-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/a/audioread/audioread-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+    - ffmpeg
+
+test:
+  imports:
+    - audioread
+
+about:
+  home: https://github.com/sampsyo/audioread
+  license: MIT
+  summary: 'multi-library, cross-platform audio decoding'
+
+extra:
+  recipe-maintainers:
+    - bmcfee

--- a/recipes/audioread/meta.yaml
+++ b/recipes/audioread/meta.yaml
@@ -14,7 +14,6 @@ source:
 build:
   number: 0
   script: python setup.py install # This package uses distutils, no egg magic necessary
-  skip: true # [win32]
 
 requirements:
   build:
@@ -22,7 +21,7 @@ requirements:
 
   run:
     - python
-    - ffmpeg
+    - ffmpeg  # [not win]
 
 test:
   imports:

--- a/recipes/audioread/meta.yaml
+++ b/recipes/audioread/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python setup.py install # This package uses distutils, no egg magic necessary
+  skip: true # [win32]
 
 requirements:
   build:


### PR DESCRIPTION
This adds a recipe for audioread.

At runtime, we have a requirement for `ffmpeg`, since it's the only (and most general) backend codec currently in conda.