### PR TITLE
Use stashing more selectively in feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -7,8 +7,14 @@ set -e
 # recipes from. Currently this is `master`.
 git checkout "${TRAVIS_BRANCH}"
 
+# Download and setup Miniconda
+mkdir -p ~/miniconda_staging
+pushd ~/miniconda_staging
 wget https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
+popd
+rm -rf ~/miniconda_staging
+
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
 conda install --yes --quiet git

--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -252,10 +252,17 @@ if __name__ == '__main__':
                 team.url + "/memberships/" + new_member
             )
 
-    # Update status based on remote
-    subprocess.check_call(['git', 'stash'])
-    subprocess.check_call(['git', 'pull', '--rebase'])
-    subprocess.check_call(['git', 'stash', 'pop', '--index'])
+    # Update status based on the remote.
+    subprocess.check_call(['git', 'stash', '--keep-index', '--include-untracked'])
+    subprocess.check_call(['git', 'fetch'])
+    subprocess.check_call(['git', 'rebase', '--autostash'])
+    subprocess.check_call(['git', 'add', '.'])
+    try:
+        subprocess.check_call(['git', 'stash', 'pop'])
+    except subprocess.CalledProcessError:
+        # In case there was nothing to stash.
+        # Finish quietly.
+        pass
 
     # Generate a fresh listing of recipes removed.
     # This gets pretty ugly as we parse `git status --porcelain`.


### PR DESCRIPTION
As `git stash pop --index` can fail sometimes (particularly if there are conflicts like the same file being deleted 😉), we needed to rewrite this yet again.

* Stash only everything that is not staged.
* Fetch upstream
* Then use rebases autostash mechanism to handle all the staged changes.
* Readd the staged changes after as they tend to fall out of the index.
* Drop everything else back out of the stash.
* As a bonus put the miniconda stuff somewhere where it won't be in the repo.