### PR TITLE
Added flask-restplus recipe

### DIFF
--- a/recipes/flask-restplus/meta.yaml
+++ b/recipes/flask-restplus/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "flask-restplus" %}
+{% set version = "0.9.2" %}
+{% set sha256 = "c4313097a673ef2cffabceb44b6fdd03132ee5e7ab34d0289c37af12a3d11186" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - flask >=0.8
+    - six >=1.3.0
+    - jsonschema
+    - pytz
+    - aniso8601 >=0.82
+ 
+test:
+  imports:
+    - flask_restplus
+
+about:
+  home: https://github.com/noirbizarre/flask-restplus
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Fully featured framework for fast, easy and documented API development with Flask'
+
+  description: |
+    Flask-RESTPlus is an extension for Flask that adds support for quickly
+    building REST APIs. Flask-RESTPlus encourages best practices with minimal
+    setup. If you are familiar with Flask, Flask-RESTPlus should be easy to
+    pick up. It provides a coherent collection of decorators and tools to
+    describe your API and expose its documentation properly using Swagger.
+  doc_url: http://flask-restplus.readthedocs.org/
+  dev_url: https://github.com/noirbizarre/flask-restplus
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
[Flask-RESTPlus](http://flask-restplus.readthedocs.org/) is an extension for Flask that adds support for quickly building REST APIs. Flask-RESTPlus encourages best practices with minimal setup. If you are familiar with Flask, Flask-RESTPlus should be easy to pick up. It provides a coherent collection of decorators and tools to describe your API and expose its documentation properly using Swagger.