### PR TITLE
Made XCode 6.4 the OSX image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 matrix:
   include:
     - os: osx
+      osx_image: xcode6.4
       env: ACTION="build-all"
     - os: linux
       env: ACTION="create-feedstocks-on-merge"
@@ -34,4 +35,3 @@ script:
         echo "Building all recipes.";
         source ./.CI/build_all;
       fi
-


### PR DESCRIPTION
This PR changes the OS X image to one that uses XCode 6.4 instead of the (default) XCode 6.1. It is needed for complete C++14 support and, among other things, libdynd.

@jakirkham @msarahan Can we merge this?
