### PR TITLE
Add constructor

### DIFF
--- a/recipes/constructor/meta.yaml
+++ b/recipes/constructor/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "1.3.0" %}
+{%set sha256 = "06f33a92b7a80b296b1a7d993b8b7eeab5e1a1993807d9b43fff0fe6a779f303" %}
+
+package:
+  name: constructor
+  version: {{ version }}
+
+source:
+  fn: constructor-{{ version }}.tar.gz
+  url: https://github.com/conda/constructor/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+    - libconda
+    - pillow >=3.1  # [win]
+    - nsis          # [win]
+
+test:
+  imports:
+    - constructor
+
+  commands:
+    - constructor --help
+
+about:
+  home: http://github.com/conda/constructor
+  license: BSD 3-Clause
+  summary: create installer from conda packages
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe to build the `constructor` package (not the installer). Written from scratch. Requires PR ( https://github.com/conda-forge/staged-recipes/pull/1077 ) for `libconda` and PR ( https://github.com/conda-forge/staged-recipes/pull/1089 ) for `nsis`.

cc @conda-forge/core @ilanschnell