### PR TITLE
Add backports.lzma

### DIFF
--- a/recipes/backports.lzma/meta.yaml
+++ b/recipes/backports.lzma/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "backports.lzma" %}
+{% set version = "0.0.8" %}
+{% set sha256 = "200584ad5079d8ca6b1bfe14890c7be58666ab0128d8ca26cfb2669b476085f3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: python setup.py install
+
+requirements:
+  build:
+    - toolchain
+    - python
+    - xz 5.2.*
+
+  run:
+    - python
+    - xz 5.2.*
+
+test:
+  source_files:
+    - test
+  imports:
+    - backports
+    - backports.lzma
+  commands:
+    - python -m unittest discover -s test
+
+about:
+  home: https://github.com/peterjc/backports.lzma
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Backport of Python 3.3's 'lzma' module for XZ/LZMA compressed files.
+
+extra:
+  recipe-maintainers:
+    - alimanfoo
+    - groutr
+    - jakirkham


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/pull/1981

Requires PRs ( https://github.com/conda-forge/python-feedstock/pull/112 ), ( https://github.com/conda-forge/python-feedstock/pull/113 ), and ( https://github.com/conda-forge/python-feedstock/pull/114 ).

Adds a backports package for `lzma`. This still works on Python 3, but is primarily intended for Python 2.