### PR TITLE
Add ordereddict

### DIFF
--- a/recipes/ordereddict/meta.yaml
+++ b/recipes/ordereddict/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "ordereddict" %}
+{% set version = "1.1" %}
+{% set checksum = "1c35b4ac206cef2d24816c89f89cf289dd3d38cf7c449bb3fab7bf6d43f01b1f" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ checksum }}
+
+build:
+  skip: true  # [py>=27]
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - ordereddict
+
+about:
+  # Had no home page. So pointed it to PyPI.
+  home: https://pypi.python.org/pypi/ordereddict
+  license: MIT
+  summary: A drop-in substitute for Py2.7's new collections.OrderedDict that works in Python 2.4-2.6.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
This a backport of Python 2.7 for older Pythons (e.g. 2.6). I know we don't support 2.6 and I wouldn't expect this really needs building more than once, but I do think it is worthwhile to have this source available. Even if it is for mostly historic purposes. Tested a build of it locally. Generated with `conda skeleton pypi`.