### PR TITLE
Added apispec recipe

### DIFF
--- a/recipes/apispec/meta.yaml
+++ b/recipes/apispec/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "apispec" %}
+{% set version = "0.16.0" %}
+{% set sha256 = "ecd0fc3d97dfcd7f643304cd5cc9d9d0b0964cf3d10514f0818bbc3dbe41820d" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pyyaml >=3.10
+
+test:
+  imports:
+    - apispec
+
+about:
+  home: https://github.com/marshmallow-code/apispec
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A pluggable API specification generator'
+
+  description: |
+    A pluggable API specification generator. Currently supports the OpenAPI
+    specification (f.k.a. Swagger 2.0).
+  doc_url: http://apispec.readthedocs.io/
+  dev_url: https://github.com/marshmallow-code/apispec
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
A pluggable API specification generator. Currently supports the OpenAPI specification (f.k.a. Swagger 2.0).

https://github.com/marshmallow-code/apispec