### PR TITLE
add PyAbel 

### DIFF
--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PyAbel" %}
-{% set version = "0.7.4" %}
-{% set sha256 = "95f40daeba34789119aa2391a113248763f333e567b9d65fbd3a0fde1b10ed1f" %}
+{% set version = "0.7.5" %}
+{% set sha256 = "100997198594afcfe7d4458114aa07de3c66f239a49b9281df2fdebf320cda27" %}
 
 package:
   name: {{ name|lower }}
@@ -41,7 +41,7 @@ about:
   home: https://github.com/PyAbel/PyAbel
   license: MIT
   license_family: MIT
-  #license_file: LICENSE.txt
+  license_file: LICENSE.txt
   summary: 'A Python package for forward and inverse Abel transforms'
   description: |
     PyAbel is a Python package that provides functions for the forward and inverse Abel transforms.

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -1,0 +1,76 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+{% set name = "pyabel" %}
+{% set version = "0.7.4" %}
+{% set md5 = "1f9be2ecdc1ea8424000d62e2d6a4b10" %}
+# sha256 is the prefered checksum -- you can get it for a file with:
+#  `openssl sha256 <file name>`.
+# You may need the openssl package, available on conda-forge
+#  `conda install openssl -c conda-forge``
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for Python 2.7, 3.4, and above, for all major OSs.
+  # Add the line "skip: True  # [py<34]" (for example) to limit to Python 3.4 and newer, or "skip: True  # [not win]" to limit to Windows.
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    # When setuptools is available add the `--single-version-externally-managed --record record.txt` above.
+    - setuptools
+    # if your project compiles code (such as a C extension) then add `toolchain` as a build requirement.
+	- toolchain
+    - numpy >=1.6
+    - setuptools >=16.0
+    - scipy >=0.14
+    - six >=1.10.0
+  run:
+    - python
+    - numpy >=1.6
+    - setuptools >=16.0
+    - scipy >=0.14
+    - six >=1.10.0
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - abel
+    - abel.lib
+    - abel.tests
+    - abel.tools
+
+about:
+  home: https://github.com/PyAbel/PyAbel
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'A Python package for forward and inverse Abel transforms'
+  description: |
+    PyAbel is a Python package that provides functions for the forward and inverse Abel transforms. 
+	The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the 
+	2D projection of that object. The inverse abel transform takes a 2D projection and reconstructs 
+	a slice of the cylindrically symmetric 3D distribution.
+  doc_url: http://pyabel.readthedocs.io/en/latest/readme_link.html
+  dev_url: https://github.com/PyAbel/PyAbel
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - DanHickstein
+    - rth
+	- stggh
+	- DhrubajyotiDas

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "pyabel" %}
+{% set name = "PyAbel" %}
 {% set version = "0.7.4" %}
 {% set md5 = "1f9be2ecdc1ea8424000d62e2d6a4b10" %}
 

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -21,9 +21,11 @@ requirements:
     - setuptools
     - toolchain
     - cython
+    - numpy x.x
     - numpy >=1.6
   run:
     - python
+    - numpy x.x
     - numpy >=1.6
     - scipy >=0.14
     - six >=1.10.0
@@ -54,3 +56,4 @@ extra:
     - DanHickstein
     - rth
     - stggh
+    - DhrubajyotiDas

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -42,7 +42,7 @@ about:
   home: https://github.com/PyAbel/PyAbel
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  license_file: LICENSE
   summary: 'A Python package for forward and inverse Abel transforms'
   description: |
     PyAbel is a Python package that provides functions for the forward and inverse Abel transforms.

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -42,7 +42,6 @@ about:
   home: https://github.com/PyAbel/PyAbel
   license: MIT
   license_family: MIT
-  license_file: LICENSE
   summary: 'A Python package for forward and inverse Abel transforms'
   description: |
     PyAbel is a Python package that provides functions for the forward and inverse Abel transforms.

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PyAbel" %}
 {% set version = "0.7.4" %}
-{% set md5 = "1f9be2ecdc1ea8424000d62e2d6a4b10" %}
+{% set sha256 = "95f40daeba34789119aa2391a113248763f333e567b9d65fbd3a0fde1b10ed1f" %}
 
 package:
   name: {{ name|lower }}
@@ -9,7 +9,7 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: {{ md5 }}
+  sha256: {{ sha256 }}
 
 build:
   number: 0
@@ -22,13 +22,9 @@ requirements:
     - toolchain
     - cython
     - numpy >=1.6
-    - setuptools >=16.0
-    - scipy >=0.14
-    - six >=1.10.0
   run:
     - python
     - numpy >=1.6
-    - setuptools >=16.0
     - scipy >=0.14
     - six >=1.10.0
 
@@ -43,6 +39,7 @@ about:
   home: https://github.com/PyAbel/PyAbel
   license: MIT
   license_family: MIT
+  #license_file: LICENSE.txt
   summary: 'A Python package for forward and inverse Abel transforms'
   description: |
     PyAbel is a Python package that provides functions for the forward and inverse Abel transforms.
@@ -57,4 +54,3 @@ extra:
     - DanHickstein
     - rth
     - stggh
-    - DhrubajyotiDas

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - setuptools
     - toolchain
+    - cython
     - numpy >=1.6
     - setuptools >=16.0
     - scipy >=0.14

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "PyAbel" %}
-{% set version = "0.7.5" %}
-{% set sha256 = "100997198594afcfe7d4458114aa07de3c66f239a49b9281df2fdebf320cda27" %}
+{% set version = "0.7.6" %}
+{% set sha256 = "6668c86b9b52efa0b110105cd749754db779dbe2fa9684b3c4f1a2f6784394e2" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   build:
     - python
     - setuptools
-	- toolchain
+    - toolchain
     - numpy >=1.6
     - setuptools >=16.0
     - scipy >=0.14
@@ -45,9 +45,9 @@ about:
   license_file: LICENSE.txt
   summary: 'A Python package for forward and inverse Abel transforms'
   description: |
-    PyAbel is a Python package that provides functions for the forward and inverse Abel transforms. 
-	The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the 
-	2D projection of that object. The inverse abel transform takes a 2D projection and reconstructs 
+    PyAbel is a Python package that provides functions for the forward and inverse Abel transforms.
+	The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the
+	2D projection of that object. The inverse abel transform takes a 2D projection and reconstructs
 	a slice of the cylindrically symmetric 3D distribution.
   doc_url: http://pyabel.readthedocs.io/en/latest/readme_link.html
   dev_url: https://github.com/PyAbel/PyAbel
@@ -56,5 +56,5 @@ extra:
   recipe-maintainers:
     - DanHickstein
     - rth
-	- stggh
-	- DhrubajyotiDas
+    - stggh
+    - DhrubajyotiDas

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -1,13 +1,6 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
 {% set name = "pyabel" %}
 {% set version = "0.7.4" %}
 {% set md5 = "1f9be2ecdc1ea8424000d62e2d6a4b10" %}
-# sha256 is the prefered checksum -- you can get it for a file with:
-#  `openssl sha256 <file name>`.
-# You may need the openssl package, available on conda-forge
-#  `conda install openssl -c conda-forge``
 
 package:
   name: {{ name|lower }}
@@ -20,17 +13,12 @@ source:
 
 build:
   number: 0
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for Python 2.7, 3.4, and above, for all major OSs.
-  # Add the line "skip: True  # [py<34]" (for example) to limit to Python 3.4 and newer, or "skip: True  # [not win]" to limit to Windows.
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
-    # When setuptools is available add the `--single-version-externally-managed --record record.txt` above.
     - setuptools
-    # if your project compiles code (such as a C extension) then add `toolchain` as a build requirement.
 	- toolchain
     - numpy >=1.6
     - setuptools >=16.0
@@ -44,8 +32,6 @@ requirements:
     - six >=1.10.0
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - abel
     - abel.lib
@@ -68,8 +54,6 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - DanHickstein
     - rth
 	- stggh

--- a/recipes/pyabel/meta.yaml
+++ b/recipes/pyabel/meta.yaml
@@ -46,9 +46,9 @@ about:
   summary: 'A Python package for forward and inverse Abel transforms'
   description: |
     PyAbel is a Python package that provides functions for the forward and inverse Abel transforms.
-	The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the
-	2D projection of that object. The inverse abel transform takes a 2D projection and reconstructs
-	a slice of the cylindrically symmetric 3D distribution.
+    The forward Abel transform takes a slice of a cylindrically symmetric 3D object and provides the
+    2D projection of that object. The inverse abel transform takes a 2D projection and reconstructs
+    a slice of the cylindrically symmetric 3D distribution.
   doc_url: http://pyabel.readthedocs.io/en/latest/readme_link.html
   dev_url: https://github.com/PyAbel/PyAbel
 


### PR DESCRIPTION
One of the users of the PyAbel package has requested that we make the package available for conda install (https://github.com/PyAbel/PyAbel/issues/182). I believe that adding the package to conda-forge is the best way to do this.

I've created a ``meta.yml`` recipe based on the example file. Is this all that we need to do?

Thanks!