### PR TITLE
Fix Homebrew uninstall step to ignore dependencies

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -5,7 +5,7 @@
 export CONDA_NPY=19
 
 # Remove homebrew.
-brew remove --force $(brew list)
+brew remove --force --ignore-dependencies $(brew list)
 brew cleanup -s
 rm -rf $(brew --cache)
 


### PR DESCRIPTION
Complimentary to PR ( https://github.com/conda-forge/conda-smithy/pull/428 ).

Apparently `--force` is no longer sufficient when telling Homebrew to uninstall packages. If it turns out the packages are require by other packages, then `brew` will balk and issue an error message suggesting one also use `--ignore-dependencies`. So we add it here in the hopes that this will get Homebrew to comply with our uninstall request.