### PR TITLE
Example using boost-python-numpy

### DIFF
--- a/recipes/boost-python-numpy/meta.yaml
+++ b/recipes/boost-python-numpy/meta.yaml
@@ -30,7 +30,7 @@ test:
     - true
 
 about:
-  #home: 
+  home: http://example.com
   license: GPLv3
   summary: 'Example using Numpy with Boost.Python'
 

--- a/recipes/boost-python-numpy/meta.yaml
+++ b/recipes/boost-python-numpy/meta.yaml
@@ -1,0 +1,39 @@
+
+package:
+  name: boost-python-numpy
+  version: 0.1
+
+source:
+  path: ./src
+
+build:
+  skip: true  # [win]
+  skip: true  # [not py27]
+  number: 0
+  script:
+    - make
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - boost 1.62.*
+    - python
+    - numpy x.x
+  run:
+    - boost 1.62.*
+    - python
+    - numpy x.x
+
+test:
+  commands:
+    - true
+
+about:
+  #home: 
+  license: GPLv3
+  summary: 'Example using Numpy with Boost.Python'
+
+extra:
+  recipe-maintainers:
+    - dolfim

--- a/recipes/boost-python-numpy/src/Makefile
+++ b/recipes/boost-python-numpy/src/Makefile
@@ -4,7 +4,8 @@ LDDFLAGS = -std=c++11 -g -bundle
 PY2ROOT = ${PREFIX}
 BOOST2ROOT = ${PREFIX}
 PY2FLAGS = -I${PY2ROOT}/lib/python2.7/site-packages/numpy/core/include -I${PY2ROOT}/include/python2.7 -I${BOOST2ROOT}/include
-PY2LIBS = ${BOOST2ROOT}/lib/libboost_python.dylib ${PY2ROOT}/lib/python2.7/config/libpython2.7.a
+#PY2LIBS = ${BOOST2ROOT}/lib/libboost_python.dylib ${PY2ROOT}/lib/python2.7/config/libpython2.7.dylib
+PY2LIBS = ${BOOST2ROOT}/lib/libboost_python.dylib ${PY2ROOT}/lib/libpython2.7.dylib
 
 all: test2.so test
 

--- a/recipes/boost-python-numpy/src/Makefile
+++ b/recipes/boost-python-numpy/src/Makefile
@@ -1,5 +1,5 @@
-CXXFLAGS = -std=c++14 -g -fPIC 
-LDDFLAGS = -std=c++14 -g -bundle 
+CXXFLAGS = -std=c++11 -g -fPIC 
+LDDFLAGS = -std=c++11 -g -bundle 
 
 PY2ROOT = ${PREFIX}
 BOOST2ROOT = ${PREFIX}

--- a/recipes/boost-python-numpy/src/Makefile
+++ b/recipes/boost-python-numpy/src/Makefile
@@ -1,0 +1,20 @@
+CXXFLAGS = -std=c++14 -g -fPIC 
+LDDFLAGS = -std=c++14 -g -bundle 
+
+PY2ROOT = ${PREFIX}
+BOOST2ROOT = ${PREFIX}
+PY2FLAGS = -I${PY2ROOT}/lib/python2.7/site-packages/numpy/core/include -I${PY2ROOT}/include/python2.7 -I${BOOST2ROOT}/include
+PY2LIBS = ${BOOST2ROOT}/lib/libboost_python.dylib ${PY2ROOT}/lib/python2.7/config/libpython2.7.a
+
+all: test2.so test
+
+test: test2.so
+	 ./run.sh
+
+test2.so: Makefile test.cpp
+	clang++ ${CXXFLAGS} ${PY2FLAGS} -DMODULE_NAME=test2 -c test.cpp -o test2.o
+	clang++ ${LDDFLAGS} -o test2.so test2.o  ${PY2LIBS}
+
+
+clean:
+	rm *.o *.so *.log

--- a/recipes/boost-python-numpy/src/run.sh
+++ b/recipes/boost-python-numpy/src/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+COMMAND="import numpy as np; from test2 import Test; t = Test(); t.save(np.arange(3))"
+
+$PYTHON -c "$COMMAND"
+

--- a/recipes/boost-python-numpy/src/test.cpp
+++ b/recipes/boost-python-numpy/src/test.cpp
@@ -1,0 +1,48 @@
+// Copyright Jan Gukelberger <j.gukelberger@usherbrooke.ca>
+//           Michele Dolfi <dolfim@phys.ethz.ch>
+
+#include <boost/python.hpp>
+#include <boost/python/numeric.hpp>
+#include <numpy/arrayobject.h>
+#include <string>
+#include <iostream>
+
+
+bool import_numpy() 
+{
+    static bool inited = false;
+    if( !inited ) 
+    {
+        import_array1(false)
+        boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
+        inited = true;
+    }
+    return true;
+}
+
+
+class Test
+{
+public:
+    void save(boost::python::object const & value) 
+    {
+        import_numpy();
+
+        std::string dtype = value.ptr()->ob_type->tp_name;
+        if (dtype == "numpy.ndarray")
+        {
+            auto v = boost::python::extract<boost::python::numeric::array>(value)();
+        }
+        else
+            std::cerr << "invalid dtype: " << dtype << std::endl;
+    }
+};
+
+#ifndef MODULE_NAME
+#define MODULE_NAME test
+#endif
+
+BOOST_PYTHON_MODULE(MODULE_NAME) 
+{
+    boost::python::class_<Test>("Test").def("save", &Test::save);
+}


### PR DESCRIPTION
This should show if boost-python is indeed compiled with a different version of python and numpy.