### PR TITLE
Add ragel 6.6 recipe.

### DIFF
--- a/recipes/ragel/build.sh
+++ b/recipes/ragel/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -ex
+
+./configure --prefix=$PREFIX
+
+make -j${CPU_COUNT} VERBOSE=1
+make check
+make install

--- a/recipes/ragel/meta.yaml
+++ b/recipes/ragel/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "ragel" %}
+{% set version = "6.6" %}
+{% set hash_type = "sha256" %}
+{% set hash_val = "a8f38166d57163ff821ad4608ba258ed3b01ac8abb890440e03163cbb835e932" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{version }}.tar.gz
+  url: https://www.colm.net/files/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+  patches:
+    # Fix compiler errors (unqualified lookup of 'compare' and 'setiosflags' functions).
+    # Source: https://trac.macports.org/browser/trunk/dports/lang/ragel?rev=94741&order=name
+    - patches/cxx_syntax.patch
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - toolchain
+
+about:
+  home: https://www.colm.net/open-source/ragel/
+  license: GPLv2
+  license_file: COPYING
+  summary: Ragel State Machine Compiler
+  description: |
+    Ragel provides a very flexible interface to the host language that attempts
+    to place minimal restrictions on how the generated code is integrated into
+    the application. The generated code has no dependencies.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/ragel/patches/cxx_syntax.patch
+++ b/recipes/ragel/patches/cxx_syntax.patch
@@ -1,0 +1,154 @@
+--- aapl/bstcommon.h.orig	2011-02-11 15:14:44.000000000 +1100
++++ aapl/bstcommon.h	2012-06-28 18:22:04.000000000 +1000
+@@ -361,7 +361,7 @@ template <BST_TEMPL_DEF> bool BstTable<B
+ 		}
+ 
+ 		mid = lower + ((upper-lower)>>1);
+-		keyRelation = compare(key, GET_KEY(*mid));
++		keyRelation = this->compare(key, GET_KEY(*mid));
+ 
+ 		if ( keyRelation < 0 )
+ 			upper = mid - 1;
+@@ -373,12 +373,12 @@ template <BST_TEMPL_DEF> bool BstTable<B
+ 
+ 			lower = mid - 1;
+ 			while ( lower != lowEnd && 
+-					compare(key, GET_KEY(*lower)) == 0 )
++					this->compare(key, GET_KEY(*lower)) == 0 )
+ 				lower--;
+ 
+ 			upper = mid + 1;
+ 			while ( upper != highEnd && 
+-					compare(key, GET_KEY(*upper)) == 0 )
++					this->compare(key, GET_KEY(*upper)) == 0 )
+ 				upper++;
+ 			
+ 			low = (Element*)lower + 1;
+@@ -419,7 +419,7 @@ template <BST_TEMPL_DEF> Element *BstTab
+ 		}
+ 
+ 		mid = lower + ((upper-lower)>>1);
+-		keyRelation = compare(key, GET_KEY(*mid));
++		keyRelation = this->compare(key, GET_KEY(*mid));
+ 
+ 		if ( keyRelation < 0 )
+ 			upper = mid - 1;
+@@ -457,7 +457,7 @@ template <BST_TEMPL_DEF> Element *BstTab
+ 		}
+ 
+ 		mid = lower + ((upper-lower)>>1);
+-		keyRelation = compare(key, GET_KEY(*mid));
++		keyRelation = this->compare(key, GET_KEY(*mid));
+ 
+ 		if ( keyRelation < 0 )
+ 			upper = mid - 1;
+@@ -508,7 +508,7 @@ template <BST_TEMPL_DEF> Element *BstTab
+ 		}
+ 
+ 		mid = lower + ((upper-lower)>>1);
+-		keyRelation = compare(key, GET_KEY(*mid));
++		keyRelation = this->compare(key, GET_KEY(*mid));
+ 
+ 		if ( keyRelation < 0 )
+ 			upper = mid - 1;
+@@ -603,7 +603,7 @@ template <BST_TEMPL_DEF> Element *BstTab
+ 		}
+ 
+ 		mid = lower + ((upper-lower)>>1);
+-		keyRelation = compare(GET_KEY(el), GET_KEY(*mid));
++		keyRelation = this->compare(GET_KEY(el), GET_KEY(*mid));
+ 
+ 		if ( keyRelation < 0 )
+ 			upper = mid - 1;
+@@ -662,7 +662,7 @@ template <BST_TEMPL_DEF> Element *BstTab
+ 		}
+ 
+ 		mid = lower + ((upper-lower)>>1);
+-		keyRelation = compare(GET_KEY(el), GET_KEY(*mid));
++		keyRelation = this->compare(GET_KEY(el), GET_KEY(*mid));
+ 
+ 		if ( keyRelation < 0 )
+ 			upper = mid - 1;
+--- aapl/mergesort.h.orig	2011-02-11 15:14:44.000000000 +1100
++++ aapl/mergesort.h	2012-06-28 18:24:41.000000000 +1000
+@@ -110,7 +110,7 @@ template< class T, class Compare> void M
+ 		}
+ 		else {
+ 			/* Both upper and lower left. */
+-			if ( compare(*lower, *upper) <= 0 )
++			if ( this->compare(*lower, *upper) <= 0 )
+ 				memcpy( dest++, lower++, sizeof(T) );
+ 			else
+ 				memcpy( dest++, upper++, sizeof(T) );
+--- aapl/bubblesort.h.orig	2011-02-11 15:14:44.000000000 +1100
++++ aapl/bubblesort.h	2012-06-28 18:25:59.000000000 +1000
+@@ -72,7 +72,7 @@ template <class T, class Compare> void B
+ 		changed = false;
+ 		for ( long i = 0; i < len-pass; i++ ) {
+ 			/* Do we swap pos with the next one? */
+-			if ( compare( data[i], data[i+1] ) > 0 ) {
++			if ( this->compare( data[i], data[i+1] ) > 0 ) {
+ 				char tmp[sizeof(T)];
+ 
+ 				/* Swap the two items. */
+--- aapl/avlcommon.h.orig	2011-02-11 15:14:44.000000000 +1100
++++ aapl/avlcommon.h	2012-06-28 18:27:36.000000000 +1000
+@@ -881,9 +881,9 @@ template <AVLMEL_TEMPDEF> Element *AvlTr
+ 		}
+ 
+ #ifdef AVL_BASIC
+-		keyRelation = compare( *element, *curEl );
++		keyRelation = this->compare( *element, *curEl );
+ #else
+-		keyRelation = compare( element->BASEKEY(getKey()), 
++		keyRelation = this->compare( element->BASEKEY(getKey()), 
+ 				curEl->BASEKEY(getKey()) );
+ #endif
+ 
+@@ -920,7 +920,7 @@ template <AVLMEL_TEMPDEF> Element *AvlTr
+ 	long keyRelation;
+ 
+ 	while (curEl) {
+-		keyRelation = compare( *element, *curEl );
++		keyRelation = this->compare( *element, *curEl );
+ 
+ 		/* Do we go left? */
+ 		if ( keyRelation < 0 )
+@@ -969,7 +969,7 @@ template <AVLMEL_TEMPDEF> Element *AvlTr
+ 			return element;
+ 		}
+ 
+-		keyRelation = compare( key, curEl->BASEKEY(getKey()) );
++		keyRelation = this->compare( key, curEl->BASEKEY(getKey()) );
+ 
+ 		/* Do we go left? */
+ 		if ( keyRelation < 0 ) {
+@@ -1023,7 +1023,7 @@ template <AVLMEL_TEMPDEF> Element *AvlTr
+ 			return element;
+ 		}
+ 
+-		keyRelation = compare(key, curEl->getKey());
++		keyRelation = this->compare(key, curEl->getKey());
+ 
+ 		/* Do we go left? */
+ 		if ( keyRelation < 0 ) {
+@@ -1058,7 +1058,7 @@ template <AVLMEL_TEMPDEF> Element *AvlTr
+ 	long keyRelation;
+ 
+ 	while (curEl) {
+-		keyRelation = compare( key, curEl->BASEKEY(getKey()) );
++		keyRelation = this->compare( key, curEl->BASEKEY(getKey()) );
+ 
+ 		/* Do we go left? */
+ 		if ( keyRelation < 0 )
+--- ragel/javacodegen.cpp.orig	2011-02-11 15:14:43.000000000 +1100
++++ ragel/javacodegen.cpp	2012-06-28 18:29:53.000000000 +1000
+@@ -1184,7 +1184,7 @@ std::ostream &JavaTabCodeGen::ARRAY_ITEM
+ {
+ 	item_count++;
+ 
+-	out << setw(5) << setiosflags(ios::right) << item;
++	out << setw(5) << std::setiosflags(ios::right) << item;
+ 	
+ 	if ( !last ) {
+ 		if ( item_count % SAIIC == 0 ) {

--- a/recipes/ragel/run_test.sh
+++ b/recipes/ragel/run_test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ex
+
+cat > testprog.rl << EOF
+#include <stdio.h>
+#include <string.h>
+
+%%{
+  machine ragel_test;
+  main := ( 'r' @ { printf("ragel"); }
+          | 't' @ { printf("test"); }
+          )*;
+}%%
+
+%% write data;
+
+int main(int argc, char **argv) 
+{
+  int cs, res = 0;
+  if (argc > 1) {
+    char *p = argv[1];
+    char *pe = p + strlen(p) + 1;
+    %% write init;
+    %% write exec;
+  }
+}
+EOF
+
+ragel -Cs testprog.rl
+
+gcc testprog.c -o testprog
+
+OUTPUT=$(./testprog rttr)
+
+if [ "$OUTPUT" != "rageltesttestragel" ]; then
+  echo "test failed"
+  exit 1
+fi


### PR DESCRIPTION
Ragel is a state machine compiler. This particular version aims to have
ragel 6.6 which is the version required for another library Squash.

Once this recipe is merged we plan to update it to newer ragel releases.

The maintainers list is open.