### PR TITLE
slepc, slepc4py

### DIFF
--- a/recipes/slepc/build.sh
+++ b/recipes/slepc/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export PETSC_DIR=$PREFIX
+export SLEPC_DIR=$SRC_DIR
+export SLEPC_ARCH=installed-arch-conda-c-opt
+
+python2 ./configure \
+  --prefix=$PREFIX
+
+sedinplace() { [[ $(uname) == Darwin ]] && sed -i "" $@ || sed -i"" $@; }
+sedinplace s%$SLEPC_DIR%\${SLEPC_DIR}%g $SLEPC_ARCH/include/slepc*.h
+sedinplace s%$PETSC_DIR%\${PETSC_DIR}%g $SLEPC_ARCH/include/slepc*.h
+
+make
+make install
+
+rm -fr $PREFIX/bin
+rm -fr $PREFIX/share
+rm -fr $PREFIX/lib/lib$PKG_NAME.*.dylib.dSYM
+rm -f  $PREFIX/lib/$PKG_NAME/conf/files
+rm -f  $PREFIX/lib/$PKG_NAME/conf/*.py
+rm -f  $PREFIX/lib/$PKG_NAME/conf/*.log
+rm -f  $PREFIX/lib/$PKG_NAME/conf/RDict.db
+rm -f  $PREFIX/lib/$PKG_NAME/conf/*BuildInternal.cmake
+find   $PREFIX/include -name '*.html' -delete

--- a/recipes/slepc/meta.yaml
+++ b/recipes/slepc/meta.yaml
@@ -1,0 +1,47 @@
+{% set build = 0 %}
+{% set version = '3.7.1' %}
+{% set sha256 = '670216f263e3074b21e0623c01bc0f562fdc0bffcd7bd42dd5d8edbe73a532c2' %}
+{% set mpi = os.environ.get('MPI') or 'mpich' %}
+
+package:
+  name: slepc
+  version: {{version}}
+
+source:
+  fn:  slepc-{{version}}.tar.gz
+  url: http://slepc.upv.es/download/distrib/slepc-{{version}}.tar.gz
+  sha256: {{sha256}}
+  patches:
+    - slepc.patch  # [osx]
+
+build:
+  number: {{build}}
+  binary_relocation: true
+  detect_binary_files_with_prefix: true
+  skip: true  # [win]
+
+requirements:
+  build:
+    - python 2.*
+    - {{mpi}}
+    - petsc {{version[:3]}}*
+  run:
+    - {{mpi}}
+    - petsc {{version[:3]}}*
+
+test:
+  requires:
+    - pkg-config
+  commands:
+    - PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig pkg-config --cflags SLEPc
+
+about:
+  home: http://slepc.upv.es/
+  summary: 'SLEPc: Scalable Library for Eigenvalue Problem Computations'
+  license: LGPL 3
+  license_file: COPYING.LESSER
+
+extra:
+  recipe-maintainers:
+    - dalcinl
+    - minrk

--- a/recipes/slepc/meta.yaml
+++ b/recipes/slepc/meta.yaml
@@ -1,6 +1,9 @@
 {% set build = 0 %}
 {% set version = '3.7.1' %}
 {% set sha256 = '670216f263e3074b21e0623c01bc0f562fdc0bffcd7bd42dd5d8edbe73a532c2' %}
+# TODO:
+# wait for decision on mpi metapackage, then we can set values for supported mpi
+# implementations in conda-forge.yml
 {% set mpi = os.environ.get('MPI') or 'mpich' %}
 
 package:

--- a/recipes/slepc/slepc.patch
+++ b/recipes/slepc/slepc.patch
@@ -1,0 +1,19 @@
+--- config/install.py
++++ config/install.py
+@@ -25,6 +25,7 @@ class Installer:
+ 
+   def setupDirectories(self):
+     self.installDir        = self.destDir
++    self.archDir           = os.path.join(self.rootDir, self.arch)
+     self.rootIncludeDir    = os.path.join(self.rootDir, 'include')
+     self.archIncludeDir    = os.path.join(self.rootDir, self.arch, 'include')
+     self.rootConfDir       = os.path.join(self.rootDir, 'lib','slepc','conf')
+@@ -220,7 +221,7 @@ for dir in dirs:
+     if os.path.splitext(dst)[1] == '.dylib' and os.path.isfile('/usr/bin/install_name_tool'):
+       (result, output) = commands.getstatusoutput('otool -D '+src)
+       oldname = output[output.find("\n")+1:]
+-      installName = oldname.replace(self.destDir, self.installDir)
++      installName = oldname.replace(self.archDir, self.installDir)
+       (result, output) = commands.getstatusoutput('/usr/bin/install_name_tool -id ' + installName + ' ' + dst)
+     # preserve the original timestamps - so that the .a vs .so time order is preserved
+     shutil.copystat(src,dst)

--- a/recipes/slepc4py/meta.yaml
+++ b/recipes/slepc4py/meta.yaml
@@ -1,0 +1,49 @@
+{% set build = 0 %}
+{% set version = '3.7.0' %}
+{% set sha256 = '5836334ec62f007b0e527c3d63577a43fee3c870c80df23256c55521ad6f4cc6' %}
+{% set mpi = os.environ.get('MPI') or 'mpich' %}
+
+package:
+  name: slepc4py
+  version: {{version}}
+
+source:
+  fn: slepc4py-{{version}}.tar.gz
+  url: https://bitbucket.org/slepc/slepc4py/downloads/slepc4py-{{version}}.tar.gz
+  sha256: {{sha256}}
+
+build:
+  number: {{build}}
+  script: $PYTHON setup.py build --petsc-dir=$PREFIX --slepc-dir=$PREFIX install
+  skip: true  # [win]
+
+requirements:
+  build:
+    - python
+    - numpy
+    - {{mpi}}
+    - petsc {{version[:3]}}*
+    - slepc {{version[:3]}}*
+    - petsc4py {{version[:3]}}*
+  run:
+    - python
+    - numpy
+    - {{mpi}}
+    - petsc {{version[:3]}}*
+    - slepc {{version[:3]}}*
+    - petsc4py {{version[:3]}}*
+
+test:
+  imports:
+    - slepc4py
+    - slepc4py.SLEPc
+
+about:
+  home: https://bitbucket.org/slepc/slepc4py
+  summary: Python bindings for SLEPc
+  license: BSD 2-Clause
+
+extra:
+  recipe-maintainers:
+    - dalcinl
+    - minrk

--- a/recipes/slepc4py/meta.yaml
+++ b/recipes/slepc4py/meta.yaml
@@ -14,12 +14,13 @@ source:
 
 build:
   number: {{build}}
-  script: $PYTHON setup.py build --petsc-dir=$PREFIX --slepc-dir=$PREFIX install
+  script: PETSC_DIR=$PREFIX SLEPC_DIR=$PREFIX pip install --no-deps .
   skip: true  # [win]
 
 requirements:
   build:
     - python
+    - pip
     - numpy
     - {{mpi}}
     - petsc {{version[:3]}}*


### PR DESCRIPTION
follow-up now that PETSc is up

sourced from https://bitbucket.org/petsc/conda-recipes/

changes from original:

- remove MPI feature for now (only use mpich, pending MPI metapackage)
- reorder sections according to recipe lint
- remove replace-binary.py now that conda-build should do this correctly

cc @dalcinl I added you as a maintainer like on PETSc, let me know if that's okay.