### PR TITLE
Add ftputil recipe

### DIFF
--- a/recipes/ftputil/meta.yaml
+++ b/recipes/ftputil/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "ftputil" %}
+{% set version = "3.3.1" %}
+{% set md5 = "464c5c9ccabceff4fd20346bf801e5d3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  script: python setup.py install --record record.txt
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - ftputil
+  commands:
+    - python -c 'from ftputil import FTPHost'
+
+about:
+  home: http://ftputil.sschwarzer.net/
+  license: BSD 3-Clause
+  summary: 'High-level FTP client library (virtual file system and more)'
+
+  description: |
+    ftputil is a high-level FTP client library for the Python programming
+    language. ftputil implements a virtual file system for accessing FTP
+    servers, that is, it can generate file-like objects for remote files.
+    The library supports many functions similar to those in the os, os.path
+    and shutil modules. ftputil has convenience functions for conditional
+    uploads and downloads, and handles FTP clients and servers in different
+    timezones.
+  doc_url: http://ftputil.sschwarzer.net/trac/wiki/Documentation
+
+extra:
+  recipe-maintainers:
+    - edisongustavo

--- a/recipes/ftputil/meta.yaml
+++ b/recipes/ftputil/meta.yaml
@@ -25,7 +25,7 @@ test:
   imports:
     - ftputil
   commands:
-    - python -c 'from ftputil import FTPHost'
+    - python -c "from ftputil import FTPHost"
 
 about:
   home: http://ftputil.sschwarzer.net/


### PR DESCRIPTION
I know the recipe doesn't declare a `license_file`, that's because the file does not exist on the source code.

The references for license I found were:
- at the PyPI (`setup.py`) which says:
-- License: Open source (revised BSD license)
-- License :: OSI Approved :: BSD License
- at the file `doc/README.txt`
-- It says: "ftputil is open source software. It is distributed under the new/modified/revised BSD license (see http://opensource.org/licenses/BSD-3-Clause ).

So I'm assuming it's a BSD License. I don't know if it's a 2-clause, or 3-clause though.