### PR TITLE
Add snzip 1.0.4 recipe.

### DIFF
--- a/recipes/snzip/build.sh
+++ b/recipes/snzip/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+# Set paths for snappy headers and library.
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+export CFLAGS="${CFLAGS} -L${PREFIX}/lib"
+export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+
+./configure --prefix=${PREFIX} --with-snappy=${PREFIX}/include
+
+make -j${CPU_COUNT}
+make check
+make install

--- a/recipes/snzip/meta.yaml
+++ b/recipes/snzip/meta.yaml
@@ -1,0 +1,46 @@
+{% set author = "kubo" %}
+{% set name = "snzip" %}
+{% set version = "1.0.4" %}
+{% set hash_type = "sha256" %}
+{% set hash_val = "a45081354715d48ed31899508ebed04a41d4b4a91dca37b79fc3b8ee0c02e25e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://bintray.com/{{ author }}/generic/download_file?file_path={{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - snappy
+
+  run:
+    - snappy
+
+test:
+  commands:
+    - snzip -h
+
+about:
+  home: https://github.com/kubo/snzip
+  license: BSD 2-Clause
+  license_file: COPYING
+  summary: Snzip, a compression/decompression tool based on snappy
+  description: |
+    Snzip is one of command line tools using snappy. This supports several file
+    formats; framing-format, old framing-format, hadoop-snappy format, raw
+    format and obsolete three formats used by snzip, snappy-java and
+    snappy-in-java before official framing-format was defined. The default
+    format is framing-format.
+
+extra:
+  recipe-maintainers:
+    - rolando


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/2274

Snzip, a compression/decompression tool based on snappy.