### PR TITLE
MAINT: toolchain comments in example recipe

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -30,11 +30,13 @@ requirements:
     - python
     # When setuptools is available add the `--single-version-externally-managed --record record.txt` above.
     - setuptools
+    # if your project compiles code (such as a C extension) then add `toolchain` as a build requirement.
   run:
     - python
 
 test:
   # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
   imports:
     - simplejson
     - simplejson.tests


### PR DESCRIPTION
The example recipe should make clear that if you're compiling code for e.g. a C-extension, then a build requirement is the `toolchain` meta package.

Also added a comment to make clear that the imports in the test section should list all the packages/modules imported in `run_test.py`.