### PR TITLE
Add pies2overrides

### DIFF
--- a/recipes/ipaddress/meta.yaml
+++ b/recipes/ipaddress/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "ipaddress" %}
+{% set version = "1.0.16" %}
+{% set sha256 = "5a3182b322a706525c46282ca6f064d27a02cffbd449f9f47416f1dc96aa71b0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [py>=33]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - ipaddress
+
+about:
+  home: https://github.com/phihag/ipaddress
+  license: PSF 2
+  summary: 'IPv4/IPv6 manipulation library'
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/pies2overrides/meta.yaml
+++ b/recipes/pies2overrides/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pies2overrides" %}
+{% set version = "2.6.7" %}
+{% set sha256 = "d8fa2879d038faca9e41bd470a77f66acdb04d5726ad0fa60f52fbd427d92390" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not py2k]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - ipaddress
+    - argparse     # [py26]
+    - ordereddict  # [py26]
+  run:
+    - python
+    - ipaddress
+    - argparse     # [py26]
+    - ordereddict  # [py26]
+
+test:
+  imports:
+    - builtins
+    - copyreg
+    - queue
+    - reprlib
+    - socketserver
+    - html
+    - http
+    - xmlrpc
+
+about:
+  home: https://github.com/timothycrosley/pies
+  license: MIT
+  summary: 'Defines override classes that should be included with pies only if running on Python2.'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Generated via `conda skeleton pypi` and cleaned up. Backports from Python 3 to Python 2 as part of `pies`.