### PR TITLE
Fast finish AppVeyor (Pt. 2)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,14 +47,18 @@ install:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
 
+    # Simplify check for whether we need to skip the build.
+    - cmd: set APPVEYOR_SKIP=0
+    - cmd: if "%APPVEYOR_REPO_NAME%" == "conda-forge/staged-recipes" if not defined APPVEYOR_PULL_REQUEST_NUMBER set APPVEYOR_SKIP=1
+
     # Run the AppVeyor script.
-    - cmd: call scripts\appveyor_setup.bat
+    - cmd: if %APPVEYOR_SKIP% neq 1 call scripts\appveyor_setup.bat
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - cmd: call scripts\build_windows.bat
+    - cmd: if %APPVEYOR_SKIP% neq 1 call scripts\build_windows.bat
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
     # Uncomment the following two lines to make any conda packages created

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,39 +56,8 @@ install:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
 
-    # Find the recipes from master in this PR and remove them.
-    - cmd: echo Finding recipes merged in master and removing them.
-    - cmd: cd recipes
-    - cmd: git fetch https://github.com/conda-forge/staged-recipes.git master
-    - cmd: |
-             for /f "tokens=*" %%a in ('git ls-tree --name-only FETCH_HEAD -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
-    - cmd: cd ..
-
-    # Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.
-    - cmd: set CONDA_NPY=19
-
-    # Remove cygwin (and therefore the git that comes with it).
-    - cmd: rmdir C:\cygwin /s /q
-
-    # Use the pre-installed Miniconda for the desired arch
-    #
-    # However, it is really old. So, we need to update some
-    # things before we proceed. That seems to require it being
-    # on the path. So, we temporarily put conda on the path
-    # so that we can update it. Then we remove it so that
-    # we can do a proper activation.
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda update --yes --quiet conda
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda config --add channels conda-forge
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda update --yes --quiet conda
-
-    - cmd: conda install --yes --quiet obvious-ci conda-build-all
-    - cmd: conda install --yes --quiet conda-forge-build-setup
-    - cmd: run_conda_forge_build_setup
+    # Run the AppVeyor script.
+    - cmd: call scripts\appveyor_setup.bat
 
 # Skip .NET project specific build phase.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,4 @@
 environment:
-
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script interpreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
-  # Workaround for https://github.com/conda/conda-build/issues/636
-  PYTHONIOENCODING: "UTF-8"
-
   matrix:
     # Note: Because we have to separate the py2 and py3 components due to compiler version, we have a race condition for non-python packages.
     # Not sure how to resolve this, but maybe we should be tracking the VS version in the build string anyway?
@@ -63,7 +54,7 @@ install:
 build: off
 
 test_script:
-    - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.10" "%PY_CONDITION%"'
+    - cmd: call scripts\build_windows.bat
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
     # Uncomment the following two lines to make any conda packages created

--- a/scripts/appveyor_setup.bat
+++ b/scripts/appveyor_setup.bat
@@ -1,0 +1,32 @@
+:: Find the recipes from master in this PR and remove them.
+echo Finding recipes merged in master and removing them.
+cd recipes
+git fetch https://github.com/conda-forge/staged-recipes.git master
+for /f "tokens=*" %%a in ('git ls-tree --name-only FETCH_HEAD -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
+cd ..
+
+:: Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.
+set CONDA_NPY=19
+
+:: Remove cygwin (and therefore the git that comes with it).
+rmdir C:\cygwin /s /q
+
+:: Use the pre-installed Miniconda for the desired arch
+::
+:: However, it is really old. So, we need to update some
+:: things before we proceed. That seems to require it being
+:: on the path. So, we temporarily put conda on the path
+:: so that we can update it. Then we remove it so that
+:: we can do a proper activation.
+set "OLDPATH=%PATH%"
+set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+conda update --yes --quiet conda
+set "PATH=%OLDPATH%"
+call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+conda config --add channels conda-forge
+conda config --set show_channel_urls true
+conda update --yes --quiet conda
+
+conda install --yes --quiet obvious-ci conda-build-all
+conda install --yes --quiet conda-forge-build-setup
+run_conda_forge_build_setup

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -1,0 +1,10 @@
+:: Workaround for https://github.com/conda/conda-build/issues/636
+set "PYTHONIOENCODING=UTF-8"
+
+:: SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+:: /E:ON and /V:ON options are not enabled in the batch script interpreter
+:: See: http://stackoverflow.com/a/13751649/163740
+set "CMD_IN_ENV=call cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
+
+:: Build all of the recipes.
+%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.10" "%PY_CONDITION%"


### PR DESCRIPTION
Continues work that was done in PR ( https://github.com/conda-forge/staged-recipes/pull/332 ).

Basically it still feels to me that builds on `master` on AppVeyor are taking too long (~5 mins). So trying to speed this up more. Also, the recent issues downloading packages from `defaults` ( https://github.com/Anaconda-Platform/support/issues/49 ) are a bit concerning. Removing downloads from merged PRs at staged-recipes in AppVeyor builds should help mitigate that issue.

Also we have taken this opportunity to break up the `appveyor.yml` file into components. For instance, there is a `build_windows.bat`, which should hopefully be useful for offline builds (read debugging). There is `appveyor_setup.bat` as well, which wraps up our Windows setup nicely. It may be useful to have this batch file for configure other Windows VMs in the future.

cc @pelson @ocefpaf @msarahan @patricksnape @jjhelmus @gillins
