### PR TITLE
Use Travis' generic language VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # The language in this case has no bearing - we are going to be making use of conda.
-language: objective-c
+language: generic
 
 sudo: false
 


### PR DESCRIPTION
On Travis CI, switch to using the generic language VM. After all, the OS is already determined in the build matrix. Also we don't need Objective-C on Linux. This should improve VM boot time.