### PR TITLE
Re-add repeated_test recipe

### DIFF
--- a/recipes/repeated_test/meta.yaml
+++ b/recipes/repeated_test/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "repeated_test" %}
+{% set version = "1.0.1" %}
+{% set sha256 = "65107444a4945668ab7be6d1a3e1814cee9b2cfc577e7c70381700b11b809d27" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six >=1.7
+
+test:
+  imports:
+    - repeated_test
+    - repeated_test.tests
+
+  requires:
+    - unittest2  # [py26]
+
+about:
+  home: https://github.com/epsy/repeated_test
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'A quick unittest-compatible framework for repeating a test function over many fixtures'
+  dev_url: https://github.com/epsy/repeated_test
+
+extra:
+  recipe-maintainers:
+    - proinsias


### PR DESCRIPTION
As requested by @jakirkham, I'm re-adding this recipe from #1505, with the directory renamed from `repeated-test` to `repeated_test`. This will fix #1660.