### PR TITLE
First cut at xorg-xproto package

### DIFF
--- a/recipes/xorg-xproto/bld.bat
+++ b/recipes/xorg-xproto/bld.bat
@@ -1,3 +1,6 @@
-:: Just delegate to the Unixy script.
+:: Just delegate to the Unixy script; but some of the X.org tarballs have
+:: config.guess files too ancient to recognize 64-bit Windows!
+curl -sSL -o config.guess https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess
+if errorlevel 1 exit 1
 bash %RECIPE_DIR%\build.sh
 if errorlevel 1 exit 1

--- a/recipes/xorg-xproto/bld.bat
+++ b/recipes/xorg-xproto/bld.bat
@@ -1,0 +1,3 @@
+:: Just delegate to the Unixy script.
+bash %RECIPE_DIR%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xproto/bld.bat
+++ b/recipes/xorg-xproto/bld.bat
@@ -1,6 +1,7 @@
 :: Just delegate to the Unixy script; but some of the X.org tarballs have
 :: config.guess files too ancient to recognize 64-bit Windows!
-curl -sSL -o config.guess https://raw.githubusercontent.com/gcc-mirror/gcc/master/config.guess
+curl -sSL -o config.guess "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess"
+curl -sSL -o config.sub "http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub"
 if errorlevel 1 exit 1
 bash %RECIPE_DIR%\build.sh
 if errorlevel 1 exit 1

--- a/recipes/xorg-xproto/build.sh
+++ b/recipes/xorg-xproto/build.sh
@@ -3,7 +3,13 @@
 set -e
 IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
 export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig
-./configure --prefix=$PREFIX
+configure_args=(
+    --prefix=$PREFIX
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
 make -j${CPU_COUNT}
 make install
 make check

--- a/recipes/xorg-xproto/build.sh
+++ b/recipes/xorg-xproto/build.sh
@@ -2,6 +2,7 @@
 
 set -e
 IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+export PKG_CONFIG_LIBDIR=$PREFIX/lib/pkgconfig:$PREFIX/share/pkgconfig
 ./configure --prefix=$PREFIX
 make -j${CPU_COUNT}
 make install

--- a/recipes/xorg-xproto/build.sh
+++ b/recipes/xorg-xproto/build.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+./configure --prefix=$PREFIX
+make -j${CPU_COUNT}
+make install
+make check

--- a/recipes/xorg-xproto/meta.yaml
+++ b/recipes/xorg-xproto/meta.yaml
@@ -6,7 +6,7 @@
 
 package:
   name: {{ name|lower }}
-  vesion: {{ version }}
+  version: {{ version }}
 
 source:
   fn: {{ name }}-{{ version }}.tar.bz2

--- a/recipes/xorg-xproto/meta.yaml
+++ b/recipes/xorg-xproto/meta.yaml
@@ -19,7 +19,8 @@ build:
 
 requirements:
   build:
-    - pkg-config
+    - m2w64-pkg-config  # [win]
+    - pkg-config  # [not win]
     - posix  # [win]
     - toolchain
 

--- a/recipes/xorg-xproto/meta.yaml
+++ b/recipes/xorg-xproto/meta.yaml
@@ -12,6 +12,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.bz2
   url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
+  patches:
+    - windows-fd_bits.patch  # [win]
 
 build:
   number: 0

--- a/recipes/xorg-xproto/meta.yaml
+++ b/recipes/xorg-xproto/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - curl  # [win]
     - m2w64-pkg-config  # [win]
     - pkg-config  # [not win]
     - posix  # [win]

--- a/recipes/xorg-xproto/meta.yaml
+++ b/recipes/xorg-xproto/meta.yaml
@@ -1,8 +1,8 @@
-{% xorg_name = "xproto" %}
-{% xorg_category = "proto" %}
-{% name = "xorg-" ~ xorg_name %}
-{% version = "7.0.31" %}
-{% sha256 = "c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747" %}
+{% set xorg_name = "xproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "7.0.31" %}
+{% set sha256 = "c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/xorg-xproto/meta.yaml
+++ b/recipes/xorg-xproto/meta.yaml
@@ -1,0 +1,40 @@
+{% xorg_name = "xproto" %}
+{% xorg_category = "proto" %}
+{% name = "xorg-" ~ xorg_name %}
+{% version = "7.0.31" %}
+{% sha256 = "c6f9747da0bd3a95f86b17fb8dd5e717c8f3ab7f0ece3ba1b247899ec1ef7747" %}
+
+package:
+  name: {{ name|lower }}
+  vesion: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - pkg-config
+    - posix  # [win]
+    - toolchain
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX {{ name }}  # [not win]
+    - conda inspect objects -p $PREFIX {{ name }}  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Definitions for the core X Windows protocol.'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xorg-xproto/windows-fd_bits.patch
+++ b/recipes/xorg-xproto/windows-fd_bits.patch
@@ -1,0 +1,10 @@
+--- configure.orig	2017-01-13 19:04:32.919054606 -0500
++++ configure	2017-01-13 19:05:19.280851728 -0500
+@@ -11415,6 +11415,7 @@
+ # Avoid determining fds_bits on WIN32 hosts (not including cygwin)
+ case $host_os in
+ 	mingw*)		fds_bits_found=true;;
++	*msys*)		fds_bits_found=true;;
+ 	*)		fds_bits_found=false;;
+ esac
+ 


### PR DESCRIPTION
The first of many ...

Just last week I thought that the existing X11 support on OSX in Anaconda was sufficient for my needs, but I realized that I was wrong: the base OS cannot be expected to have *any* X11 files, and the `tk` package only provides some stubs that are used as a hack in its internal build process. (The `tk` package should definitely stop installing those headers once we deploy real X11 libraries.) So, I now believe that I need to package up the full X.org X client library stack in conda-forge in order to build the software that I want. Here we go ...