### PR TITLE
Add recipe for mosh - mobile shell

### DIFF
--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,7 +1,10 @@
 # See https://github.com/conda-forge/toolchain-feedstock/pull/11
-export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include $(pkg-config --cflags zlib)"
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib $(pkg-config --libs zlib)"
+export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 
-./configure --prefix="${PREFIX}"
+./configure --prefix="${PREFIX}" \
+            --with-ncurses \
+            --with-curses=$PREFIX \
+            --with-crypto-library=openssl
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -5,7 +5,7 @@ then
     export CC=clang
     export CXX=clang++
     export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11 -I${PREFIX}/include"
     export LIBS="-lc++"
 elif [ "$(uname)" == "Linux" ];
 then

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,6 +1,6 @@
 # See https://github.com/conda-forge/toolchain-feedstock/pull/11
-export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include `pkg-config --cflags zlib`"
-export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib `pkg-config --libs zlib`"
+export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include $(pkg-config --cflags zlib)"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib $(pkg-config --libs zlib)"
 
 ./configure --prefix="${PREFIX}"
 make -j"${CPU_COUNT}"

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,4 +1,5 @@
 export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+
 ./configure --prefix="${PREFIX}"
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,3 +1,23 @@
-./configure --prefix=$PREFIX
+if [ "$(uname)" == "Darwin" ];
+then
+    # Switch to clang with C++11 ASAP.
+    export MACOSX_VERSION_MIN=10.7
+    export CC=clang
+    export CXX=clang++
+    export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
+    export LIBS="-lc++"
+elif [ "$(uname)" == "Linux" ];
+then
+    export CC=gcc
+    export CXX=g++
+fi
+
+./configure --prefix="${PREFIX}" \
+        CC="${CC}" \
+        CXX="${CXX}" \
+        CXXFLAGS="${CXXFLAGS}" \
+        LDFLAGS="${LDFLAGS}"
+make
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,23 +1,4 @@
-if [ "$(uname)" == "Darwin" ];
-then
-    # Switch to clang with C++11 ASAP.
-    export MACOSX_VERSION_MIN=10.7
-    export CC=clang
-    export CXX=clang++
-    export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11 -I${PREFIX}/include"
-    export LIBS="-lc++"
-elif [ "$(uname)" == "Linux" ];
-then
-    export CC=gcc
-    export CXX=g++
-fi
-
-./configure --prefix="${PREFIX}" \
-        CC="${CC}" \
-        CXX="${CXX}" \
-        CXXFLAGS="${CXXFLAGS}" \
-        LDFLAGS="${LDFLAGS}"
-make
+export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+./configure --prefix="${PREFIX}"
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,6 +1,7 @@
-export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+# See https://github.com/conda-forge/toolchain-feedstock/pull/11
+export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include `pkg-config --cflags zlib`"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib `pkg-config --libs zlib`"
 
-ZLIB_ROOT=$PREFIX
 ./configure --prefix="${PREFIX}"
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,5 +1,6 @@
 export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
 
+ZLIB_ROOT=$PREFIX
 ./configure --prefix="${PREFIX}"
 make -j"${CPU_COUNT}"
 make install

--- a/recipes/mosh/build.sh
+++ b/recipes/mosh/build.sh
@@ -1,0 +1,3 @@
+./configure --prefix=$PREFIX
+make -j"${CPU_COUNT}"
+make install

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -17,14 +17,13 @@ build:
 
 requirements:
   build:
-    - gcc  # [linux]
+    - toolchain
     - pkg-config
     - protobuf
     - ncurses
     - zlib
     - openssl
   run:
-    - libgcc  # [linux]
     - protobuf
     - ncurses
     - zlib

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - gcc
+    - pkg-config
     - protobuf
     - ncurses
     - zlib

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -17,14 +17,14 @@ build:
 
 requirements:
   build:
-    - gcc
+    - gcc  # [linux]
     - pkg-config
     - protobuf
     - ncurses
     - zlib
     - openssl
   run:
-    - libgcc
+    - libgcc  # [linux]
     - protobuf
     - ncurses
     - zlib

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -33,7 +33,6 @@ requirements:
 
 test:
   commands:
-    - mosh-client -c
     - mosh-server -h
 
 about:

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -37,7 +37,7 @@ test:
 about:
   home: https://mosh.org/
   license: GPLv3+
-  license_family: GPL
+  license_family: GPL3
   summary: 'Mobile shell that supports roaming and intelligent local echo'
 
   description: |

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mosh" %}
 {% set version = "1.2.6" %}
-{% set sha256 = "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85" %}
+{% set sha256 = "82b4c52adc527d802351a4d1ba0b193ee3dfc9b3e203b4919516f6ae0e471a72" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "mosh" %}
+{% set version = "1.2.6" %}
+{% set sha256 = "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://mosh.org/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - gcc
+    - protobuf
+    - ncurses
+    - zlib
+    - openssl
+  run:
+    - protobuf
+    - ncurses
+    - zlib
+    - openssl
+    - perl
+
+test:
+  commands:
+    - mosh-client -c
+    - mosh-server -h
+
+about:
+  home: https://mosh.org/
+  license: GPLv3+
+  license_family: GPL
+  summary: 'Mobile shell that supports roaming and intelligent local echo'
+
+  description: |
+      Mosh is a remote terminal application that supports:
+          - intermittent network connectivity,
+          - roaming to different IP address without dropping the connection, and
+          - intelligent local echo and line editing to reduce the effects
+            of "network lag" on high-latency connections.
+
+extra:
+  recipe-maintainers:
+    - gokceneraslan

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - zlib
     - openssl
   run:
+    - libgcc
     - protobuf
     - ncurses
     - zlib

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -20,14 +20,14 @@ requirements:
     - toolchain
     - pkg-config
     - protobuf
-    - ncurses
-    - zlib
-    - openssl
+    - ncurses 5.9*
+    - zlib 1.2.*
+    - openssl 1.0.*
   run:
     - protobuf
-    - ncurses
-    - zlib
-    - openssl
+    - ncurses 5.9*
+    - zlib 1.2.*
+    - openssl 1.0.*
     - perl
 
 test:

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -38,6 +38,7 @@ about:
   home: https://mosh.org/
   license: GPLv3+
   license_family: GPL3
+  license_file: COPYING
   summary: 'Mobile shell that supports roaming and intelligent local echo'
 
   description: |

--- a/recipes/mosh/meta.yaml
+++ b/recipes/mosh/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mosh" %}
 {% set version = "1.2.6" %}
-{% set sha256 = "82b4c52adc527d802351a4d1ba0b193ee3dfc9b3e203b4919516f6ae0e471a72" %}
+{% set sha256 = "7e82b7fbfcc698c70f5843bb960dadb8e7bd7ac1d4d2151c9d979372ea850e85" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Mosh (mobile shell)

> Remote terminal application that allows roaming, supports intermittent connectivity, and provides intelligent local echo and line editing of user keystrokes.
> 
> Mosh is a replacement for SSH. It's more robust and responsive, especially over Wi-Fi, cellular, and long-distance links.
> 

Packaging mosh for conda is highly important because `mosh` is required to be installed on both server and client side. However users may not have the root account on servers and manual compilation of mosh can be tricky especially if header packages or protobuf compiler are not installed on server. 

Aim of this packages is to make things easier e.g. users can run just `conda install -c conda-forge mosh` and they're done.