### PR TITLE
Appveyor remote run

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,13 +46,6 @@ platform:
     - x64
 
 install:
-    # We don't need to build the example recipe.
-    - cmd: rmdir recipes\example /s /q
-    # Skip if we are not in a PR.
-    - cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER rmdir /q /s recipes
-    # Make sure the `recipes` directory exists if we removed it.
-    - cmd: if not exist recipes mkdir recipes
-
     # If there is a newer build queued for the same PR, cancel this one.
     # The AppVeyor 'rollout builds' option is supposed to serve the same
     # purpose but it is problematic because it tends to cancel builds pushed
@@ -62,6 +55,13 @@ install:
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
+
+    # We don't need to build the example recipe.
+    - cmd: rmdir recipes\example /s /q
+    # Skip if we are not in a PR.
+    - cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER rmdir /q /s recipes
+    # Make sure the `recipes` directory exists if we removed it.
+    - cmd: if not exist recipes mkdir recipes
 
     # Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.
     - cmd: set CONDA_NPY=19

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ install:
     # We don't need to build the example recipe.
     - cmd: rmdir recipes\example /s /q
     # Skip if we are not in a PR.
-    - cmd: if not defined APPVEYOR_PULL_REQUEST_NUMBER rmdir /q /s recipes
+    - cmd: if "%APPVEYOR_REPO_NAME%" == "conda-forge/staged-recipes" if not defined APPVEYOR_PULL_REQUEST_NUMBER rmdir /q /s recipes
     # Make sure the `recipes` directory exists if we removed it.
     - cmd: if not exist recipes mkdir recipes
 


### PR DESCRIPTION
It looks to me that my previous attempt ( https://github.com/conda-forge/staged-recipes/pull/332 ) at fast finishing builds on AppVeyor was too aggressive. Namely that one cannot build recipes in their forks and test them in their own AppVeyor queue. This PR changes that by checking to make sure the repo is actually `conda-forge/staged-recipes` and not `<some_user>/staged-recipes`. If it is not `conda-forge/staged-recipes`, then it will continue with the build per usual.