### PR TITLE
Adding bagit

### DIFF
--- a/recipes/bagit/meta.yaml
+++ b/recipes/bagit/meta.yaml
@@ -1,0 +1,42 @@
+# https://github.com/LibraryOfCongress/bagit-python/issues/70
+{% set name = "bagit" %}
+{% set version = "1.5.5" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/LibraryOfCongress/bagit-python.git
+  git_rev: 613a82849d0dd43761e005606cd4c7ba3cd44188
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - setuptools_scm
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - bagit
+  commands:
+    - bagit.py --version
+    
+about:
+  home: https://libraryofcongress.github.io/bagit-python/
+  summary: 'Work with BagIt packages from Python'
+  license: Public-Domain
+  license_family: Public-Domain
+  dev_url: https://github.com/LibraryOfCongress/bagit-python
+  doc_url: https://libraryofcongress.github.io/bagit-python/
+
+extra:
+  recipe-maintainers:
+    - kwilcox


### PR DESCRIPTION
I'm tagging a git commit due to lack of response here: https://github.com/LibraryOfCongress/bagit-python/issues/70. There is no python 3.5 support in the latest pypi release.