### PR TITLE
Add ipaddress

### DIFF
--- a/recipes/ipaddress/meta.yaml
+++ b/recipes/ipaddress/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "ipaddress" %}
+{% set version = "1.0.16" %}
+{% set sha256 = "5a3182b322a706525c46282ca6f064d27a02cffbd449f9f47416f1dc96aa71b0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [py>=33]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - ipaddress
+
+about:
+  home: https://github.com/phihag/ipaddress
+  license: PSF 2
+  summary: 'IPv4/IPv6 manipulation library'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds the Python 3.3 backport library `ipaddress`. Generated with `conda skeleton pypi` and cleaned up.