### PR TITLE
Non-meta Chemfiles recipes

### DIFF
--- a/recipes/chemfiles-lib/get-tests-data.cmake
+++ b/recipes/chemfiles-lib/get-tests-data.cmake
@@ -1,0 +1,24 @@
+# Cmake script to download and unpack test data files for chemfiles
+#
+# The tests files are ususlly updated using a git submodule, but git is not
+# available, so this script download and unpack the archive.
+#
+# This is written as a cmake script to be cross-platform
+
+set(COMMIT c07bdfb010a6a4a0c5940bb9db6348e963dda43d)
+
+file(DOWNLOAD
+    https://github.com/chemfiles/tests-data/archive/${COMMIT}.tar.gz
+    ./tests-data-${COMMIT}.tar.gz
+    EXPECTED_MD5 "2ef24f94fe5e6d7514803edea02b177d"
+)
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xzf tests-data-${COMMIT}.tar.gz
+    WORKING_DIRECTORY ${SRC_DIR}
+)
+
+file(GLOB DATA_DIRS RELATIVE ${SRC_DIR}/tests-data-${COMMIT} tests-data-${COMMIT}/*)
+foreach(path ${DATA_DIRS})
+    file(RENAME tests-data-${COMMIT}/${path} ${SRC_DIR}/tests/data/${path})
+endforeach()

--- a/recipes/chemfiles-lib/meta.yaml
+++ b/recipes/chemfiles-lib/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.6.2" %}
+{% set sha256 = "7dc508282e429f2b1efa38287d1f420f64c34fd4e40a57b7d6e2bc6964379d6e" %}
+
+package:
+  name: chemfiles-lib
+  version: {{ version }}
+
+source:
+  fn: chemfiles-{{ version }}.tar.gz
+  url: https://github.com/chemfiles/chemfiles/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  skip: true  # [win]
+  number: 0
+  script:
+    - cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX -DENABLE_NETCDF=ON .
+    - cmake --build . --config release --target install
+    - cmake -DBUILD_SHARED_LIBS=ON .
+    - cmake --build . --config release --target install
+    # run the tests
+    - cmake -DSRC_DIR=$SRC_DIR -P $RECIPE_DIR/get-tests-data.cmake
+    - cmake -DBUILD_TESTS=ON .
+    - cmake --build . --config release
+    - ctest --output-on-failure
+
+requirements:
+  build:
+    - cmake
+    - libnetcdf 4.4.*
+    - toolchain
+  run:
+    - libnetcdf 4.4.*
+
+test:
+  commands:
+    - true  # this was already done during the build
+
+about:
+  home: http://chemfiles.github.io
+  license: MPL-v2.0
+  license_file: LICENCE.txt
+  summary: Modern library for chemistry file reading and writing
+  doc_url: http://chemfiles.github.io/chemfiles/latest/
+  dev_url: https://github.com/chemfiles/chemfiles
+
+extra:
+  recipe-maintainers:
+    - luthaf

--- a/recipes/chemfiles-python/find_library.patch
+++ b/recipes/chemfiles-python/find_library.patch
@@ -1,0 +1,31 @@
+--- chemfiles/find_chemfiles.py
++++ chemfiles/find_chemfiles.py
+@@ -1,7 +1,7 @@
+ # -* coding: utf-8 -*
+ import os
++import sys
+ from ctypes import cdll
+-from ctypes.util import find_library
+
+ from chemfiles import ffi
+
+@@ -10,10 +10,15 @@ ROOT = os.path.dirname(__file__)
+
+ def load_clib():
+     '''Load chemfiles C++ library'''
+-    libpath = find_library("chemfiles")
+-    if not libpath:
+-        # Rely on the library built by the setup.py function
+-        libpath = os.path.join(ROOT, "_chemfiles.so")
++    if os.name == 'nt':
++        libpath = os.path.join(sys.prefix, "Library", "bin", "chemfiles.dll")
++    elif os.name == 'posix':
++        platform = os.uname()[0]
++        if platform == 'Linux':
++            libname = 'libchemfiles.so'
++        else:
++            libname = 'libchemfiles.dylib'
++        libpath = os.path.join(sys.prefix, 'lib', libname)
+     try:
+         return cdll.LoadLibrary(libpath)
+     except OSError:

--- a/recipes/chemfiles-python/meta.yaml
+++ b/recipes/chemfiles-python/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.6.0" %}
+{% set sha256 = "913a9ca911287e342918458619c29dfd094f4b25f7d6866048b9968fc63be207" %}
+
+package:
+  name: chemfiles-python
+  version: {{ version }}
+
+source:
+  fn: chemfiles.py-{{ version }}.tar.gz
+  url: https://github.com/chemfiles/chemfiles.py/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+      - find_library.patch
+
+build:
+  skip: true  # [win]
+  number: 0
+  script:
+      - python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - enum34  # [py<34]
+    - numpy
+    - chemfiles-lib ==0.6.2
+  run:
+    - python
+    - enum34  # [py<34]
+    - numpy
+    - chemfiles-lib ==0.6.2
+
+test:
+  commands:
+    - cd $SRC_DIR/tests
+    - python -m unittest discover
+
+about:
+  home: http://chemfiles.github.io
+  license: MPL-v2.0
+  license_file: LICENCE.txt
+  summary: Python binding to chemfiles, a modern library for chemistry file reading and writing
+  doc_url: http://chemfiles.github.io/chemfiles.py/latest/
+  dev_url: https://github.com/chemfiles/chemfiles.py
+
+extra:
+  recipe-maintainers:
+    - luthaf


### PR DESCRIPTION
These are the non-meta recipes from #1571. The python recipe still depends on the C++ recipe to build.