### PR TITLE
Use `conda-forge-build-setup` in feedstock creation

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -7,6 +7,8 @@ python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci &
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
 conda install --yes --quiet conda-smithy
+conda install --yes --quiet conda-forge-build-setup
+source run_conda_forge_build_setup
 
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token


### PR DESCRIPTION
Fixes https://github.com/conda-forge/status/issues/11

So staged-recipes is blocked because of an incompatibility between the new `conda-build` and `conda-smithy` as evidenced by [build]( https://travis-ci.org/conda-forge/staged-recipes#L153 ). One solution would be to add yet another kludgy hack to this repo. Instead I'm suggesting we use `conda-forge-build-setup` in this stage too, which will also fix it. May need to merge soon to get things moving, but that doesn't mean there can't be a discussion about whether we want to keep this long term or not.

cc @pelson