### PR TITLE
Add python-graphviz

### DIFF
--- a/recipes/python-graphviz/meta.yaml
+++ b/recipes/python-graphviz/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.5.1" %}
+{% set sha256 = "d8f8f369a5c109d3fc971bbc1860b6848515d210aee8f5019c460351dbb00a50" %}
+
+package:
+  name: python-graphviz
+  version: {{ version }}
+
+source:
+  fn: python-graphviz-{{ version }}.zip
+  url: https://pypi.io/packages/source/g/graphviz/graphviz-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - graphviz
+
+test:
+  imports:
+    - graphviz
+
+about:
+  home: http://github.com/xflr6/graphviz
+  doc_url: http://graphviz.readthedocs.io
+  dev_url: https://github.com/xflr6/graphviz
+
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+  summary: Simple Python interface for Graphviz
+  description: |
+    This package facilitates the creation and rendering of graph
+    descriptions in the DOT language of the Graphviz graph
+    drawing software (repo) from Python.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for the Python `graphviz` library. Needed to prefix here as [`graphviz`]( https://github.com/conda-forge/graphviz-feedstock ) is already a thing. ( https://github.com/conda-forge/staged-recipes/pull/568 ) Please let me know your thoughts.

cc @ccordoba12 @mrocklin 