### PR TITLE
Add modern-xorg-stack feedstock.

### DIFF
--- a/recipes/modern-xorg-stack/build.sh
+++ b/recipes/modern-xorg-stack/build.sh
@@ -53,5 +53,5 @@ cp xcb-proto-*/missing xextproto-*/
 (cd gccmakedep-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
 
 cd $PREFIX
-rm -rf share/aclocal share/doc share/man share/pkgconfig lib/python2.7
+rm -rf share/doc share/man lib/python2.7/site-packages/xcbgen
 rm -f lib/*.a lib/*.la

--- a/recipes/modern-xorg-stack/build.sh
+++ b/recipes/modern-xorg-stack/build.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+
+# Build a bunch of X.org packages at once. The list of packages below should
+# be kept synchronized with make-tarball.sh.
+
+set -e
+
+export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig
+
+if [ -n "$OSX_ARCH" ] ; then
+    export MACOSX_DEPLOYMENT_TARGET=10.6
+    sdk=/
+    export CFLAGS="$CFLAGS -isysroot $sdk"
+    export LDFLAGS="$LDFLAGS -Wl,-syslibroot,$sdk"
+fi
+
+# Work around weird packaging bug? (See also how we weirdly need to give
+# xextproto --disable-specs.)
+cp xcb-proto-*/missing xextproto-*/
+
+# Note that `-e` mode doesn't cause us to exit when the inner pipelines fail,
+# even though they exit with error codes.
+(cd util-macros-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd xproto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd xcb-proto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd xextproto-* && ./configure --prefix=$PREFIX --disable-specs && make install) || exit $?
+(cd fixesproto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd kbproto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd inputproto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd recordproto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd renderproto-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd xtrans-* && ./configure --prefix=$PREFIX && make install) || exit $?
+(cd libpthread-stubs-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libICE-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libSM-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXau-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXdmcp-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libxcb-* && ./configure --prefix=$PREFIX --enable-xinput && make && make install) || exit $?
+(cd libX11-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXext-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXfixes-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXi-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXtst-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXrender-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXcursor-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXt-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXmu-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXpm-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXaw-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd libXaw3d-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd imake-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd xorg-cf-files-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+(cd gccmakedep-* && ./configure --prefix=$PREFIX && make && make install) || exit $?
+
+cd $PREFIX
+rm -rf share/aclocal share/doc share/man share/pkgconfig lib/python2.7
+rm -f lib/*.a lib/*.la

--- a/recipes/modern-xorg-stack/make-tarball.sh
+++ b/recipes/modern-xorg-stack/make-tarball.sh
@@ -1,0 +1,70 @@
+#! /bin/bash
+
+# This script builds a mega-tarball of all the sources of the X11 libraries we
+# require. This is necessary because Conda doesn't let us define a package with
+# multiple source tarballs, and I don't want to ship a separate package for all
+# of these stupid dependencies.
+#
+# The list of packages below should be kept synchronized with the commands in
+# build.sh.
+
+if [ -z "$1" ] ; then
+    echo >&2 "usage: $0 <version>
+
+Where the recommended version is of the form YYYY.MM, e.g., 2015.12."
+    exit 1
+fi
+
+tarbase="modern-xorg-stack-$1"
+
+work="$(mktemp -d)"
+origpwd="$(pwd)"
+cd "$work"
+mkdir src unpacked
+cd src
+
+while read sha1 pkg ; do
+    wget -q http://xorg.freedesktop.org/releases/individual/$pkg
+    echo "$sha1 $(basename $pkg)" |sha1sum --check || exit 1
+    (cd ../unpacked && tar xjf ../src/$(basename $pkg))
+done <<EOF
+3c3a857a117ce48a1947a16860056e77cd494fdf  lib/libICE-1.0.9.tar.bz2
+e6d5dab6828dfd296e564518d2ed0a349a25a714  lib/libSM-1.2.2.tar.bz2
+6f2aadf8346ee00b7419bd338461c6986e274733  lib/libX11-1.6.3.tar.bz2
+d9512d6869e022d4e9c9d33f6d6199eda4ad096b  lib/libXau-1.0.8.tar.bz2
+15f891fb88aae966b3064dcc1510790a0ebc75a0  lib/libXaw-1.0.13.tar.bz2
+0b1db72e9d5be0edae57cda213860c0289fac12f  lib/libXaw3d-1.6.2.tar.bz2
+89870756758439f9216ddf5f2d3dca56570fc6b7  lib/libXcursor-1.1.14.tar.bz2
+3c09eabb0617c275b5ab09fae021d279a4832cac  lib/libXdmcp-1.1.2.tar.bz2
+43abab84101159563e68d9923353cc0b3af44f07  lib/libXext-1.3.3.tar.bz2
+e14fa072bd70b30eef47391cac637bdb4de9e8a3  lib/libXfixes-5.0.1.tar.bz2
+0bf1c2b8279915d8c94e45cd0b9ec064f7a177a9  lib/libXi-1.7.6.tar.bz2
+7e6aeef726743d21aa272c424e7d7996e92599eb  lib/libXmu-1.1.2.tar.bz2
+77b95dd1c8cd9bc00b3b834b53d824409202acbb  lib/libXpm-3.5.11.tar.bz2
+31bf63dfb4fcb82a6db73abe98df87cb50c17176  lib/libXrender-0.9.9.tar.bz2
+c79e2c4f7de5259a2ade458817a139b66a043d59  lib/libXt-1.1.5.tar.bz2
+7fd92a3c865c3c5e1cc724646babc3e1cdc799bc  lib/libXtst-1.2.2.tar.bz2
+2d3ae1839d841f568bc481c6116af7d2a9f9ba59  lib/xtrans-1.3.5.tar.bz2
+ab605af5da8c98c0c2f8b2c578fed7c864ee996a  proto/fixesproto-5.0.tar.bz2
+4eacc1883593d3f0040e410be3afc8483c7d2409  proto/inputproto-2.3.tar.bz2
+bc9c0fa7d39edf4ac043e6eeaa771d3e245ac5b2  proto/kbproto-1.0.7.tar.bz2
+1f48c4b0004d8b133efd0498e8d88d68d3b9199c  proto/recordproto-1.14.2.tar.bz2
+7ae9868a358859fe539482b02414aa15c2d8b1e4  proto/renderproto-0.11.1.tar.bz2
+b8d736342dcb73b71584d99a1cb9806d93c25ff8  proto/xextproto-7.3.0.tar.bz2
+d62c43e1b3619ab85732e0113eaa2104920730ac  proto/xproto-7.0.28.tar.bz2
+03018e2fb9d7df4fec1623cedb1c090bc224f971  util/gccmakedep-1.0.3.tar.bz2
+52e236776133f217d438622034b8603d201a6ec5  util/imake-1.0.7.tar.bz2
+00cfc636694000112924198e6b9e4d72f1601338  util/util-macros-1.19.0.tar.bz2
+9b6ed71c74a83181a47eb180787e9ab9a5efdfa2  util/xorg-cf-files-1.0.6.tar.bz2
+7fc486ad0ec54938f8b781cc374218f50eac8b99  xcb/libpthread-stubs-0.3.tar.bz2
+28e47aa699d2c2cffed31d1aa2473a9fefe77f17  xcb/libxcb-1.11.1.tar.bz2
+608bd60663e223464d38acec0183ddb827776401  xcb/xcb-proto-1.11.tar.bz2
+EOF
+
+cd ../unpacked
+tar cjf ../"$tarbase".tar.bz2 *
+
+cd "$origpwd"
+mv "$work/$tarbase".tar.bz2 .
+sha1sum "$tarbase".tar.bz2
+rm -rf "$work"

--- a/recipes/modern-xorg-stack/meta.yaml
+++ b/recipes/modern-xorg-stack/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "modern-xorg-stack" %}
+{% set version = "2016.03" %}
+{% set sha256 = "e1b113064a7dea7b1ea7e7f2bb5fda771587f816b423d81c918904e3e19dc2af" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{name }}-{{ version }}.tar.bz2
+  url: http://newton.cx/~peter/files/{{ name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+  patches:
+    - no-lib64.patch
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  skip: true #[win]
+
+requirements:
+  build:
+    - python
+    - toolchain
+
+about:
+  home: http://www.x.org/
+  license: X.org license
+  summary: 'Modern versions of the X11 client libraries'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/modern-xorg-stack/meta.yaml
+++ b/recipes/modern-xorg-stack/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - pkg-config
     - python
     - toolchain
 

--- a/recipes/modern-xorg-stack/meta.yaml
+++ b/recipes/modern-xorg-stack/meta.yaml
@@ -16,16 +16,22 @@ source:
 build:
   number: 0
   detect_binary_files_with_prefix: true
-  skip: true #[win]
+  skip: true  # [win]
 
 requirements:
   build:
     - python
     - toolchain
 
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libX11.so  # [linux]
+    - test -f ${PREFIX}/lib/libX11.dylib  # [osx]
+
+
 about:
   home: http://www.x.org/
-  license: X.org license
+  license: X.org
   summary: 'Modern versions of the X11 client libraries'
 
 extra:

--- a/recipes/modern-xorg-stack/meta.yaml
+++ b/recipes/modern-xorg-stack/meta.yaml
@@ -18,17 +18,30 @@ build:
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
+# The requirement of configparser below is a total hack. For some reason,
+# conda-build-all errors out when it tries to build multiple versions of this
+# package on the OSX builders: the first build succeeds, but then it doesn't
+# install pkg-config for the second build attempt for some reason, leading to
+# a failure. But, the only reason it was attempting to build multiple versions
+# of the package was because I was requiring `python`, which is needed by
+# X.org build tools but not actually used by the resulting binaries -- so
+# there should not be multiple output packages for different Python versions.
+# It turns out that conda-build-all decides to build multiple packages if
+# `python` is explicitly required in meta.yaml -- but not if it's implicitly
+# required. So, by requiring `configparser`, we draw in the Python dep needed
+# to do the build, but fool conda-build-all's logic, so that we only require
+# one package build and avoid the missing-pkg-config problem. Fun times.
+
 requirements:
   build:
+    - configparser
     - pkg-config
-    - python
     - toolchain
 
 test:
   commands:
     - test -f ${PREFIX}/lib/libX11.so  # [linux]
     - test -f ${PREFIX}/lib/libX11.dylib  # [osx]
-
 
 about:
   home: http://www.x.org/

--- a/recipes/modern-xorg-stack/no-lib64.patch
+++ b/recipes/modern-xorg-stack/no-lib64.patch
@@ -1,0 +1,24 @@
+--- xorg-cf-files-1.0.6/linux.cf.orig	2016-01-16 15:23:08.121009598 +0000
++++ xorg-cf-files-1.0.6/linux.cf	2016-01-16 15:23:50.711116569 +0000
+@@ -578,11 +578,7 @@
+ #define MkdirHierCmd		mkdir -p
+ 
+ #ifndef HaveLib64
+-# if defined (AMD64Architecture) || defined (s390xArchitecture) || defined (Ppc64Architecture) || defined (AArch64Architecture)
+-#  define HaveLib64	YES
+-# else
+-#  define HaveLib64	NO
+-# endif
++# define HaveLib64	NO
+ #endif
+ 
+ #if UseElfFormat
+@@ -1072,7 +1068,7 @@
+ 
+ #if HaveLib64
+ # ifndef LibDirName
+-#  define LibDirName		lib64
++#  define LibDirName		lib
+ # endif
+ # ifndef SystemUsrLibDir
+ #  define SystemUsrLibDir	/usr/lib64


### PR DESCRIPTION
This adds a package called "modern-xorg-stack" that bundles up a consistent, modern X11 client library experience for Linux and MacOS. In particular, it provides XInput2, which is required by newer GUI libraries but not available on some old Linux distributions.

Since X11 is a protocol, it should be noted that applications can link with these libraries and work successfully regardless of the particular way in which their host machine's X11 setup is configured.