### PR TITLE
Fix whitespace error

### DIFF
--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -18,7 +18,7 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-	                -v ${REPO_ROOT}:/staged-recipes \
+                        -v ${REPO_ROOT}:/staged-recipes \
                         -a stdin -a stdout -a stderr \
                         $IMAGE_NAME \
                         bash || exit $?


### PR DESCRIPTION
Fixes a whitespace error in this [line]( https://github.com/conda-forge/staged-recipes/blob/068ed713d6a7b0c4a05ef32f1de38d6dfbeb983b/scripts/run_docker_build.sh#L21 ), which was introduced in PR ( https://github.com/conda-forge/staged-recipes/pull/1373 ).