### PR TITLE
Add bc recipe

### DIFF
--- a/recipes/bc/build.sh
+++ b/recipes/bc/build.sh
@@ -1,0 +1,3 @@
+./configure --prefix=$PREFIX
+make
+make install-exec

--- a/recipes/bc/build.sh
+++ b/recipes/bc/build.sh
@@ -1,3 +1,4 @@
 ./configure --prefix=$PREFIX
 make
+bash verify_checklib_results.sh
 make install-exec

--- a/recipes/bc/meta.yaml
+++ b/recipes/bc/meta.yaml
@@ -19,6 +19,10 @@ build:
   number: 0
   skip: True  # [win]
 
+requirements:
+  build:
+    - flex
+
 test:
   commands:
     - bc --version

--- a/recipes/bc/meta.yaml
+++ b/recipes/bc/meta.yaml
@@ -12,6 +12,8 @@ source:
   url: http://ftpmirror.gnu.org/{{ pkgname }}/{{ pkgname }}-{{ version }}.tar.gz
   sha1: {{ sha1 }}
   md5: {{ md5 }}
+  patches:
+    - verify_checklib_results.sh.patch
 
 build:
   number: 0

--- a/recipes/bc/meta.yaml
+++ b/recipes/bc/meta.yaml
@@ -1,0 +1,31 @@
+{% set pkgname = "bc" %}
+{% set version = "1.06" %}
+{% set sha1 = "c8f258a7355b40a485007c40865480349c157292" %}
+{% set md5 = "d44b5dddebd8a7a7309aea6c36fda117" %}
+
+package:
+  name: {{ pkgname }}
+  version: {{ version }}
+
+source:
+  fn: {{ pkgname }}-{{ version }}.tar.gz
+  url: http://ftpmirror.gnu.org/{{ pkgname }}/{{ pkgname }}-{{ version }}.tar.gz
+  sha1: {{ sha1 }}
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+test:
+  commands:
+    - bc --version
+
+about:
+  home: https://www.gnu.org/software/bc/
+  license: GPL-3.0
+  summary: bc is an arbitrary precision numeric processing language.
+
+extra:
+  recipe-maintainers:
+    - shahin

--- a/recipes/bc/verify_checklib_results.sh.patch
+++ b/recipes/bc/verify_checklib_results.sh.patch
@@ -15,7 +15,7 @@ index 0000000..1d94e6d
 +# failed.
 +
 +test_results=checklib_results.out
-+bc -l Test/checklib.b <(echo "quit") >$test_results
++bc/bc -l Test/checklib.b <(echo "quit") >$test_results
 +
 +# verify that the expected 10 tests failed
 +# on many platforms these fail due to a small roundoff error

--- a/recipes/bc/verify_checklib_results.sh.patch
+++ b/recipes/bc/verify_checklib_results.sh.patch
@@ -1,0 +1,35 @@
+new file mode 100644
+index 0000000..1d94e6d
+--- /dev/null
++++ verify_checklib_results.sh
+@@ -0,0 +1,30 @@
++#!/bin/bash
++
++# On OS X 10.11.5 and Ubuntu 16.04, this recipe builds a bc that fails
++# on exactly 10 tests. On both platforms, the system bc fails on the same
++# tests with the same values. This seems par for the course for bc:
++#
++# http://www.linuxfromscratch.org/blfs/view/7.4/general/bc.html
++#
++# The tests added here simply verify that that only those 10 tests have
++# failed.
++
++test_results=checklib_results.out
++bc -l Test/checklib.b <(echo "quit") >$test_results
++
++# verify that the expected 10 tests failed
++# on many platforms these fail due to a small roundoff error
++# see also: http://www.linuxfromscratch.org/blfs/view/7.4/general/bc.html
++read -r -d '' expected_failed_tests <<'EOF'
++  index = 97
++  index = 8651
++  index = .80
++  index = 4.47
++  index = 2.19
++  index = 4.31
++  index = 2.36
++  index = 2.04
++  index = .65
++  index = 1.07
++EOF
++diff <(grep 'index = ' $test_results) <(echo "  $expected_failed_tests")


### PR DESCRIPTION
Note that bc doesn't come with a `make check` target, and not all the included tests are expected to pass. This motivates the awkward `verify_checklib_results.sh` included here. Including this test on build seems safer than running no tests at all, especially for an "arbitrary precision" calculator utility. Definitely open to suggestions.