### PR TITLE
Revert "create_feedstocks: Disable Travis token cache until token is regenerated"

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -11,8 +11,7 @@ if [ -n "$GH_TOKEN" ]; then
     conda install --yes --quiet conda-smithy
 
     mkdir -p ~/.conda-smithy
-    # Commented until we update `TRAVIS_TOKEN`.
-    #echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
+    echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 
     python .CI/create_feedstocks.py
 fi


### PR DESCRIPTION
This reverts commit bfd9cf48312cb60c8ad261b41c48af5a04e09f7d.