### PR TITLE
Add imageio recipe

### DIFF
--- a/recipes/imageio/meta.yaml
+++ b/recipes/imageio/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.0" %}
+{% set version = "2.1.1" %}
 
 package:
   name: imageio
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: imageio-{{ version }}.zip
-  url: https://pypi.python.org/packages/f4/2a/fdec06f4f9231730c96f3ac79e6af619355a3def00a925dae62a454517eb/imageio-2.1.0.zip
-  md5: 3a7f0646d07ffd645491dbc40b48a244
+  url: https://pypi.python.org/packages/71/67/a6a3192355e9ffabb16e84695592d51fdde6d4d884a219509bea8560876e/imageio-2.1.1.zip
+  md5: 6ec6e58f3616ba3439c080be3b98cac4
 
 build:
   script: python setup.py install

--- a/recipes/imageio/meta.yaml
+++ b/recipes/imageio/meta.yaml
@@ -36,3 +36,4 @@ extra:
   recipe-maintainers:
     - almarklein
     - blink1073
+    - jni

--- a/recipes/imageio/meta.yaml
+++ b/recipes/imageio/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "2.0.0" %}
+
+package:
+  name: imageio
+  version: {{ version }}
+
+source:
+  fn: imageio-{{ version }}.zip
+  url: https://pypi.python.org/packages/37/24/3a8f65e100a668950219e79ecd09f20fedd2a07d24e9cafa29c841fc748f/imageio-2.0.0.zip
+  md5: 571db7852109ad9ac77fb493cc461f43
+
+build:
+  script: python setup.py install
+  number: 0
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+    - numpy
+    - pillow
+
+test:
+  imports:
+    - imageio
+
+about:
+  home: http://imageio.github.io
+  doc_url: http://imageio.readthedocs.io
+  dev_url: https://github.com/imageio/imageio
+  summary: a Python library for reading and writing image data
+  license: BSD 2-Clause
+
+extra:
+  recipe-maintainers:
+    - almarklein
+    - blink1073

--- a/recipes/imageio/meta.yaml
+++ b/recipes/imageio/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.0.0" %}
+{% set version = "2.1.0" %}
 
 package:
   name: imageio
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: imageio-{{ version }}.zip
-  url: https://pypi.python.org/packages/37/24/3a8f65e100a668950219e79ecd09f20fedd2a07d24e9cafa29c841fc748f/imageio-2.0.0.zip
-  md5: 571db7852109ad9ac77fb493cc461f43
+  url: https://pypi.python.org/packages/f4/2a/fdec06f4f9231730c96f3ac79e6af619355a3def00a925dae62a454517eb/imageio-2.1.0.zip
+  md5: 3a7f0646d07ffd645491dbc40b48a244
 
 build:
   script: python setup.py install

--- a/recipes/imageio/meta.yaml
+++ b/recipes/imageio/meta.yaml
@@ -1,4 +1,8 @@
+# Info that changes with each new release
+# (get sha256 from https://pypi.org/project/imageio/#files)
+
 {% set version = "2.1.1" %}
+{% set sha256 = "fb18af15088d2be50ecf25af78ae516829bb406ed7bd981b9efabebd48a54fb7" %}
 
 package:
   name: imageio
@@ -6,8 +10,8 @@ package:
 
 source:
   fn: imageio-{{ version }}.zip
-  url: https://pypi.python.org/packages/71/67/a6a3192355e9ffabb16e84695592d51fdde6d4d884a219509bea8560876e/imageio-2.1.1.zip
-  md5: 6ec6e58f3616ba3439c080be3b98cac4
+  url: https://pypi.io/packages/source/i/imageio/imageio-{{ version }}.zip
+  sha256: {{ sha256 }}
 
 build:
   script: python setup.py install
@@ -31,6 +35,7 @@ about:
   dev_url: https://github.com/imageio/imageio
   summary: a Python library for reading and writing image data
   license: BSD 2-Clause
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Imageio now depends on Pillow instead of FreeImage. This resolves some license issues that were holding back the conda package. But here it is, finally!

@blink1073 I added you as a co-maintainer, in case I get hit by a bus. Let me know if you'd rather not.