### PR TITLE
Drop matrix on Travis CI (use OS X only)

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -4,25 +4,22 @@
 # Set the numpy variable. This isn't used, but conda-build complains if we haven't set it already.
 export CONDA_NPY=19
 
-# We only build if we aren't a merged PR (that is, only build for PRs).
-if [ -z "$GH_TOKEN" ]; then
-    # Remove homebrew.
-    brew remove --force $(brew list)
-    brew cleanup -s
-    rm -rf $(brew --cache)
+# Remove homebrew.
+brew remove --force $(brew list)
+brew cleanup -s
+rm -rf $(brew --cache)
 
-    # Install and configure conda environment.
-    curl -L -O https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
-    python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
-    conda config --add channels conda-forge
-    conda config --set show_channel_urls true
-    conda install --yes --quiet conda-build-all
-    conda install --yes --quiet conda-forge-build-setup
-    source run_conda_forge_build_setup
+# Install and configure conda environment.
+curl -L -O https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
+conda config --add channels conda-forge
+conda config --set show_channel_urls true
+conda install --yes --quiet conda-build-all
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
-    # We don't need to build the example recipe.
-    rm -rf ./recipes/example
+# We don't need to build the example recipe.
+rm -rf ./recipes/example
 
-    # We just want to build all of the recipes.
-    conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.4"
-fi
+# We just want to build all of the recipes.
+conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.4"

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -2,24 +2,21 @@
 
 set -e
 
+wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
+python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
+conda config --set show_channel_urls true
+conda config --add channels conda-forge
+conda install --yes --quiet conda-smithy
 
-if [ -n "$GH_TOKEN" ]; then
-    wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
-    python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
-    conda config --set show_channel_urls true
-    conda config --add channels conda-forge
-    conda install --yes --quiet conda-smithy
+# Pinned to workaround an incompatibility between
+# `conda-smithy` and `conda-build >=1.21.12`.
+# Please see the linked issue below for details.
+#
+# https://github.com/conda-forge/conda-smithy/issues/260
+#
+conda install --yes --quiet conda-build=1.21.11
 
-    # Pinned to workaround an incompatibility between
-    # `conda-smithy` and `conda-build >=1.21.12`.
-    # Please see the linked issue below for details.
-    #
-    # https://github.com/conda-forge/conda-smithy/issues/260
-    #
-    conda install --yes --quiet conda-build=1.21.11
+mkdir -p ~/.conda-smithy
+echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 
-    mkdir -p ~/.conda-smithy
-    echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
-
-    python .CI/create_feedstocks.py
-fi
+python .CI/create_feedstocks.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # The language in this case has no bearing - we are going to be making use of conda.
 language: generic
 
+os: osx
+
 sudo: false
 
 env:
@@ -20,20 +22,13 @@ env:
         # Add the TRAVIS_TOKEN environment variable for the "conda-forge" Travis user.
         - secure: "BBJrw5OcEG4zEUxjXt2txNoz+o7ilTb0e8Tj1626USKqi6HAWOdSFHW7PLYR6vyefWsHnGLAeYMRr9UB56O2oDwS7jgClBKbyut2+Q+8SQBwEtNCMHdU996IzSuDP4AM3h7DLjTsuinWhwpqLu72z2ZjE9OMz4q03SyyiBOecWU1btYbp/u3bpNzyhb2u0HMkRUnS8MxPUa8aHZBKp/JpLrGQmIT0LcjLNp4/jTZp+cs+J//02hAhJHV3vMmyefVvRZayu3xKzutpb3qIga0JAP3d0j2FWXRHVTW6Ke5H4u/4NU7iTpdRjpymnzH7H2kfOrNzgCJ23NfNhScDJDc5URvdXlstgkC4lDkd7BbSVgKKaVy2vVcMkz98qbBnhi0akMHNZXPLvT9tec9AsAX5/pdNaa1rH/iRhjWRfTCnqODX+RTwMhA1/3rkmhzI/8JFCcaZet8+lA2LtOf95jGmwcRwPlNFX0Jdd1QBk2nUAUpCePWIdg7GRxYuO7a4QCbhc6bSyB/WrCQZ1oEmtwGSRqxpMKvQmjxJObg40MgP0DaquGov30A4QLoEdvXCnM7w3QyIr5L/BrLlnCy8LesAZIBn2l5LAHrBFGh9t/lCK9APlUjD9dgT6eCYOSbfdBghKCGsajAsM/fwsPvcjOmpFCLf+UZTer36B57ccHrYdU="
 
-matrix:
-  include:
-    - os: osx
-      env: ACTION="build-all"
-    - os: linux
-      env: ACTION="create-feedstocks-on-merge"
-
 script:
-    - if [ "$ACTION" = "create-feedstocks-on-merge" ]; then
-        echo "Creating feedstocks from the recipe(s) (this simply does nothing if this isn't a merged commit to master).";
+    - if [ -n "$GH_TOKEN" ]; then
+        echo "Creating feedstocks from the recipe(s).";
         git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
         git config --global user.email "conda-forge@googlegroups.com";
         source ./.CI/create_feedstocks;
-      elif [ "$ACTION" = "build-all" ]; then
+      else
         echo "Building all recipes.";
         source ./.CI/build_all;
       fi


### PR DESCRIPTION
This removes the Travis CI matrix and only uses OS X to do everything.

To give a bit of history, the two builds use to both have a purpose when building a PR. Travis CI has had a matrix of two builds for a long time. Initially they were both OS X builds. One was used (as it is today) to build the recipe(s). The other was used to lint the recipes. When a PR was merged, the build matrix element did nothing (as it does now) and the linting matrix element became the feedstock conversion element.

We eventually decided after some brief discussion in issue ( https://github.com/conda-forge/staged-recipes/issues/154 ) that it was silly for the linting/feedstock conversion part to be on OS X as the boot time was slower and it could just as well run on a Linux container build. So we switched it over to use Linux in PR ( https://github.com/conda-forge/staged-recipes/pull/167 ).

Soon after we decided that linting should become a webservice that would comment on PRs. Once that happened there was really no need to lint in the CI at all so we dropped in PR ( https://github.com/conda-forge/staged-recipes/pull/261 ).

Since then we have basically had two CI jobs on Travis CI for every build and merge. Though in reality we only ever use one. Generally this has not been an issue, so we have left it alone even though it is a bit inefficient. However, in light of recent Travis CI instability on either Linux or OS X builds, it seems that this inefficiency can no longer be tolerated. Especially when knowing that all Travis CI builds use the same queue for the org regardless of the VM type (e.g. Linux or OS X) as was discovered in issue ( https://github.com/travis-ci/travis-ci/issues/6211 ). This means that Linux or OS X build that is merely fast finishing could be holding up our queue. In fact, of the queue at staged-recipes half of it is fast finishing builds.

While it would be nice to keep the fast startup time that we are use to with the Linux container builds for feedstock conversion, the roughly minute loss on boot time does not seem so unreasonable given we are halving the staged-recipes queue. Further there are always more jobs due to actively worked on PRs than there are due to conversions. Cutting down the number of builds need for those jobs will be quite helpful for shortening the queue and improving build start times throughout conda-forge. Thus this should still be a net win.

In the long run, we have discussed in issue ( https://github.com/conda-forge/staged-recipes/issues/916 ) moving feedstock conversion to CircleCI. After all CircleCI has a very fast startup time, allows us to use our custom Docker image to cutdown on setup time, and the ability to get a fresh log on restart (thus preserving past errors in old logs) makes it a very nice option for feedstock conversion. However, this will take a bit more work and coordination to get right. This simple fix is already a big win and starts us moving in that direction.

Please let me know your thoughts on this.

cc @conda-forge/core