### PR TITLE
Add pudb

### DIFF
--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "2016.2" %}
+
+ackage:
+  name: pudb
+  version: {{ version }}
+
+source:
+  fn: pudb-{{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/50/1a/d9b692e32afff09ccb5aa33c3d51c6d5a80efbb59de90307b33601e7fa62/pudb-{{ version }}.tar.gz
+  md5: 4573b70163329c1cb59836a357bfdf7c
+
+build:
+  # conda skeleton added this, but I'm unsure why it would be needed.
+  # preserve_egg_dir: True
+  entry_points:
+    - pudb = pudb.run:main
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - urwid >=1.1.1
+    - pygments >=1.0
+  run:
+    - python
+    - setuptools
+    - urwid >=1.1.1
+    - pygments >=1.0
+
+test:
+  imports:
+    - pudb
+
+  commands:
+    - pudb --help
+
+about:
+  home: http://pypi.python.org/pypi/pudb
+  license: MIT License
+  summary: 'A full-screen, console-based Python debugger'
+
+  dev_url: https://github.com/inducer/pudb
+
+extra:
+  recipe-maintainers:
+    - asmeurer

--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -16,7 +16,8 @@ build:
     - pudb = pudb.run:main
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-
+  # Urwid is skipped on Windows
+  skip: true  # [win]
 requirements:
   build:
     - python

--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "2016.2" %}
 
-ackage:
+package:
   name: pudb
   version: {{ version }}
 

--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: pudb-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/p/pudb/pudb-{{ version }}.tar.g
+  url: https://pypi.io/packages/source/p/pudb/pudb-{{ version }}.tar.gz
   md5: 4573b70163329c1cb59836a357bfdf7c
 
 build:

--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: pudb-{{ version }}.tar.gz
-  url: https://files.pythonhosted.org/packages/50/1a/d9b692e32afff09ccb5aa33c3d51c6d5a80efbb59de90307b33601e7fa62/pudb-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pudb/pudb-{{ version }}.tar.g
   md5: 4573b70163329c1cb59836a357bfdf7c
 
 build:

--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: http://pypi.python.org/pypi/pudb
-  license: MIT License
+  license: MIT
   summary: 'A full-screen, console-based Python debugger'
 
   dev_url: https://github.com/inducer/pudb

--- a/recipes/pudb/meta.yaml
+++ b/recipes/pudb/meta.yaml
@@ -47,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - asmeurer
+    - inducer


### PR DESCRIPTION
Note that this breaks from the pip pudb install slightly in that it always
uses `pudb` as the entry-point, not pudb3 for Python 3. I'm one of the PuDB
developers, and I think that `pudb3` is a bad idea. If you want we can ask
Andreas what he thinks as well.