### PR TITLE
Remove `conda-build` pinning for `conda-smithy`

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -8,14 +8,6 @@ conda config --set show_channel_urls true
 conda config --add channels conda-forge
 conda install --yes --quiet conda-smithy
 
-# Pinned to workaround an incompatibility between
-# `conda-smithy` and `conda-build >=1.21.12`.
-# Please see the linked issue below for details.
-#
-# https://github.com/conda-forge/conda-smithy/issues/260
-#
-conda install --yes --quiet conda-build=1.21.11
-
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 


### PR DESCRIPTION
Reverts https://github.com/conda-forge/staged-recipes/pull/1293
Reverts https://github.com/conda-forge/staged-recipes/pull/1299

Removes the `conda-build` pinning during feedstock conversion.

cc @pelson