### PR TITLE
Add recipe for spyder-unittest

### DIFF
--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "spyder-unittest" %}
+{% set version = "0.1b2" %}
+{% set hash_type = "sha256" %}
+{% set hash = "786d9d96fa39396f409845a558363c92ad30744173d1cd6dea0d147d71e773b6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - lxml
+    - nose
+    - pytest
+    - python
+    - spyder >=3
+
+test:
+  imports:
+    - spyder_unittest
+
+about:
+  home: https://github.com/spyder-ide/spyder-unittest
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Spyder plugin that integrates popular unit test frameworks.
+  description: |
+    It allows you to run tests and view the results.
+  dev_url: https://github.com/spyder-ide/spyder-unittest
+
+extra:
+  recipe-maintainers:
+    - ccordoba12
+    - jitseniesen
+    - goanpeca


### PR DESCRIPTION
spyder-unittest is a plugin for the Spyder IDE supporting testing frameworks. This is a pure Python package from PyPI.