### PR TITLE
Add prefsync

### DIFF
--- a/recipes/prefsync/meta.yaml
+++ b/recipes/prefsync/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   fn: prefsync-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/s/prefsync/prefsync-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/prefsync/prefsync-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/prefsync/meta.yaml
+++ b/recipes/prefsync/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true # [not osx]
+  skip: true  # [not osx]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/prefsync/meta.yaml
+++ b/recipes/prefsync/meta.yaml
@@ -36,10 +36,6 @@ about:
     A little tool to help synchronize Mac OS X plist files (used for
     preferences for most Mac Apps) seamlessly, in a way that can be tracked by
     git.
-  description: |
-    A little tool to help synchronize Mac OS X plist files (used for
-    preferences for most Mac Apps) seamlessly, in a way that can be tracked by
-    git.
   doc_url: https://github.com/asmeurer/prefsync
   dev_url: https://github.com/asmeurer/prefsync
 

--- a/recipes/prefsync/meta.yaml
+++ b/recipes/prefsync/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.2" %}
+{% set sha256 = "66f0d3870b442e715de23b632e83f27f5971885b40bb3f6b211437138c554496" %}
+
+package:
+  name: prefsync
+  version: {{ version }}
+
+source:
+  fn: prefsync-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/s/prefsync/prefsync-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - prefsync
+
+  commands:
+    - python -m prefsync --help
+    - prefsync --help
+
+about:
+  home: https://github.com/asmeurer/prefsync
+  license: MIT
+  summary: |
+    A little tool to help synchronize Mac OS X plist files (used for
+    preferences for most Mac Apps) seamlessly, in a way that can be tracked by
+    git.
+  description: |
+    A little tool to help synchronize Mac OS X plist files (used for
+    preferences for most Mac Apps) seamlessly, in a way that can be tracked by
+    git.
+  doc_url: https://github.com/asmeurer/prefsync
+  dev_url: https://github.com/asmeurer/prefsync
+
+extra:
+  recipe-maintainers:
+    - asmeurer

--- a/recipes/prefsync/meta.yaml
+++ b/recipes/prefsync/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: true # [not osx]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/prefsync/meta.yaml
+++ b/recipes/prefsync/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   skip: true  # [not osx]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python setup.py install
 
 requirements:
   build:


### PR DESCRIPTION
It's a little tool that I wrote. Just testing this out, to see how it works.

This tool is pure Python, so it will technically work anywhere, but it only makes sense on OS X. How can I disable Linux and Windows?