### PR TITLE
Drop NumPy 1.10.x

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -25,4 +25,4 @@ git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf {} && echo Remov
 popd > /dev/null
 
 # We just want to build all of the recipes.
-conda-build-all ./recipes --matrix-condition "numpy >=1.10" "python >=2.7,<3|>=3.5"
+conda-build-all ./recipes --matrix-condition "numpy >=1.11" "python >=2.7,<3|>=3.5"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -96,7 +96,7 @@ install:
 build: off
 
 test_script:
-    - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.10" "%PY_CONDITION%"'
+    - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.11" "%PY_CONDITION%"'
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
     # Uncomment the following two lines to make any conda packages created

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -57,5 +57,5 @@ find conda-recipes -mindepth 2 -maxdepth 2 -type f -name "yum_requirements.txt" 
     | xargs -n1 cat | grep -v -e "^#" -e "^$" | \
     xargs -r yum install -y
 
-conda-build-all /conda-recipes --matrix-conditions "numpy >=1.10" "python >=2.7,<3|>=3.5"
+conda-build-all /conda-recipes --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.5"
 EOF


### PR DESCRIPTION
We are not in a hurry to merge this.  I am leaving this PR here as a remainder that we agreed to drop `numpy 1.10.x` from the build matrix soon.

See https://github.com/conda-forge/conda-smithy/pull/418