### PR TITLE
Add trackpy

### DIFF
--- a/recipes/trackpy/meta.yaml
+++ b/recipes/trackpy/meta.yaml
@@ -17,24 +17,23 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy >= 1.7
-    - scipy >= 0.12
-    - six >= 1.8
-    - pandas >= 0.13
-    - pims >= 0.3.3
+    - numpy >=1.7
+    - scipy >=0.12
+    - six >=1.8
+    - pandas >=0.13
+    - pims >=0.3.3
     - pyyaml
     - matplotlib
   run:
     - python
-    - numpy >= 1.7
-    - scipy >= 0.12
-    - six >= 1.8
-    - pandas >= 0.13
-    - pims >= 0.3.3
+    - numpy >=1.7
+    - scipy >=0.12
+    - six >=1.8
+    - pandas >=0.13
+    - pims >=0.3.3
     - pyyaml
     - matplotlib
     - pytables  # optional
-    - numba  # optional numba-accelerated code
 
 test:
   imports:

--- a/recipes/trackpy/meta.yaml
+++ b/recipes/trackpy/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "0.3.2" %}
+
+package:
+  name: trackpy
+  version: {{ version }}
+
+source:
+  fn: trackpy-{{ version }}.tar.gz
+  url: https://github.com/soft-matter/trackpy/archive/v{{ version }}.tar.gz
+  sha256: 4d1a1b0adfcef651c65b9155fc851ee094ad4341d637dcf6ac0237a541c260a5
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy >= 1.7
+    - scipy >= 0.12
+    - six >= 1.8
+    - pandas >= 0.13
+    - pims >= 0.3.3
+    - pyyaml
+    - matplotlib
+  run:
+    - python
+    - numpy >= 1.7
+    - scipy >= 0.12
+    - six >= 1.8
+    - pandas >= 0.13
+    - pims >= 0.3.3
+    - pyyaml
+    - matplotlib
+    - pytables  # optional
+    - numba  # optional numba-accelerated code
+
+test:
+  imports:
+    - trackpy
+
+about:
+  home: https://github.com/soft-matter/trackpy
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: 'Python particle tracking toolkit'
+  description: |
+    trackpy is a Python package for particle tracking in 2D, 3D,
+    and higher dimensions.
+  doc_url: http://soft-matter.github.io/trackpy
+
+extra:
+  recipe-maintainers:
+    - danielballan
+    - tacaswell
+    - nkeim
+    - caspervdw
+    - ericdill

--- a/recipes/trackpy/meta.yaml
+++ b/recipes/trackpy/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - matplotlib
   run:
     - python
+    - setuptools
     - numpy >=1.7
     - scipy >=0.12
     - six >=1.8


### PR DESCRIPTION
This adds a recipe for trackpy. I am not 100% sure about including the optional dependencies `numba` and `pytables`. Should we run some basic tests?

And do you want to be maintainers? @ericdill @danielballan @tacaswell @nkeim