### PR TITLE
Added a recipe for Flask-Admin

### DIFF
--- a/recipes/flask-admin/meta.yaml
+++ b/recipes/flask-admin/meta.yaml
@@ -1,20 +1,21 @@
-{%set name = "flask-admin" %}
-{%set camelName = "Flask-Admin" %}
+{%set name = "Flask-Admin" %}
 {%set version = "1.4.2" %}
+{%set compress_type = "tar.gz" %}
 {%set hash_type = "sha256" %}
 {%set hash_val = "7d1cfdcb29a7135d4275dc22628c0f068cccfdb84dadad885bde685d0511597c" %}
+{%set build_num = "0" %}
 
 package:
-  name: {{ name }}
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
   {{ hash_type }}: {{ hash_val }}
 
 build:
-  number: 0
+  number: {{ build_num }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipes/flask-admin/meta.yaml
+++ b/recipes/flask-admin/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - python
     - flask >=0.7
     - wtforms
+    - wtforms-appengine
     # - flask-babelex
     # - flask-mongoengine
     # - flask-sqlalchemy

--- a/recipes/flask-admin/meta.yaml
+++ b/recipes/flask-admin/meta.yaml
@@ -29,47 +29,38 @@ requirements:
     - python
     - flask >=0.7
     - wtforms
-    - wtforms-appengine
-    # - flask-babelex
-    # - flask-mongoengine
-    # - flask-sqlalchemy
+    # Required for flask_admin.contrib.appengine:
+    # - wtforms-appengine
+    # Required for flask_admin.contrib.geoa:
     # - geoalchemy2
-    # - mongoengine
-    # - pillow ==2.9.0
-    # - psycopg2
-    # - pymongo
     # - shapely
-    # - sqlalchemy
+    # Required for flask_admin.contrib.mongoengine:
+    # - flask-mongoengine
+    # Required for flask_admin.contrib.peewee and flask_admin.contrib.peeweemodel:
+    # - peewee
     # - wtf-peewee
+    #  Required for flask_admin.contrib.pymongo:
+    # - pymongo
+    # Required for flask_admin.contrib.sqla and flask_admin.contrib.sqlamodel:
+    # - sqlalchemy
 
 test:
   imports:
     - flask_admin
     - flask_admin.contrib
-    - flask_admin.contrib.appengine
     - flask_admin.contrib.fileadmin
-    - flask_admin.contrib.geoa
-    - flask_admin.contrib.mongoengine
-    - flask_admin.contrib.peewee
-    - flask_admin.contrib.peeweemodel
-    - flask_admin.contrib.pymongo
-    - flask_admin.contrib.sqla
-    - flask_admin.contrib.sqlamodel
     - flask_admin.form
     - flask_admin.model
-    - flask_admin.tests
-    - flask_admin.tests.fileadmin
-    - flask_admin.tests.geoa
-    - flask_admin.tests.mongoengine
-    - flask_admin.tests.peeweemodel
-    - flask_admin.tests.pymongo
-    - flask_admin.tests.sqla
     - flask_admin.translations
 
 about:
   home: https://github.com/flask-admin/flask-admin/
   license: BSD 3-Clause
+  license_file: LICENSE
+  license_family: BSD
   summary: 'Simple and extensible admin interface framework for Flask'
+  doc_url: https://flask-admin.readthedocs.io/en/latest/
+  dev_url: https://github.com/flask-admin/flask-admin/
 
 extra:
   recipe-maintainers:

--- a/recipes/flask-admin/meta.yaml
+++ b/recipes/flask-admin/meta.yaml
@@ -22,8 +22,6 @@ requirements:
   build:
     - python
     - setuptools
-    - flask >=0.7
-    - wtforms
 
   run:
     - python

--- a/recipes/flask-admin/meta.yaml
+++ b/recipes/flask-admin/meta.yaml
@@ -1,0 +1,74 @@
+{%set name = "flask-admin" %}
+{%set camelName = "Flask-Admin" %}
+{%set version = "1.4.2" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "7d1cfdcb29a7135d4275dc22628c0f068cccfdb84dadad885bde685d0511597c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ camelName }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - flask >=0.7
+    - wtforms
+
+  run:
+    - python
+    - flask >=0.7
+    - wtforms
+    # - flask-babelex
+    # - flask-mongoengine
+    # - flask-sqlalchemy
+    # - geoalchemy2
+    # - mongoengine
+    # - pillow ==2.9.0
+    # - psycopg2
+    # - pymongo
+    # - shapely
+    # - sqlalchemy
+    # - wtf-peewee
+
+test:
+  imports:
+    - flask_admin
+    - flask_admin.contrib
+    - flask_admin.contrib.appengine
+    - flask_admin.contrib.fileadmin
+    - flask_admin.contrib.geoa
+    - flask_admin.contrib.mongoengine
+    - flask_admin.contrib.peewee
+    - flask_admin.contrib.peeweemodel
+    - flask_admin.contrib.pymongo
+    - flask_admin.contrib.sqla
+    - flask_admin.contrib.sqlamodel
+    - flask_admin.form
+    - flask_admin.model
+    - flask_admin.tests
+    - flask_admin.tests.fileadmin
+    - flask_admin.tests.geoa
+    - flask_admin.tests.mongoengine
+    - flask_admin.tests.peeweemodel
+    - flask_admin.tests.pymongo
+    - flask_admin.tests.sqla
+    - flask_admin.translations
+
+about:
+  home: https://github.com/flask-admin/flask-admin/
+  license: BSD 3-Clause
+  summary: 'Simple and extensible admin interface framework for Flask'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
`Flask-Admin` is a very flexible package, with many modules that have outside dependencies but, at the same time, aren't likely to be used. As such, I've left those dependencies out but provided some guidance within the recipe itself. The documentation is obviously the definitive source.