### PR TITLE
Added recipe for Ghost.py

### DIFF
--- a/recipes/ghost.py/meta.yaml
+++ b/recipes/ghost.py/meta.yaml
@@ -40,7 +40,7 @@ about:
   home: https://github.com/jeanphix/Ghost.py
   license: MIT
   # license_file: No LICENSE in MANIFEST.in - see https://github.com/jeanphix/Ghost.py/issues/311
-  licnse_family: MIT
+  license_family: MIT
   summary: 'Webkit based webclient.'
   dev_url: https://github.com/jeanphix/Ghost.py
   doc_url: https://ghost-py.readthedocs.io/en/latest/

--- a/recipes/ghost.py/meta.yaml
+++ b/recipes/ghost.py/meta.yaml
@@ -1,0 +1,50 @@
+{%set name = "Ghost.py" %}
+{%set version = "0.2.3" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "efd1a2b027fd803cf615570b1520a07dc80cc13fc656646221428d86a653310a" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - ghost
+    - ghost.ext
+    - ghost.ext.django
+    - tests
+    - tests.ghost
+    - tests.ghost.ext
+    - tests.ghost.ext.django
+
+about:
+  home: https://github.com/jeanphix/Ghost.py
+  license: MIT
+  # license_file: No LICENSE in MANIFEST.in - see 
+  licnse_family: MIT
+  summary: 'Webkit based webclient.'
+  dev_url: https://github.com/jeanphix/Ghost.py
+  doc_url: https://ghost-py.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/ghost.py/meta.yaml
+++ b/recipes/ghost.py/meta.yaml
@@ -39,7 +39,7 @@ test:
 about:
   home: https://github.com/jeanphix/Ghost.py
   license: MIT
-  # license_file: No LICENSE in MANIFEST.in - see 
+  # license_file: No LICENSE in MANIFEST.in - see https://github.com/jeanphix/Ghost.py/issues/311
   licnse_family: MIT
   summary: 'Webkit based webclient.'
   dev_url: https://github.com/jeanphix/Ghost.py


### PR DESCRIPTION
The install requires `PySide` and some other material to be pre-installed. I'm (naively?) assuming that the conda build of `PySide` will solve this.