### PR TITLE
Added recipe for snakebite

### DIFF
--- a/recipes/snakebite/meta.yaml
+++ b/recipes/snakebite/meta.yaml
@@ -1,0 +1,42 @@
+{%set name = "snakebite" %}
+{%set version = "2.10.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "11a81ba48b88b4f82d5dbf07e3556c86a94f639591390666a45bc1c60588ba55" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  skip: True  # [py3k]
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - protobuf >2.4.1
+    - argparse
+
+test:
+  imports:
+    - snakebite
+    - snakebite.protobuf
+
+about:
+  home: http://github.com/spotify/snakebite
+  license: Apache 2.0
+  summary: 'Pure Python HDFS client'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/snakebite/meta.yaml
+++ b/recipes/snakebite/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - protobuf >2.4.1
-    - argparse
+    - argparse  # [py26]
 
 test:
   imports:

--- a/recipes/snakebite/meta.yaml
+++ b/recipes/snakebite/meta.yaml
@@ -1,7 +1,7 @@
 {%set name = "snakebite" %}
-{%set version = "2.10.0" %}
+{%set version = "2.10.1" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "11a81ba48b88b4f82d5dbf07e3556c86a94f639591390666a45bc1c60588ba55" %}
+{%set hash_val = "5827bb94a0c92ede9fa54f1bfe9d9d65d7941e72a3b5e545dc19cc3f3e389f50" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Two notes on this build:

1. I've left out the requirements for `snakebite[kerberos]` because it requires both `sasl` and `python-krbV`, and both of those have been giving us build trouble. I don't know if the default anaconda `snakebite` supports kerberos, but it certainly *doesn’t* support windows. So this seemed like a decent idea.
2. For reasons that are unclear, if I test the `snakebite` console commands, `conda build` reports a test failure. The commands themselves appear to run fine (based on printed output) so I'm not certain what's up. As is, I've omitted those tests, but that's hardly a satisfying explanation.