### PR TITLE
Handle race condition when pushing new feedstock

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -201,9 +201,24 @@ if __name__ == '__main__':
 
             subprocess.check_call(['conda', 'smithy', 'rerender'], cwd=feedstock_dir)
             subprocess.check_call(['git', 'commit', '-am', "Re-render the feedstock after CI registration."], cwd=feedstock_dir)
-            # Capture the output, as it may contain the GH_TOKEN.
-            out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,
-                                          stderr=subprocess.STDOUT)
+            try:
+                # Capture the output, as it may contain the GH_TOKEN.
+                out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,
+                                              stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError:
+                # Likely another job has already pushed to this repo.
+                # Place our changes on top of theirs and try again.
+                out = subprocess.check_output(['git', 'fetch', 'upstream_with_token', 'master'], cwd=feedstock_dir,
+                                              stderr=subprocess.STDOUT)
+                try:
+                    subprocess.check_call(['git', 'rebase', 'upstream_with_token/master', 'master'], cwd=feedstock_dir)
+                except subprocess.CalledProcessError:
+                    # Handle rebase failure by choosing the changes in `master`.
+                    subprocess.check_call(['git', 'checkout', 'master', '--', '.'], cwd=feedstock_dir)
+                    subprocess.check_call(['git', 'rebase', '--continue'], cwd=feedstock_dir)
+                # Capture the output, as it may contain the GH_TOKEN.
+                out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,
+                                              stderr=subprocess.STDOUT)
 
             # Add team members as maintainers.
             if conda_forge:

--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
 
             subprocess.check_call(['conda', 'smithy', 'rerender'], cwd=feedstock_dir)
             subprocess.check_call(['git', 'commit', '-am', "Re-render the feedstock after CI registration."], cwd=feedstock_dir)
-            while True:
+            for i in range(5):
                 try:
                     # Capture the output, as it may contain the GH_TOKEN.
                     out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,

--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -201,11 +201,15 @@ if __name__ == '__main__':
 
             subprocess.check_call(['conda', 'smithy', 'rerender'], cwd=feedstock_dir)
             subprocess.check_call(['git', 'commit', '-am', "Re-render the feedstock after CI registration."], cwd=feedstock_dir)
-            try:
-                # Capture the output, as it may contain the GH_TOKEN.
-                out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,
-                                              stderr=subprocess.STDOUT)
-            except subprocess.CalledProcessError:
+            while True:
+                try:
+                    # Capture the output, as it may contain the GH_TOKEN.
+                    out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,
+                                                  stderr=subprocess.STDOUT)
+                    break
+                except subprocess.CalledProcessError:
+                    pass
+
                 # Likely another job has already pushed to this repo.
                 # Place our changes on top of theirs and try again.
                 out = subprocess.check_output(['git', 'fetch', 'upstream_with_token', 'master'], cwd=feedstock_dir,
@@ -216,9 +220,6 @@ if __name__ == '__main__':
                     # Handle rebase failure by choosing the changes in `master`.
                     subprocess.check_call(['git', 'checkout', 'master', '--', '.'], cwd=feedstock_dir)
                     subprocess.check_call(['git', 'rebase', '--continue'], cwd=feedstock_dir)
-                # Capture the output, as it may contain the GH_TOKEN.
-                out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master'], cwd=feedstock_dir,
-                                              stderr=subprocess.STDOUT)
 
             # Add team members as maintainers.
             if conda_forge:


### PR DESCRIPTION
There are some cases where two different conversion jobs may be trying to convert the same recipe to a feedstock. If one jobs pushes to the feedstock first, the lagging job will fail as it is not a fast forward push. This will result in failing the conversion build. To handle things a little more gracefully, this PR tries to resolve this race condition for the lagging job.

We solve this problem by rebasing our changes on top of the changes already in the feedstock if pushing fails. This can result in one of two scenarios. They are as follows.

1. Local and upstream feedstocks are the same
2. Local and upstream feedstocks differ

Scenario 1 is uninteresting as it resolves cleanly and pushing is a no-op. Scenario 2 has merge conflicts we need to resolve probably due to different encrypted tokens. To resolve scenario 2, we prefer our local changes. Thus we push one new commit that shows how the encrypted tokens were changed. This result is the same as cycling a recipe through staged-recipes again.

This should eliminate one race condition and provides a result that meets one's expectations.

cc @pelson