### PR TITLE
Add build recipe for Arrow HEAD commit, 0.1 pre-release

### DIFF
--- a/recipes/arrow-cpp/build.sh
+++ b/recipes/arrow-cpp/build.sh
@@ -7,17 +7,6 @@ set -x
 export FLATBUFFERS_HOME=$PREFIX
 
 cd cpp
-
-# TODO(wesm): Disabled unit tests in conda-forge for now
-
-# Build googletest for running unit tests
-
-# ./thirdparty/download_thirdparty.sh
-# ./thirdparty/build_thirdparty.sh gtest
-
-# source thirdparty/versions.sh
-# export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
-
 mkdir build-dir
 cd build-dir
 
@@ -29,6 +18,5 @@ cmake \
     -DARROW_HDFS=on \
     ..
 
-make -j4
-# ctest -VV -L unittest
+make -j${CPU_COUNT}
 make install

--- a/recipes/arrow-cpp/build.sh
+++ b/recipes/arrow-cpp/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Build dependencies
+export FLATBUFFERS_HOME=$PREFIX
+
+cd cpp
+
+# Build googletest for running unit tests
+
+./thirdparty/download_thirdparty.sh
+./thirdparty/build_thirdparty.sh gtest
+
+source thirdparty/versions.sh
+export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
+
+mkdir build-dir
+cd build-dir
+
+cmake \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DARROW_BUILD_BENCHMARKS=off \
+    -DARROW_HDFS=on \
+    ..
+
+make -j4
+ctest -VV -L unittest
+make install

--- a/recipes/arrow-cpp/build.sh
+++ b/recipes/arrow-cpp/build.sh
@@ -8,13 +8,15 @@ export FLATBUFFERS_HOME=$PREFIX
 
 cd cpp
 
+# TODO(wesm): Disabled unit tests in conda-forge for now
+
 # Build googletest for running unit tests
 
-./thirdparty/download_thirdparty.sh
-./thirdparty/build_thirdparty.sh gtest
+# ./thirdparty/download_thirdparty.sh
+# ./thirdparty/build_thirdparty.sh gtest
 
-source thirdparty/versions.sh
-export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
+# source thirdparty/versions.sh
+# export GTEST_HOME=`pwd`/thirdparty/$GTEST_BASEDIR
 
 mkdir build-dir
 cd build-dir
@@ -23,9 +25,10 @@ cmake \
     -DCMAKE_BUILD_TYPE=release \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DARROW_BUILD_BENCHMARKS=off \
+    -DARROW_BUILD_TESTS=off \
     -DARROW_HDFS=on \
     ..
 
 make -j4
-ctest -VV -L unittest
+# ctest -VV -L unittest
 make install

--- a/recipes/arrow-cpp/meta.yaml
+++ b/recipes/arrow-cpp/meta.yaml
@@ -19,8 +19,6 @@ requirements:
     - boost
     - flatbuffers
     - cmake
-    - curl
-    - perl
 
 test:
   commands:

--- a/recipes/arrow-cpp/meta.yaml
+++ b/recipes/arrow-cpp/meta.yaml
@@ -1,13 +1,15 @@
 {% set version = "0.1.pre" %}
-{% set git_sha = "f1a4bd176bc2139ba785522200d7630408328911" %}
+{% set commit = "f1a4bd176bc2139ba785522200d7630408328911" %}
 
 package:
   name: arrow-cpp
   version: {{ version }}
 
+
 source:
-  git_url: https://github.com/apache/arrow.git
-  git_rev: {{ git_sha }}
+  fn: {{ commit }}.tar.gz
+  url: https://github.com/apache/arrow/archive/{{ commit }}.tar.gz
+  sha256: e8327f2c95822d0cfbace183a6419d9cf987daeddb62242eaead463e9072131d
 
 build:
   number: 0

--- a/recipes/arrow-cpp/meta.yaml
+++ b/recipes/arrow-cpp/meta.yaml
@@ -11,9 +11,6 @@ source:
 
 build:
   number: 0
-  script_env:
-    - CC [linux]
-    - CXX [linux]
   skip: true  # [win]
 
 requirements:

--- a/recipes/arrow-cpp/meta.yaml
+++ b/recipes/arrow-cpp/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.1.pre" %}
+{% set git_sha = "f1a4bd176bc2139ba785522200d7630408328911" %}
+
+package:
+  name: arrow-cpp
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/apache/arrow.git
+  git_rev: {{ git_sha }}
+
+build:
+  number: 0
+  script_env:
+    - CC [linux]
+    - CXX [linux]
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - boost
+    - flatbuffers
+    - cmake
+    - curl
+    - perl
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libarrow.so  # [linux]
+    - test -f $PREFIX/lib/libarrow.dylib  # [osx]
+
+about:
+  home: http://github.com/apache/arrow
+  license: Apache 2.0
+  summary: 'C++ libraries for Apache Arrow'
+
+extra:
+  recipe-maintainers:
+    - wesm
+    - xhochy


### PR DESCRIPTION
We've inverted the dependency relationship between Arrow and Parquet, so I'll update the parquet-cpp recipe, and this will need to become feedstock before parquet-cpp can