### PR TITLE
Add jobtastic package.

### DIFF
--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -45,7 +45,14 @@ about:
   license: BSD
   license_file: LICENSE
   summary: 'Make your user-facing Celery jobs totally awesomer'
-  description: 'Jobtastic makes your user-responsive long-running Celery jobs totally awesomer. Celery is the ubiquitous python job queueing tool and jobtastic is a python library that adds useful features to your Celery tasks. Specifically, these are features you probably want if the results of your jobs are expensive or if your users need to wait while they compute their results.'
+
+  description: |
+    Jobtastic makes your user-responsive long-running Celery jobs totally awesomer. 
+    Celery is the ubiquitous python job queueing tool and jobtastic is a python 
+    library that adds useful features to your Celery tasks. Specifically, these are
+    features you probably want if the results of your jobs are expensive or if your 
+    users need to wait while they compute their results.
+  dev_url: http://policystat.github.com/jobtastic
 
 extra:
   recipe-maintainers:

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "jobtastic" %}
 {% set version = "0.3.1" %}
-{% set hash_type = "md5" %}
-{% set hash_val = "8278124850eabeef59dcf72c39895fbf" %}
+{% set hash_type = "sha256" %}
+{% set hash_val = "da49cd83756d6899f2f7b57b1c65b3e3c2a5c3ce7b9fc296aab9ebaa10ec83cc" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,7 @@ source:
 
 build:
   skip: true  # [not py27]
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "jobtastic" %}
+{% set version = "0.3.1" %}
+{% set hash_type = "md5" %}
+{% set hash_val = "e43f1017fd76726955dd8afdf78a1a04" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/PolicyStat/{{ name }}/archive/v{{ version }}.tar.gz
+  {{hash_type}}: {{ md5 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - psutil >=3.0,<4
+    - celery >=2.5,<4
+
+  run:
+    - python
+    - psutil >=3.0,<4
+    - celery >=2.5,<4
+
+test:
+  # Python imports
+  imports:
+    - jobtastic
+
+  requires:
+    - django
+    - django-nose
+    - mock
+    - unittest2  # [ py26 ]
+
+about:
+  home: http://policystat.github.com/jobtastic
+  license: BSD
+  summary: 'Make your user-facing Celery jobs totally awesomer'
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -13,7 +13,7 @@ source:
   {{hash_type}}: {{ hash_val }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -34,7 +34,8 @@ test:
     - jobtastic
 
   requires:
-    - django
+    - django >=1.4,<2
+    - django-celery >=3.0,<4
     - django-nose
     - mock
     - unittest2  # [ py26 ]

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -10,7 +10,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/PolicyStat/{{ name }}/archive/v{{ version }}.tar.gz
-  {{hash_type}}: {{ md5 }}
+  {{hash_type}}: {{ hash_val }}
 
 build:
   number: 0
@@ -43,6 +43,7 @@ about:
   home: http://policystat.github.com/jobtastic
   license: BSD
   summary: 'Make your user-facing Celery jobs totally awesomer'
+  description: 'Jobtastic makes your user-responsive long-running Celery jobs totally awesomer. Celery is the ubiquitous python job queueing tool and jobtastic is a python library that adds useful features to your Celery tasks. Specifically, these are features you probably want if the results of your jobs are expensive or if your users need to wait while they compute their results.'
 
 extra:
   recipe-maintainers:

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -42,7 +42,7 @@ test:
 
 about:
   home: http://policystat.github.com/jobtastic
-  license: BSD
+  license: MIT 
   license_file: LICENSE
   summary: 'Make your user-facing Celery jobs totally awesomer'
 

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "jobtastic" %}
 {% set version = "0.3.1" %}
 {% set hash_type = "md5" %}
-{% set hash_val = "e43f1017fd76726955dd8afdf78a1a04" %}
+{% set hash_val = "8278124850eabeef59dcf72c39895fbf" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -13,6 +13,7 @@ source:
   {{hash_type}}: {{ hash_val }}
 
 build:
+  skip: true  # [not py27]
   number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
@@ -29,7 +30,6 @@ requirements:
     - celery >=2.5,<4
 
 test:
-  # Python imports
   imports:
     - jobtastic
 
@@ -43,6 +43,7 @@ test:
 about:
   home: http://policystat.github.com/jobtastic
   license: BSD
+  license_file: LICENSE
   summary: 'Make your user-facing Celery jobs totally awesomer'
   description: 'Jobtastic makes your user-responsive long-running Celery jobs totally awesomer. Celery is the ubiquitous python job queueing tool and jobtastic is a python library that adds useful features to your Celery tasks. Specifically, these are features you probably want if the results of your jobs are expensive or if your users need to wait while they compute their results.'
 

--- a/recipes/jobtastic/meta.yaml
+++ b/recipes/jobtastic/meta.yaml
@@ -21,9 +21,7 @@ requirements:
   build:
     - python
     - setuptools
-    - psutil >=3.0,<4
-    - celery >=2.5,<4
-
+ 
   run:
     - python
     - psutil >=3.0,<4
@@ -38,7 +36,7 @@ test:
     - django-celery >=3.0,<4
     - django-nose
     - mock
-    - unittest2  # [ py26 ]
+    - unittest2  # [py26]
 
 about:
   home: http://policystat.github.com/jobtastic


### PR DESCRIPTION
from the [website](https://policystat.github.io/jobtastic/):

> Jobtastic makes your user-responsive long-running Celery jobs totally awesomer. Celery is the ubiquitous python job queueing tool and jobtastic is a python library that adds useful features to your Celery tasks. Specifically, these are features you probably want if the results of your jobs are expensive or if your users need to wait while they compute their results.

Waiting for conda-forge packages:
- [x] django-nose: PR #1389

Waiting for Upstream:
- [x] License issue: It is MIT.

Build packages for:
- [x] Linux
- [x] OSX
- [x] Windows
