### PR TITLE
Add twine

### DIFF
--- a/recipes/twine/meta.yaml
+++ b/recipes/twine/meta.yaml
@@ -42,7 +42,7 @@ test:
 
 about:
   home: https://github.com/pypa/twine
-  license: Apache Software License
+  license: Apache Software License 2.0
   summary: 'Collection of utilities for interacting with PyPI'
 
 extra:

--- a/recipes/twine/meta.yaml
+++ b/recipes/twine/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.8.1" %}
+
+package:
+  name: twine
+  version: {{ version }}
+
+source:
+  fn: twine-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/twine/twine-{{ version }}.tar.gz
+  sha256: 68b663691a947b844f92853c992d42bb68b6333bffc9ab7f661346b001c1da82
+
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - twine = twine.__main__:main
+
+requirements:
+  build:
+    - python
+    - pkginfo >=1.0
+    - requests >=2.5.0
+    - requests-toolbelt >=0.5.1
+    - setuptools >=0.7.0
+    - clint
+    
+  run:
+    - python
+    - pkginfo >=1.0
+    - requests >=2.5.0
+    - requests-toolbelt >=0.5.1
+    - setuptools >=0.7.0
+    - clint
+
+test:
+  imports:
+    - twine
+    - twine.commands
+  commands:
+    - twine --help
+
+about:
+  home: https://github.com/pypa/twine
+  license: Apache Software License
+  summary: 'Collection of utilities for interacting with PyPI'
+
+extra:
+  recipe-maintainers:
+    - janschulz


### PR DESCRIPTION
This adds twine https://github.com/pypa/twine/ which lets you upload wheels to pypi. I want this to make it easier to build wheels on CI services (twine now supports working without a pypirc file, using only commandline flags and env variables)