### PR TITLE
Add port_for

### DIFF
--- a/recipes/port_for/meta.yaml
+++ b/recipes/port_for/meta.yaml
@@ -33,7 +33,7 @@ about:
   summary: 'port-for is a command-line utility and a python library that helps with local TCP ports managment'
   description: |
     port-for is a command-line utility and a python library that helps with local TCP ports managment.
-    port-for <foo>` script finds an unused port and associates it with <foo>. Subsequent calls will
+    port-for <foo> script finds an unused port and associates it with <foo>. Subsequent calls will
     return the same port number.
   dev_url: https://github.com/kmike/port-for
 

--- a/recipes/port_for/meta.yaml
+++ b/recipes/port_for/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.3.1" %}
+{% set sha256 = "b16a84bb29c2954db44c29be38b17c659c9c27e33918dec16b90d375cc596f1c" %}
+
+package:
+  name: port-for
+  version: {{ version }}
+
+source:
+  fn: port_for-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/port-for/port-for-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - port_for
+  commands:
+    - port-for --version
+
+about:
+  home: https://github.com/kmike/port-for/
+  license: MIT
+  summary: 'port-for is a command-line utility and a python library that helps with local TCP ports managment'
+  description: |
+    port-for is a command-line utility and a python library that helps with local TCP ports managment.
+    port-for <foo>` script finds an unused port and associates it with <foo>. Subsequent calls will
+    return the same port number.
+  dev_url: https://github.com/kmike/port-for
+
+extra:
+  recipe-maintainers:
+    - chohner


### PR DESCRIPTION
Package is port_for, CLI is port-for. Also, it wouldn't work with with setup.py option `--single-version-externally-managed`:
```
error: option --single-version-externally-managed not recognized
```

Works fine without it, at least locally.