### PR TITLE
Fix name

### DIFF
--- a/recipes/iris-sample-data/meta.yaml
+++ b/recipes/iris-sample-data/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.0.0" %}
 
 package:
-    name: iris_sample_data
+    name: iris-sample-data
     version: {{ version }}
 
 source:


### PR DESCRIPTION
Not sure if there is a reason for the original package to use `iris_sample_data` but this change will make the `conda-forge` version drift from `scitools`.