### PR TITLE
Add ReproZip

### DIFF
--- a/recipes/reprounzip-docker/meta.yaml
+++ b/recipes/reprounzip-docker/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "reprounzip-docker" %}
+{% set version = "1.0.9" %}
+{% set sha256 = "dd72bab85fa2731b810d02b952f65d0f122c5d687b8d1913f400b3e2d5486be4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - reprounzip >=1.0.7
+    - rpaths >=0.8
+
+test:
+  imports:
+    - reprounzip.unpackers.docker
+
+  commands:
+    - reprounzip docker --help
+
+about:
+  home: http://github.com/ViDA-NYU/reprozip
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Linux tool enabling reproducible experiments (docker plugin)'
+  description: |
+    ReproZip is a tool aimed at simplifying the process of creating reproducible
+    experiments from command-line executions, a frequently-used common
+    denominator in computational science. It tracks operating system calls and
+    creates a package that contains all the binaries, files and dependencies
+    required to run a given command on the author's computational environment
+    (packing step). A reviewer can then extract the experiment in his
+    environment to reproduce the results (unpacking step).
+  doc_url: https://docs.reprozip.org/
+  dev_url: https://github.com/ViDA-NYU/reprozip
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/reprounzip-vagrant/meta.yaml
+++ b/recipes/reprounzip-vagrant/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "reprounzip-vagrant" %}
+{% set version = "1.0.9" %}
+{% set sha256 = "52cc00c9279d523f576ec39817f5a94c1c5b8e7164f84ae56f86bbf7084a51a9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - reprounzip >=1.0.7
+    - rpaths >=0.8
+    - paramiko
+
+test:
+  imports:
+    - reprounzip.unpackers.vagrant
+
+  commands:
+    - reprounzip vagrant --help
+
+about:
+  home: http://github.com/ViDA-NYU/reprozip
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Linux tool enabling reproducible experiments (vagrant plugin)'
+  description: |
+    ReproZip is a tool aimed at simplifying the process of creating reproducible
+    experiments from command-line executions, a frequently-used common
+    denominator in computational science. It tracks operating system calls and
+    creates a package that contains all the binaries, files and dependencies
+    required to run a given command on the author's computational environment
+    (packing step). A reviewer can then extract the experiment in his
+    environment to reproduce the results (unpacking step).
+  doc_url: https://docs.reprozip.org/
+  dev_url: https://github.com/ViDA-NYU/reprozip
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/reprounzip/meta.yaml
+++ b/recipes/reprounzip/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "reprounzip" %}
+{% set version = "1.0.9" %}
+{% set sha256 = "6fbceb902ce58079b8bec80b9e9a8dabd4a6cc819e8435ec941d381f4cfe6906" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools  # for pkg_resources
+    - pyyaml
+    - requests
+    - rpaths >=0.8
+    - usagestats >=0.3
+
+test:
+  imports:
+    - reprounzip.main
+    - reprounzip.unpackers.default
+
+  commands:
+    - reprounzip --help
+
+about:
+  home: http://github.com/ViDA-NYU/reprozip
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Linux tool enabling reproducible experiments (unpacker)'
+  description: |
+    ReproZip is a tool aimed at simplifying the process of creating reproducible
+    experiments from command-line executions, a frequently-used common
+    denominator in computational science. It tracks operating system calls and
+    creates a package that contains all the binaries, files and dependencies
+    required to run a given command on the author's computational environment
+    (packing step). A reviewer can then extract the experiment in his
+    environment to reproduce the results (unpacking step).
+  doc_url: https://docs.reprozip.org/
+  dev_url: https://github.com/ViDA-NYU/reprozip
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/reprozip/meta.yaml
+++ b/recipes/reprozip/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "reprozip" %}
+{% set version = "1.0.9" %}
+{% set sha256 = "20412ac156fb8cdbc62a26890f5dd92d403c923755d84d739e1316cac252dd2b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  skip: true  # [not linux32 and not linux64]
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+  run:
+    - python
+    - setuptools  # for pkg_resources
+    - pyyaml
+    - requests
+    - rpaths >=0.8
+    - usagestats >=0.3
+
+test:
+  imports:
+    - reprozip.main
+    - reprozip._pytracer
+
+  commands:
+    - reprozip --help
+
+about:
+  home: http://github.com/ViDA-NYU/reprozip
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Linux tool enabling reproducible experiments (packer)'
+  description: |
+    ReproZip is a tool aimed at simplifying the process of creating reproducible
+    experiments from command-line executions, a frequently-used common
+    denominator in computational science. It tracks operating system calls and
+    creates a package that contains all the binaries, files and dependencies
+    required to run a given command on the author's computational environment
+    (packing step). A reviewer can then extract the experiment in his
+    environment to reproduce the results (unpacking step).
+  doc_url: https://docs.reprozip.org/
+  dev_url: https://github.com/ViDA-NYU/reprozip
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/reprozip/meta.yaml
+++ b/recipes/reprozip/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - python
     - setuptools
     - toolchain
+    - sqlite
   run:
     - python
     - setuptools  # for pkg_resources

--- a/recipes/reprozip/meta.yaml
+++ b/recipes/reprozip/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python
     - setuptools
     - toolchain
-    - sqlite
+    - sqlite 3.13.*
   run:
     - python
     - setuptools  # for pkg_resources

--- a/recipes/reprozip/meta.yaml
+++ b/recipes/reprozip/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   skip: true  # [not linux32 and not linux64]
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: "INCLUDE_PATH=${PREFIX}/include C_INCLUDE_PATH=${PREFIX}/include python setup.py install --single-version-externally-managed --record record.txt"
 
 requirements:
   build:

--- a/recipes/rpaths/meta.yaml
+++ b/recipes/rpaths/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "rpaths" %}
+{% set version = "0.12" %}
+{% set sha256 = "902c3552b1c826cde1eb7c88b3d85b8a74f7f57bbf3ef6c955ffdb52a1603d25" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - rpaths
+
+about:
+  home: http://github.com/remram44/rpaths
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Path manipulation library'
+  description: |
+    rpaths is another path manipulation library. It is heavily inspired by
+    Unipath and pathlib.
+
+    It aims at total Python 2/3 and Windows/POSIX compatibility. To my
+    knowledge, no other library can handle all the possible paths on every
+    platform.
+  doc_url: http://rpaths.remram.fr/
+  dev_url: http://github.com/remram44/rpaths
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/usagestats/meta.yaml
+++ b/recipes/usagestats/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "usagestats" %}
+{% set version = "0.5" %}
+{% set sha256 = "383b5db49381e7ae937a18bbb6c4975c23d2190bf55222cab4b94370c45ab775" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - requests
+
+test:
+  imports:
+    - usagestats
+
+about:
+  home: http://github.com/remram44/usagestats
+  license: Apache-2.0
+  license_file: LICENSE.txt
+  summary: 'Anonymous usage statistics collecter'
+  description: |
+    This package is meant to easily get usage statistics from the users of your
+    program.
+
+    Statistics will be collected but won't be uploaded until the user opts in.
+    A message will be printed on stderr asking the user to explicitely opt in or
+    opt out.
+  dev_url: http://github.com/remram44/usagestats
+
+extra:
+  recipe-maintainers:
+    - remram44


### PR DESCRIPTION
Reprozip is a command line tool that helps make computational experiments reproducible. It tracks operating system calls via a C extension to creates a package that contains all the binaries, files and dependencies of the experiment. Reprounzip is the unpacker component.

To ease installation on scientists' or reviewers' machines, this can be installed in a number of ways, including from PyPI, or via installers for Windows or MacOS. I also have Conda packages, but building them for all kinds of architectures is a hassle, and they live under my organization's channel at [anaconda.org/vida-nyu](https://anaconda.org/vida-nyu).

We would love for our software to be included here instead.

rpaths and usagestats are dependencies authored by myself.