### PR TITLE
Purges merged recipes from PRs for CI

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -18,8 +18,12 @@ conda install --yes --quiet conda-build-all
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# We don't need to build the example recipe.
-rm -rf ./recipes/example
+# Find the recipes from master in this PR and remove them.
+pushd ./recipes > /dev/null
+echo "Finding recipes merged in master and removing them from the build."
+git fetch https://github.com/conda-forge/staged-recipes.git master
+git ls-tree --name-only FETCH_HEAD -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
+popd > /dev/null
 
 # We just want to build all of the recipes.
 conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,12 +56,13 @@ install:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
 
-    # We don't need to build the example recipe.
-    - cmd: if exist recipes\example rmdir recipes\example /s /q
-    # Skip if we are not in a PR.
-    - cmd: if "%APPVEYOR_REPO_NAME%" == "conda-forge/staged-recipes" if not defined APPVEYOR_PULL_REQUEST_NUMBER rmdir /q /s recipes
-    # Make sure the `recipes` directory exists if we removed it.
-    - cmd: if not exist recipes mkdir recipes
+    # Find the recipes from master in this PR and remove them.
+    - cmd: echo Finding recipes merged in master and removing them.
+    - cmd: cd recipes
+    - cmd: git fetch https://github.com/conda-forge/staged-recipes.git master
+    - cmd: |
+             for /f "tokens=*" %%a in ('git ls-tree --name-only FETCH_HEAD -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
+    - cmd: cd ..
 
     # Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.
     - cmd: set CONDA_NPY=19


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/942

The goal here is to avoid building or checking things we don't need to. In other words, things that have been merged into `master`. Further it is to improve the user experience when proposing new additions. In particular, this should be very helpful for new users that are frequently confused by this behavior.

This uses a `git` trick to find the recipes that are already in `master` and remove them. As a bonus this already picks up `example`, so we no longer need to handle that in a special way. It should also provide a fast-finish for all builds on `master` too. As a result, we can drop the custom check from AppVeyor that does this.

Should add that we are effectively testing this functionality in this PR as there are two recipes in `master` and we are building neither of them.

cc @pelson @ocefpaf @mwcraig