### PR TITLE
numpy-sugar

### DIFF
--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "numpy-sugar" %}
+{% set version = "1.0.10" %}
+{% set sha256 = "7014fe2193cda8f812f74ac1eaca3750d6fe9589aee270a5c4d43cd881e9bf26" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True           # [win and py<35]
+  features:
+    - vc14             # [win]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pytest-runner
+    - build-capi
+    - ncephes
+    - cffi
+    - numba
+    - toolchain
+    - vc 14           # [win]
+  run:
+    - python
+    - ncephes
+    - scipy
+    - numpy
+    - numba
+    - cffi
+
+test:
+  requires:
+    - pytest
+    - numpy
+    - scipy
+    - numba
+  imports:
+    - numpy_sugar
+  commands:
+    - python -c "import numpy_sugar; numpy_sugar.test()"
+
+about:
+  home: https://github.com/glimix/numpy-sugar
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Missing NumPy functionalities'
+  doc_url: http://numpy-sugar.readthedocs.io
+  dev_url: https://github.com/glimix/numpy-sugar
+
+extra:
+  recipe-maintainers:
+    - Horta

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "numpy-sugar" %}
-{% set version = "1.0.10" %}
-{% set sha256 = "7014fe2193cda8f812f74ac1eaca3750d6fe9589aee270a5c4d43cd881e9bf26" %}
+{% set version = "1.0.12" %}
+{% set sha256 = "6d9f876ccea5780030db93ea57a248774b8a67d876d8e154c880a3fdf6eff67c" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -40,9 +40,6 @@ requirements:
 test:
   requires:
     - pytest
-    - numpy
-    - scipy
-    - numba
   imports:
     - numpy
     - numpy.linalg

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - build-capi
     - ncephes
     - cffi
-    - numba
+    - numba >=0.28
 
   run:
     - python
@@ -47,7 +47,7 @@ requirements:
     - numpy x.x
     - ncephes
     - scipy
-    - numba
+    - numba >=0.28
     - cffi
 
 test:

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -21,16 +21,20 @@ build:
 requirements:
   build:
     - python
+    - toolchain
+    - vc 14  # [win]
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.19|0.2.19.*
     - setuptools
     - pytest-runner
     - build-capi
     - ncephes
     - cffi
     - numba
-    - toolchain
-    - vc 14  # [win]
   run:
     - python
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.19|0.2.19.*
     - ncephes
     - scipy
     - numpy

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -44,9 +44,11 @@ test:
     - scipy
     - numba
   imports:
-    - numpy_sugar
     - numpy
+    - numpy.linalg
     - scipy
+    - scipy.linalg
+    - numpy_sugar
   commands:
     - python -c "import numpy_sugar; numpy_sugar.test()"
 

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "numpy-sugar" %}
-{% set version = "1.0.12" %}
-{% set sha256 = "6d9f876ccea5780030db93ea57a248774b8a67d876d8e154c880a3fdf6eff67c" %}
+{% set version = "1.0.13" %}
+{% set sha256 = "e2c10d20fc97ec00aa4eabb23778379b2adacfa00e89595e7a9d4969e5c16ae5" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   number: 0
   # skip: True  # [(win and py<35) or py34]
-  skip: True  # [not (osx and py35)]
+  skip: True  # [not osx]
   features:
     - blas_{{ variant }}
   # skip: False  # [osx and py35]

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -15,32 +15,38 @@ source:
 build:
   number: 0
   # skip: True  # [(win and py<35) or py34]
-  skip: False  # [osx and py35]
+  skip: True  # [not (osx and py35)]
+  features:
+    - blas_{{ variant }}
+  # skip: False  # [osx and py35]
   # features:
   #   - vc14  # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
-    - python
     - toolchain
     - gcc  # [osx]
+    - python
+    - setuptools
+    - cython
     # - vc 14  # [win]
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
-    - setuptools
+    - numpy x.x
     - pytest-runner
     - build-capi
     - ncephes
     - cffi
     - numba
+
   run:
     - python
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
+    - numpy x.x
     - ncephes
     - scipy
-    - numpy
     - numba
     - cffi
 

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -45,6 +45,8 @@ test:
     - numba
   imports:
     - numpy_sugar
+    - numpy
+    - scipy
   commands:
     - python -c "import numpy_sugar; numpy_sugar.test()"
 

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -13,9 +13,9 @@ source:
 
 build:
   number: 0
-  skip: True  # [win and py<35]
+  skip: True  # [(win and py<35) or py34]
   features:
-    - vc14             # [win]
+    - vc14  # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -14,16 +14,18 @@ source:
 
 build:
   number: 0
-  skip: True  # [(win and py<35) or py34]
-  features:
-    - vc14  # [win]
+  # skip: True  # [(win and py<35) or py34]
+  skip: False  # [osx and py35]
+  # features:
+  #   - vc14  # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - toolchain
-    - vc 14  # [win]
+    - gcc  # [osx]
+    # - vc 14  # [win]
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
     - setuptools
@@ -47,9 +49,9 @@ test:
     - pytest
   imports:
     - numpy
-    - numpy.linalg
-    - scipy
-    - scipy.linalg
+    # - numpy.linalg
+    # - scipy
+    # - scipy.linalg
     - numpy_sugar
   commands:
     - python -c "import numpy_sugar; numpy_sugar.test()"

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   number: 0
   # skip: True  # [(win and py<35) or py34]
-  skip: True  # [not osx]
+  skip: True  # [not (osx and py27 or osx and py35)]
   features:
     - blas_{{ variant }}
   # skip: False  # [osx and py35]

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "numpy-sugar" %}
 {% set version = "1.0.13" %}
+{% set variant = "openblas" %}
 {% set sha256 = "e2c10d20fc97ec00aa4eabb23778379b2adacfa00e89595e7a9d4969e5c16ae5" %}
 
 package:

--- a/recipes/numpy-sugar/meta.yaml
+++ b/recipes/numpy-sugar/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True           # [win and py<35]
+  skip: True  # [win and py<35]
   features:
     - vc14             # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
@@ -28,7 +28,7 @@ requirements:
     - cffi
     - numba
     - toolchain
-    - vc 14           # [win]
+    - vc 14  # [win]
   run:
     - python
     - ncephes


### PR DESCRIPTION
Normalizing package names. Please, remove https://github.com/conda-forge/numpy_sugar-feedstock in place of this one.