### PR TITLE
Pin `conda-build-all` to `1.0.0`

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -14,7 +14,7 @@ curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84b
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet conda-build-all
+conda install --yes --quiet conda-build-all=1.0.0
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,7 +88,7 @@ install:
     - cmd: conda config --set show_channel_urls true
     - cmd: conda update --yes --quiet conda
 
-    - cmd: conda install --yes --quiet obvious-ci conda-build-all
+    - cmd: conda install --yes --quiet obvious-ci conda-build-all=1.0.0
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -48,7 +48,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update conda conda-build
-conda install conda-build-all
+conda install conda-build-all=1.0.0
 conda install conda-forge-build-setup
 source run_conda_forge_build_setup
 


### PR DESCRIPTION
Closes https://github.com/conda-forge/numpy-feedstock/issues/42

This pinning of `conda-build-all` is being done as a workaround for issues installing `numpy` into the build/test environment.

xref: https://github.com/conda-forge/staged-recipes/pull/2110
xref: https://github.com/conda-forge/staged-recipes/pull/2054
xref: https://github.com/conda-forge/staged-recipes/pull/2105
xref: https://github.com/conda-forge/staged-recipes/pull/2063