### PR TITLE
Add lazy-object-proxy

### DIFF
--- a/recipes/lazy-object-proxy/meta.yaml
+++ b/recipes/lazy-object-proxy/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "lazy-object-proxy" %}
+{% set version = "1.2.2" %}
+{% set sha256 = "ddd4cf1c74279c349cb7b9c54a2efa5105854f57de5f2d35829ee93631564268" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  {% set pypi_name = name.replace("_", "-") %}
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - toolchain
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - lazy_object_proxy
+
+about:
+  home: https://github.com/ionelmc/python-lazy-object-proxy
+  license: BSD 2-Clause
+  summary: 'A fast and thorough lazy object proxy.'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Generated with `conda skeleton pypi` and cleaned up. I apparently missed that it uses `-` and not `_`. Am considering just re-adding it with this fix.