### PR TITLE
[msinttypes] added tiny helper package for missing stdint headers

### DIFF
--- a/recipes/msinttypes/meta.yaml
+++ b/recipes/msinttypes/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "msinttypes" %}
+{% set version = "1.0" %}
+{% set sha256 = "cfccfbacce883ab982b052da3c8d1f9c72147cf8b9277076f859c7f2e3770139" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/chemeris/msinttypes/archive/f9e7c5758ed9e3b9f4b2394de1881c704dd79de0.zip
+  sha256: {{ sha256 }}
+  patches:
+    - patches/license.patch
+    - patches/test.py.patch
+
+build:
+  number: 0
+  script: copy *.h {{ environ.get("LIBRARY_INC") }}
+  # we only need this package for python2.7 and windows platforms
+  skip: True # [py3k and not win]
+
+test:
+  source_files:
+    - test_setup.py
+  requires:
+    - python <3
+  commands:
+    - python test_setup.py
+
+about:
+  home: http://github.com/chemeris/msinttypes
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: 'Provide missing stdint.h and inttypes.h headers for Python-2.7 Windows VC2008'
+  description: |
+    Include this package as a build time dependency in your meta.yaml,
+    if you want to compile a package needing stdint.h or inttypes.h
+    on Windows for Python-2.7. We need this, because this Python version
+    is built against an old version of Visual Studio, which lacks these headers.
+  dev_url:  https://github.com/chemeris/msinttypes
+
+extra:
+  recipe-maintainers:
+    - marscher

--- a/recipes/msinttypes/patches/license.patch
+++ b/recipes/msinttypes/patches/license.patch
@@ -1,0 +1,33 @@
+diff --git a/LICENSE.txt b/LICENSE.txt
+new file mode 100644
+index 0000000..8981754
+--- LICENSE.txt
++++ b/LICENSE.txt
+@@ -0,0 +1,26 @@
++ Copyright (c) 2006-2013 Alexander Chemeris
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++  1. Redistributions of source code must retain the above copyright notice,
++     this list of conditions and the following disclaimer.
++
++  2. Redistributions in binary form must reproduce the above copyright
++     notice, this list of conditions and the following disclaimer in the
++     documentation and/or other materials provided with the distribution.
++
++  3. Neither the name of the product nor the names of its contributors may
++     be used to endorse or promote products derived from this software
++     without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
++WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
++MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
++EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
++SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
++OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
++WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
++OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
++ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+\ No newline at end of file

--- a/recipes/msinttypes/patches/test.py.patch
+++ b/recipes/msinttypes/patches/test.py.patch
@@ -1,0 +1,29 @@
+diff --git a/test_setup.py b/test_setup.py
+new file mode 100644
+index 0000000..1232460
+--- test_setup.py
++++ b/test_setup.py
+@@ -0,0 +1,22 @@
++from distutils import ccompiler
++import tempfile
++
++test_src = tempfile.mktemp(suffix='.c') 
++
++content = """
++#include <stdint.h>
++#include <inttypes.h>
++#ifndef  INT64_MIN
++#error "not defined"
++#endif
++void main() {
++    int64_t i;
++}
++"""
++
++with open(test_src, 'w') as f:
++    f.write(content)
++
++compiler = ccompiler.new_compiler()
++compiler.compile([test_src])
++print("compile succeeded")
+\ No newline at end of file


### PR DESCRIPTION
This package is only built on Windows, Python-2.7, because the compiler this python version is built against lacks full C99 support and misses the headers stdint.h and inttypes.h.

It can be simply included as a build time dependency to avoid monkey patching the build environment manually.