### PR TITLE
Added recipe for parsedatetime

### DIFF
--- a/recipes/parsedatetime/meta.yaml
+++ b/recipes/parsedatetime/meta.yaml
@@ -1,0 +1,45 @@
+{%set name = "parsedatetime" %}
+{%set version = "2.0" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "74aaed8e8639842ff48c05c1e3708a26ffa138eb00d557be6681b5df771f7c8c" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - parsedatetime
+    - parsedatetime.pdt_locales
+
+about:
+  home: https://github.com/bear/parsedatetime
+  license: Apache 2.0
+  license_file: LICENSE.txt
+  license_family: Apache
+  summary: 'Parse human-readable date/time text.'
+  dev_url: https://github.com/bear/parsedatetime
+  doc_url: https://bear.im/code/parsedatetime/docs/index.html
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
This is an old version -`2.0`, not `2.1`- that is required by `caravel`