### PR TITLE
Fast finish old PR builds on CIs

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 
 
+# Fast finish the PR.
+echo ""
+(curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+    python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
 # Set the numpy variable. This isn't used, but conda-build complains if we haven't set it already.
 export CONDA_NPY=19
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,14 +50,10 @@ platform:
 
 install:
     # If there is a newer build queued for the same PR, cancel this one.
-    # The AppVeyor 'rollout builds' option is supposed to serve the same
-    # purpose but it is problematic because it tends to cancel builds pushed
-    # directly to master instead of just PR builds (or the converse).
-    # credits: JuliaLang developers.
-    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          throw "There are newer queued builds for this pull request, failing early." }
+    - cmd: |
+        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        del ff_ci_pr_build.py
 
     # Find the recipes from master in this PR and remove them.
     - cmd: echo Finding recipes merged in master and removing them.

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ general:
 
 checkout:
   post:
+    - ./scripts/fast_finish_ci_pr_build.sh
     - ./scripts/checkout_merge_commit.sh
 
 machine:

--- a/scripts/fast_finish_ci_pr_build.sh
+++ b/scripts/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"


### PR DESCRIPTION
Adds a Python script to help fast finish old PR builds on the various CIs. This should be reusable throughout the feedstocks as well. Also it should be usable outside conda-forge by those interested in it.

* [x] Only run on PRs
* [x] Support CircleCI
* [x] Support Travis CI
* [x] Support AppVeyor
* [x] Move script to central location (e.g. `conda-forge-build-setup`) ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/52 )
* [x] Use script from central location (e.g. `curl` from `conda-forge-build-setup` and run)