### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf


### PR DESCRIPTION
Adds a `.gitattributes` file for specifying how to handle line endings with recipe content.

cc @goanpeca

xref: https://github.com/conda-forge/conda-smithy/pull/380