### PR TITLE
Add iris_sample_data

### DIFF
--- a/recipes/iris-sample-data/meta.yaml
+++ b/recipes/iris-sample-data/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "2.0.0" %}
+
+package:
+    name: iris_sample_data
+    version: {{ version }}
+
+source:
+    fn: iris-sample-data-{{ version }}.tar.gz
+    url: https://github.com/SciTools/iris-sample-data/archive/v{{ version }}.tar.gz
+    sha256: 8907f2ac0e38a32e39f79db7e6426d25c27cb18b9ad510a33f3f2538ebac12ac
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - iris_sample_data
+
+about:
+    home: https://github.com/SciTools/iris-sample-data
+    license: Open Government
+    summary: 'Iris sample data.'
+
+extra:
+    recipe-maintainers:
+        - bjlittle
+        - pelson
+        - ocefpaf

--- a/recipes/iris-sample-data/meta.yaml
+++ b/recipes/iris-sample-data/meta.yaml
@@ -31,6 +31,4 @@ about:
 
 extra:
     recipe-maintainers:
-        - bjlittle
-        - pelson
         - ocefpaf


### PR DESCRIPTION
@bjlittle and @pelson can I add you two as maintainers here?

PS: I wonder if we should take a different path here. Instead of making `iris_sample_data` a Python package maybe we should put it `$PREFIX/share`, similar to what we do with `basemap`, and patch iris to find it there. This would result in one build instead of 3 (`PY27`, `PY34`, and `PY35`).