### PR TITLE
First cut at xerces-c28 recipe.

### DIFF
--- a/recipes/xerces-c28/build.sh
+++ b/recipes/xerces-c28/build.sh
@@ -36,4 +36,4 @@ make install
 cd $PREFIX
 find . '(' -name '*.la' -o -name '*.a' ')' -delete
 mv include/xercesc include/xercesc28
-rm -f lib/libxerces*.$soext
+rm -f lib/libxerces-c.$soext lib/libxerces-depdom.$soext

--- a/recipes/xerces-c28/build.sh
+++ b/recipes/xerces-c28/build.sh
@@ -35,5 +35,5 @@ make install
 
 cd $PREFIX
 find . '(' -name '*.la' -o -name '*.a' ')' -delete
-mv include/xerces include/xercesc28
+mv include/xercesc include/xercesc28
 rm -f lib/libxerces*.$soext

--- a/recipes/xerces-c28/build.sh
+++ b/recipes/xerces-c28/build.sh
@@ -3,12 +3,7 @@
 set -e
 
 if [ -n "$OSX_ARCH" ] ; then
-    export MACOSX_DEPLOYMENT_TARGET=10.7 # C++ libc++ needs this
-    sdk=/
-    export CFLAGS="$CFLAGS -isysroot $sdk"
-    export CXXFLAGS="$CXXFLAGS -isysroot $sdk -stdlib=libc++"
-    export LDFLAGS="$LDFLAGS -Wl,-syslibroot,$sdk"
-
+    export CXXFLAGS="-stdlib=libc++"
     platform=macosx
     soext=dylib
 else

--- a/recipes/xerces-c28/build.sh
+++ b/recipes/xerces-c28/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -n "$OSX_ARCH" ] ; then
-    export CXXFLAGS="-stdlib=libc++"
+    export CXXFLAGS="$CXXFLAGS -stdlib=libc++"
     platform=macosx
     soext=dylib
 else

--- a/recipes/xerces-c28/build.sh
+++ b/recipes/xerces-c28/build.sh
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+set -e
+
+if [ -n "$OSX_ARCH" ] ; then
+    export MACOSX_DEPLOYMENT_TARGET=10.7 # C++ libc++ needs this
+    sdk=/
+    export CFLAGS="$CFLAGS -isysroot $sdk"
+    export CXXFLAGS="$CXXFLAGS -isysroot $sdk -stdlib=libc++"
+    export LDFLAGS="$LDFLAGS -Wl,-syslibroot,$sdk"
+
+    platform=macosx
+    soext=dylib
+else
+    platform=linux
+    soext=so
+fi
+
+# We've added stock (version 3) xerces-c as a build-time dep to make sure that
+# we don't clobber any of its files -- if we create a file with the same name,
+# conda-build will think that it comes from the main package. But, we don't
+# actually want it to be available! So clobber its files.
+
+rm -rf $PREFIX/include/xercesc $PREFIX/lib/libxerces-c* $PREFIX/lib/pkgconfig/xerces-c*
+
+export XERCESCROOT=$(pwd)
+cd src/xercesc
+bash ./runConfigure -p$platform -cgcc -xg++ -minmem -nsocket -tnative -rpthread -b64 -P$PREFIX
+make # note: build is not parallel-compatible
+make install
+
+# We need to rename our output files so as to not conflict with the files in
+# the stock (version 3) xerces-c. This includes the unversion dynamic library
+# files.
+
+cd $PREFIX
+find . '(' -name '*.la' -o -name '*.a' ')' -delete
+mv include/xerces include/xercesc28
+rm -f lib/libxerces*.$soext

--- a/recipes/xerces-c28/macsvn.diff
+++ b/recipes/xerces-c28/macsvn.diff
@@ -1,0 +1,946 @@
+Index: src/xercesc/Makefile.incl
+===================================================================
+--- src/xercesc/Makefile.incl	(revision 607729)
++++ src/xercesc/Makefile.incl	(working copy)
+@@ -1070,6 +1070,9 @@
+     SO_DEPDOM  =${LIBDEPDOM}.${SO_TARGET_VERSION}${SHLIBSUFFIX}
+     REAL_DEPDOM=${LIBDEPDOM}.${SO_TARGET_VERSION}.${SO_TARGET_VERSION_MAJOR}${SHLIBSUFFIX}
+ 
++    RESLIB_LINK_NAME=${RESLIBNAME}${SHLIBSUFFIX}
++    RESLIB_SO_NAME  =${RESLIBNAME}${SO_TARGET_VERSION}${SHLIBSUFFIX}
++    RESLIB_REAL_NAME=${RESLIBNAME}${VER}${SHLIBSUFFIX}	        
+ endif
+ ifeq (${PLATFORM}, QNX)
+     #
+Index: src/xercesc/runConfigure
+===================================================================
+--- src/xercesc/runConfigure	(revision 607729)
++++ src/xercesc/runConfigure	(working copy)
+@@ -471,6 +471,9 @@
+                        ;;
+                   esac
+               fi ;;
++           macosx)
++              bitstobuildDefines=" $bitstobuildDefines -m64 "
++              bitstobuildLink=" -m64 " ;;              
+            aix)
+               if test $cppcompiler; then
+                   case $cppcompiler in
+Index: src/xercesc/util/Platforms/MacOS/MacCarbonFile.cpp
+===================================================================
+--- src/xercesc/util/Platforms/MacOS/MacCarbonFile.cpp	(revision 607729)
++++ src/xercesc/util/Platforms/MacOS/MacCarbonFile.cpp	(working copy)
+@@ -45,6 +45,9 @@
+ unsigned int
+ XMLMacCarbonFile::currPos()
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return 0;
++#else
+     OSErr err = noErr;
+     unsigned int pos = 0;
+ 
+@@ -70,12 +73,14 @@
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotGetCurPos);
+ 
+     return pos;
++#endif
+ }
+ 
+ 
+ void
+ XMLMacCarbonFile::close()
+ {
++#ifndef XML_BITSTOBUILD_64
+     OSErr err = noErr;
+     if (!mFileValid)
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotCloseFile);
+@@ -89,12 +94,16 @@
+ 
+     if (err != noErr)
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotCloseFile);
++#endif
+ }
+ 
+ 
+ unsigned int
+ XMLMacCarbonFile::size()
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return 0;
++#else
+     OSErr err = noErr;
+     unsigned int len = 0;
+ 
+@@ -120,12 +129,16 @@
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotGetSize);
+ 
+     return len;
++#endif
+ }
+ 
+ 
+ bool
+ XMLMacCarbonFile::openWithPermission(const XMLCh* const fileName, int macPermission)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return false;
++#else
+     OSErr err = noErr;
+ 
+     if (mFileValid)
+@@ -159,12 +172,14 @@
+ 
+     mFileValid = true;
+ 	return mFileValid;
++#endif
+ }
+ 
+ 
+ void
+ XMLMacCarbonFile::create(const XMLCh* const filePath)
+ {
++#ifndef XML_BITSTOBUILD_64
+     OSErr err = noErr;
+ 
+     //	Split path into directory and filename components
+@@ -255,12 +270,16 @@
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotReadFromFile);
+         //ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotWriteToFile);
+     }
++#endif
+ }
+ 
+ 
+ bool
+ XMLMacCarbonFile::open(const XMLCh* const path, bool toWrite)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return false;
++#else
+ 	bool success = false;
+ 	
+ 	if (toWrite)
+@@ -274,12 +293,16 @@
+ 	}
+ 	
+ 	return success;
++#endif
+ }
+ 
+ 
+ bool
+ XMLMacCarbonFile::open(const char* fileName, bool toWrite)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return false;
++#else
+ 	//	Transcode the input filename from UTF8 into UTF16
+ 	UniChar uniBuf[kMaxMacStaticPathChars];
+ 	std::size_t pathLen = TranscodeUTF8ToUniChars(fileName, uniBuf, kMaxMacStaticPathChars-1);
+@@ -287,12 +310,16 @@
+ 	
+ 	//	Call through to the unicode open routine
+ 	return open(uniBuf, toWrite);
++#endif
+ }
+ 
+ 
+ unsigned int
+ XMLMacCarbonFile::read(const unsigned int toRead, XMLByte* const toFill)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return 0;
++#else
+     unsigned int bytesRead = 0;
+     OSErr err = noErr;
+ 
+@@ -316,12 +343,14 @@
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotReadFromFile);
+ 
+     return bytesRead;
++#endif
+ }
+ 
+ 
+ void
+ XMLMacCarbonFile::write(const long byteCount, const XMLByte* const buffer)
+ {
++#ifndef XML_BITSTOBUILD_64
+     long bytesWritten = 0;
+     OSErr err = noErr;
+ 
+@@ -350,12 +379,14 @@
+     {
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotWriteToFile);
+     }
++#endif
+ }
+ 
+ 
+ void
+ XMLMacCarbonFile::reset()
+ {
++#ifndef XML_BITSTOBUILD_64
+     OSErr err = noErr;
+ 
+     if (!mFileValid)
+@@ -368,13 +399,16 @@
+ 
+     if (err != noErr)
+         ThrowXML(XMLPlatformUtilsException, XMLExcepts::File_CouldNotResetFile);
++#endif
+ }
+ 
+ 
+ XMLMacCarbonFile::~XMLMacCarbonFile()
+ {
++#ifndef XML_BITSTOBUILD_64
+     if (mFileValid)
+         close();
++#endif
+ }
+ 
+ XERCES_CPP_NAMESPACE_END
+Index: src/xercesc/util/Platforms/MacOS/MacOSPlatformUtils.cpp
+===================================================================
+--- src/xercesc/util/Platforms/MacOS/MacOSPlatformUtils.cpp	(revision 607729)
++++ src/xercesc/util/Platforms/MacOS/MacOSPlatformUtils.cpp	(working copy)
+@@ -31,6 +31,13 @@
+ #include <algorithm>
+ #include <unistd.h>
+ 
++#if defined(XML_BITSTOBUILD_64)
++#include <stdio.h>
++#include <sys/time.h>
++#include <xercesc/util/Mutexes.hpp>
++#endif
++
++
+ #if defined(__APPLE__)
+     //	Include from Frameworks Headers under ProjectBuilder
+     #include <Carbon/Carbon.h>
+@@ -60,7 +67,9 @@
+ #include <xercesc/util/PanicHandler.hpp>
+ #include <xercesc/util/OutOfMemoryException.hpp>
+ 
+-#if (defined(XML_USE_INMEMORY_MSGLOADER) || defined(XML_USE_INMEM_MESSAGELOADER))
++#if defined(XML_USE_ICU_MESSAGELOADER)
++    #include <xercesc/util/MsgLoaders/ICU/ICUMsgLoader.hpp>
++#elif (defined(XML_USE_INMEMORY_MSGLOADER) || defined(XML_USE_INMEM_MESSAGELOADER))
+    #include <xercesc/util/MsgLoaders/InMemory/InMemMsgLoader.hpp>
+ #endif
+ 
+@@ -156,6 +165,9 @@
+ bool gUseGETCWD				= false;
+ 
+ 
++#if defined(XML_BITSTOBUILD_64)
++static XMLMutex* atomicOpsMutex = 0;
++#endif
+ // ---------------------------------------------------------------------------
+ //  XMLPlatformUtils: The panic method
+ // ---------------------------------------------------------------------------
+@@ -176,22 +188,63 @@
+ XMLPlatformUtils::curFilePos(const FileHandle theFile
+                              , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    int curPos = ftell( (FILE*)theFile);
++    if (curPos == -1)
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotGetSize, manager);
++
++    return (unsigned int)curPos;
++#else
+ 	return reinterpret_cast<XMLMacAbstractFile*>(theFile)->currPos();
++#endif
+ }
+ 
+ void
+ XMLPlatformUtils::closeFile(const FileHandle theFile
+                             , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    if (fclose((FILE*)theFile))
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotCloseFile, manager);
++#else
+     reinterpret_cast<XMLMacAbstractFile*>(theFile)->close();
+ 	delete reinterpret_cast<XMLMacAbstractFile*>(theFile);
++#endif
+ }
+ 
+ unsigned int
+ XMLPlatformUtils::fileSize(const FileHandle theFile
+                            , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    // Get the current position
++    long  int curPos = ftell((FILE*) theFile);
++    if (curPos == -1)
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotGetCurPos, manager);
++
++    // Seek to the end and save that value for return
++     if (fseek((FILE*) theFile, 0, SEEK_END))
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotSeekToEnd, manager);
++
++    long int retVal = ftell((FILE*)theFile);
++    if (retVal == -1)
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotSeekToEnd, manager);
++
++    // And put the pointer back
++
++    if (fseek( (FILE*)theFile, curPos, SEEK_SET) )
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotSeekToPos, manager);
++
++    return (unsigned int)retVal;
++#else
+     return reinterpret_cast<XMLMacAbstractFile*>(theFile)->size();
++#endif
+ }
+ 
+ 
+@@ -199,6 +252,13 @@
+ XMLPlatformUtils::openFile(const char* const fileName
+                            , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    FileHandle retVal = (FILE*)fopen( fileName , "rb" );
++
++    if (retVal == NULL)
++        return 0;
++    return retVal;
++#else
+     // Check to make sure the file system is in a state where we can use it
+     if (!gFileSystemCompatible)
+         ThrowXMLwithMemMgr1(XMLPlatformUtilsException, XMLExcepts::File_CouldNotOpenFile, fileName, manager);
+@@ -206,12 +266,22 @@
+     Janitor<XMLMacAbstractFile> file(XMLMakeMacFile(manager));
+     
+     return (file->open(fileName, false)) ? file.release() : NULL;
++#endif
+ }
+ 
+ 
+ FileHandle
+ XMLPlatformUtils::openFile(const XMLCh* const fileName, MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    const char* tmpFileName = XMLString::transcode(fileName, manager);
++    ArrayJanitor<char> janText((char*)tmpFileName, manager);
++    FileHandle retVal = (FILE*)fopen( tmpFileName , "rb" );
++
++    if (retVal == NULL)
++        return 0;
++    return retVal;
++#else
+     // Check to make sure the file system is in a state where we can use it
+     if (!gFileSystemCompatible)
+         ThrowXMLwithMemMgr1(XMLPlatformUtilsException, XMLExcepts::File_CouldNotOpenFile, fileName, manager);
+@@ -219,6 +289,7 @@
+     Janitor<XMLMacAbstractFile> file(XMLMakeMacFile(manager));
+ 
+     return (file->open(fileName, false)) ? file.release() : NULL;
++#endif
+ }
+ 
+ 
+@@ -226,6 +297,9 @@
+ XMLPlatformUtils::openFileToWrite(const char* const fileName
+                                   , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return fopen( fileName , "wb" );
++#else
+     // Check to make sure the file system is in a state where we can use it
+     if (!gFileSystemCompatible)
+         ThrowXMLwithMemMgr1(XMLPlatformUtilsException, XMLExcepts::File_CouldNotOpenFile, fileName, manager);
+@@ -233,6 +307,7 @@
+     Janitor<XMLMacAbstractFile> file(XMLMakeMacFile(manager));
+ 
+     return (file->open(fileName, true)) ? file.release() : NULL;
++#endif
+ }
+ 
+ 
+@@ -240,6 +315,11 @@
+ XMLPlatformUtils::openFileToWrite(const XMLCh* const fileName
+                                   , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    const char* tmpFileName = XMLString::transcode(fileName, manager);
++    ArrayJanitor<char> janText((char*)tmpFileName, manager);
++    return fopen( tmpFileName , "wb" );
++#else
+     // Check to make sure the file system is in a state where we can use it
+     if (!gFileSystemCompatible)
+         ThrowXMLwithMemMgr1(XMLPlatformUtilsException, XMLExcepts::File_CouldNotOpenFile, fileName, manager);
+@@ -247,15 +327,31 @@
+     Janitor<XMLMacAbstractFile> file(XMLMakeMacFile(manager));
+ 
+     return (file->open(fileName, true)) ? file.release() : NULL;
++#endif
+ }
+ 
+ 
+ FileHandle
+ XMLPlatformUtils::openStdInHandle(MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    int nfd = dup(0);
++    FileHandle fh;
++    if (nfd == -1)
++	    ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++		    XMLExcepts::File_CouldNotDupHandle, manager);
++    fh = (FileHandle) fdopen(nfd, "r");
++    if (fh == 0) {
+     XMLCh stdinStr[] = {chLatin_s, chLatin_t, chLatin_d, chLatin_i, chLatin_n, chNull};
+     ThrowXMLwithMemMgr1(XMLPlatformUtilsException, XMLExcepts::File_CouldNotOpenFile, stdinStr, manager);
+     return NULL;
++    } 
++    return fh;
++#else
++    XMLCh stdinStr[] = {chLatin_s, chLatin_t, chLatin_d, chLatin_i, chLatin_n, chNull};
++    ThrowXMLwithMemMgr1(XMLPlatformUtilsException, XMLExcepts::File_CouldNotOpenFile, stdinStr, manager);
++    return NULL;
++#endif
+ }
+ 
+ 
+@@ -265,17 +361,60 @@
+                                  ,        XMLByte* const  toFill
+                                  ,  MemoryManager* const  manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    size_t noOfItemsRead = fread((void*) toFill, 1, toRead, (FILE*)theFile);
++
++    if(ferror((FILE*)theFile))
++    {
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotReadFromFile, manager);
++    }
++
++    return (unsigned int)noOfItemsRead;
++#else
+     return reinterpret_cast<XMLMacAbstractFile*>(theFile)->read(toRead, toFill);
++#endif
+ }
+ 
+ 
+ void
+ XMLPlatformUtils::writeBufferToFile(   const   FileHandle   theFile
+-                                    ,  const long		    toWrite
++                                    ,  long		    toWrite
+                                     ,  const XMLByte* const toFlush
+                                     ,  MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    if (!theFile        ||
++        (toWrite <= 0 ) ||
++        !toFlush         )
++        return;
++
++    const XMLByte* tmpFlush = (const XMLByte*) toFlush;
++    size_t bytesWritten = 0;
++
++    while (true)
++    {
++        bytesWritten=fwrite(tmpFlush, sizeof(XMLByte), toWrite, (FILE*)theFile);
++
++        if(ferror((FILE*)theFile))
++        {
++            ThrowXMLwithMemMgr(XMLPlatformUtilsException, XMLExcepts::File_CouldNotWriteToFile, manager);
++        }
++
++        if (bytesWritten < toWrite) //incomplete write
++        {
++            tmpFlush+=bytesWritten;
++            toWrite-=bytesWritten;
++            bytesWritten=0;
++        }
++        else
++            return;
++    }
++
++    return;
++#else
+     return reinterpret_cast<XMLMacAbstractFile*>(theFile)->write(toWrite, toFlush);
++#endif
+ }
+ 
+ 
+@@ -283,7 +422,14 @@
+ XMLPlatformUtils::resetFile(FileHandle theFile
+                             , MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    // Seek to the start of the file
++    if (fseek((FILE*)theFile, 0, SEEK_SET))
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotResetFile, manager);
++#else
+     reinterpret_cast<XMLMacAbstractFile*>(theFile)->reset();
++#endif
+ }
+ 
+ 
+@@ -294,6 +440,24 @@
+ XMLPlatformUtils::getFullPath(const XMLCh* const srcPath,
+                               MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    //
++    //  NOTE: The path provided has always already been opened successfully,
++    //  so we know that its not some pathological freaky path. It comes in
++    //  in native format, and goes out as Unicode always
++    //
++    char* newSrc = XMLString::transcode(srcPath, manager);
++    ArrayJanitor<char> janText(newSrc, manager);
++
++    // Use a local buffer that is big enough for the largest legal path
++    char absPath[PATH_MAX + 1];
++    
++    // get the absolute path
++    if (!realpath(newSrc, absPath))
++   		ThrowXMLwithMemMgr(XMLPlatformUtilsException, XMLExcepts::File_CouldNotGetBasePathName, manager);
++
++    return XMLString::transcode(absPath, manager);
++#else
+     XMLCh* path = NULL;
+ 
+     if (gHasHFSPlusAPIs)
+@@ -314,6 +478,7 @@
+     }
+ 
+     return path;
++#endif
+ }
+ 
+ 
+@@ -327,6 +492,16 @@
+ 
+ XMLCh* XMLPlatformUtils::getCurrentDirectory(MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    char dirBuf[PATH_MAX + 2];
++    char *curDir = getcwd(&dirBuf[0], PATH_MAX + 1);
++
++    if (!curDir)
++        ThrowXMLwithMemMgr(XMLPlatformUtilsException,
++                 XMLExcepts::File_CouldNotGetBasePathName, manager);
++
++    return XMLString::transcode(curDir, manager);
++#else
+ 	//	Get a newly allocated path to the current directory
+ 	FSSpec spec;
+ 
+@@ -344,6 +519,7 @@
+ 	           XMLExcepts::File_CouldNotGetBasePathName, manager);
+ 	           
+ 	return path;
++#endif
+ }
+ 
+ 
+@@ -360,6 +536,11 @@
+ unsigned long
+ XMLPlatformUtils::getCurrentMillis()
+ {
++#if defined(XML_BITSTOBUILD_64)
++	struct timeval aTime;
++	gettimeofday(&aTime, NULL);
++	return (unsigned long) (aTime.tv_sec * 1000 + aTime.tv_usec / 1000);
++#else
+ 	if ((void*)kUnresolvedCFragSymbolAddress != UpTime)
+ 	{
+ 		// Use Driver services routines, now in Carbon,
+@@ -369,6 +550,7 @@
+ 	}
+ 	else
+ 		return TickCount() * 100 / 6;
++#endif
+ }
+ 
+ 
+@@ -462,12 +644,21 @@
+     // Replace *toFill with newValue iff *toFill == toCompare,
+     // returning previous value of *toFill
+ 
++#if defined(XML_BITSTOBUILD_64)
++    XMLMutexLock lockMutex(atomicOpsMutex);
++
++    void *retVal = *toFill;
++    if (*toFill == toCompare)
++        *toFill = (void *)newValue;
++
++    return retVal;
++#else
+     Boolean success = CompareAndSwap(
+         reinterpret_cast<UInt32>(toCompare),
+         reinterpret_cast<UInt32>(newValue),
+         reinterpret_cast<UInt32*>(toFill));
+-
+     return (success) ? const_cast<void*>(toCompare) : *toFill;
++#endif
+ }
+ 
+ 
+@@ -482,14 +673,24 @@
+ int
+ XMLPlatformUtils::atomicIncrement(int &location)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    XMLMutexLock lockMutex(atomicOpsMutex);
++    return ++location;
++#else
+     return IncrementAtomic(reinterpret_cast<long*>(&location)) + 1;
++#endif
+ }
+ 
+ 
+ int
+ XMLPlatformUtils::atomicDecrement(int &location)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    XMLMutexLock lockMutex(atomicOpsMutex);
++    return --location;
++#else
+     return DecrementAtomic(reinterpret_cast<long*>(&location)) - 1;
++#endif
+ }
+ 
+ 
+@@ -508,10 +709,15 @@
+ 	//	Detect available functions
+ 	
+ 	//  Check whether we're on OS X
++#if defined(XML_BITSTOBUILD_64)
++        gMacOSXOrBetter = true;
++	gUsePosixFiles	= true;
++        gFileSystemCompatible = true;
++	gHasMPAPIs	= true;
++#else
+ 	gMacOSXOrBetter			= noErr == Gestalt(gestaltSystemVersion, &value)
+ 							  && value >= 0x00001000
+ 							  ;
+-	
+     //	Look for file system services
+     if (noErr == Gestalt(gestaltFSAttr, &value))
+     {
+@@ -551,6 +757,16 @@
+ 
+     //	Look for MP
+ 	gHasMPAPIs				= MPLibraryIsLoaded();
++#endif
++
++#if defined(XML_BITSTOBUILD_64)
++    if ( atomicOpsMutex == 0 )
++    {
++       	atomicOpsMutex = new (fgMemoryManager) XMLMutex(fgMemoryManager);
++	if (atomicOpsMutex->fHandle == 0)
++	   atomicOpsMutex->fHandle = XMLPlatformUtils::makeMutex(fgMemoryManager);
++    }
++#endif
+ }
+ 
+ 
+@@ -560,6 +776,13 @@
+ void
+ XMLPlatformUtils::platformTerm()
+ {
++#if defined(XML_BITSTOBUILD_64)
++    // delete the mutex we created
++    closeMutex(atomicOpsMutex->fHandle);
++    atomicOpsMutex->fHandle = 0;
++    delete atomicOpsMutex;
++    atomicOpsMutex = 0;
++#endif
+ }
+ 
+ 
+@@ -613,7 +836,9 @@
+     XMLMsgLoader* retVal;
+     try
+     {
+-#if (defined(XML_USE_INMEMORY_MSGLOADER) || defined(XML_USE_INMEM_MESSAGELOADER))
++#if defined (XML_USE_ICU_MESSAGELOADER)
++        retVal = new (fgMemoryManager) ICUMsgLoader(msgDomain);
++#elif (defined(XML_USE_INMEMORY_MSGLOADER) || defined(XML_USE_INMEM_MESSAGELOADER))
+         retVal = new (fgMemoryManager) InMemMsgLoader(msgDomain);
+ #else
+         #error You must provide a message loader
+@@ -766,6 +991,9 @@
+ bool
+ XMLParsePathToFSRef(const XMLCh* const pathName, FSRef& ref, MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return false;
++#else
+ 	bool result;
+ 	
+ 	//	If FSPathMakeRef is available, we use it to parse the
+@@ -789,12 +1017,16 @@
+ 		result = XMLParsePathToFSRef_Classic(pathName, ref, manager);
+ 		
+ 	return result;
++#endif
+ }
+ 
+ 
+ bool
+ XMLParsePathToFSRef_X(const XMLCh* const pathName, FSRef& ref, MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	//	Parse Path to FSRef using FSPathMakeRef as available under
+ 	//	Mac OS X and CarbonLib 1.1 and greater.
+ 	
+@@ -861,12 +1093,16 @@
+ 		
+ 	//	Return true on success
+ 	return (err == noErr);
++#endif
+ }
+ 
+ 
+ bool
+ XMLParsePathToFSRef_Classic(const XMLCh* const pathName, FSRef& ref, MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	//	Parse Path to FSRef by stepping manually through path components.
+ 	
+ 	//	Path's parsed in this way must always begin with a volume name.
+@@ -993,6 +1229,7 @@
+     }
+ 
+     return err == noErr;
++#endif
+ }
+ 
+ 
+@@ -1000,6 +1237,9 @@
+ XMLParsePathToFSSpec(const XMLCh* const pathName, FSSpec& spec,
+                             MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	//	Parse Path to an FSSpec
+ 
+ 	//	If we've got HFS+ APIs, do this in terms of refs so that
+@@ -1029,6 +1269,7 @@
+ 		
+ 	//	Return true on success
+ 	return result;
++#endif
+ }
+ 
+ 
+@@ -1036,6 +1277,9 @@
+ XMLParsePathToFSSpec_Classic(const XMLCh* const pathName, FSSpec& spec,
+                             MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	//	Manually parse the path using FSSpec APIs.
+ 	
+     //	Transcode the path into ascii
+@@ -1188,6 +1432,7 @@
+     }
+ 
+     return err == noErr;
++#endif
+ }
+ 
+ 
+@@ -1195,6 +1440,9 @@
+ XMLCreateFullPathFromFSRef(const FSRef& startingRef,
+                             MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	XMLCh* result = NULL;
+ 	
+ 	//	If FSRefMakePath is available, we use it to create the
+@@ -1216,6 +1464,7 @@
+ 		result = XMLCreateFullPathFromFSRef_Classic(startingRef, manager);
+ 		
+ 	return result;
++#endif
+ }
+ 
+ 
+@@ -1223,6 +1472,9 @@
+ XMLCreateFullPathFromFSRef_X(const FSRef& startingRef,
+                             MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	//	Create the path using FSRefMakePath as available on Mac OS X
+ 	//	and under CarbonLib 1.1 and greater.
+ 	OSStatus err = noErr;
+@@ -1250,6 +1502,7 @@
+ 		CopyUniCharsToXMLChs(uniBuf, result.get(), pathLen, pathLen);
+ 		
+ 	return result.release();
++#endif
+ }
+ 
+ 
+@@ -1257,6 +1510,9 @@
+ XMLCreateFullPathFromFSRef_Classic(const FSRef& startingRef,
+                             MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	//	Manually create the path using FSRef APIs.
+     OSStatus err = noErr;
+     FSCatalogInfo catalogInfo;
+@@ -1336,6 +1592,7 @@
+ 		std::memcpy(final.get() + bufCnt, result.get(), resultLen * sizeof(XMLCh));
+ 	
+     return final.release();
++#endif
+ }
+ 
+ 
+@@ -1343,6 +1600,9 @@
+ XMLCreateFullPathFromFSSpec(const FSSpec& startingSpec,
+                             MemoryManager* const manager)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
+ 	XMLCh* result = NULL;
+ 	
+ 	//	If FSRefs are available, do this operation in terms of refs...this
+@@ -1368,6 +1628,7 @@
+ 	}
+ 		
+ 	return result;
++#endif
+ }
+ 
+ 
+@@ -1375,7 +1636,10 @@
+ XMLCreateFullPathFromFSSpec_Classic(const FSSpec& startingSpec,
+                                     MemoryManager* const manager)
+ {
+-	//	Manually create the path using FSSpec APIs.
++#if defined(XML_BITSTOBUILD_64)
++    return NULL;
++#else
++    //	Manually create the path using FSSpec APIs.
+     OSStatus err = noErr;
+     FSSpec spec = startingSpec;
+ 
+@@ -1458,6 +1722,7 @@
+ 
+     // Cleanup and transcode to unicode
+     return XMLString::transcode(final.get(), manager);
++#endif
+ }
+ 
+ 
+Index: src/xercesc/util/Transcoders/MacOSUnicodeConverter/MacOSUnicodeConverter.cpp
+===================================================================
+--- src/xercesc/util/Transcoders/MacOSUnicodeConverter/MacOSUnicodeConverter.cpp	(revision 607729)
++++ src/xercesc/util/Transcoders/MacOSUnicodeConverter/MacOSUnicodeConverter.cpp	(working copy)
+@@ -98,7 +98,11 @@
+   : fCollator(NULL)
+ {
+ 	//	Test for presense of unicode collation functions
++#if defined(XML_BITSTOBUILD_64)
++	fHasUnicodeCollation = true;
++#else
+ 	fHasUnicodeCollation = (UCCompareText != (void*)kUnresolvedCFragSymbolAddress);
++#endif
+     
+     //  Create a unicode collator for doing string comparisons
+     if (fHasUnicodeCollation)
+@@ -441,10 +445,17 @@
+ 	UnicodeToTextInfo unicodeToTextInfo = NULL;
+ 
+ 	//	Map the encoding to a Mac OS Encoding value
+-	Str255 pasEncodingName;
+ 	char cEncodingName[256];
+ 	ConvertWideToNarrow(encodingName, cEncodingName, sizeof(cEncodingName));
++#if defined(XML_BITSTOBUILD_64)
++        CFStringRef temp;
++        temp = CFStringCreateWithCString(NULL, cEncodingName, kCFStringEncodingUTF16);
++        const unsigned char* pasEncodingName = CFStringGetPascalStringPtr (temp, kCFStringEncodingASCII);
++
++#else
++	Str255 pasEncodingName;
+ 	CopyCStringToPascal(cEncodingName, pasEncodingName);
++#endif
+ 	
+ 	TextEncoding textEncoding = 0;
+ 	OSStatus status = TECGetTextEncodingFromInternetName (
+@@ -515,9 +526,13 @@
+ bool
+ MacOSUnicodeConverter::IsMacOSUnicodeConverterSupported(void)
+ {
++#if defined(XML_BITSTOBUILD_64)
++    return true;
++#else
+     return UpgradeScriptInfoToTextEncoding != (void*)kUnresolvedCFragSymbolAddress
+         && CreateTextToUnicodeInfoByEncoding != (void*)kUnresolvedCFragSymbolAddress
+         ;
++#endif
+ }
+ 
+ 
+@@ -626,7 +641,12 @@
+     	if (status == kTECUnmappableElementErr && options == UnRep_Throw)
+     	{
+     		XMLCh tmpBuf[17];
++#if defined(XML_BITSTOBUILD_64)
++            unsigned int tmpValue = (unsigned int)srcData[charsConsumed];
++            XMLString::binToText(tmpValue, tmpBuf, 16, 16);
++#else
+             XMLString::binToText((unsigned int)&srcData[charsConsumed], tmpBuf, 16, 16);
++#endif
+             ThrowXML2
+             (
+                 TranscodingException
+Index: tests/runConfigure
+===================================================================
+--- tests/runConfigure	(revision 607729)
++++ tests/runConfigure	(working copy)
+@@ -381,6 +381,9 @@
+                        ;;
+                   esac
+               fi ;;
++           macosx)
++              bitstobuildDefines=" $bitstobuildDefines -m64 "
++              bitstobuildLink=" -m64 " ;;              
+            aix)
+               if test $cppcompiler; then
+                   case $cppcompiler in
+Index: samples/runConfigure
+===================================================================
+--- samples/runConfigure	(revision 607729)
++++ samples/runConfigure	(working copy)
+@@ -382,6 +382,9 @@
+                        ;;
+                   esac
+               fi ;;
++           macosx)
++              bitstobuildDefines=" $bitstobuildDefines -m64 "
++              bitstobuildLink=" -m64 " ;;              
+            aix)
+               if test $cppcompiler; then
+                   case $cppcompiler in

--- a/recipes/xerces-c28/meta.yaml
+++ b/recipes/xerces-c28/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "xerces-c28" %}
+{% set version = "2.8.0" %}
+{% set sha256 = "f41960813bde1846bbf3e77d7539c90e0983c34bfb99f5ebe32e9ad47a911f89" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: openlogic-xerces-c-{{ version }}-all-src-1.zip
+  url: https://olex-secure.openlogic.com/content/openlogic/xerces-c/{{ version }}/openlogic-xerces-c-{{ version }}-all-src-1.zip
+  sha256: {{ sha256 }}
+  # OS X patch from: https://issues.apache.org/jira/secure/attachment/12372362/macsvn.diff
+  patches:
+    - macsvn.diff  # [osx]
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    # We include xerces-c as a build-time dep to make sure that we don't overwrite
+    # any of its files.
+    - xerces-c
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libxerces-c.so.28  # [linux]
+    - test -f ${PREFIX}/lib/libxerces-2.dylib.28  # [osx]
+
+about:
+  home: http://xerces.apache.org/xerces-c/
+  license: Apache 2.0
+  summary: 'An outdated version of the Xerces XML parsing framework'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xerces-c28/meta.yaml
+++ b/recipes/xerces-c28/meta.yaml
@@ -29,7 +29,7 @@ requirements:
 test:
   commands:
     - test -f ${PREFIX}/lib/libxerces-c.so.28  # [linux]
-    - test -f ${PREFIX}/lib/libxerces-2.dylib.28  # [osx]
+    - test -f ${PREFIX}/lib/libxerces-c.28.dylib  # [osx]
 
 about:
   home: http://xerces.apache.org/xerces-c/


### PR DESCRIPTION
This adds the legacy version 2.8 of the `xerces-c` library. Upstream strongly discourages people from using it, but I have a large application that requires it as a dependency.

The package has been structured to not conflict with the stock (version 3) `xerces-c` package. Users should be able to install both without any ill effects.