### PR TITLE
Enable autostash config with rebase automatically

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -254,7 +254,8 @@ if __name__ == '__main__':
 
     # Update status based on remote
     subprocess.check_call(['git', 'checkout', os.environ.get('TRAVIS_BRANCH')])
-    subprocess.check_call(['git', 'pull', '--rebase', '--autostash'])
+    subprocess.check_call(['git', 'config', 'rebase.autoStash', 'true'])
+    subprocess.check_call(['git', 'pull', '--rebase'])
 
     # Generate a fresh listing of recipes removed.
     # This gets pretty ugly as we parse `git status --porcelain`.


### PR DESCRIPTION
Apparently our `git` doesn't not expose the `--autostash` flag for `git pull`. Appears that flag is not added until `git` version `2.9.0`. Here is the commit ( https://github.com/git/git/commit/f66398eb57c627169429f47bbe4d943d2c975959 ) that appears to add it.

However, we can work around this minor limitation by simply allowing rebases to do an autostash. Here we enable such a configuration to keep life simple. Tried this out locally with our `git` and verified that it worked.