### PR TITLE
TST: AppVeyor skip builds on `master`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  except:
+    - master
+
 environment:
 
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the


### PR DESCRIPTION
Trying this out to see if it works.

Follow-up on PR ( https://github.com/conda-forge/staged-recipes/pull/329 ). There should never be a need to build anything on `master` at this repo. In fact, the only time we should care about building on `master` is for feedstock conversion. This only happens on Travis CI. We were able to successfully disable builds on `master` for CircleCI. However, AppVeyor is still wasting cycles on `master`. We had tried to use this exclude branch technique before on AppVeyor. However, it didn't work last time. This time it seems in my AppVeyor account. So am going to give it another try at staged-recipes.

Note: PRing from my `master` branch to see if this has a negative effect on PRs from one's `master` branch generally.