### PR TITLE
Fix nested directories in removal commit message

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -275,7 +275,8 @@ if __name__ == '__main__':
     removed_recipes = removed_recipes.splitlines()
     removed_recipes = filter(lambda _: _.startswith("D "), removed_recipes)
     removed_recipes = map(lambda _ : _.replace("D", "", 1).lstrip(), removed_recipes)
-    removed_recipes = map(lambda _ : os.path.basename(os.path.dirname(_)), removed_recipes)
+    removed_recipes = map(lambda _ : os.path.relpath(_, recipe_directory_name), removed_recipes)
+    removed_recipes = map(lambda _ : _.split(os.path.sep)[0], removed_recipes)
     removed_recipes = sorted(set(removed_recipes))
 
     # Commit any removed packages.


### PR DESCRIPTION
Includes https://github.com/conda-forge/staged-recipes/pull/1573

Notice that in some cases we are getting subdirectories of a recipe are included as removed recipes in the commit message like commit ( https://github.com/conda-forge/staged-recipes/commit/b9de86389fb9e4b499af3e5d3797a64a812713ac ). There is only one recipe `dlib`. However, the `test_data` subdirectory gets included in the list. This shouldn't be the case.

This PR fixes handling of this case of nested directories in recipes when making the removal commit message.