### PR TITLE
Datreant.data

### DIFF
--- a/recipes/datreant.data/build.sh
+++ b/recipes/datreant.data/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt
+rm -f $SP_DIR/*-nspkg.pth

--- a/recipes/datreant.data/meta.yaml
+++ b/recipes/datreant.data/meta.yaml
@@ -32,8 +32,8 @@ requirements:
 test:
   imports:
     - datreant.data
-#   requires:
-#     - pytest
+  requires:
+    - pytest
 
 about:
   home: http://datreant.org/

--- a/recipes/datreant.data/meta.yaml
+++ b/recipes/datreant.data/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.6.0" %}
+{% set sha256 = "a124c0598ac55b71de43447a2398b1508452e07ea7d7369ee70428a1de9f977f"%}
+
+package:
+  name: datreant.data
+  version: {{ version }}
+
+source:
+  fn: datreant.data-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/d/datreant.data/datreant.data-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - datreant
+    - datreant.core
+    - numpy
+    - pandas
+    - six
+    - pytables
+    - h5py
+
+test:
+  imports:
+    - datreant.data
+#   requires:
+#     - pytest
+
+about:
+  home: http://datreant.org/
+  license: BSD 3-Clause
+  summary: 'persistent, pythonic trees for heterogeneous data'
+
+extra:
+  recipe-maintainers:
+    - dotsdl
+    - kain88-de

--- a/recipes/datreant.data/run_test.py
+++ b/recipes/datreant.data/run_test.py
@@ -1,0 +1,5 @@
+import pytest
+import os
+import datreant.data
+
+pytest.main([os.path.dirname(datreant.data.__file__)])

--- a/recipes/datreant.data/run_test.py.old
+++ b/recipes/datreant.data/run_test.py.old
@@ -1,0 +1,5 @@
+import pytest
+import os
+import datreant.data as dtr
+
+pytest.main(os.path.dirname(dtr.__file__))

--- a/recipes/datreant.data/run_test.py.old
+++ b/recipes/datreant.data/run_test.py.old
@@ -1,5 +1,0 @@
-import pytest
-import os
-import datreant.data as dtr
-
-pytest.main(os.path.dirname(dtr.__file__))


### PR DESCRIPTION
This adds a recipe for [datreant.data](https://github.com/datreant/datreant.data). It is an extension package for datreant.core.

