### PR TITLE
Add tmux

### DIFF
--- a/recipes/tmux/build.sh
+++ b/recipes/tmux/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+chmod +x ./autogen.sh
+
+# Needed for Linux build to work.
+export CFLAGS="-I${PREFIX}/include ${CFLAGS}"
+export CPPFLAGS="-I${PREFIX}/include ${CPPFLAGS}"
+export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"
+
+./autogen.sh
+./configure --prefix=$PREFIX
+make
+make install

--- a/recipes/tmux/meta.yaml
+++ b/recipes/tmux/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "2.2" %}
+
+package:
+  name: tmux
+  version: {{ version }}
+
+source:
+  fn: tmux-{{ version }}.tar.gz
+  url: https://github.com/tmux/tmux/archive/{{ version }}.tar.gz
+  sha256: f17f4d98454bd87d0065047ef0a4cf78da180ec5e957124bedee3a5fdd72a598
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - autoconf
+    - automake
+    - libtool
+    - m4
+    - pkg-config
+    - libevent 2.0.*
+    - ncurses 5.9*
+
+  run:
+    - libevent 2.0.*
+    - ncurses 5.9*
+
+test:
+  commands:
+    # Verify command existence.
+    - which tmux
+
+    # Check that no server is running.
+    - $(tmux info || true) 2> >(grep "no server running on")
+
+about:
+  home: https://tmux.github.io/
+  license: ISC
+  license_file: COPYING
+  summary: A terminal multiplexer.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a package for `tmux` a terminal multiplexer. Impetus for me is to have `tmux` on Mac. This seems to work ok from my testing. Should work just as well on Linux too.

Depends on `libevent`, which is provided in PR ( https://github.com/conda-forge/staged-recipes/pull/1491 ).

Added a pinning to `libevent` to start with based on info that I found. See PR ( https://github.com/conda-forge/conda-forge.github.io/pull/233 ) for generally adding this pinning and relevant info.

Letting you know in case of interest, @parente.
