### PR TITLE
Add flake8-quotes 0.8.1

### DIFF
--- a/recipes/flake8-quotes/meta.yaml
+++ b/recipes/flake8-quotes/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "flake8-quotes" %}
+{% set version = "0.8.1" %}
+{% set sha256 = "668ec2fb0fbf1574a95f49e393364f8a114c7180e5cedc7377c5f4b5257e00fb" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  preserve_egg_dir: True
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - flake8 >=3.0.4,<4.0.0
+
+test:
+  imports:
+    - flake8_quotes
+
+about:
+  home: https://github.com/zheller/flake8-quotes
+  license: MIT
+  license_file: LICENSE
+  summary: Flake8 lint for quotes.
+
+  description: |
+    Now you don't need to worry about people constantly complaining that you are
+    using double-quotes and not single-quotes.
+  doc_url: https://pypi.python.org/pypi/flake8-quotes
+  dev_url: https://github.com/zheller/flake8-quotes
+
+extra:
+  recipe-maintainers:
+    - flamingbear
+    - michael-brandt-cu
+    - michaeljb


### PR DESCRIPTION
Quick note on the recipe maintainers: @michaeljb is my personal account. @nsidc is an organization account; does it work / make sense to have an organization listed as a maintainer?

@zheller: as the author of [flake8-quotes](https://github.com/zheller/flake8-quotes), I thought you may be interested in this PR and/or being added as a maintainer. If not, no problem; looks like being a maintainer of the recipe will mostly involve updating it when a new release of flake8-quotes is available. Additionally, the summary and description included were taken from the [flake8-quotes description on pypi](https://pypi.python.org/pypi/flake8-quotes), hope that's alright with you.