### PR TITLE
WIP: Travis CI Setup Optimizations

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -12,11 +12,12 @@ chmod +x ~/uninstall_homebrew.sh
 ~/uninstall_homebrew.sh -fq
 rm ~/uninstall_homebrew.sh
 
-# Install miniconda.
+# Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py
-python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
+curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > ~/miniconda.sh
+bash ~/miniconda.sh -b -p ~/miniconda
+source ~/miniconda/bin/activate root
 
 # Configure conda.
 echo ""

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -5,11 +5,15 @@
 export CONDA_NPY=19
 
 # Remove homebrew.
+echo ""
+echo "Removing homebrew from Travis CI to avoid conflicts."
 brew remove --force --ignore-dependencies $(brew list)
 brew cleanup -s
 rm -rf $(brew --cache)
 
 # Install and configure conda environment.
+echo ""
+echo "Installing a fresh version of Miniconda."
 curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
 conda config --add channels conda-forge
@@ -19,10 +23,12 @@ conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.
-pushd ./recipes > /dev/null
+echo ""
 echo "Finding recipes merged in master and removing them from the build."
+pushd ./recipes > /dev/null
 git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
 popd > /dev/null
+echo ""
 
 # We just want to build all of the recipes.
 conda-build-all ./recipes --matrix-condition "numpy >=1.11" "python >=2.7,<3|>=3.5"

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -7,9 +7,10 @@ export CONDA_NPY=19
 # Remove homebrew.
 echo ""
 echo "Removing homebrew from Travis CI to avoid conflicts."
-brew remove --force --ignore-dependencies $(brew list)
-brew cleanup -s
-rm -rf $(brew --cache)
+curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew.sh
+chmod +x ~/uninstall_homebrew.sh
+~/uninstall_homebrew.sh -fq
+rm ~/uninstall_homebrew.sh
 
 # Install and configure conda environment.
 echo ""

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -12,11 +12,15 @@ chmod +x ~/uninstall_homebrew.sh
 ~/uninstall_homebrew.sh -fq
 rm ~/uninstall_homebrew.sh
 
-# Install and configure conda environment.
+# Install miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
 curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py
 python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
+
+# Configure conda.
+echo ""
+echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
 conda install --yes --quiet conda-build-all=1.0.0

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 
+# Fast finish the PR.
+echo ""
+echo "Checking to see if this build is outdated."
+.CI/travis_fast_finish.py || { echo "Failing outdated build to end it."; exit 1; }
+
 # Set the numpy variable. This isn't used, but conda-build complains if we haven't set it already.
 export CONDA_NPY=19
 

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -20,8 +20,8 @@ rm ~/uninstall_homebrew.sh
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > ~/miniconda.sh
-bash ~/miniconda.sh -b -p ~/miniconda
+[ ! -f ~/cache/miniconda.sh ] && curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > ~/cache/miniconda.sh
+bash ~/cache/miniconda.sh -b -p ~/miniconda
 source ~/miniconda/bin/activate root
 
 # Reuse packages from the cache.

--- a/.CI/build_all
+++ b/.CI/build_all
@@ -24,6 +24,11 @@ curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh >
 bash ~/miniconda.sh -b -p ~/miniconda
 source ~/miniconda/bin/activate root
 
+# Reuse packages from the cache.
+mv -n ~/miniconda/pkgs ~/cache/pkgs
+rm -rf ~/miniconda/pkgs
+ln -s ~/cache/pkgs ~/miniconda/pkgs
+
 # Configure conda.
 echo ""
 echo "Configuring conda."

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -10,12 +10,9 @@ git checkout "${TRAVIS_BRANCH}"
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-mkdir -p ~/miniconda_staging
-pushd ~/miniconda_staging
-curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py
-python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
-popd
-rm -rf ~/miniconda_staging
+curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > ~/miniconda.sh
+bash ~/miniconda.sh -b -p ~/miniconda
+source ~/miniconda/bin/activate root
 
 # Configure conda.
 echo ""

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -7,7 +7,9 @@ set -e
 # recipes from. Currently this is `master`.
 git checkout "${TRAVIS_BRANCH}"
 
-# Download and setup Miniconda
+# Install Miniconda.
+echo ""
+echo "Installing a fresh version of Miniconda."
 mkdir -p ~/miniconda_staging
 pushd ~/miniconda_staging
 curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py
@@ -15,6 +17,9 @@ python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci &
 popd
 rm -rf ~/miniconda_staging
 
+# Configure conda.
+echo ""
+echo "Configuring conda."
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
 conda install --yes --quiet git

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -14,6 +14,11 @@ curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh >
 bash ~/miniconda.sh -b -p ~/miniconda
 source ~/miniconda/bin/activate root
 
+# Reuse packages from the cache.
+mv -n ~/miniconda/pkgs ~/cache/pkgs
+rm -rf ~/miniconda/pkgs
+ln -s ~/cache/pkgs ~/miniconda/pkgs
+
 # Configure conda.
 echo ""
 echo "Configuring conda."

--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -10,8 +10,8 @@ git checkout "${TRAVIS_BRANCH}"
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > ~/miniconda.sh
-bash ~/miniconda.sh -b -p ~/miniconda
+[ ! -f ~/cache/miniconda.sh ] && curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh > ~/cache/miniconda.sh
+bash ~/cache/miniconda.sh -b -p ~/miniconda
 source ~/miniconda/bin/activate root
 
 # Reuse packages from the cache.

--- a/.CI/travis_fast_finish.py
+++ b/.CI/travis_fast_finish.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+try:
+    from future_builtins import (
+        map,
+        filter,
+    )
+except ImportError:
+    pass
+
+import codecs
+import contextlib
+import json
+import os
+
+try:
+    from urllib.request import (
+        Request,
+        urlopen,
+    )
+except ImportError:
+    from urllib2 import (
+        Request,
+        urlopen,
+    )
+
+
+def check_latest_pr_build(repo, pr, build_num):
+    # Not a PR so it is latest.
+    if pr is None:
+        return True
+
+    headers = {
+        "Accept": "application/vnd.travis-ci.2+json",
+    }
+    url = "https://api.travis-ci.org/repos/{repo}/builds?event_type=pull_request"
+
+    request = Request(url.format(repo=repo), headers=headers)
+    with contextlib.closing(urlopen(request)) as response:
+        reader = codecs.getreader("utf-8")
+        data = json.load(reader(response))
+
+    # Parse the response to get a list of build numbers for this PR.
+    builds = data["builds"]
+    pr_builds = filter(lambda b: b["pull_request_number"] == pr, builds)
+    pr_build_nums = sorted(map(lambda b: int(b["number"]), pr_builds))
+
+    # Check if our build number is the latest (largest)
+    # out of all of the builds for this PR.
+    if build_num < max(pr_build_nums):
+        return False
+    else:
+        return True
+
+
+def main():
+    repo = os.environ["TRAVIS_REPO_SLUG"]
+
+    pr = os.environ["TRAVIS_PULL_REQUEST"]
+    pr = None if pr == "false" else int(pr)
+
+    build_num = int(os.environ["TRAVIS_BUILD_NUMBER"])
+
+    return int(check_latest_pr_build(repo, pr, build_num) is False)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ env:
         - secure: "BBJrw5OcEG4zEUxjXt2txNoz+o7ilTb0e8Tj1626USKqi6HAWOdSFHW7PLYR6vyefWsHnGLAeYMRr9UB56O2oDwS7jgClBKbyut2+Q+8SQBwEtNCMHdU996IzSuDP4AM3h7DLjTsuinWhwpqLu72z2ZjE9OMz4q03SyyiBOecWU1btYbp/u3bpNzyhb2u0HMkRUnS8MxPUa8aHZBKp/JpLrGQmIT0LcjLNp4/jTZp+cs+J//02hAhJHV3vMmyefVvRZayu3xKzutpb3qIga0JAP3d0j2FWXRHVTW6Ke5H4u/4NU7iTpdRjpymnzH7H2kfOrNzgCJ23NfNhScDJDc5URvdXlstgkC4lDkd7BbSVgKKaVy2vVcMkz98qbBnhi0akMHNZXPLvT9tec9AsAX5/pdNaa1rH/iRhjWRfTCnqODX+RTwMhA1/3rkmhzI/8JFCcaZet8+lA2LtOf95jGmwcRwPlNFX0Jdd1QBk2nUAUpCePWIdg7GRxYuO7a4QCbhc6bSyB/WrCQZ1oEmtwGSRqxpMKvQmjxJObg40MgP0DaquGov30A4QLoEdvXCnM7w3QyIr5L/BrLlnCy8LesAZIBn2l5LAHrBFGh9t/lCK9APlUjD9dgT6eCYOSbfdBghKCGsajAsM/fwsPvcjOmpFCLf+UZTer36B57ccHrYdU="
 
 script:
-    - if [ -n "$GH_TOKEN" ]; then
+    - mkdir -p $HOME/cache;
+      if [ -n "$GH_TOKEN" ]; then
         echo "Creating feedstocks from the recipe(s).";
         git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
         git config --global user.email "conda-forge@googlegroups.com";
@@ -34,3 +35,8 @@ script:
         source ./.CI/build_all;
       fi
 
+cache:
+    directories:
+        - $HOME/cache
+before_cache:
+    - find $HOME/cache/pkgs/ -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;


### PR DESCRIPTION
Provides various optimizations to Travis CI's startup. Also cleans up a few things to help make them easier to follow. Highlights of the changes are listed below. More details can be found in the individual commits and their messages.

* Use Homebrew's uninstall script to quietly remove Homebrew in a standard way.
* Fast finish old PR builds when newer ones are queued. 
  * Similar to what is done on AppVeyor ( https://github.com/conda-forge/staged-recipes/pull/123 ).
  * Also inspired by this [script]( https://github.com/JuliaLang/julia/blob/111f5e5a0d18be556060fb4f91a89505f9116ff7/contrib/travis_fastfail.sh ). Thanks @tkelman!
  * Given we do simply this on AppVeyor where we have fewer concurrent builds and it is in better shape, this probably already enough to get Travis CI back to a better place. Though we will need it in the feedstocks too.
* Cache basic conda package tarballs and Miniconda install script to cutdown on startup time.
  * Only deals with basic packages (e.g. what is in `root`).
  * Could extend to allow PRs to cache build related packages as well.