### PR TITLE
Add recipes for Chemfiles

### DIFF
--- a/recipes/chemfiles/meta.yaml
+++ b/recipes/chemfiles/meta.yaml
@@ -1,0 +1,29 @@
+{% set version = "0.6.0" %}
+
+package:
+  name: chemfiles
+  version: {{ version }}
+
+build:
+  skip: true  # [win]
+  number: 0
+
+requirements:
+  run:
+    - chemfiles-lib ==0.6.2
+    - chemfiles-python ==0.6.0
+
+test:
+  commands:
+    # If we can load the python extension and create new object, both the python
+    # binding and the shared library are installled in the right place
+    - python -c "import chemfiles; chemfiles.Atom('H')"
+
+about:
+  home: http://chemfiles.github.io
+  license: MPL-v2.0
+  summary: Modern library for chemistry file reading and writing
+
+extra:
+  recipe-maintainers:
+    - luthaf


### PR DESCRIPTION
A C++ library for reading/writing theoretical chemistry trajectories, with Python bindings. See http://chemfiles.github.io/ for more informations. 

I added three recipes: C++ library, Python binding and meta-package. If you prefer having everything in one recipe, I can to it.