### PR TITLE
Drop Python 3.4 AppVeyor update hack

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,16 +73,6 @@ install:
     - cmd: rmdir C:\cygwin /s /q
 
     # Use the pre-installed Miniconda for the desired arch
-    #
-    # However, it is really old. So, we need to update some
-    # things before we proceed. That seems to require it being
-    # on the path. So, we temporarily put conda on the path
-    # so that we can update it. Then we remove it so that
-    # we can do a proper activation.
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda update --yes --quiet conda
-    - cmd: set "PATH=%OLDPATH%"
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda config --add channels conda-forge
     - cmd: conda config --set show_channel_urls true


### PR DESCRIPTION
This hack was added because Python 3.4's copy of `conda` was so old that activation did not work properly. So instead of activating it right away, this hack updated `conda` to a more recent version and then activated. However, we have decided to drop Python 3.4. Further the Python 3.5 Miniconda install on AppVeyor has been upgraded. Therefore a hack of this nature is not really needed any more and can be dropped.

xref: https://github.com/conda-forge/conda-smithy/pull/427