### PR TITLE
Final round of X.org packages: xorg-cf-files font-util gccmakedep image libXaw libXaw3d

### DIFF
--- a/recipes/xorg-cf-files/bld.bat
+++ b/recipes/xorg-cf-files/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-cf-files/build.sh
+++ b/recipes/xorg-cf-files/build.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+rm -rf $uprefix/share/man $uprefix/share/doc/xorg-cf-files

--- a/recipes/xorg-cf-files/meta.yaml
+++ b/recipes/xorg-cf-files/meta.yaml
@@ -43,7 +43,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: COPYING
-  summary: ''
+  summary: 'Configuration files for the X.org "imake" utility.'
 
 extra:
   recipe-maintainers:

--- a/recipes/xorg-cf-files/meta.yaml
+++ b/recipes/xorg-cf-files/meta.yaml
@@ -1,0 +1,49 @@
+{% set xorg_name = "xorg-cf-files" %}
+{% set xorg_category = "util" %}
+{% set name = "xorg-cf-files" %}
+{% set version = "1.0.6" %}
+{% set sha256 = "4dcf5a9dbe3c6ecb9d2dd05e629b3d373eae9ba12d13942df87107fdc1b3934d" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ xorg_name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+  patches:
+    - no-lib64.patch
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: ''
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xorg-cf-files/no-lib64.patch
+++ b/recipes/xorg-cf-files/no-lib64.patch
@@ -1,0 +1,24 @@
+--- linux.cf.orig	2017-02-06 15:13:43.029920163 -0500
++++ linux.cf	2017-02-06 15:15:13.206667177 -0500
+@@ -578,11 +578,7 @@
+ #define MkdirHierCmd		mkdir -p
+ 
+ #ifndef HaveLib64
+-# if defined (AMD64Architecture) || defined (s390xArchitecture) || defined (Ppc64Architecture) || defined (AArch64Architecture)
+-#  define HaveLib64	YES
+-# else
+-#  define HaveLib64	NO
+-# endif
++# define HaveLib64	NO
+ #endif
+ 
+ #if UseElfFormat
+@@ -1072,7 +1068,7 @@
+ 
+ #if HaveLib64
+ # ifndef LibDirName
+-#  define LibDirName		lib64
++#  define LibDirName		lib
+ # endif
+ # ifndef SystemUsrLibDir
+ #  define SystemUsrLibDir	/usr/lib64

--- a/recipes/xorg-font-util/bld.bat
+++ b/recipes/xorg-font-util/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-font-util/build.sh
+++ b/recipes/xorg-font-util/build.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+rm -rf $uprefix/share/man $uprefix/share/doc/font-util

--- a/recipes/xorg-font-util/meta.yaml
+++ b/recipes/xorg-font-util/meta.yaml
@@ -1,8 +1,8 @@
-{% set xorg_name = "xorg-cf-files" %}
-{% set xorg_category = "util" %}
-{% set name = "xorg-cf-files" %}
-{% set version = "1.0.6" %}
-{% set sha256 = "4dcf5a9dbe3c6ecb9d2dd05e629b3d373eae9ba12d13942df87107fdc1b3934d" %}
+{% set xorg_name = "font-util" %}
+{% set xorg_category = "font" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.3.1" %}
+{% set sha256 = "aa7ebdb0715106dd255082f2310dbaa2cd7e225957c2a77d719720c7cc92b921" %}
 {% set am_version = "1.15" %} # keep synchronized with build.sh
 
 package:
@@ -13,12 +13,14 @@ source:
   fn: {{ xorg_name }}-{{ version }}.tar.bz2
   url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
-  patches:
-    - no-lib64.patch
 
 build:
   number: 0
   detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
 
 requirements:
   build:
@@ -29,9 +31,16 @@ requirements:
     - m2w64-toolchain  # [win]
     - pkg-config  # [not win]
     - posix  # [win]
+    - python  # [win]
     - toolchain
-    - xorg-font-util
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
     - xorg-util-macros
+  run:
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
 
 test:
   commands:
@@ -43,7 +52,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: COPYING
-  summary: ''
+  summary: 'X.org font-related utilities.'
 
 extra:
   recipe-maintainers:

--- a/recipes/xorg-gccmakedep/bld.bat
+++ b/recipes/xorg-gccmakedep/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-gccmakedep/build.sh
+++ b/recipes/xorg-gccmakedep/build.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+rm -rf $uprefix/share/man $uprefix/share/doc/gccmakedep

--- a/recipes/xorg-gccmakedep/meta.yaml
+++ b/recipes/xorg-gccmakedep/meta.yaml
@@ -1,0 +1,59 @@
+{% set xorg_name = "gccmakedep" %}
+{% set xorg_category = "util" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.0.3" %}
+{% set sha256 = "b275dcf1f7323ed89e8b36f8fbd5da665d8700005f1779fa5b90a1688bbf2ee4" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ xorg_name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - python  # [win]
+    - toolchain
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - xorg-util-macros
+  run:
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'The X.org incarnation of the X11 gccmakedep utility.'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xorg-imake/bld.bat
+++ b/recipes/xorg-imake/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-imake/build.sh
+++ b/recipes/xorg-imake/build.sh
@@ -1,0 +1,50 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+rm -rf $uprefix/share/man $uprefix/share/doc/${PKG_NAME#xorg-}

--- a/recipes/xorg-imake/meta.yaml
+++ b/recipes/xorg-imake/meta.yaml
@@ -13,6 +13,8 @@ source:
   fn: {{ xorg_name }}-{{ version }}.tar.bz2
   url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
   sha256: {{ sha256 }}
+  patches:
+    - windows.patch  # [win]
 
 build:
   number: 0

--- a/recipes/xorg-imake/meta.yaml
+++ b/recipes/xorg-imake/meta.yaml
@@ -1,0 +1,60 @@
+{% set xorg_name = "imake" %}
+{% set xorg_category = "util" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.0.7" %}
+{% set sha256 = "690c2c4ac1fad2470a5ea73156cf930b8040dc821a0da4e322014a42c045f37e" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ xorg_name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - python  # [win]
+    - toolchain
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - xorg-util-macros
+    - xorg-xproto
+  run:
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'The X.org incarnation of the X11 IMake utility.'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xorg-imake/windows.patch
+++ b/recipes/xorg-imake/windows.patch
@@ -9,3 +9,14 @@
  #endif
  #include <sys/types.h>
  #include <fcntl.h>
+--- imakemdep.h.orig	2017-02-06 15:44:08.735302953 -0500
++++ imakemdep.h	2017-02-06 15:44:11.710327597 -0500
+@@ -1422,7 +1422,7 @@
+ # endif /* MAKEDEPEND */
+ 
+ # ifndef MAKEDEPEND
+-#  if  defined (CROSSCOMPILE_CPP)
++#  if !defined(CROSSCOMPILE) || defined (CROSSCOMPILE_CPP)
+ #   ifdef USE_CC_E
+ boolean crosscompile_use_cc_e = TRUE;
+ #    ifdef DEFAULT_CC

--- a/recipes/xorg-imake/windows.patch
+++ b/recipes/xorg-imake/windows.patch
@@ -1,0 +1,11 @@
+--- imake.c.orig	2017-02-06 15:34:47.199474238 -0500
++++ imake.c	2017-02-06 15:35:07.663653246 -0500
+@@ -160,7 +160,7 @@
+ #include <string.h>
+ #include <ctype.h>
+ #ifdef WIN32
+-# include "Xw32defs.h"
++# include <X11/Xw32defs.h>
+ #endif
+ #include <sys/types.h>
+ #include <fcntl.h>

--- a/recipes/xorg-libxaw/bld.bat
+++ b/recipes/xorg-libxaw/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-libxaw/build.sh
+++ b/recipes/xorg-libxaw/build.sh
@@ -1,0 +1,62 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+
+    # And we need to add the search path that lets libtool find the
+    # msys2 stub libraries for ws2_32.
+    platlibs=$(cd $(dirname $(gcc --print-prog-name=ld))/../lib && pwd -W)
+    export LDFLAGS="$LDFLAGS -L$platlibs"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+rm -rf $uprefix/share/man $uprefix/share/doc/libXaw
+
+# Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
+if [ -z "VS_MAJOR" ] ; then
+    for lib_ident in Xaw ; do
+        rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
+    done
+fi

--- a/recipes/xorg-libxaw/meta.yaml
+++ b/recipes/xorg-libxaw/meta.yaml
@@ -1,0 +1,73 @@
+{% set xorg_name = "libXaw" %}
+{% set xorg_category = "lib" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.0.13" %}
+{% set sha256 = "8ef8067312571292ccc2bbe94c41109dcf022ea5a4ec71656a83d8cce9edb0cd" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ xorg_name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+  patches:
+    - windows.patch  # [win]
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - python  # [win]
+    - toolchain
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - xorg-libx11 1.6.*
+    - xorg-libxext 1.3.*
+    - xorg-libxmu 1.1.*
+    - xorg-libxpm 3.5.*
+    - xorg-libxt 1.1.*
+    - xorg-util-macros
+    - xorg-xextproto
+    - xorg-xproto
+  run:
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - xorg-libx11 1.6.*
+    - xorg-libxext 1.3.*
+    - xorg-libxmu 1.1.*
+    - xorg-libxpm 3.5.*
+    - xorg-libxt 1.1.*
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'The X.org X11 Athena widgets library.'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xorg-libxaw/windows.patch
+++ b/recipes/xorg-libxaw/windows.patch
@@ -1,0 +1,20 @@
+--- configure.ac.orig	2017-02-06 14:59:51.284072932 -0500
++++ configure.ac	2017-02-06 15:03:39.715929946 -0500
+@@ -53,7 +53,7 @@
+ platform_darwin=no
+ LIBEXT=so
+ case $host_os in
+-    cygwin*|mingw*)
++    cygwin*|mingw*|*msys*)
+ 	LIBEXT=dll.a
+ 	platform_win32=yes
+ 	;;
+@@ -99,7 +99,7 @@
+ 
+ # Link with winsock if mingw target
+ case $host_os in
+-	*mingw*)
++	*mingw*|*msys*)
+ 		AC_CHECK_LIB([ws2_32],[main])
+ 	;;
+ 	*)

--- a/recipes/xorg-libxaw3d/bld.bat
+++ b/recipes/xorg-libxaw3d/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-libxaw3d/build.sh
+++ b/recipes/xorg-libxaw3d/build.sh
@@ -1,0 +1,57 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+rm -rf $uprefix/share/man $uprefix/share/doc/libXaw3d
+
+# Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
+if [ -z "VS_MAJOR" ] ; then
+    for lib_ident in Xaw3d ; do
+        rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
+    done
+fi

--- a/recipes/xorg-libxaw3d/meta.yaml
+++ b/recipes/xorg-libxaw3d/meta.yaml
@@ -1,0 +1,67 @@
+{% set xorg_name = "libXaw3d" %}
+{% set xorg_category = "lib" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.6.2" %}
+{% set sha256 = "b74f11681061c1492c03cbbe6e318f9635b3877af0761fc0e67e1467c3a6972b" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ xorg_name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - python  # [win]
+    - toolchain
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - xorg-libx11 1.6.*
+    - xorg-libxext 1.3.*
+    - xorg-libxmu 1.1.*
+    - xorg-libxt 1.1.*
+    - xorg-util-macros
+  run:
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - xorg-libx11 1.6.*
+    - xorg-libxext 1.3.*
+    - xorg-libxmu 1.1.*
+    - xorg-libxt 1.1.*
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'The X.org X11 3D Athena widgets library.'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/xorg-libxaw3d/meta.yaml
+++ b/recipes/xorg-libxaw3d/meta.yaml
@@ -2,7 +2,8 @@
 {% set xorg_category = "lib" %}
 {% set name = "xorg-" ~ xorg_name %}
 {% set version = "1.6.2" %}
-{% set sha256 = "b74f11681061c1492c03cbbe6e318f9635b3877af0761fc0e67e1467c3a6972b" %}
+# NOTE! This is the gzip! Most recent bz2 file causes mysterious problems on Python 2.7.
+{% set sha256 = "847dab01aeac1448916e3b4edb4425594b3ac2896562d9c7141aa4ac6c898ba9" %}
 {% set am_version = "1.15" %} # keep synchronized with build.sh
 
 package:
@@ -10,8 +11,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ xorg_name }}-{{ version }}.tar.bz2
-  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  fn: {{ xorg_name }}-{{ version }}.tar.gz
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
This is the last batch of libraries needed for the things I've tried to build. The OSX tests might not work off the bat since the OSX packages from the previous round haven't all been built yet. But Windows and Linux should be ready to test.