### PR TITLE
Add npctypes

### DIFF
--- a/recipes/npctypes/meta.yaml
+++ b/recipes/npctypes/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "npctypes" %}
+{% set version = "0.0.1" %}
+{% set sha256 = "d725491c0e37d809015bf385f9ebe4a67b72cbcce82b8f65d88927a041401462" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - npctypes
+
+about:
+  home: https://github.com/jakirkham/npctypes
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: Python utility functions for slices.
+  doc_url: https://npctypes.readthedocs.io/
+  dev_url: https://github.com/jakirkham/npctypes
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a utility library for working with NumPy and C Types. In particular, provides for a shared memory N-D Array type that can cross process boundaries. A context manager is provided to work with this type as an ordinary NumPy array.