### PR TITLE
Added Astropy recipe

### DIFF
--- a/recipes/astropy/RECIPE_LICENSE
+++ b/recipes/astropy/RECIPE_LICENSE
@@ -1,0 +1,26 @@
+This recipe is adapted from the anaconda-recipes repository. The original license was:
+
+(c) 2016 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/astropy/bld.bat
+++ b/recipes/astropy/bld.bat
@@ -1,0 +1,6 @@
+%PYTHON% setup.py install --offline --old-and-unmanageable
+if errorlevel 1 exit 1
+
+if "%PY3K%"=="1" (
+    rd /s /q %SP_DIR%\numpy
+)

--- a/recipes/astropy/build.sh
+++ b/recipes/astropy/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ `uname` == Linux ]]; then
+    export CFLAGS="$CFLAGS -std=c99"
+    export CC=gcc
+fi
+
+$PYTHON setup.py install --offline --old-and-unmanageable

--- a/recipes/astropy/meta.yaml
+++ b/recipes/astropy/meta.yaml
@@ -20,6 +20,7 @@ build:
     - samp_hub = astropy.vo.samp.hub_script:hub_script
     - volint = astropy.io.votable.volint:main
     - wcslint = astropy.wcs.wcslint:main
+  number: 0
 
 requirements:
 

--- a/recipes/astropy/meta.yaml
+++ b/recipes/astropy/meta.yaml
@@ -1,0 +1,63 @@
+{% set version = "1.3" %}
+
+package:
+  name: astropy
+  version: {{version}}
+
+source:
+  fn: astropy-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/a/astropy/astropy-{{version}}.tar.gz
+  md5: bf4c8a033a7085fbc9ec604eebbdbdc5
+
+build:
+  detect_binary_files_with_prefix: False
+  entry_points:
+    - fits2bitmap = astropy.visualization.scripts.fits2bitmap:main
+    - fitscheck = astropy.io.fits.scripts.fitscheck:main
+    - fitsdiff = astropy.io.fits.scripts.fitsdiff:main
+    - fitsheader = astropy.io.fits.scripts.fitsheader:main
+    - fitsinfo = astropy.io.fits.scripts.fitsinfo:main
+    - samp_hub = astropy.vo.samp.hub_script:hub_script
+    - volint = astropy.io.votable.volint:main
+    - wcslint = astropy.wcs.wcslint:main
+
+requirements:
+
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+
+  run:
+    - python
+    - numpy x.x
+
+test:
+  commands:
+    - fits2bitmap --help
+    - fitscheck --help
+    - fitsdiff --help
+    - fitsheader --help
+    - fitsinfo --help
+    - samp_hub --help
+    - volint --help
+    - wcslint --help
+  imports:
+    - astropy
+
+about:
+  home: http://www.astropy.org/
+  license: BSD
+  summary: Community-developed Python Library for Astronomy
+  description: |
+    The Astropy Project is a community effort to develop a single package for
+    Astronomy in Python. It contains core functionality and common tools
+    needed for performing astronomy and astrophysics research with Python.
+  doc_url: http://docs.astropy.org/en/stable/
+  dev_url: https://github.com/astropy/astropy
+
+extra:
+  recipe-maintainers:
+    - astrofrog
+    - mwcraig
+    - bsipocz

--- a/recipes/astropy/run_test.py
+++ b/recipes/astropy/run_test.py
@@ -1,0 +1,17 @@
+import astropy._compiler
+import astropy._erfa._core
+import astropy.convolution.boundary_extend
+import astropy.convolution.boundary_fill
+import astropy.convolution.boundary_none
+import astropy.convolution.boundary_wrap
+import astropy.cosmology.scalar_inv_efuncs
+import astropy.io.ascii.cparser
+import astropy.io.fits.compression
+import astropy.io.votable.tablewriter
+import astropy.modeling._projections
+import astropy.stats.lombscargle.implementations.cython_impl
+import astropy.table._column_mixins
+import astropy.table._np_utils
+import astropy.utils._compiler
+import astropy.utils.xml._iterparser
+import astropy.wcs._wcs


### PR DESCRIPTION
I don't think there's any reason why we shouldn't have this recipe here?

At the moment, some other conda-forge builds that depend on astropy need it to be built with Numpy 1.10 and 1.11 for Python 3.6 but only 1.11 is available in the defaults channel.

@mwcraig @bsipocz, since you've been running the astropy conda channel I added you as maintainers here.