### PR TITLE
Add cryptography-vectors

### DIFF
--- a/recipes/cryptography-vectors/meta.yaml
+++ b/recipes/cryptography-vectors/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "cryptography_vectors" %}
+{% set version = "1.4" %}
+{% set sha256 = "0728815ef0c53d67fd437aa5220450a9752d41ecb28108f5df628a092ff466ea" %}
+
+package:
+  name: cryptography-vectors
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/c/cryptography_vectors/cryptography_vectors-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - cryptography_vectors
+
+about:
+  home: https://github.com/pyca/cryptography
+  license: Apache 2.0 or BSD 3-Clause
+  #license_file: ??? TWO LICENSE FILES ???
+  summary: Test vectors for the cryptography package.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
This add the `cryptography-vectors` package, which is a test dependency of `cryptography`.

Would you please help review this, @pmlandwehr? Also please let me know if you would be interested in helping maintain this package.