### PR TITLE
Add harfbuzz

### DIFF
--- a/recipes/harfbuzz/build.sh
+++ b/recipes/harfbuzz/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Get rid of bad `defaults` .la files.
+rm -rf $PREFIX/lib/*.la
+
+
+if [ $(uname) == Darwin ]; then
+  export CC=clang
+  export CXX=clang++
+  export MACOSX_DEPLOYMENT_TARGET="10.9"
+  export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+  export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
+  export OPTS=""
+elif [[ $(uname) == Linux ]]; then
+  export OPTS="--with-gobject"
+fi
+
+autoreconf --force --install
+
+# FIXME: Locally it does have the executable bits :-/
+bash configure --prefix=$PREFIX \
+               --disable-gtk-doc \
+               --enable-static \
+               $OPTS
+
+make
+
+# =================================================
+#    HarfBuzz 1.0.6: test/shaping/test-suite.log
+# =================================================
+#
+# # TOTAL: 14
+# # PASS:  13
+# # SKIP:  0
+# # XFAIL: 0
+# # FAIL:  1
+# # XPASS: 0
+# # ERROR: 0
+#
+# .. contents:: :depth: 2
+#
+# FAIL: tests/fuzzed
+# ==================
+#
+# Running tests in ./tests/fuzzed.tests
+# Testing fonts/sha1sum/1a6f1687b7a221f9f2c834b0b360d3c8463b6daf.ttf:U+0041
+# Testing fonts/sha1sum/5a5daf5eb5a4db77a2baa3ad9c7a6ed6e0655fa8.ttf:U+0041
+# Testing fonts/sha1sum/0509e80afb379d16560e9e47bdd7d888bebdebc6.ttf:U+0041
+# Testing fonts/sha1sum/641bd9db850193064d17575053ae2bf8ec149ddc.ttf:U+0041
+# Testing fonts/sha1sum/375d6ae32a3cbe52fbf81a4e5777e3377675d5a3.ttf:U+0041
+# Actual:   [gid0=0+4352]
+# Expected: [gid0=0+2048]
+# 1 tests failed.
+# make check
+
+make install

--- a/recipes/harfbuzz/meta.yaml
+++ b/recipes/harfbuzz/meta.yaml
@@ -1,0 +1,61 @@
+{% set version = "1.0.6" %}
+package:
+    name: harfbuzz
+    version: {{ version }}
+
+source:
+    fn: harfbuzz-{{ version }}.tar.bz2
+    url: http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-{{ version }}.tar.bz2
+    sha256: f616a7fbdc78a627043f9029000bf08c0c71df59cde4143fc92a014f6a993b26
+
+build:
+    number: 0
+    detect_binary_files_with_prefix: true
+    skip: True  # [win]
+
+requirements:
+    build:
+        - perl
+        - pkg-config
+        - automake
+        - libtool
+        - cairo 1.12.*
+        - glib 2.*
+        - freetype 2.6.*
+        - icu 56.*
+    run:
+        - cairo 1.12.*
+        - glib 2.*
+        - freetype 2.6.*
+        - icu 56.*
+
+test:
+    commands:
+        # Libraries.
+        {% set libs = [
+            "libharfbuzz-icu",
+            "libharfbuzz"
+            ] %}
+        {% for lib in libs %}
+        - test -f $PREFIX/lib/{{ lib }}.dylib  # [osx]
+        - test -f $PREFIX/lib/{{ lib }}.so  # [linux]
+        {% endfor %}
+        # CLI tests.
+        - hb-view --version  # [linux]
+        - conda inspect linkages -n _test harfbuzz  # [not win]
+        - conda inspect objects -n _test harfbuzz  # [osx]
+
+about:
+    home: http://www.freedesktop.org/wiki/Software/HarfBuzz/
+    license: MIT
+    license_file: COPYING
+    summary: An OpenType text shaping engine
+    description: |
+        HarfBuzz is a text shaping library. New Harbuzz targets various font
+        technologies while Old HarfBuzz targets only OpenType fonts.
+    doc_url: https://www.freedesktop.org/wiki/Software/HarfBuzz/
+    dev_url: https://github.com/behdad/harfbuzz
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
Adding `harfbuzz`.

This package is quite complex with its options! There are many circular dependencies, etc. I am using the bar minimum here to get a working version for `pango` on `OS X` (and `pyferret`).

[skip appveyor]