### PR TITLE
Add recipe for Tweepy

### DIFF
--- a/recipes/tweepy/meta.yaml
+++ b/recipes/tweepy/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "tweepy" %}
+{% set version = "3.5.0" %}
+{% set sha256 = "f00ccf5f48c30d559ce0b750dfe3b2df6668dc799d8ce276fd90bfaa68845a58" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - requests            >=2.11.1
+    - requests-oauthlib   >=0.7.0
+    - six                 >=1.10.0
+    - pysocks             >=1.5.7
+
+test:
+  imports:
+    - tweepy
+
+about:
+  home: http://www.tweepy.org
+  license: MIT
+  license_family: MIT
+  summary: 'An easy-to-use Python library for accessing the Twitter API.'
+
+  doc_url: http://tweepy.readthedocs.io
+  dev_url: https://github.com/tweepy/tweepy
+
+extra:
+  recipe-maintainers:
+    - nikicc


### PR DESCRIPTION
https://pypi.python.org/pypi/tweepy

Blocked on:
- [x] requests-oauthlib 0.7.0 https://github.com/conda-forge/requests-oauthlib-feedstock/pull/1
- [x] pysocks osx py3k builds https://github.com/conda-forge/pysocks-feedstock/pull/2