### PR TITLE
Add numexpr

### DIFF
--- a/recipes/numexpr/meta.yaml
+++ b/recipes/numexpr/meta.yaml
@@ -1,0 +1,44 @@
+{% set version="2.5.2" %}
+
+package:
+  name: numexpr
+  version: {{ version }}
+
+source:
+  fn: numexpr-{{ version}}.tar.gz
+  url: https://pypi.io/packages/source/n/numexpr/numexpr-{{ version }}.tar.gz
+  sha256: 7e85595cf65c8c9a850fdcb073b46f29f52a9a8ab4d0e13161b73bee1229664d
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  features:
+    - blas_openblas
+
+requirements:
+  build:
+    - setuptools
+    - numpy    x.x
+  run:
+    - python
+    - numpy    x.x
+
+test:
+  imports:
+    - numexpr
+
+about:
+  home: https://github.com/pydata/numexpr
+  license: MIT
+  license_file: LICENSE.txt
+  summary: Fast numerical expression evaluator for NumPy
+  description: |
+    Numexpr is a fast numerical expression evaluator for NumPy. With it,
+    expressions that operate on arrays (like "3*a+4*b") are accelerated and use
+    less memory than doing the same calculation in Python.
+  doc_url: https://github.com/pydata/numexpr/wiki/Numexpr-Users-Guide
+  dev_url: https://github.com/pydata/numexpr
+
+extra:
+  recipe-maintainers:
+    - msarahan

--- a/recipes/numexpr/meta.yaml
+++ b/recipes/numexpr/meta.yaml
@@ -28,6 +28,8 @@ test:
     imports:
         - numexpr
         - numexpr.interpreter
+    commands:
+        - conda inspect linkages -n _test numexpr  # [linux]
 
 about:
     home: https://github.com/pydata/numexpr

--- a/recipes/numexpr/meta.yaml
+++ b/recipes/numexpr/meta.yaml
@@ -1,44 +1,47 @@
-{% set version="2.5.2" %}
+{% set version="2.6.1" %}
 
 package:
-  name: numexpr
-  version: {{ version }}
+    name: numexpr
+    version: {{ version }}
 
 source:
-  fn: numexpr-{{ version}}.tar.gz
-  url: https://pypi.io/packages/source/n/numexpr/numexpr-{{ version }}.tar.gz
-  sha256: 7e85595cf65c8c9a850fdcb073b46f29f52a9a8ab4d0e13161b73bee1229664d
+    fn: numexpr-{{ version }}.tar.gz
+    url: https://github.com/pydata/numexpr/archive/v{{ version }}.tar.gz
+    sha256: e92c83d066fa8da63864d69b5f218287cc31437ae844db77390f2183123aab22
 
 build:
-  number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
-  features:
-    - blas_openblas
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
-  build:
-    - setuptools
-    - numpy    x.x
-  run:
-    - python
-    - numpy    x.x
+    build:
+        - python
+        - setuptools
+        - numpy x.x
+    run:
+        - python
+        - numpy x.x
 
 test:
-  imports:
-    - numexpr
+    requires:
+        - setuptools
+    imports:
+        - numexpr
+        - numexpr.interpreter
 
 about:
-  home: https://github.com/pydata/numexpr
-  license: MIT
-  license_file: LICENSE.txt
-  summary: Fast numerical expression evaluator for NumPy
-  description: |
-    Numexpr is a fast numerical expression evaluator for NumPy. With it,
-    expressions that operate on arrays (like "3*a+4*b") are accelerated and use
-    less memory than doing the same calculation in Python.
-  doc_url: https://github.com/pydata/numexpr/wiki/Numexpr-Users-Guide
-  dev_url: https://github.com/pydata/numexpr
+    home: https://github.com/pydata/numexpr
+    license: MIT
+    license_file: LICENSE.txt
+    summary: Fast numerical expression evaluator for NumPy
+    description: |
+      Numexpr is a fast numerical expression evaluator for NumPy. With it,
+      expressions that operate on arrays (like "3*a+4*b") are accelerated and use
+      less memory than doing the same calculation in Python.
+    doc_url: https://github.com/pydata/numexpr/wiki/Numexpr-Users-Guide
+    dev_url: https://github.com/pydata/numexpr
 
 extra:
-  recipe-maintainers:
-    - msarahan
+    recipe-maintainers:
+        - msarahan
+        - ocefpaf

--- a/recipes/numexpr/run_test.py
+++ b/recipes/numexpr/run_test.py
@@ -1,0 +1,10 @@
+import sys
+import numpy
+import numexpr
+import numexpr.interpreter
+
+from multiprocessing import freeze_support
+
+if __name__ == "__main__":
+    freeze_support()
+    numexpr.test()


### PR DESCRIPTION
@msarahan I am trying to resurrect #547. Let me know if this is OK.

My goal is to get a `pytables` build but we can only do `numexpr`+ `mkl` from `defaults` for now b/c we don't have `numexpr` on conda-forge.