### PR TITLE
Add recipes for libgcrypt and libgpg-error

### DIFF
--- a/recipes/libgcrypt/build.sh
+++ b/recipes/libgcrypt/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+./configure --prefix=$PREFIX
+make
+make check
+make install

--- a/recipes/libgcrypt/meta.yaml
+++ b/recipes/libgcrypt/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "1.5.6" %}
+
+package:
+  name: libgcrypt
+  version: "{{ version }}"
+
+source:
+  fn: libgcrypt-{{ version }}.tar.gz
+  url: https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-{{ version }}.tar.bz2
+  md5: a6208579e346b1d57fc2a00402181361
+
+build:
+  number: 0
+  # This package is a dependency of libhdfs3, which is primarily used with HDFS on Linux.
+  skip: True  # [not linux]
+
+test:
+  commands:
+    - test -f $PREFIX/bin/dumpsexp
+    - test -f $PREFIX/bin/hmac256
+    - test -f $PREFIX/bin/libgcrypt-config
+    - test -f $PREFIX/include/gcrypt.h
+    - test -f $PREFIX/include/gcrypt-module.h
+    - test -f $PREFIX/lib/libgcrypt.la
+    - test -f $PREFIX/lib/libgcrypt.so
+
+about:
+  home: https://www.gnu.org/software/libgcrypt/
+  license: LGPL-2.0
+  summary: General purpose cryptographic library based on the code from GnuPG
+
+extra:
+  recipe-maintainers:
+    - koverholt

--- a/recipes/libgpg-error/build.sh
+++ b/recipes/libgpg-error/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+./configure --prefix=$PREFIX
+make
+make check
+make install

--- a/recipes/libgpg-error/meta.yaml
+++ b/recipes/libgpg-error/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "1.24" %}
+
+package:
+  name: libgpg-error
+  version: "{{ version }}"
+
+source:
+  fn: libgcrypt-{{ version }}.tar.gz
+  url: https://www.gnupg.org/ftp/gcrypt/libgpg-error/libgpg-error-{{ version }}.tar.bz2
+  md5: feb42198c0aaf3b28eabe8f41a34b983
+
+build:
+  number: 0
+  # This package is a dependency of libhdfs3, which is primarily used with HDFS on Linux.
+  skip: True  # [not linux]
+
+test:
+  commands:
+    - test -f $PREFIX/bin/gpg-error
+    - test -f $PREFIX/bin/gpg-error-config
+    - test -f $PREFIX/include/gpg-error.h
+    - test -f $PREFIX/lib/libgpg-error.la
+    - test -f $PREFIX/lib/libgpg-error.so
+
+about:
+  home: https://www.gnupg.org/(fr)/related_software/libgpg-error/index.html
+  license: LGPL-2.0
+  summary: Small library that defines common error values for all GnuPG components
+
+extra:
+  recipe-maintainers:
+    - koverholt


### PR DESCRIPTION
`libgcrypt` is a dependency of `libhdfs3` and came up because only `libgcrypt20` is available on Ubuntu 16.04 rather than `libgcrypt11`: https://github.com/conda-forge/libhdfs3-feedstock/issues/4

The most recent version of `libgcrypt11` is in `libgcrypt` 1.5.6, which is included in this PR.