### PR TITLE
Added recipe for testtools

### DIFF
--- a/recipes/testtools/meta.yaml
+++ b/recipes/testtools/meta.yaml
@@ -1,0 +1,46 @@
+{%set name = "testtools" %}
+{%set version = "2.2.0" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "80f606607a6e4ce4d0e24e5b786562aa42c581906f3c070607a4265f3da65810" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr >=0.11
+
+  run:
+    - python
+    - pbr >=0.11
+    - extras >=1.0.0
+    - fixtures >=1.3.0
+    - python-mimeparse
+    - unittest2 >=1.0.0
+    - traceback2
+    - six >=1.4.0
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/testing-cabal/testtools
+  license: MIT License
+  summary: 'Extensions to the Python standard library unit testing framework'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/testtools/meta.yaml
+++ b/recipes/testtools/meta.yaml
@@ -25,21 +25,19 @@ requirements:
   run:
     - python
     - pbr >=0.11
-    - extras >=1.0.0
-    - fixtures >=1.3.0
-    - python-mimeparse
-    - unittest2 >=1.0.0
-    - traceback2
-    - six >=1.4.0
 
 test:
   imports:
-    - {{ name }}
+    - testtools
 
 about:
   home: https://github.com/testing-cabal/testtools
-  license: MIT License
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
   summary: 'Extensions to the Python standard library unit testing framework'
+  dev_url: https://github.com/testing-cabal/testtools
+  doc_url: https://testtools.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
I'm a smidge concerned about this because I've omitted the libs specified in [`requirements.txt`](https://github.com/testing-cabal/testtools/blob/master/requirements.txt) from the runtime reqs. Everything builds fine and the test import works, so perhaps I'm simply too used to including extra libs for extra package requirements.