### PR TITLE
Add recipe for python-awips

### DIFF
--- a/recipes/python-awips/meta.yaml
+++ b/recipes/python-awips/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "python-awips" %}
+{% set version = "0.9.10" %}
+{% set sha256 = "ee2f182c056351b2678e9e819e3ef49d48b38f4d5d442885478b2e0e07aa2bda" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: True  # [py3k]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy
+    - shapely
+    - six
+
+test:
+  imports:
+    - awips
+    - awips.dataaccess
+
+about:
+  home: http://github.com/Unidata/python-awips
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python Data Access Framework for AWIPS II'
+
+  description: |
+    The python-awips package provides a Data Access Framework (DAF) for
+    requesting data from a remote AWIPS II EDEX server.
+    AWIPS II is a weather forecasting display and analysis package being
+    developed by the National Weather Service and Raytheon. AWIPS II is
+    a Java application consisting of a data-rendering client (CAVE,
+    which runs on Red Hat/CentOS Linux and Mac OS X) and a backend data
+    server (EDEX, which runs only on Linux)
+  doc_url: http://python-awips.readthedocs.org/en/latest/
+  dev_url: https://github.com/Unidata/python-awips
+
+extra:
+  recipe-maintainers:
+    - mjames-upc
+    - dopplershift


### PR DESCRIPTION
This is the data access framework for accessing data on a AWIPS2 EDEX server using python. The license of the code is still in a state of limbo, but we're working on getting clarification. (In the meanwhile, the packages have been on PyPI for awhile.)  I'd like to not hold up conda packages on the speed with which the NOAA/NCEP and Raytheon bureaucracies can figure this out.

cc: @mjames-upc
