### PR TITLE
Store build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build_artefacts

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -11,6 +11,9 @@ channels:
  - conda-forge
  - defaults
 
+conda-build:
+ root-dir: /staged-recipes/build_artefacts
+
 always_yes: true
 show_channel_urls: true
 


### PR DESCRIPTION
Adds the same functionality present in feedstocks to staged-recipes. Namely if one runs the `run_docker_build.sh` script, it will ensure all build artifacts are stored outside the container for inspection. These are ignored by `git` to avoid being accidentally committed.

cc @pelson