### PR TITLE
Add aspell recipes based on the ones from conda-recipes

### DIFF
--- a/recipes/aspell-en/build.sh
+++ b/recipes/aspell-en/build.sh
@@ -1,0 +1,3 @@
+./configure --vars ASPELL="$PREFIX/bin/aspell"
+make
+make install

--- a/recipes/aspell-en/build.sh
+++ b/recipes/aspell-en/build.sh
@@ -1,3 +1,4 @@
 ./configure --vars ASPELL="$PREFIX/bin/aspell"
 make
 make install
+make check

--- a/recipes/aspell-en/build.sh
+++ b/recipes/aspell-en/build.sh
@@ -1,4 +1,3 @@
 ./configure --vars ASPELL="$PREFIX/bin/aspell"
 make
 make install
-make check

--- a/recipes/aspell-en/meta.yaml
+++ b/recipes/aspell-en/meta.yaml
@@ -1,0 +1,25 @@
+package:
+  name: aspell-en
+  version: 7.1.0
+
+source:
+  fn: aspell6-en-7.1-0.tar.bz2
+  url: ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-7.1-0.tar.bz2
+  sha1: d45ccda0c03e2a679c2936487ec851a1896b8150
+
+requirements:
+  build:
+    - aspell
+  run:
+    - aspell
+
+test:
+  files:
+    - test-file.txt
+  commands:
+    - aspell list < test-file.txt
+
+about:
+  home: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
+  license: "Various (see Copyright file from the aspell6-en source)"
+  summary: "An (American, British, and Canadian) English dictionary for aspell."

--- a/recipes/aspell-en/meta.yaml
+++ b/recipes/aspell-en/meta.yaml
@@ -13,6 +13,9 @@ requirements:
   run:
     - aspell
 
+build:
+  number: 0
+
 test:
   files:
     - test-file.txt
@@ -23,3 +26,7 @@ about:
   home: ftp://ftp.gnu.org/gnu/aspell/dict/0index.html
   license: "Various (see Copyright file from the aspell6-en source)"
   summary: "An (American, British, and Canadian) English dictionary for aspell."
+
+extra:
+  recipe-maintainers:
+    - asmeurer

--- a/recipes/aspell-en/meta.yaml
+++ b/recipes/aspell-en/meta.yaml
@@ -14,6 +14,7 @@ requirements:
     - aspell
 
 build:
+  skip: true  # [win]
   number: 0
 
 test:

--- a/recipes/aspell-en/meta.yaml
+++ b/recipes/aspell-en/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: aspell-en
-  version: 7.1.0
+  version: 2016.06.26.0
 
 source:
-  fn: aspell6-en-7.1-0.tar.bz2
-  url: ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-7.1-0.tar.bz2
-  sha1: d45ccda0c03e2a679c2936487ec851a1896b8150
+  fn: aspell6-en-2016.06.26-0.tar.bz2
+  url: ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-2016.06.26-0.tar.bz2
+  sha1: 64d3a6fd5ad22e63130cac94648aebdc80e55f8f
 
 build:
   skip: true  # [win]

--- a/recipes/aspell-en/meta.yaml
+++ b/recipes/aspell-en/meta.yaml
@@ -7,15 +7,15 @@ source:
   url: ftp://ftp.gnu.org/gnu/aspell/dict/en/aspell6-en-7.1-0.tar.bz2
   sha1: d45ccda0c03e2a679c2936487ec851a1896b8150
 
+build:
+  skip: true  # [win]
+  number: 0
+
 requirements:
   build:
     - aspell
   run:
     - aspell
-
-build:
-  skip: true  # [win]
-  number: 0
 
 test:
   files:

--- a/recipes/aspell-en/test-file.txt
+++ b/recipes/aspell-en/test-file.txt
@@ -1,0 +1,1 @@
+This fille has some mispelled words

--- a/recipes/aspell/aspell.patch
+++ b/recipes/aspell/aspell.patch
@@ -1,0 +1,18 @@
+--- interfaces/cc/aspell.h	2013-10-13 20:29:33.000000000 +0200
++++ interfaces/cc/aspell.h	2013-10-13 20:30:01.000000000 +0200
+@@ -237,6 +237,7 @@
+ /******************************** errors ********************************/
+ 
+ 
++#ifndef __cplusplus
+ extern const struct AspellErrorInfo * const aerror_other;
+ extern const struct AspellErrorInfo * const aerror_operation_not_supported;
+ extern const struct AspellErrorInfo * const   aerror_cant_copy;
+@@ -322,6 +323,7 @@
+ extern const struct AspellErrorInfo * const   aerror_bad_magic;
+ extern const struct AspellErrorInfo * const aerror_expression;
+ extern const struct AspellErrorInfo * const   aerror_invalid_expression;
++#endif
+ 
+ 
+ /******************************* speller *******************************/

--- a/recipes/aspell/build.sh
+++ b/recipes/aspell/build.sh
@@ -1,0 +1,3 @@
+./configure --prefix="$PREFIX"
+make
+make install

--- a/recipes/aspell/build.sh
+++ b/recipes/aspell/build.sh
@@ -1,3 +1,4 @@
 ./configure --prefix="$PREFIX"
 make
 make install
+make check

--- a/recipes/aspell/meta.yaml
+++ b/recipes/aspell/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win]
   detect_binary_files_with_prefix: true
 
 test:

--- a/recipes/aspell/meta.yaml
+++ b/recipes/aspell/meta.yaml
@@ -1,0 +1,26 @@
+package:
+  name: aspell
+  version: 0.60.7.20110707
+
+source:
+  fn: aspell-0.60.7-20110707.tar.gz
+  url: ftp://alpha.gnu.org/gnu/aspell/aspell-0.60.7-20110707.tar.gz
+  sha1: fcd3430a03fcda27d7359d6bbbc3c1396438c183
+  patches:
+    # http://www.freebsd.org/cgi/query-pr.cgi?pr=180565&cat=
+    - aspell.patch
+
+
+build:
+  detect_binary_files_with_prefix: true
+
+test:
+  commands:
+    - aspell --help
+    # Make sure the build prefix is not hard-coded into aspell
+    - if aspell dump config | grep "_build"; then exit 1; fi
+
+about:
+  home: http://aspell.net/
+  license: LGPL
+  summary: GNU Aspell is a Free and Open Source spell checker designed to eventually replace Ispell.

--- a/recipes/aspell/meta.yaml
+++ b/recipes/aspell/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 
 build:
+  number: 0
   detect_binary_files_with_prefix: true
 
 test:
@@ -24,3 +25,7 @@ about:
   home: http://aspell.net/
   license: LGPL
   summary: GNU Aspell is a Free and Open Source spell checker designed to eventually replace Ispell.
+
+extra:
+  recipe-maintainers:
+    - asmeurer

--- a/recipes/aspell/meta.yaml
+++ b/recipes/aspell/meta.yaml
@@ -16,6 +16,10 @@ build:
   skip: true  # [win]
   detect_binary_files_with_prefix: true
 
+requirements:
+  build:
+    - perl
+
 test:
   commands:
     - aspell --help

--- a/recipes/aspell/meta.yaml
+++ b/recipes/aspell/meta.yaml
@@ -7,7 +7,7 @@ source:
   url: ftp://alpha.gnu.org/gnu/aspell/aspell-0.60.7-20110707.tar.gz
   sha1: fcd3430a03fcda27d7359d6bbbc3c1396438c183
   patches:
-    # http://www.freebsd.org/cgi/query-pr.cgi?pr=180565&cat=
+    # http://www.freebsd.org/cgi/query-pr.cgi?pr=180565
     - aspell.patch
 
 

--- a/recipes/aspell/post-link.sh
+++ b/recipes/aspell/post-link.sh
@@ -1,0 +1,7 @@
+# Unfortunately, this can't detect if you actually did install a dictionary
+# alongside aspell, as aspell would be a dependency of such a package and
+# would be linked first.
+if [ ! -e "$PREFIX/conda-meta/aspell-[!0123456789]*" ]; then
+    echo "Note: The aspell package does not come with any dictionaries. You should
+install at least one dictionary, e.g., aspell-en." > "$PREFIX/.messages.txt"
+fi

--- a/recipes/hunspell-en/build.sh
+++ b/recipes/hunspell-en/build.sh
@@ -1,0 +1,3 @@
+unzip dict-en.oxt
+mkdir $PREFIX/hunspell_dictionaries
+mv ./*.dic ./*.aff $PREFIX/hunspell_dictionaries

--- a/recipes/hunspell-en/meta.yaml
+++ b/recipes/hunspell-en/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: hunspell-en
+  version: 2014.02.10
+
+source:
+  url: http://extensions.openoffice.org/en/download/17707
+  fn: dict-en.oxt
+
+requirements:
+  run:
+    - hunspell
+
+test:
+  commands:
+    - echo 'test' | hunspell
+    - echo 'mispellled' | hunspell
+
+about:
+  home: http://extensions.openoffice.org/en/project/english-dictionaries-apache-openoffice
+  summary: "English spelling dictionaries for hunspell. Includes en_AU (Australian), en_CA (Canadian), en_GB (British), en_US (American), and en_ZA (South African)"
+  license: GPL

--- a/recipes/hunspell-en/meta.yaml
+++ b/recipes/hunspell-en/meta.yaml
@@ -19,3 +19,7 @@ about:
   home: http://extensions.openoffice.org/en/project/english-dictionaries-apache-openoffice
   summary: "English spelling dictionaries for hunspell. Includes en_AU (Australian), en_CA (Canadian), en_GB (British), en_US (American), and en_ZA (South African)"
   license: GPL
+
+extra:
+  recipe-maintainers:
+    - asmeurer

--- a/recipes/hunspell-en/meta.yaml
+++ b/recipes/hunspell-en/meta.yaml
@@ -8,6 +8,7 @@ source:
   sha256: 4d9692342c714e05342b29e7013f041b229a6e517f8eb44ab04d93fa1039d252
 
 build:
+  skip: true  # [win]
   number: 0
 
 requirements:

--- a/recipes/hunspell-en/meta.yaml
+++ b/recipes/hunspell-en/meta.yaml
@@ -5,6 +5,10 @@ package:
 source:
   url: http://extensions.openoffice.org/en/download/17707
   fn: dict-en.oxt
+  sha256: 4d9692342c714e05342b29e7013f041b229a6e517f8eb44ab04d93fa1039d252
+
+build:
+  number: 0
 
 requirements:
   run:

--- a/recipes/hunspell/build.sh
+++ b/recipes/hunspell/build.sh
@@ -1,0 +1,16 @@
+./configure --prefix=$PREFIX --with-readine --with-ui
+make
+make check
+make install
+mv $PREFIX/bin/hunspell $PREFIX/bin/.hunspell
+
+# We have to make a wrapper to add a spelling dictionary path to hunspell,
+# since none of the default ones are relative to the binary (i.e., can be
+# installed as a conda package)
+cat <<EOF > $PREFIX/bin/hunspell
+#!/bin/sh
+export DICPATH='/opt/anaconda1anaconda2anaconda3/hunspell_dictionaries'
+/opt/anaconda1anaconda2anaconda3/bin/.hunspell "\$@"
+EOF
+
+chmod a+x $PREFIX/bin/hunspell

--- a/recipes/hunspell/meta.yaml
+++ b/recipes/hunspell/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: hunspell
+  version: 1.3.2
+
+source:
+  fn: hunspell-1.3.2.tar.gz
+  url: http://downloads.sourceforge.net/hunspell/hunspell-1.3.2.tar.gz
+  sha1: 902c76d2b55a22610e2227abc4fd26cbe606a51c
+  md5: 3121aaf3e13e5d88dfff13fb4a5f1ab8
+
+build:
+  number: 1
+
+  has_prefix_files:
+    - bin/hunspell
+
+requirements:
+  build:
+    - readline
+
+  run:
+    - readline
+
+test:
+  commands:
+    - hunspell --help
+
+about:
+  home: http://hunspell.sourceforge.net/
+  summary: Spell checker
+  license: MPL 1.1/GPL 2.0/LGPL 2.1

--- a/recipes/hunspell/meta.yaml
+++ b/recipes/hunspell/meta.yaml
@@ -15,6 +15,7 @@ build:
 requirements:
   build:
     - readline
+    - automake  # [linux]
 
   run:
     - readline

--- a/recipes/hunspell/meta.yaml
+++ b/recipes/hunspell/meta.yaml
@@ -1,16 +1,14 @@
 package:
   name: hunspell
-  version: 1.3.2
+  version: 1.4.1
 
 source:
-  fn: hunspell-1.3.2.tar.gz
-  url: http://downloads.sourceforge.net/hunspell/hunspell-1.3.2.tar.gz
-  sha1: 902c76d2b55a22610e2227abc4fd26cbe606a51c
-  md5: 3121aaf3e13e5d88dfff13fb4a5f1ab8
+  git_url: https://github.com/hunspell/hunspell.git
+  git_tag: v1.4.1
 
 build:
-  number: 1
-
+  skip: true  # [win]
+  number: 0
   has_prefix_files:
     - bin/hunspell
 
@@ -29,3 +27,7 @@ about:
   home: http://hunspell.sourceforge.net/
   summary: Spell checker
   license: MPL 1.1/GPL 2.0/LGPL 2.1
+
+extra:
+  recipe-maintainers:
+    - asmeure

--- a/recipes/hunspell/post-link.sh
+++ b/recipes/hunspell/post-link.sh
@@ -1,0 +1,7 @@
+# Unfortunately, this can't detect if you actually did install a dictionary
+# alongside aspell, as hunpell would be a dependency of such a package and
+# would be linked first.
+if [ ! -e "$PREFIX/conda-meta/aspell-[!0123456789]*" ]; then
+    echo "Note: The hunspell package does not come with any dictionaries. You should
+install at least one dictionary, e.g., hunspell-en." > "$PREFIX/.messages.txt"
+fi


### PR DESCRIPTION
I replaced the manual binary prefix replacement with the automatic
detect_binary_files_with_prefix replacement.
