### PR TITLE
add asciitree recipe

### DIFF
--- a/recipes/asciitree/meta.yaml
+++ b/recipes/asciitree/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "0.3.2" %}
+{% set sha256 = "eb10abcd9b079b905bb7b4b23bb030331e8aa1ab76a9a1323bd43a9d3138f0e7" %}
+
+package:
+  name: asciitree
+  version: {{ version }}
+
+source:
+  fn: asciitree-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/a/asciitree/asciitree-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - asciitree
+
+about:
+  home: http://github.com/mbr/asciitree
+  license: MIT
+  summary: 'Draws ASCII trees.'
+
+extra:
+  recipe-maintainers:
+    - kain88-de


### PR DESCRIPTION
This adds a recipe for the current asciitree package. According to the docs all python versions and operating systems are ok.