### PR TITLE
Add an example license_file entry.

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -42,6 +42,7 @@ about:
   # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
   # See https://opensource.org/licenses/alphabetical
   license: MIT
+  license_file: LICENSE.txt
   summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
 
   # The remaining entries in this section are optional, but recommended

--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -42,6 +42,9 @@ about:
   # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
   # See https://opensource.org/licenses/alphabetical
   license: MIT
+  # It is strongly encouraged to include a license file in the  package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
   license_file: LICENSE.txt
   summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
 


### PR DESCRIPTION
Add an example of adding a license file entry, to encourage new recipes to include it.