### PR TITLE
Add falcon

### DIFF
--- a/recipes/falcon/meta.yaml
+++ b/recipes/falcon/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.0.0" %}
+{% set sha256 = "18532f28d92e8a3b3097285a986c8bc2ec4573efcd965c85c3fe433b37e65dc4" %}
+
+package:
+    name: falcon
+    version: {{ version }}
+
+source:
+    fn: falcon-{{ version }}.tar.gz
+    url: https://github.com/falconry/falcon/archive/{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - cython
+        - six >=1.4.0
+        - python-mimeparse
+    run:
+        - python
+        - six >=1.4.0
+        - python-mimeparse
+
+test:
+    imports:
+        - falcon
+        - falcon.cmd
+        - falcon.routing
+        - falcon.testing
+        - falcon.util
+
+about:
+    home: http://falconframework.org
+    license: Apache Software License
+    summary: 'An unladen web framework for building APIs and app backends.'
+    description: |
+        Falcon is a high-performance Python framework for building cloud APIs. It
+        encourages the REST architectural style, and tries to do as little as
+        possible while remaining highly effective.
+    doc_url: http://falcon.readthedocs.io/en/stable/
+    dev_url: https://github.com/falconry/falcon/
+
+extra:
+    recipe-maintainers:
+        - daf

--- a/recipes/falcon/meta.yaml
+++ b/recipes/falcon/meta.yaml
@@ -48,3 +48,4 @@ about:
 extra:
     recipe-maintainers:
         - daf
+        - synapticarbors


### PR DESCRIPTION
This should add the faster version of `falcon` compiled with `cython` (ping @synapticarbors) and fixes the downloading issues from #1292 by changing the URL to the GitHub source (ping @daf).

PS: @synapticarbors do you want to be a maintainer here? I can add you in this PR.

[Closes #1292]