### PR TITLE
Add enum34

### DIFF
--- a/recipes/enum34/meta.yaml
+++ b/recipes/enum34/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "enum34" %}
+{% set version = "1.1.6" %}
+{% set sha256 = "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - enum
+
+about:
+  home: https://bitbucket.org/stoneleaf/enum34
+  license: BSD 3-Clause
+  summary: 'Python 3.4 Enum backported to 3.3, 3.2, 3.1, 2.7, 2.6, 2.5, and 2.4'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Backport of `enum` module from Python 3.4. Generated with `conda skeleton pypi` and cleaned up.