### PR TITLE
Add argparse

### DIFF
--- a/recipes/argparse/meta.yaml
+++ b/recipes/argparse/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [(py2k and py>26) or (py3k and py>31)]
+  skip: true  # [not py26]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/argparse/meta.yaml
+++ b/recipes/argparse/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 about:
   home: https://github.com/ThomasWaldmann/argparse/
-  license: Python Software Foundation License
+  license: PSF 2
   summary: 'Python command-line parsing library'
 
 extra:

--- a/recipes/argparse/meta.yaml
+++ b/recipes/argparse/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [not py26]
+  skip: true  # [(py2k and py>26) or (py3k and py>31)]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/argparse/meta.yaml
+++ b/recipes/argparse/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: https://github.com/ThomasWaldmann/argparse/
   license: PSF 2
+  license_file: doc/source/Python-License.txt
   summary: 'Python command-line parsing library'
 
 extra:

--- a/recipes/argparse/meta.yaml
+++ b/recipes/argparse/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "argparse" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  {% set pypi_name = name.replace("_", "-") %}
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [(py2k and py>26) or (py3k and py>31)]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - argparse
+
+about:
+  home: https://github.com/ThomasWaldmann/argparse/
+  license: Python Software Foundation License
+  summary: 'Python command-line parsing library'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Generated with `conda skeleton pypi`. Basically for backcompat. Might try to build once and otherwise it will just be disabled.