### PR TITLE
Fix feedstock removal commit message

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -275,6 +275,7 @@ if __name__ == '__main__':
     removed_recipes = removed_recipes.splitlines()
     removed_recipes = filter(lambda _: _.startswith("D "), removed_recipes)
     removed_recipes = list(map(lambda _ : _.replace("D", "", 1).lstrip(), removed_recipes))
+    removed_recipes = list(set(map(lambda _ : os.path.basename(os.path.dirname(_)), removed_recipes)))
 
     # Commit any removed packages.
     subprocess.check_call(['git', 'status'])


### PR DESCRIPTION
Previously this was listing all files removed from the recipes directory. It was also listing their full directory name. This cleans it up so that it only lists each recipe name.