### PR TITLE
Add dodgy

### DIFF
--- a/recipes/dodgy/meta.yaml
+++ b/recipes/dodgy/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "dodgy" %}
+{% set version = "0.1.9" %}
+{% set sha256 = "65e13cf878d7aff129f1461c13cb5fd1bb6dfe66bb5327e09379c3877763280c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - dodgy
+
+about:
+  home: https://github.com/landscapeio/dodgy
+  license: MIT
+  summary: 'Dodgy: Searches for dodgy looking lines in Python code'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Generated with `conda skeleton pypi` (and cleaned up afterwards). Adds a recipe for `dodgy`. A linting tool that looks for content committed that shouldn't be like password, keys, etc.