### PR TITLE
Boost recipe without python bindings for osx and linux

### DIFF
--- a/recipes/boost-cpp/bld.bat
+++ b/recipes/boost-cpp/bld.bat
@@ -12,7 +12,6 @@ if errorlevel 1 exit 1
     threading=multi ^
     link=static,shared ^
     --without-python
-    -j%CPU_COUNT%
 if errorlevel 1 exit 1
 
 :: Get the major minor version info (e.g. `1_61`)

--- a/recipes/boost-cpp/bld.bat
+++ b/recipes/boost-cpp/bld.bat
@@ -1,19 +1,3 @@
-:: Set the right msvc version according to Python version
-REM write a temporary batch file to map cl.exe version to visual studio version
-echo @echo 15=9 > msvc_versions.bat
-echo @echo 16=10 >> msvc_versions.bat
-echo @echo 17=11 >> msvc_versions.bat
-echo @echo 18=12 >> msvc_versions.bat
-echo @echo 19=14 >> msvc_versions.bat
-
-REM Run cl.exe to find which version our compiler is
-for /f "delims=" %%A in ('cl /? 2^>^&1 ^| findstr /C:"Version"') do set "CL_TEXT=%%A"
-FOR /F "tokens=1,2 delims==" %%i IN ('msvc_versions.bat') DO echo %CL_TEXT% | findstr /C:"Version %%i" > nul && set VSTRING=%%j && goto FOUND
-EXIT 1
-:FOUND
-
-call :TRIM VSTRING %VSTRING%
-
 :: Start with bootstrap
 call bootstrap.bat
 if errorlevel 1 exit 1
@@ -22,7 +6,7 @@ if errorlevel 1 exit 1
 .\b2 install ^
     --build-dir=buildboost ^
     --prefix=%LIBRARY_PREFIX% ^
-    toolset=msvc-%VSTRING%.0 ^
+    toolset=msvc-%VS_MAJOR%.0 ^
     address-model=%ARCH% ^
     variant=release ^
     threading=multi ^
@@ -40,12 +24,5 @@ move %LIBRARY_INC%\boost-%MAJ_MIN_VER%\boost %LIBRARY_INC%
 if errorlevel 1 exit 1
 
 :: Move dll's to LIBRARY_BIN
-move %LIBRARY_LIB%\*vc%VSTRING%0-mt-%MAJ_MIN_VER%.dll "%LIBRARY_BIN%"
+move %LIBRARY_LIB%\*vc%VS_MAJOR%0-mt-%MAJ_MIN_VER%.dll "%LIBRARY_BIN%"
 if errorlevel 1 exit 1
-
-
-:TRIM
-  SetLocal EnableDelayedExpansion
-  set Params=%*
-  for /f "tokens=1*" %%a in ("!Params!") do EndLocal & set %1=%%b
-  exit /B

--- a/recipes/boost-cpp/bld.bat
+++ b/recipes/boost-cpp/bld.bat
@@ -27,6 +27,7 @@ if errorlevel 1 exit 1
     variant=release ^
     threading=multi ^
     link=static,shared ^
+    --without-python
     -j%CPU_COUNT%
 if errorlevel 1 exit 1
 

--- a/recipes/boost-cpp/bld.bat
+++ b/recipes/boost-cpp/bld.bat
@@ -11,6 +11,7 @@ if errorlevel 1 exit 1
     variant=release ^
     threading=multi ^
     link=static,shared ^
+    -j%CPU_COUNT% ^
     --without-python
 if errorlevel 1 exit 1
 

--- a/recipes/boost-cpp/bld.bat
+++ b/recipes/boost-cpp/bld.bat
@@ -1,0 +1,50 @@
+:: Set the right msvc version according to Python version
+REM write a temporary batch file to map cl.exe version to visual studio version
+echo @echo 15=9 > msvc_versions.bat
+echo @echo 16=10 >> msvc_versions.bat
+echo @echo 17=11 >> msvc_versions.bat
+echo @echo 18=12 >> msvc_versions.bat
+echo @echo 19=14 >> msvc_versions.bat
+
+REM Run cl.exe to find which version our compiler is
+for /f "delims=" %%A in ('cl /? 2^>^&1 ^| findstr /C:"Version"') do set "CL_TEXT=%%A"
+FOR /F "tokens=1,2 delims==" %%i IN ('msvc_versions.bat') DO echo %CL_TEXT% | findstr /C:"Version %%i" > nul && set VSTRING=%%j && goto FOUND
+EXIT 1
+:FOUND
+
+call :TRIM VSTRING %VSTRING%
+
+:: Start with bootstrap
+call bootstrap.bat
+if errorlevel 1 exit 1
+
+:: Build step
+.\b2 install ^
+    --build-dir=buildboost ^
+    --prefix=%LIBRARY_PREFIX% ^
+    toolset=msvc-%VSTRING%.0 ^
+    address-model=%ARCH% ^
+    variant=release ^
+    threading=multi ^
+    link=static,shared ^
+    -j%CPU_COUNT%
+if errorlevel 1 exit 1
+
+:: Get the major minor version info (e.g. `1_61`)
+python -c "import os; print('_'.join(os.environ['PKG_VERSION'].split('.')[:2]))" > temp.txt
+set /p MAJ_MIN_VER=<temp.txt
+
+:: Install fix-up for a non version-specific boost include
+move %LIBRARY_INC%\boost-%MAJ_MIN_VER%\boost %LIBRARY_INC%
+if errorlevel 1 exit 1
+
+:: Move dll's to LIBRARY_BIN
+move %LIBRARY_LIB%\*vc%VSTRING%0-mt-%MAJ_MIN_VER%.dll "%LIBRARY_BIN%"
+if errorlevel 1 exit 1
+
+
+:TRIM
+  SetLocal EnableDelayedExpansion
+  set Params=%*
+  for /f "tokens=1*" %%a in ("!Params!") do EndLocal & set %1=%%b
+  exit /B

--- a/recipes/boost-cpp/build.sh
+++ b/recipes/boost-cpp/build.sh
@@ -22,6 +22,8 @@ elif [ "$(uname)" == "Linux" ]; then
     TOOLSET=gcc
 fi
 
+LINKFLAGS="${LINKFLAGS} -L${LIBRARY_PATH}"
+
 ./bootstrap.sh \
     --prefix="${PREFIX}" \
     --without-libraries=python \

--- a/recipes/boost-cpp/build.sh
+++ b/recipes/boost-cpp/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Hints:
+# http://boost.2283326.n4.nabble.com/how-to-build-boost-with-bzip2-in-non-standard-location-td2661155.html
+# http://www.gentoo.org/proj/en/base/amd64/howtos/?part=1&chap=3
+# http://www.boost.org/doc/libs/1_55_0/doc/html/bbv2/reference.html
+
+# Hints for OSX:
+# http://stackoverflow.com/questions/20108407/how-do-i-compile-boost-for-os-x-64b-platforms-with-stdlibc
+
+set -x -e
+
+INCLUDE_PATH="${PREFIX}/include"
+LIBRARY_PATH="${PREFIX}/lib"
+
+# Always build PIC code for enable static linking into other shared libraries
+CXXFLAGS="${CXXFLAGS} -fPIC"
+
+if [ "$(uname)" == "Darwin" ]; then
+    MACOSX_VERSION_MIN=10.7
+    CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    LINKFLAGS="${LINKFLAGS} -stdlib=libc++ -std=c++11 -L${LIBRARY_PATH}"
+
+    ./bootstrap.sh \
+        --prefix="${PREFIX}" \
+        --without-libraries=python \
+        --with-icu="${PREFIX}" \
+        | tee bootstrap.log 2>&1
+
+    ./b2 -q \
+        variant=release \
+        address-model=64 \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        link=static,shared \
+        toolset=clang \
+        include="${INCLUDE_PATH}" \
+        cxxflags="${CXXFLAGS}" \
+        linkflags="${LINKFLAGS}" \
+        -j"$(sysctl -n hw.ncpu)" \
+        install | tee b2.log 2>&1
+fi
+
+if [ "$(uname)" == "Linux" ]; then
+    CXXFLAGS="${CXXFLAGS} -std=c++11"
+    LINKFLAGS="${LINKFLAGS} -std=c++11 -L${LIBRARY_PATH}"
+
+    ./bootstrap.sh \
+        --prefix="${PREFIX}" \
+        --without-libraries=python \
+        --with-icu="${PREFIX}" \
+        | tee bootstrap.log 2>&1
+
+    ./b2 -q \
+        variant=release \
+        address-model="${ARCH}" \
+        architecture=x86 \
+        debug-symbols=off \
+        threading=multi \
+        runtime-link=shared \
+        link=static,shared \
+        toolset=gcc \
+        include="${INCLUDE_PATH}" \
+        cxxflags="${CXXFLAGS}" \
+        linkflags="${LINKFLAGS}" \
+        --layout=system \
+        -j"${CPU_COUNT}" \
+        install | tee b2.log 2>&1
+fi

--- a/recipes/boost-cpp/build.sh
+++ b/recipes/boost-cpp/build.sh
@@ -17,7 +17,7 @@ LIBRARY_PATH="${PREFIX}/lib"
 CXXFLAGS="${CXXFLAGS} -fPIC"
 
 if [ "$(uname)" == "Darwin" ]; then
-    MACOSX_VERSION_MIN=10.7
+    MACOSX_VERSION_MIN=10.9
     CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
     CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
     LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"

--- a/recipes/boost-cpp/meta.yaml
+++ b/recipes/boost-cpp/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - icu 56.*          # [unix]
     - bzip2 1.0.*       # [unix]
     - zlib 1.2.*

--- a/recipes/boost-cpp/meta.yaml
+++ b/recipes/boost-cpp/meta.yaml
@@ -1,0 +1,103 @@
+{% set version = "1.62.0" %}
+{% set filename = "boost_%s.tar.bz2" % version.replace(".", "_") %}
+
+package:
+  name: boost-cpp
+  version: {{ version }}
+
+source:
+  fn:  {{ filename }}
+  url: http://sourceforge.net/projects/boost/files/boost/{{ version }}/{{ filename }}
+  sha256: 36c96b0f6155c98404091d8ceb48319a28279ca0333fba1ad8611eb90afb2ca0
+
+build:
+  number: 0
+  features:
+    - vc9               # [win and py27]
+    - vc10              # [win and py34]
+    - vc14              # [win and py35]
+
+requirements:
+  build:
+    - python                 # [win]
+    - icu 56.*               # [unix]
+    - bzip2 1.0.*            # [unix]
+    - zlib 1.2.*
+
+  run:
+    - python                 # [win]
+    - icu 56.*               # [unix]
+    - zlib 1.2.*
+
+test:
+  commands:
+    # Verify static-only libraries.
+    - test -f $PREFIX/lib/libboost_exception.a                   # [unix]
+    - test -f $PREFIX/lib/libboost_test_exec_monitor.a           # [unix]
+
+    # Verify libraries.
+    {% set win_vstr = "_".join(version.split(".")[:2]) %}
+    {% set boost_libs = [
+            "atomic",
+            "chrono",
+            "container",
+            "context",
+            "coroutine",
+            "date_time",
+            "filesystem",
+            "graph",
+            "iostreams",
+            "locale",
+            "log",
+            "log_setup",
+            "math_c99",
+            "math_c99f",
+            "math_c99l",
+            "math_tr1",
+            "math_tr1f",
+            "math_tr1l",
+            "prg_exec_monitor",
+            "program_options",
+            "random",
+            "regex",
+            "serialization",
+            "signals",
+            "system",
+            "thread",
+            "timer",
+            "type_erasure",
+            "unit_test_framework",
+            "wave",
+            "wserialization"
+    ] %}
+    {% for each_boost_lib in boost_libs %}
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.a                                                 # [unix]
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.dylib                                             # [osx]
+    - test -f $PREFIX/lib/libboost_{{ each_boost_lib }}.so                                                # [linux]
+    - if not exist %PREFIX%\\Library\\bin\\boost_{{ each_boost_lib }}-vc90-mt-{{ win_vstr }}.dll exit 1   # [win and py27]
+    - if not exist %PREFIX%\\Library\\bin\\boost_{{ each_boost_lib }}-vc100-mt-{{ win_vstr }}.dll exit 1  # [win and py34]
+    - if not exist %PREFIX%\\Library\\bin\\boost_{{ each_boost_lib }}-vc140-mt-{{ win_vstr }}.dll exit 1  # [win and py35]
+    - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc90-mt-{{ win_vstr }}.lib exit 1   # [win and py27]
+    - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc100-mt-{{ win_vstr }}.lib exit 1  # [win and py34]
+    - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc140-mt-{{ win_vstr }}.lib exit 1  # [win and py35]
+    {% endfor %}
+    - if not exist %PREFIX%\\Library\\bin\\boost_python-vc90-mt-{{ win_vstr }}.dll exit 1   # [win and py27]
+    - if not exist %PREFIX%\\Library\\bin\\boost_python-vc100-mt-{{ win_vstr }}.dll exit 1  # [win and py34]
+    - if not exist %PREFIX%\\Library\\bin\\boost_python-vc140-mt-{{ win_vstr }}.dll exit 1  # [win and py35]
+    - if not exist %PREFIX%\\Library\\lib\\boost_python-vc90-mt-{{ win_vstr }}.lib exit 1   # [win and py27]
+    - if not exist %PREFIX%\\Library\\lib\\boost_python-vc100-mt-{{ win_vstr }}.lib exit 1  # [win and py34]
+    - if not exist %PREFIX%\\Library\\lib\\boost_python-vc140-mt-{{ win_vstr }}.lib exit 1  # [win and py35]
+
+about:
+  home: http://www.boost.org/
+  license: Boost-1.0
+  summary: Free peer-reviewed portable C++ source libraries.
+
+extra:
+  recipe-maintainers:
+    - ccordoba12
+    - jakirkham
+    - msarahan
+    - ocefpaf
+    - jschueller
+    - isuruf

--- a/recipes/boost-cpp/meta.yaml
+++ b/recipes/boost-cpp/meta.yaml
@@ -19,15 +19,20 @@ build:
 
 requirements:
   build:
-    - python                 # [win]
-    - icu 56.*               # [unix]
-    - bzip2 1.0.*            # [unix]
+    - icu 56.*          # [unix]
+    - bzip2 1.0.*       # [unix]
     - zlib 1.2.*
+    - vc 9              # [win and py27]
+    - vc 10             # [win and py34]
+    - vc 14             # [win and py35]
 
   run:
-    - python                 # [win]
-    - icu 56.*               # [unix]
+    - icu 56.*          # [unix]
+    - bzip2 1.0.*       # [unix]
     - zlib 1.2.*
+    - vc 9              # [win and py27]
+    - vc 10             # [win and py34]
+    - vc 14             # [win and py35]
 
 test:
   commands:
@@ -81,12 +86,6 @@ test:
     - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc100-mt-{{ win_vstr }}.lib exit 1  # [win and py34]
     - if not exist %PREFIX%\\Library\\lib\\boost_{{ each_boost_lib }}-vc140-mt-{{ win_vstr }}.lib exit 1  # [win and py35]
     {% endfor %}
-    - if not exist %PREFIX%\\Library\\bin\\boost_python-vc90-mt-{{ win_vstr }}.dll exit 1   # [win and py27]
-    - if not exist %PREFIX%\\Library\\bin\\boost_python-vc100-mt-{{ win_vstr }}.dll exit 1  # [win and py34]
-    - if not exist %PREFIX%\\Library\\bin\\boost_python-vc140-mt-{{ win_vstr }}.dll exit 1  # [win and py35]
-    - if not exist %PREFIX%\\Library\\lib\\boost_python-vc90-mt-{{ win_vstr }}.lib exit 1   # [win and py27]
-    - if not exist %PREFIX%\\Library\\lib\\boost_python-vc100-mt-{{ win_vstr }}.lib exit 1  # [win and py34]
-    - if not exist %PREFIX%\\Library\\lib\\boost_python-vc140-mt-{{ win_vstr }}.lib exit 1  # [win and py35]
 
 about:
   home: http://www.boost.org/

--- a/recipes/boost-cpp/meta.yaml
+++ b/recipes/boost-cpp/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - toolchain
+    - python            # [win]
     - icu 56.*          # [unix]
     - bzip2 1.0.*       # [unix]
     - zlib 1.2.*

--- a/recipes/boost-cpp/meta.yaml
+++ b/recipes/boost-cpp/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.62.0" %}
+{% set version = "1.63.0" %}
 {% set filename = "boost_%s.tar.bz2" % version.replace(".", "_") %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn:  {{ filename }}
   url: http://sourceforge.net/projects/boost/files/boost/{{ version }}/{{ filename }}
-  sha256: 36c96b0f6155c98404091d8ceb48319a28279ca0333fba1ad8611eb90afb2ca0
+  sha256: beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0
 
 build:
   number: 0


### PR DESCRIPTION
This is an attempt to split boost libraries and the python library. This recipe is the same as the boost recipe except that this does not build the python bindings on linux and osx and therefore doesn't depend on python. See conda-forge/boost-feedstock#1. 

Diff from boost-feedstock https://gist.github.com/isuruf/1797b33871f90f01a74d24e1970ea580

Next step would be to have boost-feedstock recipe depend on this package boost-cpp and build only the python libraries. If you have any suggestions for the name (instead of `boost-cpp`), let me know.

This approach does not break any packages depending on boost. Another approach to solve conda-forge/boost-feedstock#1 would be to change boost-feedstock recipe to build without python and have a new package boost-python that does.

cc @ccordoba12, @jakirkham, @msarahan, @ocefpaf, @jschueller