### PR TITLE
Add rpy2 recipe

### DIFF
--- a/recipes/rpy2/bld.bat
+++ b/recipes/rpy2/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install 
+if errorlevel 1 exit 1

--- a/recipes/rpy2/bld.bat
+++ b/recipes/rpy2/bld.bat
@@ -1,2 +1,46 @@
-"%PYTHON%" setup.py install 
+:: See: https://github.com/conda/conda-recipes/blob/master/python/rpy2/bld.bat
+::
+:: Mixing MS CRT headers and mingw-w64 headers doesn't work
+:: so build the whole thing with mingw-w64 instead.
+echo [build]              > setup.cfg
+echo compiler = mingw32  >> setup.cfg
+set CFLAGS=-D__USE_MINGW_ANSI_STDIO
+gendef %PREFIX%\python%CONDA_PY%.dll - > python%CONDA_PY%.def
+dlltool -d python%CONDA_PY%.def -l %CONDA_DEFAULT_ENV%\libs\libpython%CONDA_PY%.dll.a
+
+:: Create an empty library for msvcrt??? since CygwinCCompiler seems to
+:: think that linking to that is a good idea (it is not).
+if "%CONDA_PY%" == "36" (
+  ar cru %CONDA_DEFAULT_ENV%\libs\libmsvcr140.dll.a
+) else (
+  if "%CONDA_PY%" == "35" (
+    ar cru %CONDA_DEFAULT_ENV%\libs\libmsvcr140.dll.a
+  ) else (
+    if "%CONDA_PY%" == "34" (
+      ar cru %CONDA_DEFAULT_ENV%\libs\libmsvcr120.dll.a
+    ) else (
+      ar cru %CONDA_DEFAULT_ENV%\libs\libmsvcr90.dll.a
+    )
+  )
+)
+
+gendef %PREFIX%\python%CONDA_PY%.dll - > python%CONDA_PY%.def
+dlltool -d python%CONDA_PY%.def -l %PREFIX%\lib\libpython%CONDA_PY%.dll.a
+
+"%PYTHON%" setup.py install
 if errorlevel 1 exit 1
+
+:: Cleanup the libs we made:
+del %CONDA_DEFAULT_ENV%\libs\libpython%CONDA_PY%.dll.a
+if "%CONDA_PY%" == "36" (
+  del %CONDA_DEFAULT_ENV%\libs\libmsvcr140.dll.a
+) else (
+  if "%CONDA_PY%" == "35" (
+    del %CONDA_DEFAULT_ENV%\libs\libmsvcr140.dll.a
+  ) else (
+    if "%CONDA_PY%" == "34" (
+      del %CONDA_DEFAULT_ENV%\libs\libmsvcr120.dll.a
+    ) else (
+      del %CONDA_DEFAULT_ENV%\libs\libmsvcr90.dll.a
+    )
+  )

--- a/recipes/rpy2/build.sh
+++ b/recipes/rpy2/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install 

--- a/recipes/rpy2/build.sh
+++ b/recipes/rpy2/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install 
+CFLAGS="-I${PREFIX}/include ${CFLAGS}" "${PYTHON}" setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/rpy2/meta.yaml
+++ b/recipes/rpy2/meta.yaml
@@ -16,29 +16,37 @@ build:
 
 requirements:
   build:
+    - readline  # [not win]
     - python
     - setuptools
     - six
     - r-base
   run:
+    - readline  # [not win]
     - python
     - six
     - r-base
+    - singledispatch  # [not (py34 or py35)]
 
 test:
-  # Python imports - excluding those with 3rd party dependencies (rpy2.ipython)
   imports:
     - rpy2
     - rpy2.interactive
     - rpy2.interactive.tests
     - rpy2.rinterface
     - rpy2.rinterface.tests
+    - rpy2.ipython
+    - rpy2.ipython.tests
     - rpy2.rlike
     - rpy2.rlike.tests
     - rpy2.robjects
     - rpy2.robjects.lib
     - rpy2.robjects.lib.tests
     - rpy2.robjects.tests
+  requires:
+    - ipython
+    - numpy
+    - pandas
 
 about:
   home: http://rpy2.bitbucket.org

--- a/recipes/rpy2/meta.yaml
+++ b/recipes/rpy2/meta.yaml
@@ -2,6 +2,7 @@
 {% set version = "2.8.5" %}
 {% set version_ = "2_8_5" %}
 {% set sha1 = "517487daef8556c08db86f0f919fd4558c39f137" %}
+{% set native = 'm2w64-' if win else '' %}
 
 package:
   name: {{ name|lower }}
@@ -14,15 +15,22 @@ source:
 
 build:
   number: 0
+  # conda-forge r-base skips win32
+  skip: true  # [win32]
 
 requirements:
   build:
+    - posix  # [win]
+    - gcc  # [not win]
+    - {{ native }}toolchain  # [win]
     - readline  # [not win]
     - python
     - setuptools
     - six
     - r-base
   run:
+    - {{ native }}gcc-libs  # [win]
+    - libgcc  # [win]
     - readline  # [not win]
     - python
     - six

--- a/recipes/rpy2/meta.yaml
+++ b/recipes/rpy2/meta.yaml
@@ -1,15 +1,16 @@
 {% set name = "rpy2" %}
 {% set version = "2.8.5" %}
-{% set md5 = "b1c3ef432b3a5c83cec06658eeb85581" %}
+{% set version_ = "2_8_5" %}
+{% set sha1 = "517487daef8556c08db86f0f919fd4558c39f137" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/d9/ca/c53301591b5d1e2fdeb49f2e4256ff24b185a1fc1b9711c15a73f0f61741/{{ name }}-{{ version }}.tar.gz
-  md5: b1c3ef432b3a5c83cec06658eeb85581
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://bitbucket.org/rpy2/rpy2/get/RELEASE_{{ version_ }}.tar.bz2
+  sha1: {{ sha1 }}
 
 build:
   number: 0

--- a/recipes/rpy2/meta.yaml
+++ b/recipes/rpy2/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "rpy2" %}
+{% set version = "2.8.5" %}
+{% set md5 = "b1c3ef432b3a5c83cec06658eeb85581" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/d9/ca/c53301591b5d1e2fdeb49f2e4256ff24b185a1fc1b9711c15a73f0f61741/{{ name }}-{{ version }}.tar.gz
+  md5: b1c3ef432b3a5c83cec06658eeb85581
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+    - r-base
+  run:
+    - python
+    - six
+    - r-base
+
+test:
+  # Python imports - excluding those with 3rd party dependencies (rpy2.ipython)
+  imports:
+    - rpy2
+    - rpy2.interactive
+    - rpy2.interactive.tests
+    - rpy2.rinterface
+    - rpy2.rinterface.tests
+    - rpy2.rlike
+    - rpy2.rlike.tests
+    - rpy2.robjects
+    - rpy2.robjects.lib
+    - rpy2.robjects.lib.tests
+    - rpy2.robjects.tests
+
+about:
+  home: http://rpy2.bitbucket.org
+  license: GPL-2.0
+  license_family: GPL2
+  license_file: gpl-2.0.txt
+  summary: 'Python interface to the R language (embedded R)'
+  description: |
+    rpy2 is an interface to R running embedded in a Python process.
+  doc_url: https://rpy2.readthedocs.io
+  dev_url: https://bitbucket.org/rpy2/rpy2
+
+extra:
+  recipe-maintainers:
+    - ceholden


### PR DESCRIPTION
Adds `rpy2`, a Python library that allows you to run R code from within Python!

Getting this in would really helpful to me now that ICU creates conflicts with the `r` channel (:tada: for getting `r-base`!). Assuming this builds on all platforms, it should also address an issue recently reported in #1788.

One thought I had was about the minimum required specs. It's easy to just have `r-base` right now without more of R ported, but I'm open to suggestions if there's anything else that should be added eventually. Similarly, the Python requirements are sparse enough (no NumPy necessarily) to make `rpy2` not very useful! Again, I'm open to suggestions for additions but I'm assuming people will install NumPy/Pandas/etc as needed.

