### PR TITLE
WIP: Add imbalanced-learn recipe – Why ImportError: No module named imblearn?

### DIFF
--- a/recipes/imbalanced-learn/meta.yaml
+++ b/recipes/imbalanced-learn/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "imbalanced-learn" %}
+{% set version = "0.1.8" %}
+{% set sha256 = "0f2763e1d748c713349ff746d67a90010f5c1314830bfa7c5cdf17fd679cacdc" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python >=2.7
+    - setuptools
+    - numpy >=1.10.4
+    - scipy >=0.17.0
+    - scikit-learn >=0.17.1
+  run:
+    - python >=2.7
+    - numpy >=1.10.4
+    - scipy >=0.17.0
+    - scikit-learn >=0.17.1
+
+test:
+  requires:
+    - nose
+    - coverage
+  imports:
+    - imblearn
+
+about:
+  home: http://contrib.scikit-learn.org/imbalanced-learn
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Python module to perform under sampling and over sampling with various techniques'
+  dev_url: https://github.com/scikit-learn-contrib/imbalanced-learn
+  doc_url: http://contrib.scikit-learn.org/imbalanced-learn
+
+extra:
+  recipe-maintainers:
+    - glemaitre
+    - proinsias

--- a/recipes/imbalanced-learn/meta.yaml
+++ b/recipes/imbalanced-learn/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "imbalanced-learn" %}
-{% set version = "0.1.8" %}
-{% set sha256 = "0f2763e1d748c713349ff746d67a90010f5c1314830bfa7c5cdf17fd679cacdc" %}
+{% set version = "0.2.1" %}
+{% set sha256 = "5a515f0c1af2bda7eb18926f2f517c11cfd284cb43c9b14245023260e20d0e12" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
@glemaitre previously submitted PR #1204 for this – I've updated the meta.yaml file used for that PR.
- [ ] Tidy up `meta.yaml` when build succeeds.
