### PR TITLE
Added recipe for SpeechRecognition

### DIFF
--- a/recipes/speechrecognition/meta.yaml
+++ b/recipes/speechrecognition/meta.yaml
@@ -1,0 +1,38 @@
+{%set name = "speechrecognition" %}
+{%set version = "3.4.6" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "insert-real-hash" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - speech_recognition
+
+about:
+  home: https://github.com/Uberi/speech_recognition
+  license: BSD 3-Clause
+  summary: 'Library for performing speech recognition, with support for several engines and APIs, online and offline.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/speechrecognition/meta.yaml
+++ b/recipes/speechrecognition/meta.yaml
@@ -34,6 +34,6 @@ about:
   license: BSD 3-Clause
   summary: 'Library for performing speech recognition, with support for several engines and APIs, online and offline.'
 
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/speechrecognition/meta.yaml
+++ b/recipes/speechrecognition/meta.yaml
@@ -1,7 +1,8 @@
 {%set name = "speechrecognition" %}
+{%set camelName = "SpeechRecognition" %}
 {%set version = "3.4.6" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "insert-real-hash" %}
+{%set hash_val = "393eab35f102e6406dcacd54ff06473c2c86371cd566f8b314cf79df2d89ac31" %}
 
 package:
   name: {{ name }}
@@ -9,7 +10,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
   {{ hash_type }}: {{ hash_val }}
 
 build:


### PR DESCRIPTION
The [SpeechRecognition repo](https://github.com/Uberi/speech_recognition#readme) defines a number of extra requirements, but includes none of them as "extras" in `setup.py`. As such, I feel ok building without taking care of them, but it's arguably un-`conda`-like.