### PR TITLE
Add watchtower recipe

### DIFF
--- a/recipes/watchtower/meta.yaml
+++ b/recipes/watchtower/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "watchtower" %}
+{% set version = "0.3.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/kislyuk/watchtower.git
+  git_rev: "v{{ version }}"
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - boto3 >=1.3.0
+
+test:
+  imports:
+    - watchtower
+
+about:
+  home: http://github.com/kislyuk/watchtower
+  license: Apache 2.0 
+  license_file: LICENSE
+  summary: 'Python CloudWatch Logging: Log Analytics and Application Intelligence'
+
+  description: |
+    Watchtower is a log handler for Amazon Web Services CloudWatch Logs. CloudWatch 
+    Logs is a log management service built into AWS. It is conceptually similar to 
+    services like Splunk and Loggly, but is more lightweight, cheaper, and tightly
+    integrated with the rest of AWS.  Watchtower, in turn, is a lightweight adapter
+    between the Python logging system and CloudWatch Logs. It uses the boto3 AWS 
+    SDK, and lets you plug your application logging directly into CloudWatch without
+    the need to install a system-wide log collector. It aggregates logs into batches 
+    to avoid sending an API request per each log message, while guaranteeing a 
+    delivery deadline (60 seconds by default).  
+  doc_url: https://watchtower.readthedocs.io/
+  dev_url: https://github.com/kislyuk/watchtower
+
+extra:
+  recipe-maintainers:
+    - mcg1969

--- a/recipes/watchtower/meta.yaml
+++ b/recipes/watchtower/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "watchtower" %}
 {% set version = "0.3.3" %}
+{% set sha256 = "ca42e70617a1a35e5dd0663010ef588489a83cfaf273d018b7affaec225c0a54" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  git_url: https://github.com/kislyuk/watchtower.git
-  git_rev: "v{{ version }}"
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/kislyuk/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 0
@@ -27,7 +29,8 @@ test:
 
 about:
   home: http://github.com/kislyuk/watchtower
-  license: Apache 2.0 
+  license: Apache 2.0
+  license_family: Apache
   license_file: LICENSE
   summary: 'Python CloudWatch Logging: Log Analytics and Application Intelligence'
 


### PR DESCRIPTION
This is a straightforward recipe, except that it cannot run the test suite, because it requires AWS credentials. Not sure what people thing about that...