### PR TITLE
Added recipe for msg-extractor

### DIFF
--- a/recipes/msg-extractor/meta.yaml
+++ b/recipes/msg-extractor/meta.yaml
@@ -1,0 +1,45 @@
+{%set name = "msg-extractor" %}
+{%set version = "0.2" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "insert-real-hash" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/mattgwwalker/{{ name }}.git
+
+build:
+  entry_points:
+    - ExtractMsg = ExtractMsg:__main__
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - imapclient
+    - olefile
+
+test:
+  imports:
+    - ExtractMsg
+  commands:
+    - ExtractMsg
+
+about:
+  home: https://github.com/mattgwwalker/msg-extractor
+  license: GPL 3.0
+  license_file: COPYING
+  summary: "Extracts emails and attachments saved in Microsoft Outlook's .msg files"
+  dev_url: https://github.com/mattgwwalker/msg-extractor
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/msg-extractor/meta.yaml
+++ b/recipes/msg-extractor/meta.yaml
@@ -8,13 +8,8 @@ package:
 
 source:
   git_url: https://github.com/mattgwwalker/{{ name }}.git
-  patches:
-    - 066e65.patch
-    - 80102f7.patch
 
 build:
-  # entry_points:
-  #   - ExtractMsg = ExtractMsg.__main__:main
   number: {{ build_num }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
@@ -30,8 +25,6 @@ requirements:
 
 test:
   imports:
-    - ExtractMsg
-  commands:
     - ExtractMsg
 
 about:

--- a/recipes/msg-extractor/meta.yaml
+++ b/recipes/msg-extractor/meta.yaml
@@ -7,9 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/mattgwwalker/msg-extractor/archive/v{{ version }}.tar.gz
-  sha256: 9189ab65c801c0269534e3ffb4f5923a02c8766d2b21e9412c6fa885e77e7fdb
+  git_url: https://github.com/mattgwwalker/{{ name }}.git
 
 build:
   number: {{ build_num }}

--- a/recipes/msg-extractor/meta.yaml
+++ b/recipes/msg-extractor/meta.yaml
@@ -1,7 +1,5 @@
 {%set name = "msg-extractor" %}
 {%set version = "0.2" %}
-{%set hash_type = "sha256" %}
-{%set hash_val = "insert-real-hash" %}
 {%set build_num = "0" %}
 
 package:
@@ -10,8 +8,13 @@ package:
 
 source:
   git_url: https://github.com/mattgwwalker/{{ name }}.git
+  patches:
+    - 066e65.patch
+    - 80102f7.patch
 
 build:
+  # entry_points:
+  #   - ExtractMsg = ExtractMsg.__main__:main
   number: {{ build_num }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
@@ -35,7 +38,7 @@ about:
   home: https://github.com/mattgwwalker/msg-extractor
   license: GPL 3.0
   license_file: COPYING
-  license_family: GPL
+  license_family: GPL3
   summary: "Extracts emails and attachments saved in Microsoft Outlook's .msg files"
   dev_url: https://github.com/mattgwwalker/msg-extractor
 

--- a/recipes/msg-extractor/meta.yaml
+++ b/recipes/msg-extractor/meta.yaml
@@ -7,7 +7,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/mattgwwalker/{{ name }}.git
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/mattgwwalker/msg-extractor/archive/v{{ version }}.tar.gz
+  sha256: 9189ab65c801c0269534e3ffb4f5923a02c8766d2b21e9412c6fa885e77e7fdb
 
 build:
   number: {{ build_num }}

--- a/recipes/msg-extractor/meta.yaml
+++ b/recipes/msg-extractor/meta.yaml
@@ -12,8 +12,6 @@ source:
   git_url: https://github.com/mattgwwalker/{{ name }}.git
 
 build:
-  entry_points:
-    - ExtractMsg = ExtractMsg:__main__
   number: {{ build_num }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
@@ -37,6 +35,7 @@ about:
   home: https://github.com/mattgwwalker/msg-extractor
   license: GPL 3.0
   license_file: COPYING
+  license_family: GPL
   summary: "Extracts emails and attachments saved in Microsoft Outlook's .msg files"
   dev_url: https://github.com/mattgwwalker/msg-extractor
 


### PR DESCRIPTION
[`msg-extractor`](https://github.com/mattgwwalker/msg-extractor) is a funky package since it isn't a module and isn't on pypi. The primary issue with this is that we can't easily patch it to work with an `entry_point`, so I've left that out of the build. It likely won't be possible to invoke the package from the command line, but it will still be usable in imports.