### PR TITLE
Create osx-pocl-opencl metapackage

### DIFF
--- a/recipes/osx-pocl-opencl/meta.yaml
+++ b/recipes/osx-pocl-opencl/meta.yaml
@@ -12,8 +12,8 @@ test: {}
 
 about:
   home: http://github.com/conda-forge/osx-pocl-opencl-feedstock
-  license: MIT
-  license_family: MIT
+  license: BSD 3-clause
+  license_family: BSD
   summary: Metapackage to track whether OpenCL on OSX is being provided by POCL (rather than the OS)
 
 extra:

--- a/recipes/osx-pocl-opencl/meta.yaml
+++ b/recipes/osx-pocl-opencl/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: osx-pocl-opencl
+  version: 1
+
+build:
+  number: 0
+  track_features:
+    - osx_pocl_opencl
+  skip: True  # [not osx]
+
+test: {}
+
+about:
+  home: http://github.com/conda-forge/osx-pocl-opencl-feedstock
+  license: MIT
+  license_family: MIT
+  summary: Metapackage to track whether OpenCL on OSX is being provided by POCL (rather than the OS)
+
+extra:
+  recipe-maintainers:
+    - inducer
+    - mattwala

--- a/recipes/osx-pocl-opencl/meta.yaml
+++ b/recipes/osx-pocl-opencl/meta.yaml
@@ -19,4 +19,3 @@ about:
 extra:
   recipe-maintainers:
     - inducer
-    - mattwala


### PR DESCRIPTION
This metapackage tracks whether POCL (which [just gained an OSX build](https://github.com/conda-forge/pocl-feedstock/pull/4)) or Apple's mostly-broken system OpenCL should provide OpenCL functionality in a given conda environment. It is not built and has no impact on other platforms.