### PR TITLE
add mayavi

### DIFF
--- a/recipes/mayavi/bld.bat
+++ b/recipes/mayavi/bld.bat
@@ -1,0 +1,5 @@
+%PYTHON% setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1
+
+:: move examples %EXAMPLES%
+:: if errorlevel 1 exit 1

--- a/recipes/mayavi/build.sh
+++ b/recipes/mayavi/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record record.txt
+
+# mv examples $EXAMPLES

--- a/recipes/mayavi/meta.yaml
+++ b/recipes/mayavi/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "4.5.0" %}
+
+package:
+  name: mayavi
+  version: {{ version }}
+
+source:
+  fn: mayavi-{{ version }}.tar.gz
+  url: https://github.com/enthought/mayavi/archive/{{ version }}.tar.gz
+  sha256: 36f688b3ea542e9f8cc0d7faa25e1425723cd00acc8aa640169029f33679ab85
+
+build:
+  entry_points:
+    - mayavi2 = mayavi.scripts.mayavi2:main
+    - tvtk_doc = tvtk.tools.tvtk_doc:main
+  osx_is_app: True
+
+requirements:
+  build:
+    - python
+    - numpy
+    - setuptools
+    - vtk
+    - traitsui
+    - apptools
+  run:
+    - python
+    - python.app             # [osx]
+    - numpy
+    - vtk
+    - traitsui
+    - apptools
+    - envisage
+    - pyqt
+    - setuptools
+
+test:
+  commands:
+    - mayavi2 --help
+  imports:
+    - tvtk
+    - tvtk.array_ext
+    - mayavi
+
+about:
+  home: https://github.com/enthought/mayavi
+  license: BSD
+  license_file: LICENSE.txt
+  summary: The Mayavi scientific data 3-dimensional visualizers
+
+extra:
+  recipe-maintainers:
+    - msarahan
+    - grlee77


### PR DESCRIPTION
I have updated the `mayavi` recipe from #285, with minimal changes to update it to the latest version (4.5.0).

One question I came across was how to handle installing the examples (or whether to do it?).  The build scripts had lines to move the `examples` folder to a $EXAMPLES location, but this variable doesn't seem to be defined so I have commented that out for now.  (The mayavi repo has an examples subfolder that itself contains 2 directories containing various `mayavi` and `tvtk` examples).

pinging @msarahan as the original author of this recipe. 
