### PR TITLE
Remove conda-build 2 hack

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -18,10 +18,6 @@ conda install --yes --quiet conda-build-all=1.0.0
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# install conda-build 2.x to build with a long prefix
-conda install --yes --quiet conda-build=2
-conda info
-
 # Find the recipes from master in this PR and remove them.
 pushd ./recipes > /dev/null
 echo "Finding recipes merged in master and removing them from the build."

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -52,10 +52,6 @@ conda install conda-build-all=1.0.0
 conda install conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Install conda-build 2.x to build a long prefix.
-conda install --yes --quiet conda-build=2
-conda info
-
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.
 find conda-recipes -mindepth 2 -maxdepth 2 -type f -name "yum_requirements.txt" \
     | xargs -n1 cat | grep -v -e "^#" -e "^$" | \


### PR DESCRIPTION
With https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/47 we no longer need this.