### PR TITLE
geocoders and usgs

### DIFF
--- a/recipes/geocoder/meta.yaml
+++ b/recipes/geocoder/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "1.20.0" %}
+
+package:
+  name: geocoder
+  version: {{ version }}
+
+source:
+  fn: geocoder-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/g/geocoder/geocoder-{{ version }}.tar.gz
+  md5: d34a2d89fa3b6e381a7f2663208703de
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  preserve_egg_dir: True
+  entry_points:
+    - geocode=geocoder.cli:cli
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - requests
+    - ratelim
+    - click
+    - six
+
+test:
+  imports:
+    - geocoder
+  #commands:
+    # FIXME AttributeError: 'Command' object has no attribute 'cli'
+    #- geocode "Ottawa, ON"
+
+about:
+  home: https://github.com/DenisCarriere/geocoder
+  license: Apache 2.0
+  license_file: LICENSE
+  summary: 'Geocoder is a simple and consistent geocoding library.'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/usgs/meta.yaml
+++ b/recipes/usgs/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.1.9" %}
+
+package:
+  name: usgs
+  version: {{ version }}
+
+source:
+  fn: usgs-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/7b/d4/c7d81862bc4ed225930de8286563350975c220fdb26fdc6246f1e1586fbb/usgs-{{ version }}.tar.gz
+  md5: ab6ba28b3870f804d7f887891d7b7279
+
+build:
+  number: 0
+  skip: True  # [py2k]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  preserve_egg_dir: True
+  entry_points:
+    - usgs=usgs.scripts.cli:usgs
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools
+    - click >=4.0
+    - requests >=2.7.0
+    - requests-futures >=0.9.5
+
+test:
+  imports:
+    - usgs
+    - usgs.scripts
+  commands:
+    - usgs --help
+
+about:
+  home: https://github.com/mapbox/usgs
+  license: MIT
+  summary: 'Access the USGS inventory service'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
More `landsat-utils` dependencies. (Needs https://github.com/conda-forge/staged-recipes/pull/2429)