### PR TITLE
Add markdown2

### DIFF
--- a/recipes/markdown2/meta.yaml
+++ b/recipes/markdown2/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "markdown2" %}
+{% set version = "2.3.1" %}
+{% set sha256 = "4463dd754e79e4afd490c21d81db67b85b488a0d0adf2fee2b99a69c4e67d80e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - markdown2
+
+  commands:
+    - markdown2 --help
+
+about:
+  home: https://github.com/trentm/python-markdown2
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: A fast and complete Python implementation of Markdown
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - pelson


### PR DESCRIPTION
Adds a recipe for markdown2. This is useful Python Markdown implementation that will be needed for the status page soon.

xref: https://github.com/jayfk/statuspage/issues/81

cc @pelson