### PR TITLE
Add conda-env

### DIFF
--- a/recipes/conda-env/meta.yaml
+++ b/recipes/conda-env/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "2.5.2" %}
+
+package:
+  name: conda-env
+  version: {{ version }}
+
+source:
+  fn: conda-env-{{ version }}.tar.gz
+  url: https://github.com/conda/conda-env/archive/v{{ version }}.tar.gz
+  sha256: 7ca59fa861a3145e94c0d1377bf0bd78735f19123234bd3fcf4024a8f8e8ce03
+
+build:
+  number: 0
+  script: python setup.py install
+  entry_points:
+    - conda-env = conda_env.cli.main:main
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - conda_env
+
+  commands:
+    - which conda-env  # [unix]
+    - where conda-env  # [win]
+    - conda env
+    - conda env -h
+    - conda env list -h
+    - conda env create -h
+    - conda env export -h
+    - conda env remove -h
+
+about:
+  home: https://github.com/conda/conda-env
+  summary: Tools for interacting with conda environments.
+  license: BSD 3-Clause
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - kalefranz
+    - mcg1969
+    - msarahan
+    - pelson


### PR DESCRIPTION
Breaking out the addition of `conda-env` from PR ( https://github.com/conda-forge/staged-recipes/pull/656 ). It seems to be in pretty good shape after the discussion in that PR. Though it may need a version bump and one more good once over.