### PR TITLE
Add recipe for QJSON, a Qt JSON parsing library

### DIFF
--- a/recipes/qjson/build.sh
+++ b/recipes/qjson/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+[[ -d build ]] || mkdir build
+cd build/
+
+cmake \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    ..
+
+make
+# No "make check" available
+make install

--- a/recipes/qjson/meta.yaml
+++ b/recipes/qjson/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "qjson" %}
+{% set version = "0.8.1" %}
+{% set sha256 = "920c94166cb91b1cf11c7d2745bdbcc8c0ea82411ca7b3732ce0b00ee2d56e98" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/flavio/{{ name }}/archive/{{ version }}.tar.gz 
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - qt >=4.8
+    - cmake
+  run:
+    - qt >=4.8
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libqjson.so  # [linux]
+    - test -f ${PREFIX}/lib/libqjson.dylib  # [osx]
+
+about:
+  home: http://qjson.sourceforge.net/ 
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: LGPLv2.1 
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
+  license_file: README.license 
+  summary: 'QJson is a qt-based library that maps JSON data to QVariant objects'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+      JSON (JavaScript Object Notation) is a lightweight data-interchange format.
+      It can represents integer, real number, string, an ordered sequence of value,
+      and a collection of name/value pairs.
+      QJson is a Qt-based library that maps JSON data to QVariant objects and vice versa.
+  doc_url: http://qjson.sourceforge.net/usage/
+  dev_url: https://github.com/flavio/qjson
+
+extra:
+  recipe-maintainers:
+    - ceholden 

--- a/recipes/qjson/meta.yaml
+++ b/recipes/qjson/meta.yaml
@@ -29,17 +29,9 @@ test:
 
 about:
   home: http://qjson.sourceforge.net/ 
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
   license: LGPLv2.1 
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
   license_file: README.license 
   summary: 'QJson is a qt-based library that maps JSON data to QVariant objects'
-
-  # The remaining entries in this section are optional, but recommended
   description: |
       JSON (JavaScript Object Notation) is a lightweight data-interchange format.
       It can represents integer, real number, string, an ordered sequence of value,


### PR DESCRIPTION
PR adds a recipe for QJSON, a Qt 3rd party library that parses JSON to/from Qt types. It is a dependency of QGIS, a Qt-based geographic information systems (GIS) application.