### PR TITLE
Add recipe for QCA, a Qt encryption library

### DIFF
--- a/recipes/qca/build.sh
+++ b/recipes/qca/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+[[ ! -d build ]] && mkdir build/
+cd build/
+
+# "default" channel "qt" creates "plugins" in root of environment
+# Need to put "qca" plugin -- including qca-ossl -- in that folder
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DUSE_RELATIVE_PATHS=TRUE \
+    -DQCA_PLUGINS_INSTALL_DIR=$PREFIX/plugins \
+    ..
+
+make
+# No make check
+make install

--- a/recipes/qca/meta.yaml
+++ b/recipes/qca/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - cmake
+    - pkg-config  # [unix]
     - qt 
   run:
     - qt

--- a/recipes/qca/meta.yaml
+++ b/recipes/qca/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libqca.so  # [linux]
-    - test -f ${PREFIX}/lib/libqca.dylib  # [osx]
+    - test -d ${PREFIX}/lib/qca.framework  # [osx]
 
 about:
   home: http://delta.affinix.com/qca/ 

--- a/recipes/qca/meta.yaml
+++ b/recipes/qca/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "qca" %}
+{% set version = "2.1.0" %}
+{% set md5 = "c2b00c732036244701bae4853a2101cf" %}
+
+package:
+  name: qca
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://delta.affinix.com/download/qca/2.0/{{ name }}-{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - cmake
+    - qt 
+  run:
+    - qt
+ 
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libqca.so  # [linux]
+    - test -f ${PREFIX}/lib/libqca.dylib  # [osx]
+
+about:
+  home: http://delta.affinix.com/qca/ 
+  license: LGPL-2.1
+  license_file: COPYING
+  summary: Qt Cryptographic Architecture (QCA) provides a straightforward and cross-platform crypto API, using Qt datatypes and conventions. 
+  description: |
+    Taking a hint from the similarly-named Java Cryptography Architecture, QCA
+    aims to provide a straightforward and cross-platform crypto API, using Qt
+    datatypes and conventions. QCA separates the API from the implementation,
+    using plugins known as Providers. The advantage of this model is to allow
+    applications to avoid linking to or explicitly depending on any particular
+    cryptographic library. This allows one to easily change or upgrade crypto
+    implementations without even needing to recompile the application! QCA
+    should work everywhere Qt does, including Windows/Unix/MacOSX.
+  doc_url: http://delta.affinix.com/docs/qca/
+  dev_url: https://quickgit.kde.org/?p=qca.git
+
+extra:
+  recipe-maintainers:
+    - ceholden


### PR DESCRIPTION
PR adds a recipe for the Qt Cryptographic Architecture (QCA), a Qt 3rd party library that adds cryptography functionality to the Qt world. It is a dependency of QGIS, a Qt-based geographic information systems (GIS) application.