### PR TITLE
Added recipe for zodbpickle

### DIFF
--- a/recipes/zodbpickle/meta.yaml
+++ b/recipes/zodbpickle/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   build:
     - python
     - setuptools
+    - toolchain
 
   run:
     - python

--- a/recipes/zodbpickle/meta.yaml
+++ b/recipes/zodbpickle/meta.yaml
@@ -36,7 +36,7 @@ test:
 about:
   home: http://pypi.python.org/pypi/zodbpickle
   license: ZPL 2.1
-  license_file:
+  license_file: LICENSE.txt
   license_family: Other
   summary: 'Fork of Python 3 pickle module.'
   dev_url: https://github.com/zopefoundation/zodbpickle

--- a/recipes/zodbpickle/meta.yaml
+++ b/recipes/zodbpickle/meta.yaml
@@ -27,7 +27,6 @@ requirements:
 
   run:
     - python
-    - setuptools
 
 test:
   imports:

--- a/recipes/zodbpickle/meta.yaml
+++ b/recipes/zodbpickle/meta.yaml
@@ -1,0 +1,46 @@
+{%set name = "zodbpickle" %}
+{%set version = "0.6.0" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "ea3248be966159e7791e3db0e35ea992b9235d52e7d39835438686741d196665" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  preserve_egg_dir: True
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - zodbpickle
+    - zodbpickle.tests
+
+about:
+  home: http://pypi.python.org/pypi/zodbpickle
+  license: ZPL 2.1
+  license_file:
+  license_family: Other
+  summary: 'Fork of Python 3 pickle module.'
+  dev_url: https://github.com/zopefoundation/zodbpickle
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/zodbpickle/meta.yaml
+++ b/recipes/zodbpickle/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: http://pypi.python.org/pypi/zodbpickle
-  license: ZPL 2.1
+  license: PSF 2 and ZPL 2.1
   license_file: LICENSE.txt
   license_family: Other
   summary: 'Fork of Python 3 pickle module.'


### PR DESCRIPTION
Because of how this package is set up, a bunch of `py27` files will fail when built on `py3k`, and a bunch of `py3k` files will fail when built on `py27`. This seems rather inefficient, but I'm not sure of a great fix.