### PR TITLE
Added recipe for quantities

### DIFF
--- a/recipes/quantities/meta.yaml
+++ b/recipes/quantities/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "quantities" %}
+{% set version = "0.11.1" %}
+{% set sha256 = "4382098a501b55bf0fdb3dba2061a161041253697d78811ecfd7c55449836660" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: {{ sha256 }}
+  patches:
+    - version.patch
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - numpy >=1.4.0
+
+test:
+  imports:
+    - quantities
+    - quantities.registry
+  commands:
+    - python -c "import quantities as pq; assert pq.__version__ == '0.11.1'"
+
+about:
+  home: https://pythonhosted.org/quantities/
+  license: BSD
+  summary: 'Support for physical quantities with units, based on numpy'
+  description: |
+    Quantities is designed to handle arithmetic and conversions of physical
+    quantities, which have a magnitude, dimensionality specified by various
+    units, and possibly an uncertainty. Quantities builds on the popular numpy
+    library and is designed to work with numpy’s standard ufuncs, many of which
+    are already supported.
+  doc_url: https://pythonhosted.org/quantities/
+  dev_url: https://github.com/python-quantities/python-quantities
+
+extra:
+  recipe-maintainers:
+    - bjodah

--- a/recipes/quantities/version.patch
+++ b/recipes/quantities/version.patch
@@ -1,0 +1,13 @@
+--- quantities/__init__.py	2015-12-16 09:51:34.000000000 +0100
++++ quantities/__init__.py.tgt	2016-09-30 14:17:00.359251972 +0200
+@@ -267,9 +267,7 @@
+ 
+ from __future__ import absolute_import
+ 
+-from ._version import get_versions
+-__version__ = get_versions()['version']
+-del get_versions
++__version__ = '0.11.1'
+ 
+ from .registry import unit_registry
+ 


### PR DESCRIPTION
I included a patch for incorrect `__version__`:

 - https://github.com/python-quantities/python-quantities/issues/122
 - https://github.com/python-quantities/python-quantities/issues/109
 - https://github.com/python-quantities/python-quantities/issues/107

`quantities` may have reached a status of abandon-ware, but I have some projects
still using it, so having it in conda-forge would help me (and judging by pull-requests and issues
also others) transitioning.