### PR TITLE
Add setuptools_scm_git_archive recipe

### DIFF
--- a/recipes/setuptools_scm_git_archive/meta.yaml
+++ b/recipes/setuptools_scm_git_archive/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "1.0" %}
+
+package:
+  name: setuptools_scm_git_archive
+  version: {{ version }}
+
+source:
+  fn: setuptools_scm_git_archive-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/s/setuptools_scm_git_archive/setuptools_scm_git_archive-{{ version }}.tar.gz
+  sha256: 52425f905518247c685fc64c5fdba6e1e74443c8562e141c8de56059be0e31da
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - pip
+    - setuptools
+    - setuptools_scm
+  run:
+    - python
+    - setuptools_scm
+
+test:
+  imports:
+    - setuptools_scm_git_archive
+
+about:
+  home: https://github.com/Changaco/setuptools_scm_git_archive/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'setuptools_scm plugin for git archives'
+
+extra:
+  recipe-maintainers:
+    - wesm
+    - xhochy


### PR DESCRIPTION
This endows setuptools_scm with versioning support for appropriately-configured git archives (e.g. those produced by GitHub)