### PR TITLE
Make XCode 6.4 the Travis CI OSX image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 sudo: false
 


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/pull/1094

This bump the Travis CI image to XCode 6.4 per CFEP 02.

Unfortunately had to replace the original PR with this change as it has conflicts and has not been updated yet. However, did cherry-pick the change from PR ( https://github.com/conda-forge/staged-recipes/pull/1094 ) with some conflict resolution to give the author credit.

xref: https://github.com/conda-forge/conda-forge-enhancement-proposals/pull/6

cc @conda-forge/core @izaid