### PR TITLE
Re-add waf

### DIFF
--- a/recipes/waf/meta.yaml
+++ b/recipes/waf/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "waf" %}
+{% set version = "1.8.21" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/waf-project/waf/archive/{{ name }}-{{ version }}.tar.gz
+  sha256: 4007f38b5a0de2f0def758e30e0f66b0c3d7be0f7b832299e78b514513f3b013
+
+build:
+  number: 0
+  skip: true  # [win]
+  script:
+    - python waf-light --make-waf --tool=swig,cython,boost,use_config
+    - cp waf "${PREFIX}/bin"     # [unix]
+    - copy waf "%LIBRARY_BIN%"   # [win]
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  commands:
+    - waf --help
+
+about:
+  home: https://waf.io
+  license: BSD 3-Clause
+  summary: A build automation tool.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Appears the feedstock is having trouble uploading packages from Travis CI as the `BINSTAR_TOKEN` is missing. See this issue ( https://github.com/conda-forge/waf-feedstock/issues/1 ). Here we try to re-add `waf` through staged-recipes to see if that will fix the issue.

cc @pelson