### PR TITLE
Added recipe for python-engineio

### DIFF
--- a/recipes/python-engineio/meta.yaml
+++ b/recipes/python-engineio/meta.yaml
@@ -1,0 +1,54 @@
+{%set name = "python-engineio" %}
+{%set version = "1.0.0" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "1fd34c5362d15bbc255a408cb280dded44c97d460076a324eae10515c2a05c6a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six >=1.9.0
+
+  run:
+    - python
+    - six >=1.9.0
+
+test:
+  imports:
+    - engineio
+    # - engineio.async_eventlet
+    # - engineio.async_gevent
+    # - engineio.async_gevent_uwsgi
+    - engineio.async_threading
+    - engineio.middleware
+    - engineio.packet
+    - engineio.payload
+    - engineio.server
+    - engineio.socket
+
+about:
+  home: http://github.com/miguelgrinberg/python-engineio/
+  license: MIT
+  license_file: LICENSE
+  license_family: MIT
+  summary: 'Engine.IO server'
+  doc_url: https://python-engineio.readthedocs.io
+  dev_url: http://github.com/miguelgrinberg/python-engineio/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
I've skipped testing the imports of:
* `engineio.async_eventlet`
* `engineio.async_gevent`
* `engineio.async_gevent_uwsgi`

These imports depend on `gevent` and `eventlet`, neither of which is needed for the main modules. We can add them as run reqs, but it seemed better to omit them.