### PR TITLE
Package futures

### DIFF
--- a/recipes/futures/meta.yaml
+++ b/recipes/futures/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "futures" %}
+{% set version = "3.0.5" %}
+{% set sha256 = "0542525145d5afc984c88f914a0c85c77527f65946617edb5274f72406f981df" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [py<32]
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - concurrent
+    - concurrent.futures
+
+about:
+  home: https://github.com/agronholm/pythonfutures
+  license: BSD 2-Clause
+  license_file: LICENSE
+  summary: Backport of the concurrent.futures package from Python 3.2
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/1258

Adds a recipe to build `futures`. This is a Python 2 backport of concurrent.futures added in Python 3.2 with some minor fixes pulled from upstream (Python).