### PR TITLE
mpi4py

### DIFF
--- a/recipes/mpi4py/meta.yaml
+++ b/recipes/mpi4py/meta.yaml
@@ -1,0 +1,48 @@
+{% set version="2.0.0" %}
+
+package:
+  name: mpi4py
+  version: {{ version }}
+
+source:
+  fn: mpi4py-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/m/mpi4py/mpi4py-{{ version }}.tar.gz
+  md5: 4f7d8126d7367c239fd67615680990e3
+
+build:
+  number: 0
+  script: pip install --no-deps .
+  detect_binary_files_with_prefix: true
+  # TODO: build with msmpi when it works
+  skip: true  # [win]
+
+requirements:
+  build:
+    - python
+    - pip
+    - mpich          # [unix]
+  run:
+    - python
+    - mpich          # [unix]
+
+test:
+  imports:
+    - mpi4py
+    - mpi4py.MPI
+
+about:
+  home: http://pythonhosted.org/mpi4py/
+  license: BSD 2-clause
+  summary: Provides bindings of the MPI standard for Python
+  description: |
+     MPI for Python provides bindings of the Message Passing Interface (MPI)
+     standard for the Python programming language, allowing any Python program
+     to exploit multiple processors.
+  doc_url: http://mpi4py.readthedocs.org/
+  dev_url: https://bitbucket.org/mpi4py/mpi4py
+
+extra:
+  recipe-maintainers:
+    - minrk
+    - msarahan
+    - ocefpaf


### PR DESCRIPTION
Unix-only with mpich for now, since that's what is packaged already on conda-forge.

We can add openmpi builds with features once it is packaged, and add Windows once msmpi is packaged.

cf #557