### PR TITLE
Adjusts purge merged recipes trick

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -21,8 +21,7 @@ source run_conda_forge_build_setup
 # Find the recipes from master in this PR and remove them.
 pushd ./recipes > /dev/null
 echo "Finding recipes merged in master and removing them from the build."
-git fetch https://github.com/conda-forge/staged-recipes.git master
-git ls-tree --name-only FETCH_HEAD -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
+git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
 popd > /dev/null
 
 # We just want to build all of the recipes.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,9 +62,8 @@ install:
     # Find the recipes from master in this PR and remove them.
     - cmd: echo Finding recipes merged in master and removing them.
     - cmd: cd recipes
-    - cmd: git fetch https://github.com/conda-forge/staged-recipes.git master
     - cmd: |
-             for /f "tokens=*" %%a in ('git ls-tree --name-only FETCH_HEAD -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
+             for /f "tokens=*" %%a in ('git ls-tree --name-only master -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
     - cmd: cd ..
 
     # Set the CONDA_NPY, although it has no impact on the actual build. We need this because of a test within conda-build.

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,11 @@ general:
       # then we are prepping for release an there is no need to build it again.
       - master
 
+checkout:
+  post:
+    # Update the `master` branch. Otherwise CircleCI will give us a cached one.
+    - git fetch -u origin +master:master
+
 machine:
   services:
     - docker

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -29,8 +29,7 @@ cp -r /staged-recipes/recipes /conda-recipes
 # Find the recipes from master in this PR and remove them.
 echo "Finding recipes merged in master and removing them from the build."
 pushd /staged-recipes/recipes > /dev/null
-git fetch https://github.com/conda-forge/staged-recipes.git master
-git ls-tree --name-only FETCH_HEAD -- . | xargs -I {} sh -c "rm -rf /conda-recipes/{} && echo Removing recipe: {}"
+git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf /conda-recipes/{} && echo Removing recipe: {}"
 popd > /dev/null
 
 if [ "${BINSTAR_TOKEN}" ];then


### PR DESCRIPTION
This is a follow-up on PR ( https://github.com/conda-forge/staged-recipes/pull/1373 ).

After a quick look it seems all the CIs clone `master`. This includes whether they are building PRs or are running on `master`. So there is no real need for fetching `master`.

Also, this should avoid the occasional discontinuity where the fetched `master` differs from the one previously cloned. Resolving these discontinuities will ensure all recipes that need to be purged are. Note this guarantees a fast finish when a CI builds on `master`.