### PR TITLE
Add python-igraph recipe

### DIFF
--- a/recipes/python-igraph/meta.yaml
+++ b/recipes/python-igraph/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "python-igraph" %}
+{% set version = "0.7.1.post6" %}
+{% set sha256 = "d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - igraph 0.7.1
+
+  run:
+    - python
+    - igraph 0.7.1
+
+test:
+  imports:
+    - igraph
+    - igraph.app
+    - igraph.drawing
+    - igraph.remote
+    - igraph.test
+    - igraph.vendor
+
+about:
+  home: http://pypi.python.org/pypi/python-igraph
+  license: GPL
+  license_file: COPYING
+  summary: 'High performance graph data structures and algorithms'
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/python-igraph/meta.yaml
+++ b/recipes/python-igraph/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-igraph" %}
 {% set version = "0.7.1.post6" %}
-{% set sha256 = "d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f" %}
+{% set sha256 = "a5ea42790a077eadb3d1e8f82edc47516fea4a2b26bbf52bfc148370fe0fe676" %}
 
 package:
   name: {{ name|lower }}
@@ -14,16 +14,19 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
+  skip : true  # [win]
 
 requirements:
   build:
+    - igraph 0.7.1   # [not osx]
+    - pkg-config
     - python
     - setuptools
-    - igraph 0.7.1
+    - toolchain
 
   run:
+    - igraph 0.7.1  # [not osx]
     - python
-    - igraph 0.7.1
 
 test:
   imports:


### PR DESCRIPTION
These are the python bindings to the c igraph library.

Waiting for conda-forge packages:
- [x] igraph: PR #2175 

Once that package is added, the igraph recipe in this PR will be removed.
