### PR TITLE
Fix the stash update bug

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -253,9 +253,12 @@ if __name__ == '__main__':
             )
 
     # Update status based on remote
-    subprocess.check_call(['git', 'checkout', os.environ.get('TRAVIS_BRANCH')])
-    subprocess.check_call(['git', 'config', 'rebase.autoStash', 'true'])
+    subprocess.check_call(['git', 'stash', '--keep-index'])
+    subprocess.check_call(['git', 'stash'])
     subprocess.check_call(['git', 'pull', '--rebase'])
+    subprocess.check_call(['git', 'stash', 'pop'])
+    subprocess.check_call(['git', 'add', '.'])
+    subprocess.check_call(['git', 'stash', 'pop'])
 
     # Generate a fresh listing of recipes removed.
     # This gets pretty ugly as we parse `git status --porcelain`.


### PR DESCRIPTION
`git stash` was not keeping the staged things staged. This was causing things not to be converted. Here we break down the steps so that it works exactly the way we expect.

1. Stash the things we don't want to add.
2. Stash the things we do want to add.
3. Update our branch with respect to the remote.
4. Unstash the things we want to add.
5. Add those things.
6. Unstash the things we don't want to add.