### PR TITLE
Remove the prefix

### DIFF
--- a/recipes/luarocks/meta.yaml
+++ b/recipes/luarocks/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "lua-luarocks" %}
+{% set name = "luarocks" %}
 {% set version = "2.4.2" %}
 {% set sha256 = "0e1ec34583e1b265e0fbafb64c8bd348705ad403fe85967fd05d3a659f74d2e5" %}
 


### PR DESCRIPTION
@jerowe I removed the prefixed `lua` from the package name to fix the feedstocking process.
Hopefully that is OK with you.