### PR TITLE
Checkout latest commit before feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -2,6 +2,11 @@
 
 set -e
 
+# Ensure we are on the latest commit
+# of the branch where we are converting
+# recipes from. Currently this is `master`.
+git checkout "${TRAVIS_BRANCH}"
+
 wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
 conda config --set show_channel_urls true


### PR DESCRIPTION
Travis CI has gotten much better about ensuring the specified commit is tested. For a CI service, this is good generally.

However, this behavior is a bit bad for our use case. We don't care which commit we are running as much as we care that we have the current set of recipes. Also we want to avoid reconverting things that are removed or skipping things that were recently added. Not using the latest commit has caused trouble elsewhere like the feedstock listing as can be seen in PR ( https://github.com/conda-forge/conda-forge.github.io/pull/202 ). It is also causing us [problems here]( https://travis-ci.org/conda-forge/staged-recipes/builds/155628166#L236 ).

To fix this, we can simply switch to the branch `HEAD` right before starting conversion. Once conversion is completed, we can pull the branch to make sure we have all of the latest changes. To resolve any conflicts (e.g. some recipes have been removed but not all) we can use the stash before and after the pull. This works fine in cases just like this where files are deleted. Tested this exact same strategy locally with a very similar scenario to staged-recipes. We then create a list of the recipes that were removed after this procedure.

Doing this we should be able to reduce the extra failures on `master` due to race conditions and being restricted to an outdated commit.