### PR TITLE
add pytest-catchlog

### DIFF
--- a/recipes/pytest-catchlog/meta.yaml
+++ b/recipes/pytest-catchlog/meta.yaml
@@ -1,0 +1,42 @@
+{% set pkgname = "pytest-catchlog" %}
+{% set version = "1.2.2" %}
+{% set md5 = "09d890c54c7456c818102b7ff8c182c8" %}
+
+package:
+  name: {{ pkgname }}
+  version: {{ version }}
+
+source:
+  fn: {{ pkgname }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ pkgname[0] }}/{{ pkgname }}/{{ pkgname }}-{{ version }}.zip
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - py >=1.1.1
+    - pytest
+
+  run:
+    - python
+    - py >=1.1.1
+    - pytest
+
+test:
+  imports:
+    - pytest_catchlog
+
+about:
+  home: https://github.com/eisensheng/pytest-catchlog
+  license: MIT
+  license_file: LICENSE.txt
+  summary: 'py.test plugin to capture log messages'
+
+extra:
+  recipe-maintainers:
+    - msarahan

--- a/recipes/pytest-catchlog/run_test.py
+++ b/recipes/pytest-catchlog/run_test.py
@@ -1,7 +1,20 @@
 # this test is intended to verify that the plugin has been
 #    registered correctly with pytest.
+import os
 import subprocess
-output = subprocess.check_output('py.test -h'.split())
+import sys
+
+on_win = sys.platform=="win32"
+
+prefix = os.environ['PREFIX'].replace("\\", '/')
+subdir = "Scripts" if on_win else "bin"
+prefix = os.path.join(prefix, subdir)
+
+cmd = '{prefix}/py.test{ext} -h'.format(prefix=prefix,
+                                sep=os.path.sep,
+                                ext=".exe" if on_win else "")
+cmd = 'py.test -h'
+output = subprocess.check_output(cmd.split(), env=os.environ)
 if hasattr(output, 'decode'):
     output = output.decode('utf-8')
 assert '--no-print-logs' in output

--- a/recipes/pytest-catchlog/run_test.py
+++ b/recipes/pytest-catchlog/run_test.py
@@ -1,0 +1,7 @@
+# this test is intended to verify that the plugin has been
+#    registered correctly with pytest.
+import subprocess
+output = subprocess.check_output('py.test -h'.split())
+if hasattr(output, 'decode'):
+    output = output.decode('utf-8')
+assert '--no-print-logs' in output


### PR DESCRIPTION
This is a maintained fork of pytest-capturelog, which has been dormant since 2010.  It is useful for capturing logging output during tests with pytest.