### PR TITLE
Readds `argparse`

### DIFF
--- a/recipes/argparse/meta.yaml
+++ b/recipes/argparse/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "argparse" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  {% set pypi_name = name.replace("_", "-") %}
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [(py2k and py>26) or (py3k and py>31)]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - argparse
+
+about:
+  home: https://github.com/ThomasWaldmann/argparse/
+  license: PSF 2
+  license_file: doc/source/Python-License.txt
+  summary: 'Python command-line parsing library'
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Reverts PR ( https://github.com/conda-forge/staged-recipes/pull/1318 ). It seems that the next recipe in the list had the exact same problem. This suggests it has nothing to do with which feedstock we are creating. Instead it has to do with issues using AppVeyor's API.