### PR TITLE
Add backports

### DIFF
--- a/recipes/backports/LICENSE.txt
+++ b/recipes/backports/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2016-2017, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of staged-recipes nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/backports/meta.yaml
+++ b/recipes/backports/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: backports
+  version: 1.0
+
+build:
+  number: 0
+  script:
+    - cd {{ SP_DIR if SP_DIR is defined else '' }}
+    - mkdir backports && cd backports
+    - echo.>__init__.py    # [win]
+    - echo > __init__.py   # [unix]
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - backports
+
+about:
+  home: http://github.com/conda-forge/backports-feedstock
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: {{ RECIPE_DIR if RECIPE_DIR is defined else '' }}/LICENSE.txt
+  summary: A package to ensure the `backports` namespace is available.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
This adds a shim `backports` package to ensure that `backports` is available. In `defaults`, this is used as a dependency of all backport packages during `build` and `run`. Was wondering if we should be doing the same thing. As a result, I'm proposing this to get feedback on this idea and whether we want to pursue it or not.

xref: https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/vDrXT7Y33KI