### PR TITLE
Add versioneer

### DIFF
--- a/recipes/versioneer/meta.yaml
+++ b/recipes/versioneer/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "versioneer" %}
+{% set version = "0.16" %}
+{% set sha256 = "67f9c595eba7479fc5afd867642e21b1a97d2e8cbff9684ad47d41a0db4b3048" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  commands:
+    - versioneer version
+
+about:
+  home: https://github.com/warner/python-versioneer
+  license: Public Domain
+  summary: Easy VCS-based management of project version strings
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for the CLI tool `versioneer`. Recipe generated with `conda skeleton pypi` and cleaned up afterwards. This tool helps one version their code based on VCS avoiding unnecessary duplication of version strings and allowing one to easily track version info in dev releases.