### PR TITLE
testpath

### DIFF
--- a/recipes/testpath/meta.yaml
+++ b/recipes/testpath/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "testpath" %}
+{% set version = "0.3" %}
+{% set wheel_tag = "py2.py3-none-any" %}
+{% set fn = "{}-{}-{}.whl".format(name, version, wheel_tag) %}
+{% set sha256 = "f16b2cb3b03e1ada4fb0200b265a4446f92f3ba4b9d88ace34f51c54ab6d294e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ fn }}
+  url: https://pypi.io/packages/py2.py3/{{ name[0] }}/{{ name }}/{{ fn }}
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: pip install --no-deps {{ fn }}
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - pathlib2  # [py2k]
+
+test:
+  imports:
+    - testpath
+
+about:
+  home: https://testpath.readthedocs.io
+  license: MIT
+  license_family: MIT
+  # FIXME: flit wheels don't include license file, only reference in metadata
+  # license_file
+  summary: Testpath is a collection of utilities for Python code working with files and commands.
+
+  description: |
+    Testpath contains functions to check things on the filesystem,
+    and tools for mocking system commands and recording calls to those.
+  doc_url: https://testpath.readthedocs.io
+  dev_url: https://github.com/jupyter/testpath
+
+extra:
+  recipe-maintainers:
+    - minrk
+    - takluyver


### PR DESCRIPTION
This is a test for getting things from flit wheels, since flit doesn't produce sdists.

flit's wheels seem okay to me, because flit only produces wheels for simple pure-python-only packages, so a flit wheel is basically an sdist in that it can only contain non-compiled, non-generated files plus metadata.

They are missing license files, but this should be fixed by https://github.com/takluyver/flit/pull/99

cc @takluyver