### PR TITLE
Add JPype recipe

### DIFF
--- a/recipes/jpype/meta.yaml
+++ b/recipes/jpype/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "0.6.1" %}
+
+package:
+  name: jpype
+  version: {{ version }}
+
+source:
+  fn: jpype-{{ version }}.tar.gz
+  url: https://github.com/originell/jpype/archive/v{{ version }}.tar.gz
+  sha256: f7e81ef2e722a26929d329d2a15e2638f5b28f15a30d1dff1c88e6c3d38a85d8
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+  run:
+    - python
+    - numpy x.x
+
+test:
+  imports:
+    - jpype
+
+about:
+  home: https://github.com/originell/jpype/
+  license: Apache 2.0
+  license_file: LICENSE
+  summary: 'A Python to Java bridge.'
+  description: 'A Python to Java bridge.'
+  doc_url: http://jpype.readthedocs.io/en/stable/
+
+extra:
+  recipe-maintainers:
+    - caspervdw
+    - marscher

--- a/recipes/jpype1/meta.yaml
+++ b/recipes/jpype1/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.6.1" %}
 
 package:
-  name: jpype
+  name: jpype1
   version: {{ version }}
 
 source:


### PR DESCRIPTION
cc @marscher There might be issues with the Py3.5 build (VS2014).
Am I right that we need to distribute the builds for each numpy version seperately?