### PR TITLE
Add libevent

### DIFF
--- a/recipes/libevent/build.sh
+++ b/recipes/libevent/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Needed to ensure our OpenSSL and
+# not the system one is used on OS X.
+export LIBRARY_PATH="${PREFIX}/lib"
+
+export CFLAGS="-I${PREFIX}/include ${CFLAGS}"
+export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
+export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
+
+# Set the fallback library environment variable.
+if [[ `uname` == 'Darwin' ]];
+then
+    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+else
+    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+
+chmod +x ./autogen.sh
+
+./autogen.sh
+./configure --prefix="${PREFIX}"
+make
+
+#
+# Seems to hang on Mac builds. So have commented it for now.
+#
+#eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
+
+make install

--- a/recipes/libevent/build.sh
+++ b/recipes/libevent/build.sh
@@ -9,7 +9,7 @@ export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
 export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
 
 # Set the fallback library environment variable.
-if [[ `uname` == 'Darwin' ]];
+if [[ "$(uname)" == "Darwin" ]];
 then
     export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
 else

--- a/recipes/libevent/build.sh
+++ b/recipes/libevent/build.sh
@@ -29,3 +29,6 @@ make
 #eval ${LIBRARY_SEARCH_VAR}="${PREFIX}/lib" make check
 
 make install
+
+# Remove Python script to avoid confusion and a Python dependency.
+rm -fv "${PREFIX}/bin/event_rpcgen.py"

--- a/recipes/libevent/meta.yaml
+++ b/recipes/libevent/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = "2.0.22" %}
+
+package:
+  name: libevent
+  version: {{ version }}
+
+source:
+  fn: libevent-{{ version }}.tar.gz
+  url: https://github.com/libevent/libevent/archive/release-{{ version }}-stable.tar.gz
+  sha256: ab89639b0819befb1d8b293d52047c6955f8d1c9150c2b22a0e6247930eb9128
+
+build:
+  number: 0
+  skip: True  # [win or py3k]
+
+requirements:
+  build:
+    - toolchain
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+    - openssl 1.0.*
+    - python
+
+  run:
+    - openssl 1.0.*
+    - python
+
+test:
+  files:
+    - {{ SRC_DIR }}/test/regress.rpc
+
+  commands:
+    # Check for headers.
+    - test -d "${PREFIX}/include/event2"
+
+    # Check for libraries.
+    {% set libs = [
+        "libevent",
+        "libevent_core",
+        "libevent_extra",
+        "libevent_openssl",
+        "libevent_pthreads"
+    ] %}
+
+    {% for each_lib in libs %}
+    - test -f "${PREFIX}/lib/{{ each_lib }}.a"
+    - test -f "${PREFIX}/lib/{{ each_lib }}.dylib"         # [osx]
+    - test -f "${PREFIX}/lib/{{ each_lib }}.so"            # [linux]
+    - test -f "${PREFIX}/lib/{{ each_lib }}.la"
+    {% endfor %}
+
+    {% set pkgconfigs = [
+        "libevent",
+        "libevent_openssl",
+        "libevent_pthreads"
+    ] %}
+
+    # Check for pkg-config files.
+    {% for each_pkgconfig in pkgconfigs %}
+    - test -f "${PREFIX}/lib/pkgconfig/{{ each_pkgconfig }}.pc"
+    {% endfor %}
+
+    # Run included Python script.
+    - event_rpcgen.py regress.rpc regress.gen.h regress.gen.c
+
+about:
+  home: http://libevent.org/
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: An event notification library.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/libevent/meta.yaml
+++ b/recipes/libevent/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or py3k]
+  skip: True  # [win]
 
 requirements:
   build:
@@ -21,14 +21,16 @@ requirements:
     - libtool
     - pkg-config
     - openssl 1.0.*
-    - python
 
   run:
     - openssl 1.0.*
-    - python
 
 test:
+  requires:
+    - python 2.*
+
   files:
+    - {{ SRC_DIR }}/event_rpcgen.py
     - {{ SRC_DIR }}/test/regress.rpc
 
   commands:
@@ -63,7 +65,7 @@ test:
     {% endfor %}
 
     # Run included Python script.
-    - event_rpcgen.py regress.rpc regress.gen.h regress.gen.c
+    - python event_rpcgen.py regress.rpc regress.gen.h regress.gen.c
 
 about:
   home: http://libevent.org/


### PR DESCRIPTION
This adds a package for `libevent` on OS X and Linux. It may be possible to get a Windows build once there is an official stable 2.1.x release.

Letting you know as this may be of interest for `thrift-cpp`, @wesm.
