### PR TITLE
Added recipe for python-docx

### DIFF
--- a/recipes/python-docx/meta.yaml
+++ b/recipes/python-docx/meta.yaml
@@ -12,6 +12,10 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   {{ hash_type }}: {{ hash_val }}
 
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
 requirements:
   build:
     - python

--- a/recipes/python-docx/meta.yaml
+++ b/recipes/python-docx/meta.yaml
@@ -1,0 +1,45 @@
+{%set name = "python-docx" %}
+{%set version = "0.8.6" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "55ece6fd4a4fa3389909fa0e51400fce428e1fb6f6ef3599cbba31673441f184" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - lxml >=2.3.2
+
+test:
+  imports:
+    - docx
+    - docx.dml
+    - docx.enum
+    - docx.image
+    - docx.opc
+    - docx.opc.parts
+    - docx.oxml
+    - docx.oxml.text
+    - docx.parts
+    - docx.styles
+    - docx.text
+
+about:
+  home: https://github.com/python-openxml/python-docx
+  license: MIT
+  summary: 'Create and update Microsoft Word .docx files.'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
This guy is breaking because it can't find `docx` during the test phase; I'm assuming that this is an issue with the naming scheme. Not sure if there's an easy patch for this...