### PR TITLE
Drop `.sh` extension on Homebrew uninstall script

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -7,10 +7,10 @@ export CONDA_NPY=19
 # Remove homebrew.
 echo ""
 echo "Removing homebrew from Travis CI to avoid conflicts."
-curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew.sh
-chmod +x ~/uninstall_homebrew.sh
-~/uninstall_homebrew.sh -fq
-rm ~/uninstall_homebrew.sh
+curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+chmod +x ~/uninstall_homebrew
+~/uninstall_homebrew -fq
+rm ~/uninstall_homebrew
 
 # Install and configure conda environment.
 echo ""


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/2262 ). The Homebrew uninstall script is written in Ruby not shell. So adding the `.sh` extension is misleading. Thus it is dropped in this commit.