### PR TITLE
Added libuv recipe

### DIFF
--- a/recipes/libuv/build.sh
+++ b/recipes/libuv/build.sh
@@ -1,0 +1,12 @@
+# LIBTOOLIZE setting is required to workaround missing glibtoolize on OS X:
+# https://github.com/joyent/libuv/issues/1200
+LIBTOOLIZE=libtoolize sh ./autogen.sh
+
+./configure \
+   --disable-dependency-tracking \
+   --disable-silent-rules \
+   --prefix="$PREFIX" \
+
+make
+make check
+make install

--- a/recipes/libuv/meta.yaml
+++ b/recipes/libuv/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "libuv" %}
+{% set version = "1.10.1" %}
+{% set sha256 = "4b5f71939dd4272ebcfb8e04833e9a273a08b1bf1277d37d14085d7b04b19832" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win or not py35]
+
+requirements:
+  build:
+    - python
+    - automake  # [unix]
+    - autoconf  # [unix]
+    - libtool   # [unix]
+
+test:
+  commands:
+    - test -f "$PREFIX/include/uv.h"
+    - test -f "$PREFIX/lib/libuv.a"  # [unix]
+    - test -f "$PREFIX/lib/libuv.la"  # [unix]
+    - test -f "$PREFIX/lib/libuv.so.1"  # [linux]
+    - test -f "$PREFIX/lib/libuv.1.dylib"  # [osx]
+    - test -f "$PREFIX/lib/libuv.so"  # [linux]
+    - test -f "$PREFIX/lib/libuv.dylib"  # [osx]
+
+about:
+  home: http://libuv.org/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Cross-platform asynchronous I/O'
+  description: |
+    libuv is a multi-platform support library with a focus on asynchronous I/O.
+    It was primarily developed for use by Node.js, but it’s also used by Luvit,
+    Julia, pyuv, and others.
+  doc_url: http://docs.libuv.org/
+  dev_url: https://github.com/libuv/libuv
+
+extra:
+  recipe-maintainers:
+    - frol


### PR DESCRIPTION
> [libuv](http://libuv.org/) is a multi-platform support library with a focus on asynchronous I/O. It was primarily developed for use by Node.js, but it’s also used by Luvit, Julia, pyuv, CMake, and others.

I have hit this library missing while updating CMake to 3.7.1: https://github.com/conda-forge/cmake-feedstock/pull/25

So far, I have succeeded with Linux build and I have no capacity to make Windows build, so any help is appreciated.

/cc @jakirkham