### PR TITLE
Disable Travis token cache

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -11,7 +11,8 @@ if [ -n "$GH_TOKEN" ]; then
     conda install --yes --quiet conda-smithy
 
     mkdir -p ~/.conda-smithy
-    echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
+    # Commented until we update `TRAVIS_TOKEN`.
+    #echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 
     python .CI/create_feedstocks.py
 fi


### PR DESCRIPTION
Temporarily disable using the Travis token cache introduced in this PR ( https://github.com/conda-forge/staged-recipes/pull/1114 ). It appears this token is already expired. So, we will need to regenerate it.

cc @pelson