### PR TITLE
dmd fix missing lib files

### DIFF
--- a/recipes/dmd/build.sh
+++ b/recipes/dmd/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mkdir -p $PREFIX/lib/dmd/src/phobos/
+cd $SRC_DIR/src/phobos
+cp -r * $PREFIX/lib/dmd/src/phobos/
+
+mkdir -p $PREFIX/lib/dmd/src/druntime/import/
+cd $SRC_DIR/src/druntime/import
+cp -r * $PREFIX/lib/dmd/src/druntime/import/
+
+mkdir -p $PREFIX/lib/dmd/linux/lib64/
+cd $SRC_DIR/linux/lib64/
+cp -r * $PREFIX/lib/dmd/linux/lib64/
+
+mkdir -p $PREFIX/bin
+cd $SRC_DIR/linux/bin64/
+
+chmod a+x ddemangle dman dmd dumpobj dustmite obj2asm rdmd
+cp ddemangle dman dmd dumpobj dustmite obj2asm rdmd $PREFIX/bin

--- a/recipes/dmd/meta.yaml
+++ b/recipes/dmd/meta.yaml
@@ -1,0 +1,29 @@
+{% set name = "dmd" %}
+{% set version = "2.065.0" %}
+{% set sha256 = "f3f4c8f6c2e5cdd0ac335e56613663bee075a1e797ffbb55035d6c767d7bc585" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}.{{ version }}.zip
+  url: http://downloads.dlang.org/releases/2014/{{ name }}.{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 1
+  skip: True  # [win or osx or not x86_64]  
+  
+test:
+  commands:    
+    - dmd 2>&1 | head -n 1 | grep -q '^DMD64 D Compiler v2.065'; echo $?
+
+about:
+  home: https://github.com/dlang/dmd
+  license: Boost Software, Version 1.0
+  summary: 'DMD is the reference compiler for the D programming language.'
+
+extra:
+  recipe-maintainers:
+    - pirovc


### PR DESCRIPTION
The dmd installation is working fine, but when using dmd to compile I got the following error:

```
Error: cannot find source code for runtime library file 'object.d'
       dmd might not be correctly installed. Run 'dmd -man' for installation instructions.
```

There are some library files missing that I added to the build.sh.

To dmd run properly it is necessary to specify the env. variable DFLAGS. I could do it before running my script, but it would be better if it is already set after installation. Is that possible?

`export DFLAGS="-I$PREFIX/lib/dmd/src/phobos -I$PREFIX/lib/dmd/src/druntime/import -L-L$PREFIX/lib/dmd/linux/lib64 -L--export-dynamic"`