### PR TITLE
ENH: Add flake8-import-order 0.11

### DIFF
--- a/recipes/flake8-import-order/meta.yaml
+++ b/recipes/flake8-import-order/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "flake8-import-order" %}
+{% set version = "0.11" %}
+{% set sha256 = "b56ca2793e27bd99c46f59a0a51f4847ddc1fed22697a505add882a9db2b8613" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pycodestyle
+    - flake8
+
+test:
+  commands:
+    - "flake8 --version | grep import-order:"
+
+about:
+  home: https://github.com/PyCQA/flake8-import-order
+  license: LGPL-3.0
+  license_family: LGPL
+  license_file: COPYING
+  summary: 'A flake8 and Pylama plugin that checks the ordering of your imports.'
+
+  description: |
+          A flake8 and Pylama plugin that checks the ordering of your imports.
+          In general stdlib comes first, then 3rd party, then local packages,
+          and that each group is individually alphabetized, see Configuration
+          section for details. It will not check anything else about the
+          imports. Merely that they are grouped and ordered correctly. This
+          plugin is under somewhat active development and is heavily influenced
+          by the personal preferences of the developers of cryptography. Expect
+          seemingly random changes and configuration changes as we figure out
+          how it should work.
+  dev_url: https://github.com/PyCQA/flake8-import-order
+
+extra:
+  recipe-maintainers:
+    - dopplershift


### PR DESCRIPTION
Seems to be a useful enough plugin--and it's "blessed" by the PyCQA.