### PR TITLE
Add initial recipe for girder-client

### DIFF
--- a/recipes/girder-client/meta.yaml
+++ b/recipes/girder-client/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "1.3.1" %}
+{% set sha256 = "0369c5d3f1555b8e44fb178b54549e07f680bc4d98dd2340ae9dc04c5ae917cd" %}
+
+package:
+  name: girder-client
+  version: {{ version }}
+
+source:
+  fn: girder-client-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/girder-client/girder-client-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - six
+    - requests >=2.4.2
+    - diskcache
+
+test:
+  imports:
+    - girder_client
+  commands:
+    - girder-cli -h
+
+about:
+  home: http://girder.readthedocs.io/en/latest/python-client.html 
+  license: Apache-2.0
+  summary: 'Python client for interacting with Girder servers'
+
+  description: |
+    This is a set of python libraries and a command-line tool that
+    can be used to interact with the REST API of a Girder server.
+  doc_url: http://girder.readthedocs.io/en/latest/python-client.html
+  dev_url: https://github.com/girder/girder
+
+extra:
+  recipe-maintainers:
+    - Xarthisius


### PR DESCRIPTION
In a near future it's going to be a dependency of other conda-forge package (yt)