### PR TITLE
Add slugify recipe

### DIFF
--- a/recipes/slugify/meta.yaml
+++ b/recipes/slugify/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "slugify" %}
+{% set version = "0.0.1" %}
+{% set sha256 = "c5703cc11c1a6947536f3ce8bb306766b8bb5a84a53717f5a703ce0f18235e4c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install
+  skip: True  # [win and py3k]
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - slugify
+
+about:
+  home: http://github.com/zacharyvoase/slugify
+  license: Public Domain
+  license_family: Other
+  # license_file: UNLICENSE # When added to MANIFEST.in – zacharyvoase/slugify#4
+  summary: 'A generic slugifier.'
+  dev_url: http://github.com/zacharyvoase/slugify
+
+extra:
+  recipe-maintainers:
+    - proinsias


### PR DESCRIPTION
Due to a Windows/Python 3 [issue](aerkalov/ebooklib#104) with the ebooklib dependency, skip the Windows/Python 3 builds for now.