### PR TITLE
add armadillo

### DIFF
--- a/recipes/armadillo/CMakeLists.patch
+++ b/recipes/armadillo/CMakeLists.patch
@@ -1,28 +1,56 @@
---- CMakeLists.txt	2016-06-16 12:16:11.000000000 -0400
-+++ CMakeLists_New.txt	2017-03-04 15:18:00.000000000 -0500
-@@ -100,12 +100,21 @@
+--- CMakeLists.txt	2016-06-16 12:16:15.000000000 -0400
++++ CMakeLists_New.txt	2017-03-05 01:11:29.000000000 -0500
+@@ -104,11 +104,20 @@
    
    set(ARMA_OS macos)
    
 -  set(ARMA_USE_LAPACK true)
 -  set(ARMA_USE_BLAS   true)
-+  # set(ARMA_USE_LAPACK true)
-+  # set(ARMA_USE_BLAS   true)
++#  set(ARMA_USE_LAPACK true)
++#  set(ARMA_USE_BLAS   true)
    
 -  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 -  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
-+  # set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
-+  # message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
++#  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
++#  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
++
++   include(ARMA_FindOpenBLAS)
++   message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
++ 
++   if(OpenBLAS_FOUND)
++     set(ARMA_USE_BLAS true)
++     set(ARMA_USE_LAPACK true)  # OpenBLAS includes LAPACK in same library
++     set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
++   endif()
    
-+  include(ARMA_FindOpenBLAS)
-+  message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
-+
-+  if(OpenBLAS_FOUND)
-+    set(ARMA_USE_BLAS true)
-+    set(ARMA_USE_LAPACK true)  # OpenBLAS includes LAPACK in same library
-+    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
-+  endif()
-+
    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-     message(STATUS "Clang compiler on MacOS X detected. Added '-stdlib=libc++' to compiler flags")
+@@ -195,6 +204,7 @@
+     if(OpenBLAS_FOUND)
+       
+       set(ARMA_USE_BLAS true)
++      set(ARMA_USE_LAPACK true)
+       set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
+       
+       message(STATUS "")
+@@ -219,14 +229,14 @@
+         set(ARMA_USE_BLAS true)
+         set(ARMA_LIBS ${ARMA_LIBS} ${BLAS_LIBRARIES})
+       endif()
+-      
++ 
++      if(LAPACK_FOUND)
++        set(ARMA_USE_LAPACK true)
++        set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
++      endif()
++     
+     endif()
+     
+-    if(LAPACK_FOUND)
+-      set(ARMA_USE_LAPACK true)
+-      set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
+-    endif()
+-      
+   endif()
+   
+ endif()

--- a/recipes/armadillo/CMakeLists.patch
+++ b/recipes/armadillo/CMakeLists.patch
@@ -1,28 +1,26 @@
 --- CMakeLists.txt	2016-06-16 12:16:11.000000000 -0400
-+++ CMakeLists_New.txt	2017-02-13 22:43:10.000000000 -0500
-@@ -103,9 +103,25 @@
-   set(ARMA_USE_LAPACK true)
-   set(ARMA_USE_BLAS   true)
++++ CMakeLists_New.txt	2017-03-04 15:18:00.000000000 -0500
+@@ -100,12 +100,21 @@
+   
+   set(ARMA_OS macos)
+   
+-  set(ARMA_USE_LAPACK true)
+-  set(ARMA_USE_BLAS   true)
++  # set(ARMA_USE_LAPACK true)
++  # set(ARMA_USE_BLAS   true)
    
 -  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 -  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
 +  # set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
 +  # message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
-+
-+  include(ARMA_FindOpenBLAS)
-+  include(ARMA_FindLAPACK)
-+
-+  message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
-+  message(STATUS "  LAPACK_FOUND = ${LAPACK_FOUND}"  )
    
++  include(ARMA_FindOpenBLAS)
++  message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
++
 +  if(OpenBLAS_FOUND)
 +    set(ARMA_USE_BLAS true)
++    set(ARMA_USE_LAPACK true)  # OpenBLAS includes LAPACK in same library
 +    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
-+  endif()
-+  
-+  if(LAPACK_FOUND)
-+    set(ARMA_USE_LAPACK true)
-+    set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
 +  endif()
 +
    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/recipes/armadillo/CMakeLists.patch
+++ b/recipes/armadillo/CMakeLists.patch
@@ -1,0 +1,30 @@
+--- CMakeLists.txt	2016-06-16 12:16:11.000000000 -0400
++++ CMakeLists_New.txt	2017-02-13 22:43:10.000000000 -0500
+@@ -103,9 +103,25 @@
+   set(ARMA_USE_LAPACK true)
+   set(ARMA_USE_BLAS   true)
+   
+-  set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
+-  message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
++  # set(ARMA_LIBS ${ARMA_LIBS} "-framework Accelerate")  # or "-framework accelerate" ?
++  # message(STATUS "MacOS X detected. Added '-framework Accelerate' to compiler flags")
++
++  include(ARMA_FindOpenBLAS)
++  include(ARMA_FindLAPACK)
++
++  message(STATUS "OpenBLAS_FOUND = ${OpenBLAS_FOUND}")
++  message(STATUS "  LAPACK_FOUND = ${LAPACK_FOUND}"  )
+   
++  if(OpenBLAS_FOUND)
++    set(ARMA_USE_BLAS true)
++    set(ARMA_LIBS ${ARMA_LIBS} ${OpenBLAS_LIBRARIES})
++  endif()
++  
++  if(LAPACK_FOUND)
++    set(ARMA_USE_LAPACK true)
++    set(ARMA_LIBS ${ARMA_LIBS} ${LAPACK_LIBRARIES})
++  endif()
++
+   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+     message(STATUS "Clang compiler on MacOS X detected. Added '-stdlib=libc++' to compiler flags")

--- a/recipes/armadillo/build.sh
+++ b/recipes/armadillo/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+mkdir -p build
+cd build
+
+if [[ `uname` == 'Darwin' ]]; then
+
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+        -DCMAKE_MACOSX_RPATH="ON" \
+        -DCMAKE_INSTALL_RPATH="${PREFIX}/lib"
+    #    -DDETECT_HDF5="true"
+
+else
+
+    cmake .. \
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+    #    -DDETECT_HDF5="true"
+fi
+
+make
+make install
+cd ${SRC_DIR}/tests && make && ./main

--- a/recipes/armadillo/make_tests.patch
+++ b/recipes/armadillo/make_tests.patch
@@ -1,0 +1,14 @@
+--- tests/Makefile	2017-02-11 20:49:48.000000000 -0500
++++ tests/Makefile_new	2017-02-11 21:06:53.000000000 -0500
+@@ -1,9 +1,9 @@
+ 
+-LIB_FLAGS = -larmadillo
++LIB_FLAGS = -larmadillo -L${PREFIX}/lib
+ #LIB_FLAGS = -lblas -llapack 
+ #LIB_FLAGS = -lopenblas -llapack 
+ 
+-CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
++CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -DARMA_DONT_USE_WRAPPER
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O2
+ 

--- a/recipes/armadillo/make_tests_osx.patch
+++ b/recipes/armadillo/make_tests_osx.patch
@@ -1,0 +1,14 @@
+--- tests/Makefile	2017-02-11 20:49:48.000000000 -0500
++++ tests/Makefile_new	2017-02-11 21:23:15.000000000 -0500
+@@ -1,9 +1,9 @@
+ 
+-LIB_FLAGS = -larmadillo
++LIB_FLAGS = -larmadillo -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib
+ #LIB_FLAGS = -lblas -llapack 
+ #LIB_FLAGS = -lopenblas -llapack 
+ 
+-CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0
++CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -I${PREFIX}/include -stdlib=libc++
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O0 -DARMA_DONT_USE_WRAPPER
+ #CXX_FLAGS = -std=c++11 -Wshadow -Wall -pedantic -O2
+ 

--- a/recipes/armadillo/meta.yaml
+++ b/recipes/armadillo/meta.yaml
@@ -13,8 +13,9 @@ source:
         # have to add additional ${PREFIX}/lib etc... to tests/Makefile
         - make_tests.patch  # [linux]
         - make_tests_osx.patch  # [osx]
-        # modify CMakeLists to use OpenBLAS build rather than Accelrate
-        - CMakeLists.patch  # [osx]
+        # modify CMakeLists to use OpenBLAS rather than Accelrate on OS X
+        # and to use OpenBLAS as the LAPACK library on linux
+        - CMakeLists.patch
 
 build:
   number: 200
@@ -29,14 +30,12 @@ requirements:
     - pkg-config
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
-    - lapack
     - arpack
     - superlu 5*
     # - hdf5 1.8.17|1.8.17.*
   run:
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
-    - lapack
     - arpack
     - superlu 5*
     # - hdf5 1.8.17|1.8.17.*

--- a/recipes/armadillo/meta.yaml
+++ b/recipes/armadillo/meta.yaml
@@ -17,11 +17,11 @@ source:
         - make_tests_osx.patch  # [osx]
 
 build:
-  number: 200 # [linux]
+  number: 200  # [linux]
   number: 0  # [osx]
   skip: True  # [win]
   features:
-    - blas_{{ variant }} # [linux]
+    - blas_{{ variant }}  # [linux]
 
 requirements:
   build:

--- a/recipes/armadillo/meta.yaml
+++ b/recipes/armadillo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "7.600.2" %}
+{% set version = "7.800.1" %}
 {% set variant = "openblas" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 source:
     fn: armadillo-{{ version }}.tar.xz
     url: http://sourceforge.net/projects/arma/files/armadillo-{{ version }}.tar.xz
-    sha256: 6790d5e6b41fcac6733632a9c3775239806d00178886226dec3f986a884f4c2d
+    sha256: 5ada65a5a610301ae188bb34f0ac6e7fdafbdbcd0450b0adb7715349ae14b8db
     patches:
         # have to add additional ${PREFIX}/lib etc... to tests/Makefile
         - make_tests.patch  # [linux]
@@ -50,7 +50,7 @@ test:
 
 about:
     home: http://arma.sourceforge.net
-    license: MPL 2.0
+    license: Apache 2.0
     license_file: LICENSE.txt
     summary: Armadillo C++ linear algebra library
 

--- a/recipes/armadillo/meta.yaml
+++ b/recipes/armadillo/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "7.600.2" %}
+
+# Armadillo always uses Accelerate on OS X
+{% set variant = "openblas" %}  # [linux]
+
+package:
+    name: armadillo
+    version: {{ version }}
+
+source:
+    fn: armadillo-{{ version }}.tar.xz
+    url: http://sourceforge.net/projects/arma/files/armadillo-{{ version }}.tar.xz
+    sha256: 6790d5e6b41fcac6733632a9c3775239806d00178886226dec3f986a884f4c2d
+    # have to add additional ${PREFIX}/lib etc... to tests/Makefile
+    patches:
+        - make_tests.patch  # [linux]
+        - make_tests_osx.patch  # [osx]
+
+build:
+  number: 200 # [linux]
+  number: 0  # [osx]
+  skip: True  # [win]
+  features:
+    - blas_{{ variant }} # [linux]
+
+requirements:
+  build:
+    - cmake
+    # optional items below here
+    - pkg-config
+    - blas 1.1 {{ variant }}  # [linux]
+    - openblas 0.2.19|0.2.19.*  # [linux]
+    - lapack
+    - arpack
+    - superlu 5*
+    # - hdf5 1.8.17|1.8.17.
+  run:
+    - blas 1.1 {{ variant }}  # [linux]
+    - openblas 0.2.19|0.2.19.*  # [linux]
+    - lapack
+    - arpack
+    - superlu 5*
+    # - hdf5 1.8.17|1.8.17.
+
+test:
+  commands:
+    - test -f "${PREFIX}/include/armadillo"
+    - test -d "${PREFIX}/include/armadillo_bits"
+    - test -f "${PREFIX}/lib/libarmadillo.so"  # [linux]
+    - test -f "${PREFIX}/lib/libarmadillo.dylib"  # [osx]
+
+about:
+    home: http://arma.sourceforge.net
+    license: Mozilla Public 2.0 (MPL 2.0)
+    summary: Armadillo C++ linear algebra library
+
+extra:
+    recipe-maintainers:
+      - grlee77

--- a/recipes/armadillo/meta.yaml
+++ b/recipes/armadillo/meta.yaml
@@ -1,7 +1,6 @@
 {% set version = "7.600.2" %}
 
-# Armadillo always uses Accelerate on OS X
-{% set variant = "openblas" %}  # [linux]
+{% set variant = "openblas" %}
 
 package:
     name: armadillo
@@ -11,32 +10,33 @@ source:
     fn: armadillo-{{ version }}.tar.xz
     url: http://sourceforge.net/projects/arma/files/armadillo-{{ version }}.tar.xz
     sha256: 6790d5e6b41fcac6733632a9c3775239806d00178886226dec3f986a884f4c2d
-    # have to add additional ${PREFIX}/lib etc... to tests/Makefile
     patches:
+        # have to add additional ${PREFIX}/lib etc... to tests/Makefile
         - make_tests.patch  # [linux]
         - make_tests_osx.patch  # [osx]
+        # modify CMakeLists to use OpenBLAS build rather than Accelrate
+        - CMakeLists.patch  # [osx]
 
 build:
-  number: 200  # [linux]
-  number: 0  # [osx]
+  number: 200
   skip: True  # [win]
   features:
-    - blas_{{ variant }}  # [linux]
+    - blas_{{ variant }}
 
 requirements:
   build:
     - cmake
     # optional items below here
     - pkg-config
-    - blas 1.1 {{ variant }}  # [linux]
-    - openblas 0.2.19|0.2.19.*  # [linux]
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.19|0.2.19.*
     - lapack
     - arpack
     - superlu 5*
     # - hdf5 1.8.17|1.8.17.
   run:
-    - blas 1.1 {{ variant }}  # [linux]
-    - openblas 0.2.19|0.2.19.*  # [linux]
+    - blas 1.1 {{ variant }}
+    - openblas 0.2.19|0.2.19.*
     - lapack
     - arpack
     - superlu 5*

--- a/recipes/armadillo/meta.yaml
+++ b/recipes/armadillo/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "7.600.2" %}
-
 {% set variant = "openblas" %}
 
 package:
@@ -33,14 +32,14 @@ requirements:
     - lapack
     - arpack
     - superlu 5*
-    # - hdf5 1.8.17|1.8.17.
+    # - hdf5 1.8.17|1.8.17.*
   run:
     - blas 1.1 {{ variant }}
     - openblas 0.2.19|0.2.19.*
     - lapack
     - arpack
     - superlu 5*
-    # - hdf5 1.8.17|1.8.17.
+    # - hdf5 1.8.17|1.8.17.*
 
 test:
   commands:
@@ -51,7 +50,8 @@ test:
 
 about:
     home: http://arma.sourceforge.net
-    license: Mozilla Public 2.0 (MPL 2.0)
+    license: MPL 2.0
+    license_file: LICENSE.txt
     summary: Armadillo C++ linear algebra library
 
 extra:


### PR DESCRIPTION
optional HDF5 support is not currently enabled (this is the default for Armadillo)

I could not see a way to also use OpenBLAS on OS X  (Accelerate is used)
