### PR TITLE
WIP Add textacy 0.3.3, spacy 1.1.0, and related dependencies

### DIFF
--- a/recipes/backports.csv/meta.yaml
+++ b/recipes/backports.csv/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "backports.csv" %}
+{% set version = "1.0.3" %}
+{% set sha256sum = "3e7469c2933de679267e9f60d13903e0feba0bad00eecc2dd3f7e631dbc9a0d3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - backports.csv
+
+about:
+  home: https://github.com/ryanhiebert/backports.csv/
+  license: PSFL
+  license_file: LICENSE.rst
+  summary: Backport of Python 3's csv module for Python 2
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/cld2-cffi/meta.yaml
+++ b/recipes/cld2-cffi/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "cld2-cffi" %}
+{% set version = "0.1.4" %}
+{% set sha256sum = "3a29948364ed1e426c5bf542832eee208b1c70c0ad512b1a99bec0e6486f6c67" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+requirements:
+  build:
+    - toolchain
+    - msinttypes  # [win and py<35]
+    - python
+    - setuptools
+    - cffi
+    - six
+
+  run:
+    - python
+    - cffi
+    - six
+
+test:
+  imports:
+    - cld2
+    - cld2full
+
+about:
+  home: http://github.com/GregBowyer/cld2-cffi/
+  license: Apache
+  summary: CFFI bindings for CLD2
+  description: |
+    CFFI bindings around Google Chromium's embedded compact language detection
+    library (CLD2)
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/ijson/meta.yaml
+++ b/recipes/ijson/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "ijson" %}
+{% set version = "2.3" %}
+{% set sha256sum = "ef5f9f6bf9e44f2e1721e72bcc82c7ac6bb012b525e0f8642dedf7ddc44cf474" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - ijson
+
+about:
+  home: https://github.com/isagalaev/ijson
+  license: BSD 3-clause
+  license_file: LICENSE.txt
+  summary: Ijson is an iterative JSON parser with a standard Python iterator interface.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/pyemd/meta.yaml
+++ b/recipes/pyemd/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "pyemd" %}
+{% set version = "0.4.2" %}
+{% set sha256sum = "6585b27df1efe67ac553b4351abf86302365dbddee5695628e621580c4459de3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+# Numpy version supported >=1.9
+requirements:
+  build:
+    - toolchain
+    - python
+    - setuptools
+    - numpy x.x
+
+  run:
+    - python
+    - numpy x.x
+
+test:
+  imports:
+    - pyemd
+
+about:
+  home: http://github.com/wmayner/pyemd
+  license: MIT
+  summary: A Python wrapper for the Earth Mover's Distance.
+  description: |
+    PyEMD is a Python wrapper for Ofir Pele and Michael Werman’s implementation
+    of the Earth Mover’s Distance that allows it to be used with NumPy.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/pyphen/meta.yaml
+++ b/recipes/pyphen/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "Pyphen" %}
+{% set version = "0.9.4" %}
+{% set sha256sum = "abfa9a0ab055341f6e250c1a6bef395c3a06f0e4cba216eeef37f617b32c0bd7" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - pyphen
+
+about:
+  home: http://pyphen.org/
+  license: LGPLv2+
+  summary: Pure Python module to hyphenate text
+  description: |
+    Pyphen is a pure Python module to hyphenate text using existing Hunspell
+    hyphenation dictionaries.
+  dev_url: https://github.com/Kozea/Pyphen
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/python-ftfy/meta.yaml
+++ b/recipes/python-ftfy/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "python-ftfy" %}
+{% set pypi_name = "ftfy" %}
+{% set version = "4.3.1" %}
+{% set sha256sum = "60af7f4566a966fcb9681f3c93814017e981f5bbfffc2f5f33aadf8238101f4b" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/{{ pypi_name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - html5lib
+    - wcwidth
+
+  run:
+    - python
+    - setuptools
+    - html5lib
+    - wcwidth
+
+test:
+  imports:
+    - ftfy
+
+  commands:
+    - ftfy -h
+
+about:
+  home: https://github.com/LuminosoInsight/python-ftfy/
+  license: MIT
+  summary: Fixes some problems with Unicode text after the fact
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/spacy/meta.yaml
+++ b/recipes/spacy/meta.yaml
@@ -1,0 +1,78 @@
+{% set name = "spacy" %}
+{% set version = "1.1.0" %}
+{% set sha256sum = "71d45c69ee4628105bc3ae9a8e777539d2c4c879a400cecb0462f50e6e7d8338" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win32 or linux32]
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+# Numpy version supported is >= 1.7.
+requirements:
+  build:
+    - toolchain
+    - python
+    - setuptools
+    - numpy x.x
+    - murmurhash >=0.26,<0.27
+    - cymem >=1.30,<1.32.0
+    - preshed >=0.46.1,<0.47
+    - thinc >=5.0.0,<5.1.0
+    - plac
+    - six
+    - ujson
+    - cloudpickle
+    - pathlib  # [py2k]
+    - sputnik >=0.9.2,<0.10.0
+    - ujson >=1.35
+
+  run:
+    - python
+    - numpy x.x
+    - murmurhash >=0.26,<0.27
+    - cymem >=1.30,<1.32.0
+    - preshed >=0.46.1,<0.47
+    - thinc >=5.0.0,<5.1.0
+    - plac
+    - six
+    - ujson
+    - cloudpickle
+    - pathlib  # [py2k]
+    - sputnik >=0.9.2,<0.10.0
+    - ujson >=1.35
+
+test:
+  requires:
+    - pytest
+
+  commands:
+    - export SPACY_DIR=$(python -c "import pathlib; import spacy; print(pathlib.Path(spacy.__file__).parent.resolve())")
+    - py.test $SPACY_DIR
+
+about:
+  home: https://spacy.io/
+  license: MIT
+  license_file: LICENSE
+  summary: Industrial-strength Natural Language Processing
+  description: |
+    spaCy is a library for advanced natural language processing in Python and
+    Cython.
+  doc_url: https://spacy.io/docs
+  dev_url: https://github.com/spacy-io/spaCy
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/textacy/meta.yaml
+++ b/recipes/textacy/meta.yaml
@@ -1,0 +1,105 @@
+{% set name = "textacy" %}
+{% set version = "0.3.3" %}
+{% set sha256sum = "8ab08d6cab17d05a3ee8a1d924ddbc2cdd57b668a180be43e3ba8f182b537e4e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win32 or linux32]
+
+# Numpy version supported >=1.8
+requirements:
+  build:
+    - python
+    - setuptools
+    - backports.csv >=1.0.1  # [py2k]
+    - cachetools >=2.0
+    - cld2-cffi >=0.1.4
+    - cytoolz >=0.8
+    - python-ftfy >=4.2
+    - fuzzywuzzy >=0.12
+    - ijson >=2.3
+    - matplotlib >=1.5
+    - networkx >=1.11
+    - numpy x.x
+    - pyemd >=0.3.0
+    - pyphen >=0.9.4
+    - python-levenshtein >=0.12.0
+    - requests >=2.10.0
+    - scipy >=0.17
+    - scikit-learn >=0.17
+    - spacy >=1.1
+    - unidecode >=0.04.19
+
+  run:
+    - python
+    - backports.csv >=1.0.1  # [py2k]
+    - cachetools >=2.0
+    - cld2-cffi >=0.1.4
+    - cytoolz >=0.8
+    - python-ftfy >=4.2
+    - fuzzywuzzy >=0.12
+    - ijson >=2.3
+    - matplotlib >=1.5
+    - networkx >=1.11
+    - numpy x.x
+    - pyemd >=0.3.0
+    - pyphen >=0.9.4
+    - python-levenshtein >=0.12.0
+    - requests >=2.10.0
+    - scipy >=0.17
+    - scikit-learn >=0.17
+    - spacy >=1.1
+    - unidecode >=0.04.19
+
+test:
+  imports:
+    - textacy
+    - textacy.constants
+    - textacy.corpora
+    - textacy.corpus
+    - textacy.data
+    - textacy.doc
+    - textacy.export
+    - textacy.extract
+    - textacy.fileio
+    - textacy.keyterms
+    - textacy.lexicon_methods
+    - textacy.math_utils
+    - textacy.network
+    - textacy.preprocess
+    - textacy.similarity
+    - textacy.spacy_pipelines
+    - textacy.spacy_utils
+    - textacy.text_stats
+    - textacy.text_utils
+    - textacy.tm
+    - textacy.viz
+    - textacy.vsm
+
+about:
+  home: http://textacy.readthedocs.io/
+  license: Apache
+  summary: higher-level NLP built on spaCy
+  description: |
+    textacy is a Python library for performing higher-level natural language
+    processing (NLP) tasks, built on the high-performance spaCy library. With
+    the basics --- tokenization, part-of-speech tagging, dependency parsing,
+    etc. --- offloaded to another library, textacy focuses on tasks facilitated
+    by the ready availability of tokenized, POS-tagged, and parsed text.
+    spaCy is a library for advanced natural language processing in Python and
+    Cython.
+  dev_url: https://github.com/chartbeat-labs/textacy
+
+extra:
+  recipe-maintainers:
+    - rolando


### PR DESCRIPTION
**Update:** This PR has been separated into two PRs:

* https://github.com/conda-forge/staged-recipes/pull/2454
* https://github.com/conda-forge/staged-recipes/pull/2455

---

Note: some recipes are missing `about/license_file` entry because the
source distribution itself doesn't include the license file.

Blocking issues:

- [ ] `fuzzywuzzy >=0.12` https://github.com/conda-forge/fuzzywuzzy-feedstock/pull/2
- [ ] `pathlib  [win and py27]` https://github.com/conda-forge/pathlib-feedstock/pull/3