### PR TITLE
Update conversion message on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
 
 script:
     - if [ "$ACTION" = "create-feedstocks-on-merge" ]; then
-        echo "Creating feedstocks from the recipe(s) (this simply lints the recipe if this isn't a merged commit to master).";
+        echo "Creating feedstocks from the recipe(s) (this simply does nothing if this isn't a merged commit to master).";
         git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
         git config --global user.email "conda-forge@googlegroups.com";
         source ./.CI/create_feedstocks;


### PR DESCRIPTION
Since PR ( https://github.com/conda-forge/staged-recipes/pull/261 ) we don't do linting in the feedstock conversion matrix element any more. Thus we don't need to have that in the message either. This fixes that message to note that job is idle otherwise.