### PR TITLE
Fix r-boot 2

### DIFF
--- a/recipes/r-boot/bld.bat
+++ b/recipes/r-boot/bld.bat
@@ -1,0 +1,8 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1
+
+@rem Add more build steps here, if they are necessary.
+
+@rem See
+@rem http://docs.continuum.io/conda/build.html
+@rem for a list of environment variables that are set during the build process.

--- a/recipes/r-boot/build.sh
+++ b/recipes/r-boot/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-boot/meta.yaml
+++ b/recipes/r-boot/meta.yaml
@@ -24,11 +24,11 @@ build:
     - lib/
 
 
-requirements:
-  build:
-    - r-base
-  run:
-    - r-base
+requirements:  # [not win32]
+  build:       # [not win32]
+    - r-base   # [not win32]
+  run:         # [not win32]
+    - r-base   # [not win32]
 
 test:
   commands:

--- a/recipes/r-boot/meta.yaml
+++ b/recipes/r-boot/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = 'boot' %}
+{% set version = '1.3-18' %}
+{% set sha256 = '12fd237f810a69cc8d0a51a67c57eaf9506bf0341c764f8ab7c1feb73722235e' %}
+
+package:
+  name: r-{{ name|lower }}
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: {{ name }}_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/{{ name }}_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz
+
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  # skip on windows because of this error:
+  # https://ci.appveyor.com/project/conda-forge/staged-recipes/build/1.0.10696/job/hma4wc1ms5ssj2qk#L415
+  skip: true  # [win or linux32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+
+requirements:
+  build:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('boot')"  # [not win]
+    - "\"%R%\" -e \"library('boot')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=boot
+  license: Unlimited
+  summary: 'Functions and datasets for bootstrapping from the book "Bootstrap Methods and Their
+    Application" by A. C. Davison and  D. V. Hinkley (1997, CUP), originally written
+    by Angelo Canty for S.'
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - ocefpaf


### PR DESCRIPTION
Builds off PR ( https://github.com/conda-forge/staged-recipes/pull/2361 ).

Unfortunately we seem to be unable to create `r-boot` the expected way as our tooling is getting hung up on Windows 32-bit. Am proposing we add a hack that hides the `requirements` section on Windows 32-bit. This appears to work for me locally and was seeing the same issue locally that we see on staged-recipes of [`r-base` unsatisfiable on `osx-64`]( https://travis-ci.org/conda-forge/staged-recipes/builds/198760898#L300-L301 ). So it should work on staged-recipes too. This issue actually is with Window 32-bit, but `conda` is misreporting the platform, for which we are searching for packages.

cc @johanneskoester @ocefpaf