### PR TITLE
Unpin conda during feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -15,10 +15,6 @@ python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci &
 popd
 rm -rf ~/miniconda_staging
 
-# Temporarily pin `conda` to 4.1.x for `conda-smithy`.
-touch ~/miniconda/conda-meta/pinned
-echo "conda 4.1.*" >> ~/miniconda/conda-meta/pinned
-
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
 conda install --yes --quiet git


### PR DESCRIPTION
Revert https://github.com/conda-forge/staged-recipes/pull/2019

Requires a new version of `conda-smithy` be released with PR ( https://github.com/conda-forge/conda-smithy/pull/394 ) included before proceeding forward.

Unpins `conda` during feedstock conversion so as to allow the latest version of `conda` be used.