### PR TITLE
Add PyInstaller

### DIFF
--- a/recipes/pyinstaller/PR_1971.diff
+++ b/recipes/pyinstaller/PR_1971.diff
@@ -1,0 +1,16 @@
+diff --git PyInstaller/compat.py PyInstaller/compat.py
+index dd8c7ac..f3ed99c 100644
+--- PyInstaller/compat.py
++++ PyInstaller/compat.py
+@@ -56,7 +56,10 @@
+ elif is_cygwin:
+     PYDYLIB_NAMES = {'libpython%d%d.dll' % _pyver}
+ elif is_darwin:
+-    PYDYLIB_NAMES = {'Python', '.Python', 'libpython%d.%d.dylib' % _pyver}
++    # libpython%d.%dm.dylib for Conda virtual environment installations
++    PYDYLIB_NAMES = {'Python', '.Python', 
++                     'libpython%d.%d.dylib' % _pyver, 
++                     'libpython%d.%dm.dylib' % _pyver}
+ elif is_aix:
+     # Shared libs on AIX are archives with shared object members, thus the ".a" suffix.
+     PYDYLIB_NAMES = {'libpython%d.%d.a' % _pyver}

--- a/recipes/pyinstaller/meta.yaml
+++ b/recipes/pyinstaller/meta.yaml
@@ -1,0 +1,79 @@
+{% set name = "PyInstaller" %}
+{% set version = "3.2" %}
+
+package:
+  name: {{ name.lower() }}
+  version: {{ version }}
+
+source:
+  fn: PyInstaller-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: ad924928983014e6b8ce5422d7687832
+  patches:
+    # Fixes an issue where libpython would not be found
+    # if it had a suffix (e.g. `m`). The PR used is
+    # linked below.
+    #
+    # https://github.com/pyinstaller/pyinstaller/pull/1971
+    #
+    - PR_1971.diff
+
+build:
+  number: 0
+  skip: true  # [win]
+  features:
+    - vc9     # [win and py27]
+    - vc10    # [win and py34]
+    - vc14    # [win and py35]
+  entry_points:
+    - pyinstaller = PyInstaller.__main__:run
+    - pyi-archive_viewer = PyInstaller.utils.cliutils.archive_viewer:run
+    - pyi-bindepend = PyInstaller.utils.cliutils.bindepend:run
+    - pyi-grab_version = PyInstaller.utils.cliutils.grab_version:run
+    - pyi-makespec = PyInstaller.utils.cliutils.makespec:run
+    - pyi-set_version = PyInstaller.utils.cliutils.set_version:run
+  script:
+    - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"               # [linux]
+    - pushd bootloader
+    - waf --prefix="${PREFIX}" --clang distclean all            # [osx]
+    - waf --prefix="${PREFIX}" --gcc --no-lsb distclean all     # [linux]
+    - waf --prefix="%LIBRARY_PREFIX%" distclean all             # [win]
+    - popd
+    - python setup.py install --single-version-externally-managed --record=record.txt
+  preserve_egg_dir: True
+
+requirements:
+  build:
+    - toolchain
+    - python
+    - setuptools
+    - waf
+    - zlib 1.2.*
+
+  run:
+    - python
+    - setuptools
+    - pycrypto
+    - zlib 1.2.*
+
+test:
+  imports:
+    - PyInstaller
+
+  commands:
+    - pyinstaller --help
+    - pyi-archive_viewer --help
+    - pyi-bindepend --help
+    - pyi-makespec --help
+    # These are designed for Windows only.
+    - pyi-grab_version --help     # [win]
+    - pyi-set_version --help      # [win]
+
+about:
+  home: http://www.pyinstaller.org
+  license: GPL 2
+  summary: PyInstaller bundles a Python application and all its dependencies into a single package.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Broken out from PR ( https://github.com/conda-forge/staged-recipes/pull/775 ). Requires waf as a dependency ~~so is based on top of PR ( https://github.com/conda-forge/staged-recipes/pull/1136 ). This marked as WIP until that one is addressed.~~ waf has been added so this has been rebased with waf dropped. This is ready to go.

This adds PyInstaller. A tool for bundling a Python application with all of its dependencies into a single distributable executable.