### PR TITLE
Doc8

### DIFF
--- a/recipes/doc8/meta.yaml
+++ b/recipes/doc8/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "doc8" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "b89824683a23361c3f1f6ce8743cc97c86570596455dee1bb67d555f2106af06" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{name}}-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/{{name[0]}}/{{name}}/{{name}}-{{version}}.tar.gz
+  sha256: {{sha256}}
+
+build:
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pbr
+
+  run:
+    - python
+    - chardet
+    - docutils
+    - restructuredtext_lint >=0.7
+    - six
+    - stevedore
+
+test:
+  commands:
+    - "doc8"
+
+about:
+  home: https://launchpad.net/doc8
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Doc8 is an opinionated style checker for rst (with basic support for plain text) styles of documentation.'
+  dev_url: https://github.com/openstack/doc8
+
+extra:
+  recipe-maintainers:
+    - dopplershift

--- a/recipes/restructuredtext_lint/meta.yaml
+++ b/recipes/restructuredtext_lint/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "restructuredtext_lint" %}
+{% set version = "0.17.2" %}
+{% set sha256 = "1ab9316c3426016e3b4c4b590fe5e536e17de215bd2980dc6c931fed13afc738" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{name}}-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/{{name[0]}}/{{name}}/{{name}}-{{version}}.tar.gz
+  sha256: {{sha256}}
+
+build:
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - docutils
+
+test:
+  imports:
+    - restructuredtext_lint
+
+about:
+  home: https://github.com/twolfson/restructuredtext-lint
+  license: Unlicense
+  license_family: Public Domain
+  license_file: UNLICENSE
+  summary: 'Lint reStructuredText files'
+  dev_url: https://github.com/twolfson/restructuredtext-lint
+
+extra:
+  recipe-maintainers:
+    - dopplershift


### PR DESCRIPTION
doc8 is a docstring RST checker. This also adds restructuredtext_lint, which is a dependency of doc8.