### PR TITLE
Add circleci-helpers

### DIFF
--- a/recipes/circleci-helpers/meta.yaml
+++ b/recipes/circleci-helpers/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "circleci-helpers" %}
+{% set version = "0.1.1" %}
+{% set checksum = "21e3d210de493bebce598e0209aebc588ebe16cab4be17de2684590649aace6e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ checksum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    - circle-matrix = circleci_helpers.matrix.main:main
+
+requirements:
+  build:
+    - python
+    - pip
+    - setuptools
+
+  run:
+    - python
+    - pyaml
+    - pykwalify
+    - docopt
+    - termcolor
+
+test:
+  imports:
+    - circleci_helpers
+    - circleci_helpers.matrix
+
+  commands:
+    - circle-matrix --help
+
+about:
+  home: https://github.com/dennybaa/circleci-helpers
+  license: MIT
+  summary: Provides useful helpers for Circle CI
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Generated with `conda skeleton pypi` and cleaned up afterwards. `circleci-helpers` contains some useful tools for working with CircleCI. In particular, it provides a nifty matrix build tool, which may be useful for getting matrix builds up and going on CircleCI. See issue ( https://github.com/conda-forge/conda-smithy/issues/203 ) related to matrix builds.

Depends on `pykwalify` in PR ( https://github.com/conda-forge/staged-recipes/pull/1150 ). So it has been lumped in here for the interim. Though this still may fail at present due to a `conda-build-all` issue ( https://github.com/SciTools/conda-build-all/issues/52 ). Though we should still be able to get these in one at a time.

cc @pelson @Korijn 