### PR TITLE
revert_pins_from_582

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -23,9 +23,6 @@ if [ -z "$GH_TOKEN" ]; then
     # We don't need to build the example recipe.
     rm -rf ./recipes/example
 
-    # revert conda-build to 1.21.7, to get ObsPy 1.0.2 built, see conda-forge/staged-recipes#582
-    conda install --yes conda-build=1.21.7
-
     # We just want to build all of the recipes.
     conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.4"
 fi

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -43,9 +43,6 @@ source run_conda_forge_build_setup
 # We don't need to build the example recipe.
 rm -rf /conda-recipes/example
 
-# revert conda-build to 1.21.7, to get ObsPy 1.0.2 built, see conda-forge/staged-recipes#582
-conda install --yes conda-build=1.21.7
-
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.
 find conda-recipes -mindepth 2 -maxdepth 2 -type f -name "yum_requirements.txt" \
     | xargs -n1 cat | grep -v -e "^#" -e "^$" | \


### PR DESCRIPTION
This PR reverts the `conda-build` pins that @megies had to add so we could merge `obspy`.

@megies can you review and give your :+1: if I got all the changes?

@conda-forge/core I wonder if we should leave theses pins unchanged for a while since there are other PRs suffering from the same issue.