### PR TITLE
mpi metapackage

### DIFF
--- a/recipes/mpi/LICENSE.txt
+++ b/recipes/mpi/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -1,11 +1,13 @@
 # Based on blas metapackage: https://github.com/conda-forge/blas-feedstock
 # Some useful notes can be found at https://conda-forge.hackpad.com/BLAS-Numpy-Friends-86De62hoNdT
+# See discussion: https://github.com/conda-forge/staged-recipes/pull/1501
 
 {% set variant = os.environ.get('MPI_VARIANT', 'mpich') %}
 
 # The version should be in the form X.Y, where X denotes major infrastructural change to how mpi is managed,
-# and Y denoting mpi priority. Currently Y=0 not default, Y=1 default mpi.
-{% set Y = 1 if variant == 'mpich' else 0 %}
+# and Y denoting mpi priority. Having MPI priority causes `conda upgrade --all` to switch to preferred provider,
+# so currently express no priority.
+{% set Y = 0 %}
 package:
   name: mpi
   version: 1.{{ Y }}
@@ -20,7 +22,7 @@ build:
   track_features:
     # The "mpi" package must always track a feature, else it will be
     # prioritised over all others.
-    - mpi_{{ variant }}
+    - {{ variant }}
 
 requirements: {}
   # None, mpi providers should depend on me

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -33,6 +33,7 @@ test:
 about:
   home: https://github.com/conda-forge/mpi-feedstock
   license: BSD 3-clause
+  license_file: {{ RECIPE_DIR if RECIPE_DIR is defined else '' }}/LICENSE.txt
   summary: Metapackage to select the MPI variant. Use conda's pinning mechanism in your environment to control which variant you want.
 
 extra:

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -22,7 +22,7 @@ build:
     # prioritised over all others.
     - mpi_{{ variant }}
 
-requirements:
+requirements: {}
   # None, mpi providers should depend on me
 
 test:

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -24,11 +24,9 @@ build:
     - mpi_{{ variant }}
 
 requirements:
-  run:
-    - {{ variant }}
+  # None, mpi providers should depend on me
 
 test:
-  
 
 about:
   home: https://github.com/conda-forge/mpi-feedstock

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -1,0 +1,41 @@
+# Based on blas metapackage: https://github.com/conda-forge/blas-feedstock
+# Some useful notes can be found at https://conda-forge.hackpad.com/BLAS-Numpy-Friends-86De62hoNdT
+
+{% set variant = os.environ.get('MPI_VARIANT', 'mpich') %}
+
+# The version should be in the form X.Y, where X denotes major infrastructural change to how mpi is managed,
+# and Y denoting mpi priority. Currently Y=0 not default, Y=1 default mpi.
+# TODO: decide on mpich vs openmpi priority once both are packaged:
+{% set Y = 1 if variant == 'undecided' else 0 %}
+package:
+  name: mpi
+  version: 1.{{ Y }}
+
+build:
+  # We mustn't use the build number in the mpi package - because we are defining the string,
+  # manually we would not be producing unique filenames.
+  number: 0
+  string: {{ variant }}
+  # TODO: support Windows when msmpi is packaged
+  skip: true  # [win]
+  track_features:
+    # The "mpi" package must always track a feature, else it will be
+    # prioritised over all others.
+    - mpi_{{ variant }}
+
+requirements:
+  run:
+    - {{ variant }}
+
+test:
+  
+
+about:
+  home: https://github.com/conda-forge/mpi-feedstock
+  license: BSD 3-clause
+  summary: Metapackage to select the MPI variant. Use conda's pinning mechanism in your environment to control which variant you want.
+
+extra:
+  recipe-maintainers:
+    - minrk
+    - ocefpaf

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -5,8 +5,7 @@
 
 # The version should be in the form X.Y, where X denotes major infrastructural change to how mpi is managed,
 # and Y denoting mpi priority. Currently Y=0 not default, Y=1 default mpi.
-# TODO: decide on mpich vs openmpi priority once both are packaged:
-{% set Y = 1 if variant == 'undecided' else 0 %}
+{% set Y = 1 if variant == 'mpich' else 0 %}
 package:
   name: mpi
   version: 1.{{ Y }}

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -24,6 +24,8 @@ requirements: {}
   # None, mpi providers should depend on me
 
 test:
+  commands:
+    - echo "I'm a metapackage"
 
 about:
   home: https://github.com/conda-forge/mpi-feedstock

--- a/recipes/mpi/meta.yaml
+++ b/recipes/mpi/meta.yaml
@@ -19,10 +19,6 @@ build:
   string: {{ variant }}
   # TODO: support Windows when msmpi is packaged
   skip: true  # [win]
-  track_features:
-    # The "mpi" package must always track a feature, else it will be
-    # prioritised over all others.
-    - {{ variant }}
 
 requirements: {}
   # None, mpi providers should depend on me


### PR DESCRIPTION
Current proposal (**updated 2017-12-12**):

- this PR adds `mpi` metapackage, which will have a variant for each mpi provider (only mpich variant in this PR, conda-forge.yml matrix will add openmpi)
- features will not be used anywhere
- in mpi consumers, mpi provider will be indicated by build string (e.g `mpich_0`)
- mutual exclusivity will be achieved by making MPI providers depend directly on mpi metapackage with appropriate build string, e.g. `mpi 1.0 mpich` (and marking previous builds as broken)

TODO **after** merging this PR:

- [ ] add conda-forge.yml in mpi metapackage for mpich, openmpi variants
- [ ] make mpich, openmpi packages depend on mpi metapackage:
  - [ ] https://github.com/conda-forge/mpich-feedstock/pull/11
  - [ ] https://github.com/conda-forge/openmpi-feedstock/pull/11
- [ ] mark previous builds of mpich, openmpi as broken so they don't get pulled in as a solution to avoiding mutual exclusivity (requires conda-forge admin intervention)
- begin rollout of variants
  - [ ] https://github.com/conda-forge/mpi4py-feedstock/pull/10

Sample for mpi provider (not much to do without features):

```yaml
dependencies:
  run:
    - mpi 1.0 mpich
```

Sample for mpi consumer:

```yaml
# recipe/meta.yaml
{% set mpi = os.environ.get('MPI_VARIANT', 'mpich') %}
{% set mpi_version = {'mpich': '3.2.*', 'openmpi': '3.0.*'}[mpi] %}
build:
  number: {{ build }}
  string: {{ mpi }}_{{ build }}
requirements:
  build:
    - {{ mpi }} {{ mpi_version }}
  run:
    - {{ mpi }} {{ mpi_version }}

# conda-forge.yml
matrix:
  - [[MPI_VARIANT, 'openmpi']]
  - [[MPI_VARIANT, 'mpich']]
travis:
  ...
```

Original description below:


**NOTE:** the current state of this discussion suggests that there would be no metapackage, in which case this PR should not be merged.

copy of [blas metapackage](). Only mpich for now, while we wait for openmpi.

Following the example of #643, I'll add the build matrix on the feedstock (after openmpi is packaged).

Still to decide: MPI default preference (openmpi or mpich)? I really don't have a preference, but currently mpich has fortran working, while openmpi seems to need to disable it on OS X currently,
so that would push my vote toward mpich.

cc @dalcinl for input on defaults. Not sure who else to ping.