### PR TITLE
Skip AppVeyor on merged pull requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+skip_commits:
+  message: /^Merge pull request /
+
 environment:
 
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the


### PR DESCRIPTION
The goal here is to only run Travis CI when merging a pull request. As Travis CI does the feedstock conversion on `master` after a merge, it is the only CI that is relevant for running. The other CIs exist only to build PRs. We already successfully have disabled CircleCI on `master` with PR ( https://github.com/conda-forge/staged-recipes/pull/329 ). However, it has proven tricky to do the same with AppVeyor. A very similar PR ( https://github.com/conda-forge/staged-recipes/pull/1418 ) for AppVeyor that applied the strategy from CircleCI failed completely at the PR level. So had to be abandoned.

This tries to skip AppVeyor builds if they are a merged pull request. The way it works is it searches for the message that a merged pull request would have (i.e. `Merge pull request `). If it finds such a message at the beginning of the commit, it simply does not run CI with AppVeyor on that commit.

In order to test this, it will need to be merged. However, if it doesn't work or has issues, would totally be ok ripping it out. Given that it is really quite simple and potentially useful, am hopeful there is no need for that. 