### PR TITLE
Example: Template package name

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -1,6 +1,7 @@
 # Note: there are many handy hints in commenets in this example -- remove them when you've finalized your recipe
 
 # Jinja variables help maintain the recipe as you'll update the version only here.
+{% set name = "simplejson" %}
 {% set version = "3.8.2" %}
 {% set sha256 = "d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f" %}
 # sha256 is the prefered checksum -- you can get it for a file with:
@@ -9,12 +10,12 @@
 #  `conda install openssl -c conda-forge``
 
 package:
-  name: simplejson
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: simplejson-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/s/simplejson/simplejson-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Have gone ahead and templated out the package name too. The `/s/` in the PyPI url was found to be confusing by several people. Many assumed it meant `source` or similar and was thus not tied to the package name when in fact it is. This update tries to clarify that relationship to the package name a little bit more.

Further we go ahead and ensure the package name will be lower cased even if the name has CamelCase or similar.