### PR TITLE
Add cling-patches metapackage

### DIFF
--- a/recipes/cling-patches/meta.yaml
+++ b/recipes/cling-patches/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: cling-patches
+  version: 1
+
+build:
+  number: 0
+  track_features:
+    - cling
+
+test: {}
+
+about:
+  home: https://github.com/conda-forge/cling-patches-feedstock
+  license: BSD 3-clause
+  summary: Metapackage to track the cling feature variant.
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay 
+    - inducer


### PR DESCRIPTION
This is the empty meta-package that tracks the "cling" features.

Besides cling itself, the two packages impacted by this feature will be `clangdev` and `llvmdev` so I am adding @inducer as a maintainer.

Needed for https://github.com/conda-forge/clangdev-feedstock/pull/1 and https://github.com/conda-forge/llvmdev-feedstock/pull/4
