### PR TITLE
Add cppzmq

### DIFF
--- a/recipes/cppzmq/bld.bat
+++ b/recipes/cppzmq/bld.bat
@@ -1,0 +1,6 @@
+mkdir build
+cd build
+cmake -G "NMake Makefiles" -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ..
+if errorlevel 1 exit 1
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/cppzmq/build.sh
+++ b/recipes/cppzmq/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir build
+cd build
+cmake -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=$PREFIX ..
+make install

--- a/recipes/cppzmq/meta.yaml
+++ b/recipes/cppzmq/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "cppzmq" %}
+{% set version = "4.2.1" %}
+{% set sha256 = "11c699001659336c7d46779f714f3e9d15d63343cd2ae7c1905e4bf58907cef9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/zeromq/cppzmq/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win and py27]
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - zeromq 4.2.1
+
+  run:
+    - zeromq 4.2.1
+
+test:
+  commands:
+    - test -f ${PREFIX}/share/cmake/cppzmq/cppzmqConfig.cmake         # [unix]
+    - test -f ${PREFIX}/share/cmake/cppzmq/cppzmqConfigVersion.cmake  # [unix]
+    - if exist %LIBRARY_PREFIX%\share\cmake\cppzmq\cppzmqConfig.cmake (exit 0) else (exit 1)         # [win]
+    - if exist %LIBRARY_PREFIX%\share\cmake\cppzmq\cppzmqConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+
+about:
+  home: http://zeromq.org
+  license: MIT
+  summary: C++ bindings for 0MQ
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - JohanMabille


### PR DESCRIPTION
The author of the package wants the versions of zeromq and cppzmq to be bound. I guess that this might change at some point.