### PR TITLE
Require OS X 10.9/XCode 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: generic
 
 os: osx
+osx_image: xcode6.1
 
 sudo: false
 


### PR DESCRIPTION
@conda-forge/core, this is **urgent**!

This sets the base Travis CI image so it requires OS X 10.9/XCode 6.1 explicitly as the Travis CI default changed appears to have changed to OS X 10.11/XCode 7.3. Please see [build]( https://travis-ci.org/conda-forge/staged-recipes/builds/164921320#L4 ), which appears to be the last build on `master` using OS X 10.9/XCode 6.1. Note that the next [build]( https://travis-ci.org/conda-forge/staged-recipes/builds/165091878#L4 ) and every subsequent build now appears to be using OS X 10.11/XCode 7.3 by default.

Edit: Proposed similar change to `conda-smithy` in PR ( https://github.com/conda-forge/conda-smithy/pull/325 ). We should merge that and release it after verifying this works and have merged it.

xref: https://github.com/travis-ci/travis-ci/issues/6522
xref: https://github.com/travis-ci/travis-ci/issues/6677