### PR TITLE
Adding xtensor recipe

### DIFF
--- a/recipes/xtensor/bld.bat
+++ b/recipes/xtensor/bld.bat
@@ -1,0 +1,2 @@
+REM Copy headers
+xcopy /S %SRC_DIR%\include %LIBRARY_INC%

--- a/recipes/xtensor/build.sh
+++ b/recipes/xtensor/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cp -r $SRC_DIR/include/ $PREFIX/include/

--- a/recipes/xtensor/meta.yaml
+++ b/recipes/xtensor/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "xtensor" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "025709893b89229f7723fd5c36faaaf8155c2d6558d63c2c51e9de1904f01c42" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+    fn: {{ name }}-{{ version }}.tar.gz
+    url: https://github.com/QuantStack/xtensor/archive/{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+test:
+  requires:
+    - gtest
+    - cmake
+
+  commands:
+    - test -d ${PREFIX}/include/xtensor  # [unix]
+    - test -f ${PREFIX}/include/xtensor/xarray.hpp  # [unix]
+    - if exist %LIBRARY_INC%\xtensor\xarray.hpp (exit 0) else (exit 1)  # [win]
+
+about:
+  home: http://quantstack.net/xtensor
+  license: BSD
+  license_file: LICENSE
+  summary: 'The C++ tensor algebra library'
+  description: 'Multi dimensional arrays with broadcasting and lazy computing'
+  doc_url: http://xtensor.readthedocs.io
+  dev_url: https://github.com/QuantStack/xtensor
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - jmabille

--- a/recipes/xtensor/run_test.bat
+++ b/recipes/xtensor/run_test.bat
@@ -1,0 +1,6 @@
+cd %SRC_DIR%\test
+conda env create -f .\test-environment.yml
+activate test-xtensor
+cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release .
+nmake
+.\test_xtensor

--- a/recipes/xtensor/run_test.sh
+++ b/recipes/xtensor/run_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+#cd $SRC_DIR/test
+#conda env create -f ./test-environment.yml
+#source activate test-xtensor
+#cmake .
+#make -j2
+#./test_xtensor


### PR DESCRIPTION
`xtensor` is a header-only library.

The tests are based on gtest. 

I skip them on unix since we need a `C++14` compiler.

 - The OS X build of the tests requires the xcode >= 6.4 image. The image has xcode 6.1.
 - The Linux build of the tests requires gcc >= 4.9. The docker image has gcc 4.8.

However, this formulation of the tests works on my local tests for windows and linux, so I keep it in commented out.