### PR TITLE
Pin `conda-build` to `1.21.11` for feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -9,6 +9,7 @@ if [ -n "$GH_TOKEN" ]; then
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
     conda install --yes --quiet conda-smithy
+    conda install --yes --quiet conda-build=1.21.11
 
     mkdir -p ~/.conda-smithy
     echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token


### PR DESCRIPTION
Related https://github.com/conda-forge/status/issues/3

For some reason, feedstock conversion (`conda-smithy`?) is struggling with the new `conda-build`. To keep things working smoothly, simply pin `conda-build` to version `1.21.11`, which is the last known working version.

cc @patricksnape @msarahan @pelson