### PR TITLE
Add ocw recipe

### DIFF
--- a/recipes/ocw/meta.yaml
+++ b/recipes/ocw/meta.yaml
@@ -30,10 +30,9 @@ requirements:
     - bottle
     - pydap
     - python-dateutil
-    - mock
     - myproxyclient
-    - webtest
     - esgf-pyclient
+    # Will need this later for the 1.2.0 release, leaving commended for now
     # - podaacpy >= 1.4.0
 
 test:
@@ -45,6 +44,8 @@ test:
 about:
   home: http://climate.apache.org/
   license: Apache 2.0
+  # Commented out for now as it will not be included until the 1.2.0 release.
+  # xref: apache/climate@deabaa9
   # license_file: LICENSE.txt
   license_family: Apache
   summary: 'A library for simplifying the process of climate model evaluation.'

--- a/recipes/ocw/meta.yaml
+++ b/recipes/ocw/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py3k]
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 

--- a/recipes/ocw/meta.yaml
+++ b/recipes/ocw/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "ocw" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "8f12405ec02ea327b1e0cf65547e409232f67577be6eb348d2ea9011827e2c4a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - basemap
+    - netcdf4
+    - h5py
+    - bottle
+    - pydap
+    - python-dateutil
+    - mock
+    - myproxyclient
+    - webtest
+    - esgf-pyclient
+    # - podaacpy >= 1.4.0
+
+test:
+  imports:
+    - ocw
+    - ocw.data_source
+    - ocw.esgf
+
+about:
+  home: http://climate.apache.org/
+  license: Apache 2.0
+  # license_file: LICENSE.txt
+  license_family: Apache
+  summary: 'A library for simplifying the process of climate model evaluation.'
+  doc_url: http://cwiki.apache.org/confluence/display/CLIMATE
+  dev_url: https://github.com/apache/climate
+
+extra:
+  recipe-maintainers:
+    - agoodm
+    - jarifibrahim


### PR DESCRIPTION
Take since 2 of #1606. I have added `LICENCE.txt` to `MANIFEST.in` upstream, but it won't be in the source distribution until the 1.2.0 release so I left that section commented out. Same with the `podaacpy` dependency.