### PR TITLE
Add pytest-cookies

### DIFF
--- a/recipes/pytest-cookies/meta.yaml
+++ b/recipes/pytest-cookies/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "pytest-cookies" %}
+{% set version = "0.2.0" %}
+{% set sha256 = "8822dcc1095edcd45a45db727fee647c7abbee111691380dd7e82c462c7b90f4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  preserve_egg_dir: true
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pytest >=2.8.1
+    - cookiecutter >=1.4.0
+
+test:
+  imports:
+    - pytest_cookies
+
+about:
+  home: https://github.com/hackebrot/pytest-cookies
+  license: MIT
+  license_family: MIT
+  # Not included in the sdist yet.
+  # Please see the linked PR.
+  #
+  # https://github.com/hackebrot/pytest-cookies/pull/10
+  #
+  #license_file: LICENSE
+  summary: A Pytest plugin for your Cookiecutter templates
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/1426

Adds a package for [`pytest-cookies`]( https://github.com/hackebrot/pytest-cookies ). A `pytest` package used for testing cookiecutter templates. Feedback welcome.

cc @bollwyvl @pydanny