### PR TITLE
Use our `git` for feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -11,6 +11,7 @@ wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obviou
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
+conda install --yes --quiet git
 conda install --yes --quiet conda-smithy
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup


### PR DESCRIPTION
Seems the `git` on Travis CI is too old so it doesn't know how to do `git pull --rebase --autostash` when the index is dirty. This is a requirement of PR ( https://github.com/conda-forge/staged-recipes/pull/1322 ). Handling a dirty index during rebase was added to `git` in commit ( https://github.com/git/git/commit/53c76dc05e0b5ad5b1f92db9577694e896d67a0a ). An easy fix is to switch to our `git`, which is new enough to support this functionality. 