### PR TITLE
Explain `conda-build` pin to `1.21.11` in feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -9,6 +9,13 @@ if [ -n "$GH_TOKEN" ]; then
     conda config --set show_channel_urls true
     conda config --add channels conda-forge
     conda install --yes --quiet conda-smithy
+
+    # Pinned to workaround an incompatibility between
+    # `conda-smithy` and `conda-build >=1.21.12`.
+    # Please see the linked issue below for details.
+    #
+    # https://github.com/conda-forge/conda-smithy/issues/260
+    #
     conda install --yes --quiet conda-build=1.21.11
 
     mkdir -p ~/.conda-smithy


### PR DESCRIPTION
Explain the pinning of `conda-build` to `1.21.11` done in PR ( https://github.com/conda-forge/staged-recipes/pull/1293 ). Basically this is a workaround for issue ( https://github.com/conda-forge/conda-smithy/issues/260 ).