### PR TITLE
Added recipe for hachoir-metadata

### DIFF
--- a/recipes/hachoir-metadata/meta.yaml
+++ b/recipes/hachoir-metadata/meta.yaml
@@ -1,0 +1,39 @@
+{%set name = "hachoir-metadata" %}
+{%set version = "1.3.3" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "ec403f13a44e2cf3d26001f8f440cdc4329a316a4c971035944bfadacc90eb3c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  skip: True  # [py3k]
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - hachoir_metadata
+    - hachoir_metadata.qt
+
+about:
+  home: http://bitbucket.org/haypo/hachoir/wiki/hachoir-metadata
+  license: GNU General Public License (GPL)
+  summary: 'Program to extract metadata using Hachoir library'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/hachoir-metadata/meta.yaml
+++ b/recipes/hachoir-metadata/meta.yaml
@@ -23,6 +23,8 @@ requirements:
 
   run:
     - python
+    - hachoir-core
+    - hachoir-parser
 
 test:
   imports:

--- a/recipes/hachoir-metadata/meta.yaml
+++ b/recipes/hachoir-metadata/meta.yaml
@@ -33,7 +33,7 @@ test:
 
 about:
   home: http://bitbucket.org/haypo/hachoir/wiki/hachoir-metadata
-  license: GNU General Public License (GPL)
+  license: GPL 2.0
   summary: 'Program to extract metadata using Hachoir library'
 
 extra:


### PR DESCRIPTION
This is the final `hachoir-*` module required for the build of `girder` (#1039).