### PR TITLE
OpenMC

### DIFF
--- a/recipes/openmc/build.sh
+++ b/recipes/openmc/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -x
+set -e
+
+mkdir -p build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release ..
+make -j "${CPU_COUNT}"
+make install

--- a/recipes/openmc/build.sh
+++ b/recipes/openmc/build.sh
@@ -3,16 +3,11 @@ set -x
 set -e
 
 export FC=gfortran
-#export FCFLAGS="-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8 -fdefault-integer-8"
-#rm -f cmake/Modules/FindHDF5.cmake
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
+cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_BUILD_TYPE=Release \
   -DHDF5_ROOT="${PREFIX}" \
   ..
 make -j "${CPU_COUNT}"
 make install
-
-  #-DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8 -fdefault-integer-8 -fno-underscoring" \
-  #-DCMAKE_Fortran_FLAGS="${FCFLAGS}" \
-  #-DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fno-underscoring" \

--- a/recipes/openmc/build.sh
+++ b/recipes/openmc/build.sh
@@ -3,9 +3,15 @@ set -x
 set -e
 
 export FC=gfortran
-#rm -f cmake/Modules/FindHDF5.cmake
+#export FCFLAGS="-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8 -fdefault-integer-8"
+rm -f cmake/Modules/FindHDF5.cmake
 mkdir -p build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fno-underscoring" \
+  -DHDF5_ROOT="${PREFIX}" ..
 make -j "${CPU_COUNT}"
 make install
+
+  #-DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8 -fdefault-integer-8 -fno-underscoring" \
+  #-DCMAKE_Fortran_FLAGS="${FCFLAGS}" \

--- a/recipes/openmc/build.sh
+++ b/recipes/openmc/build.sh
@@ -2,6 +2,8 @@
 set -x
 set -e
 
+export FC=gfortran
+#rm -f cmake/Modules/FindHDF5.cmake
 mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release ..

--- a/recipes/openmc/build.sh
+++ b/recipes/openmc/build.sh
@@ -4,14 +4,15 @@ set -e
 
 export FC=gfortran
 #export FCFLAGS="-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8 -fdefault-integer-8"
-rm -f cmake/Modules/FindHDF5.cmake
+#rm -f cmake/Modules/FindHDF5.cmake
 mkdir -p build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fno-underscoring" \
-  -DHDF5_ROOT="${PREFIX}" ..
+  -DHDF5_ROOT="${PREFIX}" \
+  ..
 make -j "${CPU_COUNT}"
 make install
 
   #-DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fdefault-real-8 -fdefault-double-8 -fdefault-integer-8 -fno-underscoring" \
   #-DCMAKE_Fortran_FLAGS="${FCFLAGS}" \
+  #-DCMAKE_Fortran_FLAGS="-funroll-all-loops -c -fpic -fno-underscoring" \

--- a/recipes/openmc/meta.yaml
+++ b/recipes/openmc/meta.yaml
@@ -1,0 +1,53 @@
+{% set org = "mit-crpg" %}
+{% set name = "openmc" %}
+{% set version = "0.8.0" %}
+{% set sha256 = "395408a3dc9c3db2b5c200b8722a13a60898c861633b99e6e250186adffd1370" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/{{ org }}/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - pkg-config
+    - gcc
+    - libgcc
+    - libgfortran
+    - hdf5 1.8.17|1.8.17.*
+  run:
+    - libgfortran
+    - hdf5 1.8.17|1.8.17.*
+
+test:
+  commands:
+    - test -f "${PREFIX}/bin/openmc"
+
+about:
+  home: http://mit-crpg.github.io/openmc/index.html
+  license: MIT
+  license_file: LICENSE
+  summary: 'OpenMC Monte Carlo Code'
+  description: |
+    OpenMC is a Monte Carlo particle transport simulation code focused on
+    neutron criticality calculations. It is capable of simulating 3D models
+    based on constructive solid geometry with second-order surfaces. The
+    particle interaction data is based on ACE format cross sections, also
+    used in the MCNP and Serpent Monte Carlo codes.
+  doc_url: http://mit-crpg.github.io/openmc/index.html
+  dev_url: https://github.com/mit-crpg/openmc
+
+extra:
+  recipe-maintainers:
+    - scopatz

--- a/recipes/openmc/meta.yaml
+++ b/recipes/openmc/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/{{ org }}/{{ name }}/archive/{{ version }}.tar.gz
+  url: https://github.com/{{ org }}/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/openmc/meta.yaml
+++ b/recipes/openmc/meta.yaml
@@ -1,7 +1,7 @@
 {% set org = "mit-crpg" %}
 {% set name = "openmc" %}
 {% set version = "0.8.0" %}
-{% set sha256 = "395408a3dc9c3db2b5c200b8722a13a60898c861633b99e6e250186adffd1370" %}
+{% set sha256 = "8392df2f060cf1db55bc6d6603df3c4fc8e1b58e2cf701679665668a36e35d40" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/openmc/meta.yaml
+++ b/recipes/openmc/meta.yaml
@@ -27,13 +27,16 @@ requirements:
     - libgfortran
     - hdf5 1.8.17|1.8.17.*
     - git
+    - mpich
   run:
+    - mpich
     - libgfortran
     - hdf5 1.8.17|1.8.17.*
 
 test:
   commands:
     - test -f "${PREFIX}/bin/openmc"
+    - openmc --version
 
 about:
   home: http://mit-crpg.github.io/openmc/index.html

--- a/recipes/openmc/meta.yaml
+++ b/recipes/openmc/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - libgcc
     - libgfortran
     - hdf5 1.8.17|1.8.17.*
+    - git
   run:
     - libgfortran
     - hdf5 1.8.17|1.8.17.*

--- a/recipes/openmc/meta.yaml
+++ b/recipes/openmc/meta.yaml
@@ -23,8 +23,6 @@ requirements:
     - cmake
     - pkg-config
     - gcc
-    - libgcc
-    - libgfortran
     - hdf5 1.8.17|1.8.17.*
     - git
     - mpich


### PR DESCRIPTION
This provides an OpenMC package for conda. It does not include neutron cross sections (order 2 - 8 GBs) and therefore cannot run a comprehensive test suite, so simpler tests have been implemented instead.