### PR TITLE
Add doctr

### DIFF
--- a/recipes/doctr/meta.yaml
+++ b/recipes/doctr/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   entry_points:
     - doctr = doctr.__main__:main
-  skip: true  # [not py35]
+  skip: true  # [py<35]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/doctr/meta.yaml
+++ b/recipes/doctr/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = "1.1" %}
+package:
+  name: doctr
+  version: {{ version }}
+
+source:
+  fn: doctr-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/d/doctr/doctr-{{ version }}.tar.gz
+  md5: b5eed31c06c33f338ab303ee6e3e83a8
+
+build:
+  number: 0
+  entry_points:
+    - doctr = doctr.__main__:main
+  skip:  # [not py35]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+    - cryptography
+
+  run:
+    - python
+    - requests
+    - cryptography
+
+test:
+  imports:
+    - doctr
+
+  commands:
+    - doctr --help
+    - doctr configure --help
+    - doctr deploy --help
+
+about:
+  home: https://gforsyth.github.io/doctr/docs/
+  license: MIT
+  summary: 'Deploy docs from Travis to GitHub pages.'
+
+  description: |
+    A tool for automatically building Sphinx docs on Travis CI, and deploying
+    them to GitHub pages.
+  doc_url: https://gforsyth.github.io/doctr/docs/
+  dev_url: https://github.com/gforsyth/doctr
+
+extra:
+  recipe-maintainers:
+    - asmeurer
+    - gforsyth

--- a/recipes/doctr/meta.yaml
+++ b/recipes/doctr/meta.yaml
@@ -12,7 +12,7 @@ build:
   number: 0
   entry_points:
     - doctr = doctr.__main__:main
-  skip:  # [not py35]
+  skip: true  # [not py35]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
Doctr is a tool that @gforsyth and I have been working on to make it easy to
automatically deploy docs to GitHub pages from Travis.