### PR TITLE
Add sh

### DIFF
--- a/recipes/sh/meta.yaml
+++ b/recipes/sh/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "sh" %}
+{% set version = "1.11" %}
+{% set sha256 = "590fb9b84abf8b1f560df92d73d87965f1e85c6b8330f8a5f6b336b36f0559a4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - sh
+
+about:
+  home: https://github.com/amoffat/sh
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Python subprocess interface
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/1285

Adds a package for `sh`. A nifty tool for calling shell commands from Python. May work on Windows, but have skipped it for now as I haven't seen anyone uses this on a non-POSIX OS.

Notes: Generated with `conda skeleton pypi` and cleaned up using the [`example`]( https://github.com/conda-forge/staged-recipes/blob/d936753e293ba4db0187a50343e1f11b78b8ea4c/recipes/example/meta.yaml ) as a template.