### PR TITLE
Add mocsy

### DIFF
--- a/recipes/mocsy/build.sh
+++ b/recipes/mocsy/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+make
+
+rm -rf $SP_DIR/numpy
+mkdir -p $SP_DIR/mocsy
+cp mocsy*.so $SP_DIR/mocsy

--- a/recipes/mocsy/meta.yaml
+++ b/recipes/mocsy/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [win or osx]
+  skip: True  # [win or osx or py2k]
 
 requirements:
   build:

--- a/recipes/mocsy/meta.yaml
+++ b/recipes/mocsy/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "2.3.2" %}
+
+package:
+  name: mocsy
+  version: {{ version }}
+
+source:
+  fn: mocsy-{{ version }}.tar.gz
+  url: https://github.com/jamesorr/mocsy/archive/v{{ version }}.tar.gz
+  sha256: acc8793071d36df62efdd2cd1beed7f76f69505eee1201d12d147a1a18a2b46d
+
+build:
+  number: 0
+  skip: True  # [win or osx]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+    - gcc  # [not win]
+  run:
+    - python
+    - numpy x.x
+    - libgcc  # [linux]
+
+test:
+  imports:
+    - mocsy
+
+about:
+  home: https://github.com/jamesorr/mocsy.git
+  license: MIT
+  summary: 'Routines to model ocean carbonate system thermodynamics.'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
@jamesorr and @emiliom I gave up trying to set `mocsy` up as a Python package and surrendered to a hacky conda package that calls `make` and copy the library to the appropriated directory. I still believe we should write wrappers around `mocsy` to make it more user friendly and better `docstring` that Python users are used to, but those do no necessarily need to live in the `mocsy` repo and can be based on this package.