### PR TITLE
Added flask-marshmallow recipe

### DIFF
--- a/recipes/flask-marshmallow/meta.yaml
+++ b/recipes/flask-marshmallow/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "flask-marshmallow" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "83e2a3bb767a97db63c23a84345430cd3fda51615e7e99131a6b313295f6b7f0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - flask
+    - marshmallow >=1.2.0
+    - six >=1.9.0
+
+test:
+  imports:
+    - flask_marshmallow
+
+about:
+  home: https://github.com/marshmallow-code/flask-marshmallow
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Flask + marshmallow for beautiful APIs'
+
+  description: |
+    Flask-Marshmallow is a thin integration layer for Flask (a Python web
+    framework) and marshmallow (an object serialization/deserialization
+    library) that adds additional features to marshmallow, including URL and
+    Hyperlinks fields for HATEOAS-ready APIs. It also (optionally) integrates
+    with Flask-SQLAlchemy.
+  doc_url: http://flask-marshmallow.readthedocs.io/
+  dev_url: https://github.com/marshmallow-code/flask-marshmallow
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[Flask-Marshmallow](https://github.com/marshmallow-code/flask-marshmallow) is a thin integration layer for Flask (a Python web framework) and marshmallow (an object serialization/deserialization library) that adds additional features to marshmallow, including URL and Hyperlinks fields for HATEOAS-ready APIs. It also (optionally) integrates with Flask-SQLAlchemy.