### PR TITLE
Add ruamel_yaml

### DIFF
--- a/recipes/ruamel_yaml/meta.yaml
+++ b/recipes/ruamel_yaml/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.11.7" %}
+
+package:
+  name: ruamel_yaml
+  version: 0.11.7
+
+source:
+  fn: ruamel_yaml-{{ version }}.tar.gz
+  url: https://bitbucket.org/kalefranz/yaml/get/1CBC6A8.tar.gz
+  sha256: a705cb1f0eea40d17da713161af3ed00ffa724e401fbd49f35f979bd9529cd00
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - yaml
+
+  run:
+    - python
+    - setuptools
+    - yaml
+
+test:
+  imports:
+    - ruamel.yaml
+
+about:
+  home: https://bitbucket.org/kalefranz/yaml
+  license: MIT
+  summary: A fork of ruamel.yaml.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for [`ruamel_yaml`]( https://bitbucket.org/kalefranz/yaml ). Based roughly off of the `ruamel.yaml` recipe and adapted. Feedback and maintainers welcome.

cc @conda-forge/core @kalefranz