### PR TITLE
Added recipe for jellyfish

### DIFF
--- a/recipes/jellyfish/meta.yaml
+++ b/recipes/jellyfish/meta.yaml
@@ -1,0 +1,44 @@
+{%set name = "jellyfish" %}
+{%set version = "0.5.1" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "e297b7a5d00579b0da0474a89273fff759f305de88e05d6a1d0ebd4cb58c49e8" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - jellyfish
+
+about:
+  home: http://github.com/jamesturk/jellyfish
+  license: BSD 2-Clause
+  license: LICENSE
+  license_family: BSD
+  summary: 'a library for doing approximate and phonetic matching of strings.'
+  dev_url: http://github.com/jamesturk/jellyfish
+  doc_url: https://jellyfish.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
This is a build of an old version -`0.5.1`- of [`jellyfish`](https://pypi.org/project/jellyfish), which is a dependency of [`us`](https://pypi.org/project/us).  It's worth noting that bioconda has a build of [a *different* `jellyfish`](https://bioconda.github.io/recipes/jellyfish/README.html) which we might also want in conda-forge at some point. I'm not sure how to resolve this issue; perhaps the other package could be `bioconda-jellyfish`...