### PR TITLE
Skip AppVeyor even if only some of the recipes convert to feedstocks.

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -324,7 +324,7 @@ if __name__ == '__main__':
         msg = ('Removed recipe{s} ({}) after converting into feedstock{s}.'
                ''.format(', '.join(removed_recipes),
                          s=('s' if len(removed_recipes) > 1 else '')))
-        msg += ' [ci skip]' if exit_code == 0 else ''
+        msg += ' [ci skip]' if exit_code == 0 else '[skip appveyor]'
         if is_merged_pr:
             # Capture the output, as it may contain the GH_TOKEN.
             out = subprocess.check_output(['git', 'remote', 'add', 'upstream_with_token',


### PR DESCRIPTION
This is a follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/1466 ).

In some cases conversion fails, on some recipe. Instead of erroring out completely, we changed the behavior at staged-recipes to remove the recipes that had converted and leave the rest. When doing this, we pushed a commit to `master` with these recipes removed. To ensure conversion restarted on this subset that had not converted, we did not add `[ci skip]` to the commit message.

It turns out this had the unintended consequence of starting AppVeyor as well. To see an example of this behavior, please look at this [build]( https://ci.appveyor.com/project/conda-forge/staged-recipes/branch/master/job/mvpx86c35xvqbbpx ). As AppVeyor does nothing productive for us in the case of conversion, we adjust the conversion commit behavior in this PR to ensure that AppVeyor is always skipped either by skipping all CIs or simply skipping AppVeyor and CircleCI depending on whether conversion completed or errored out part way. This should avoid any AppVeyor builds during conversion.