### PR TITLE
Added recipe for conda-workon

### DIFF
--- a/recipes/conda-workon/meta.yaml
+++ b/recipes/conda-workon/meta.yaml
@@ -1,0 +1,44 @@
+{%set name = "conda-workon" %}
+{%set version = "0.3.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "af1ee8f744c5379afa0c2b8c4156a2c0bb282fe6461cc2b087c2b789c8bb90d3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  entry_points:
+    - conda-workon = conda_workon:main
+
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - conda
+
+  run:
+    - python
+    - conda
+
+test:
+  commands:
+    - conda workon --help
+    - conda-workon --help
+
+about:
+  home: https://bitbucket.org/flub/conda-workon
+  license: BSD (Clause unspecified)
+  summary: 'Activate conda environments in subshells'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/conda-workon/meta.yaml
+++ b/recipes/conda-workon/meta.yaml
@@ -30,6 +30,9 @@ requirements:
     - conda
 
 test:
+  imports:
+    - conda_workon
+
   commands:
     - conda workon --help
     - conda-workon --help

--- a/recipes/conda-workon/meta.yaml
+++ b/recipes/conda-workon/meta.yaml
@@ -45,3 +45,4 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
+    - flub

--- a/recipes/conda-workon/meta.yaml
+++ b/recipes/conda-workon/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: https://bitbucket.org/flub/conda-workon
-  license: BSD (Clause unspecified)
+  license: BSD 3-Clause
   summary: 'Activate conda environments in subshells'
 
 extra:


### PR DESCRIPTION
Pinging @flub in case they'd like to be added as a maintainer to the `conda-workon` builder on [conda-forge](http://conda-forge.github.io), a library of community-built [`conda`](http://conda.pydata.org) packages. The maintenance burden here is light: all testing and releases are built and deployed automatically with CI. Changes to how the package is being built can be controlled by changing the recipe which will be located at https://github.com/conda-forge/conda-workon-feedstock shortly after this PR is finished and merged. If you aren't interested in helping maintain the build, that's entirely fine too.

Also, if you could let us know which BSD license you've put `conda-workon` out under, that'd be great (2-Clause or 3-Clause). Ditto if you have time to push version `0.4` to pypi at some point… :D