### PR TITLE
clang 3.9.0: Add recipe for clang for OS X

### DIFF
--- a/recipes/clang/meta.yaml
+++ b/recipes/clang/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "clang" %}
+{% set version = "3.9.0" %}
+{% set sha256 = "bd689aaeafa19832016d5a4917405a73b21bc5281846c0cb816e9545cf99e82b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://llvm.org/releases/3.9.0/{{ name }}+llvm-{{ version }}-x86_64-apple-darwin.tar.xz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not linux]
+  script:
+    cp -r * "$PREFIX"
+
+test:
+  commands:
+    - clang --version
+    - clang++ --version
+
+about:
+  home: http://clang.llvm.org/index.html
+  license: NCSA, MIT
+  license_file: include/llvm/Support/LICENSE.txt
+  summary: 'a C language family frontend for LLVM'
+
+  description: |
+    The goal of the Clang project is to create a new C, C++, Objective C
+    and Objective C++ front-end for the LLVM compiler.
+  doc_url: http://clang.llvm.org/docs/UsersManual.html
+  dev_url: http://clang.llvm.org/index.html
+
+extra:
+  recipe-maintainers:
+    - yesimon


### PR DESCRIPTION
I'm not quite familiar with the conda-feedstock process or how to test this locally. The docs don't seem to say anything about it.