### PR TITLE
Add circleclient

### DIFF
--- a/recipes/circleclient/meta.yaml
+++ b/recipes/circleclient/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "circleclient" %}
+{% set version = "0.1.6" %}
+{% set checksum = "7aadf04294b5d8e9b668e749d8781c1aecfd022b1627349fa2d9473b3f4ce0b6" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ checksum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+
+  run:
+    - python
+    - requests
+
+test:
+  imports:
+    - circleclient
+
+about:
+  home: http://github.com/qba73/circleclient/
+  license: MIT
+  summary: Python client for CircleCI API
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Generated via `conda skeleton pypi` with some tweaks after. Provides a Python library for interacting with the CircleCI API.