### PR TITLE
Temporarily use Python 2 for feedstock conversion

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -11,7 +11,7 @@ git checkout "${TRAVIS_BRANCH}"
 mkdir -p ~/miniconda_staging
 pushd ~/miniconda_staging
 curl -L -O https://raw.githubusercontent.com/conda-forge/conda-smithy/e976c7e84bb3c4846e7562afd1a42c4b535b51f5/bootstrap-obvious-ci-and-miniconda.py
-python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 3 --without-obvci && source ~/miniconda/bin/activate root
+python bootstrap-obvious-ci-and-miniconda.py ~/miniconda x64 2 --without-obvci && source ~/miniconda/bin/activate root
 popd
 rm -rf ~/miniconda_staging
 


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/2259
Closes https://github.com/conda-forge/status/issues/31

Ran into what appears to be a bug with `conda-build-all` and Python 3 during feedstock conversion. It appears the problem goes away with Python 2. An issue has been filed upstream about the problem. In the interim as this does workaround the issue, would like to switch to Python 2 to clear the current batch of recipes. May be worthwhile keeping this switch until the cause of the bug is better understood and potentially fixed or worked around in a better way.

xref: https://github.com/SciTools/conda-build-all/issues/77

cc @conda-forge/core