### PR TITLE
Add importlib

### DIFF
--- a/recipes/importlib/meta.yaml
+++ b/recipes/importlib/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "importlib" %}
+{% set version = "1.0.3" %}
+{% set checksum = "01fc0a2a1e01990a97b096615c11328fa4306ced1733c98d884160387760d479" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ checksum }}
+
+build:
+  number: 0
+  skip: true  # [py27 or py>30]
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - importlib
+
+about:
+  # Had no home page. So pointed it to PyPI.
+  home: https://pypi.python.org/pypi/importlib
+  # Version unspecified. Presumably matches that of Python 2.7.
+  license: PSF
+  summary: Backport of importlib.import_module() from Python 2.7
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
This a backport of Python 2.7 for older Pythons (e.g. 2.6) or Python 3.0. I know we don't support 2.6 or 3.0 and I wouldn't expect this really needs building more than once, but I do think it is worthwhile to have this source available. Even if it is for mostly historic purposes. Tested a build of it locally. Generated with `conda skeleton pypi`.