### PR TITLE
Add lxml

### DIFF
--- a/recipes/lxml/meta.yaml
+++ b/recipes/lxml/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "3.6.2" %}
+
+package:
+    name: lxml
+    version: {{ version }}
+
+source:
+    fn: lxml-{{ version }}.tar.gz
+    url: https://github.com/lxml/lxml/archive/lxml-{{ version }}.tar.gz
+    sha256: 90e5f33f19a8964eeb8631d477dc103c8ddbd8067a002027e3f9cc79f7fb2d80
+
+build:
+    number: 0
+    skip: True  # [win]
+    script: python setup.py install --with-xslt-config=$PREFIX/bin/xslt-config  # [not win]
+
+requirements:
+    build:
+        - python
+        - cython
+        - libxml2
+        - libxslt
+    run:
+        - python
+        - libxml2
+        - libxslt
+
+test:
+    imports:
+        - lxml
+        - lxml.etree
+        - lxml.objectify
+
+about:
+    home: http://lxml.de/
+    license: BSD 3-Clause, GPL-2.0, ZPL-2.0, and ElementTree
+    license_file: LICENSES.txt
+    summary: 'Pythonic binding for the C libraries libxml2 and libxslt.'
+    description: |
+       The lxml XML toolkit is a Pythonic binding for the C libraries libxml2 and
+       libxslt. It is unique in that it combines the speed and XML feature
+       completeness of these libraries with the simplicity of a native Python API,
+       mostly compatible but superior to the well-known ElementTree API.
+    doc_url: 'http://lxml.de/index.html#documentation'
+    dev_url: https://github.com/lxml/lxml
+
+extra:
+    recipe-maintainers:
+        - ocefpaf


### PR DESCRIPTION
Will try Windows later on the feedstock. We already have `libxml2` foe Windows but we lack `libxslt`. Maybe MSYS2 provides that... Not sure.