### PR TITLE
Add txaio

### DIFF
--- a/recipes/txaio/meta.yaml
+++ b/recipes/txaio/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - python
     - setuptools
-    - six
   run:
     - python
     - six

--- a/recipes/txaio/meta.yaml
+++ b/recipes/txaio/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "txaio" %}
+{% set version = "2.5.2" %}
+{% set sha256 = "321d441b336447b72dbe81a4d73470414454baf0543ec701fcfecbf4dcbda0fe" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - txaio
+
+about:
+  home: https://github.com/crossbario/txaio
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Compatibility API between asyncio/Twisted/Trollius'
+  dev_url: https://github.com/crossbario/txaio
+  doc_url: http://txaio.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - synapticarbors


### PR DESCRIPTION
This recipe adds txaio:

http://txaio.readthedocs.io/
https://github.com/crossbario/txaio

I'm not sure how best to handle the pip-style extras of twisted and trollius. Currently I'm not including them as specific dependencies, but I can if we think this makes sense.