### PR TITLE
Temporarily pin `conda` to `4.1.x`

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -15,6 +15,10 @@ python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci &
 popd
 rm -rf ~/miniconda_staging
 
+# Temporarily pin `conda` to 4.1.x for `conda-smithy`.
+touch ~/miniconda/conda-meta/pinned
+echo "conda 4.1.*" >> ~/miniconda/conda-meta/pinned
+
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
 conda install --yes --quiet git


### PR DESCRIPTION
Temporarily pin `conda` to `4.1.x` so that `conda-smithy` works. Working on a fix in PR ( https://github.com/conda-forge/conda-smithy/pull/394 ). Can revert after we have a patch release with a fix.

cc @conda-forge/core