### PR TITLE
Added recipe for hachoir-wx

### DIFF
--- a/recipes/hachoir-wx/meta.yaml
+++ b/recipes/hachoir-wx/meta.yaml
@@ -16,12 +16,12 @@ source:
 build:
   skip: True  # [py3k]
   number: 0
-  script: sudo apt-get install -y libgtk2.0-0; python setup.py install  # [linux]
-  script: python setup.py install  # [win or osx]
+  script: python setup.py install
 
 requirements:
   build:
     - python
+    - toolkit  # [linux]
 
   run:
     - python

--- a/recipes/hachoir-wx/meta.yaml
+++ b/recipes/hachoir-wx/meta.yaml
@@ -24,7 +24,8 @@ requirements:
 
   run:
     - python
-    - wx
+    - wxpython
+    - hachoir-core
 
 test:
   imports:

--- a/recipes/hachoir-wx/meta.yaml
+++ b/recipes/hachoir-wx/meta.yaml
@@ -16,7 +16,8 @@ source:
 build:
   skip: True  # [py3k]
   number: 0
-  script: python setup.py install
+  script: apt-get install -y libgtk2.0-0; python setup.py install  # [linux]
+  script: python setup.py install  # [win or osx]
 
 requirements:
   build:

--- a/recipes/hachoir-wx/meta.yaml
+++ b/recipes/hachoir-wx/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   skip: True  # [py3k]
   number: 0
-  script: apt-get install -y libgtk2.0-0; python setup.py install  # [linux]
+  script: sudo apt-get install -y libgtk2.0-0; python setup.py install  # [linux]
   script: python setup.py install  # [win or osx]
 
 requirements:

--- a/recipes/hachoir-wx/meta.yaml
+++ b/recipes/hachoir-wx/meta.yaml
@@ -1,0 +1,46 @@
+{%set name = "hachoir-wx" %}
+{%set version = "0.3" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "9b37a8644db62fccb2a1b303db78c18b8ef8f96951805edd461af357dd00e9cf" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  skip: True  # [py3k]
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+    - wx
+
+test:
+  imports:
+    - hachoir_wx
+    - hachoir_wx.field_view
+    - hachoir_wx.frame_view
+    - hachoir_wx.hex_view
+    - hachoir_wx.resource
+
+about:
+  home: http://hachoir.org/wiki/hachoir-wx
+  license: GPL 2.0
+  license_file: COPYING
+  license_family: Public-Domain
+  summary: "hachoir-wx is a wxWidgets GUI that's meant to provide a (more) user-friendly interface to the hachoir binary parsing engine"
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/hachoir-wx/meta.yaml
+++ b/recipes/hachoir-wx/meta.yaml
@@ -40,7 +40,7 @@ about:
   home: http://hachoir.org/wiki/hachoir-wx
   license: GPL 2.0
   license_file: COPYING
-  license_family: Public-Domain
+  license_family: GPL2
   summary: "hachoir-wx is a wxWidgets GUI that's meant to provide a (more) user-friendly interface to the hachoir binary parsing engine"
 
 extra:


### PR DESCRIPTION
During build testing I hit a memory leak, but I'm assuming that that's inherent to the module (cc @haypo)

```bash
===== testing package: hachoir-wx-0.3-py27_0 =====
import: 'hachoir_wx'
import: 'hachoir_wx.field_view'
import: 'hachoir_wx.frame_view'
import: 'hachoir_wx.hex_view'
import: 'hachoir_wx.resource'
===== hachoir-wx-0.3-py27_0 OK =====
swig/python detected a memory leak of type 'wxPyXmlSubclassFactory *', no destructor found.
TEST END: hachoir-wx-0.3-py27_0
```