### PR TITLE
Add NSIS 2

### DIFF
--- a/recipes/nsis/bld.bat
+++ b/recipes/nsis/bld.bat
@@ -1,0 +1,4 @@
+robocopy . "%PREFIX%" /S /XF bld.bat
+if errorlevel NEQ 1 exit 1
+
+exit 0

--- a/recipes/nsis/meta.yaml
+++ b/recipes/nsis/meta.yaml
@@ -1,0 +1,23 @@
+{% set version = "2.46" %}
+
+package:
+  name: nsis
+  version: {{ version }}
+
+source:
+  fn: nsis-{{ version }}.zip
+  url: http://sourceforge.net/projects/nsis/files/NSIS%20{{ version.split(".")[0] }}/{{ version }}/nsis-{{ version }}.zip
+  sha256: ced6561f8aed81c8f3d6bc5a33684e03ca36a618110c0a849880c703337f26cc
+
+build:
+  number: 0
+  skip: true  # [unix]
+
+about:
+  home: http://sourceforge.net/projects/nsis
+  summary: Nullsoft Scriptable Install System
+  license: CPL-1.0, zlib, bzip2
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/nsis/meta.yaml
+++ b/recipes/nsis/meta.yaml
@@ -21,3 +21,4 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - patricksnape

--- a/recipes/nsis/meta.yaml
+++ b/recipes/nsis/meta.yaml
@@ -21,4 +21,5 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - msarahan
     - patricksnape

--- a/recipes/nsis/run_test.bat
+++ b/recipes/nsis/run_test.bat
@@ -1,0 +1,4 @@
+makensis.exe /?
+if errorlevel 2 exit 1
+
+exit 0


### PR DESCRIPTION
Adds a recipe for NSIS 2.x. Adapted from this [recipe]( https://github.com/faph/NSIS-Conda-Recipes/tree/18a1ffc0710188934748046e00f71f9aa0ac7978/NSIS2 ) by @faph. Note it is in the Public Domain. Feedback and Maintainers welcome.

Also there is a newer version (2.51) and it will be updated in the feedstock. Trying to match what is in the anaconda channel first and then upgrading from there.

cc @conda-forge/core @patricksnape @gillins @msarahan @mingwandroid