### PR TITLE
Add RapidJSON recipe

### DIFF
--- a/recipes/rapidjson/bld.bat
+++ b/recipes/rapidjson/bld.bat
@@ -1,0 +1,18 @@
+mkdir build
+cd build
+
+cmake -G "NMake Makefiles" ^
+      -D RAPIDJSON_HAS_STDSTRING=ON ^
+      -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -D RAPIDJSON_BUILD_TESTS=OFF ^
+      -D RAPIDJSON_BUILD_EXAMPLES=OFF ^
+      -D RAPIDJSON_BUILD_DOC=OFF ^
+      -D CMAKE_VERBOSE_MAKEFILE=ON ^
+      -D CMAKE_BUILD_TYPE=Release ^
+      ..
+
+if errorlevel 1 exit 1
+
+nmake install
+
+if errorlevel 1 exit 1

--- a/recipes/rapidjson/build.sh
+++ b/recipes/rapidjson/build.sh
@@ -1,0 +1,15 @@
+#!/bin/env bash
+
+mkdir build
+cd build
+
+cmake -DRAPIDJSON_HAS_STDSTRING=ON \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DRAPIDJSON_BUILD_TESTS=OFF \
+      -DRAPIDJSON_BUILD_EXAMPLES=OFF \
+      -DRAPIDJSON_BUILD_DOC=OFF \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
+      -DCMAKE_BUILD_TYPE=release \
+      ..
+
+make install

--- a/recipes/rapidjson/meta.yaml
+++ b/recipes/rapidjson/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "rapidjson" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/miloyip/rapidjson/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/rapidjson/rapidjson.h                     # [unix]
+    - test -f ${PREFIX}/lib/cmake/RapidJSON/RapidJSONConfig.cmake         # [unix]
+    - test -f ${PREFIX}/lib/cmake/RapidJSON/RapidJSONConfigVersion.cmake  # [unix]
+    - if exist %LIBRARY_PREFIX%\include\rapidjson\rapidjson.h (exit 0) else (exit 1)                     # [win]
+    - if exist %LIBRARY_PREFIX%\lib\cmake\RapidJSON\RapidJSONConfig.cmake (exit 0) else (exit 1)         # [win]
+    - if exist %LIBRARY_PREFIX%\lib\cmake\RapidJSON\RapidJSONConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://github.com/miloyip/rapidjson
+  summary: A fast JSON parser/generator for C++ with both SAX/DOM style API
+  license: MIT
+  license_file: license.txt
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - wesm
+    - SylvainCorlay
+    - JohanMabille


### PR DESCRIPTION
As per discussions in #2192 , opening a separate PR (closes #2192).

RapidJSON is header only, so no need to track vc[8|10|14] features...