### PR TITLE
Add spaCy 1.1.0 and related dependencies

### DIFF
--- a/recipes/cymem/meta.yaml
+++ b/recipes/cymem/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "cymem" %}
+{% set version = "1.31.2" %}
+{% set sha256sum = "f06d9b50da0474d7405674d8101c319d89a17d33792d6d429fe3d5c64f0d9df1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win32 or linux32]
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+requirements:
+  build:
+    - toolchain
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/explosion/cymem
+  license: MIT
+  license_file: LICENSE
+  summary: Manage calls to calloc/free through Cython
+  description: |
+    cymem provides two small memory-management helpers for Cython. They make it
+    easy to tie memory to a Python object’s life-cycle, so that the memory is
+    freed when the object is garbage collected.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/cymem/run_test.py
+++ b/recipes/cymem/run_test.py
@@ -1,0 +1,6 @@
+import cymem
+import pytest
+import os
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname(cymem.__file__))
+pytest.main([PACKAGE_DIR])

--- a/recipes/murmurhash/meta.yaml
+++ b/recipes/murmurhash/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "murmurhash" %}
+{% set version = "0.26.4" %}
+{% set sha256sum = "869897c7c617aa94728a89edef5ae496180e85670f3c918dfc59c164912c1b66" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win32 or linux32]
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+requirements:
+  build:
+    - toolchain
+    - msinttypes  # [win and py<35]
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/explosion/murmurhash/
+  license: MIT
+  license_file: LICENSE
+  summary: Cython bindings for MurmurHash2
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/murmurhash/run_test.py
+++ b/recipes/murmurhash/run_test.py
@@ -1,0 +1,6 @@
+import murmurhash
+import os
+import pytest
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname(murmurhash.__file__))
+pytest.main([PACKAGE_DIR])

--- a/recipes/preshed/meta.yaml
+++ b/recipes/preshed/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "preshed" %}
+{% set version = "0.46.4" %}
+{% set sha256sum = "96f0ca6a0aa1347312fbe76bf55949a378b225f6a2b543eb2671208c87aabbfd" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win32 or linux32]
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+requirements:
+  build:
+    - toolchain
+    - msinttypes  # [win and py<35]
+    - python
+    - setuptools
+    - cymem >=1.30,<1.32
+
+  run:
+    - python
+    - cymem >=1.30,<1.32
+
+test:
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/explosion/preshed
+  license: MIT
+  license_file: LICENSE
+  summary: Cython Hash Table for Pre-Hashed Keys
+  description: |
+    Simple but high performance Cython hash table mapping pre-randomized keys
+    to void* values.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/preshed/run_test.py
+++ b/recipes/preshed/run_test.py
@@ -1,0 +1,6 @@
+import os
+import preshed
+import pytest
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname(preshed.__file__))
+pytest.main([PACKAGE_DIR])

--- a/recipes/semver/meta.yaml
+++ b/recipes/semver/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "semver" %}
+{% set version = "2.7.5" %}
+{% set sha256sum = "15d57e2b288b453708dda3b8b271c51353582dad2571fb0197027d69d85e6624" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - semver
+
+about:
+  home: https://github.com/k-bx/python-semver
+  license: BSD
+  summary: Python package to work with Semantic Versioning
+  description: |
+    A Python module for semantic versioning. Simplifies comparing versions.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/spacy/meta.yaml
+++ b/recipes/spacy/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "spacy" %}
+{% set version = "1.1.0" %}
+{% set sha256sum = "71d45c69ee4628105bc3ae9a8e777539d2c4c879a400cecb0462f50e6e7d8338" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  # At this time pathlib for win+py27 is missing.
+  skip: True  # [win32 or linux32 or (win and py2k)]
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+# Numpy version supported is >= 1.7.
+requirements:
+  build:
+    - toolchain
+    - python
+    - setuptools
+    - numpy x.x
+    - murmurhash >=0.26,<0.27
+    - cymem >=1.30,<1.32.0
+    - preshed >=0.46.1,<0.47
+    - thinc >=5.0.0,<5.1.0
+    - plac
+    - six
+    - ujson
+    - cloudpickle
+    - pathlib  # [py2k]
+    - sputnik >=0.9.2,<0.10.0
+    - ujson >=1.35
+
+  run:
+    - python
+    - numpy x.x
+    - murmurhash >=0.26,<0.27
+    - cymem >=1.30,<1.32.0
+    - preshed >=0.46.1,<0.47
+    - thinc >=5.0.0,<5.1.0
+    - plac
+    - six
+    - ujson
+    - cloudpickle
+    - pathlib  # [py2k]
+    - sputnik >=0.9.2,<0.10.0
+    - ujson >=1.35
+
+test:
+  requires:
+    - pytest
+
+about:
+  home: https://spacy.io/
+  license: MIT
+  license_file: LICENSE
+  summary: Industrial-strength Natural Language Processing
+  description: |
+    spaCy is a library for advanced natural language processing in Python and
+    Cython.
+  doc_url: https://spacy.io/docs
+  dev_url: https://github.com/spacy-io/spaCy
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/spacy/run_test.py
+++ b/recipes/spacy/run_test.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+import spacy
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname((spacy.__file__)))
+pytest.main([PACKAGE_DIR])

--- a/recipes/sputnik/meta.yaml
+++ b/recipes/sputnik/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "sputnik" %}
+{% set version = "0.9.3" %}
+{% set sha256sum = "2a2a506a2d68383f73dc7a546957714d316e23ce558e8d9115674f899d1f1273" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  skip: True  # [win32 or linux32]
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - semver
+
+  run:
+    - python
+    - semver
+
+test:
+  requires:
+    - pytest
+
+  commands:
+    - sputnik --help
+
+about:
+  home: https://github.com/explosion/sputnik
+  license: MIT
+  license_file: LICENSE
+  summary: 'Sputnik: a data package manager library'
+  description: |
+    Sputnik is a library for managing data packages for another library, e.g.,
+    models for a machine learning library.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/sputnik/run_test.py
+++ b/recipes/sputnik/run_test.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+import sputnik
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname(sputnik.__file__))
+pytest.main([PACKAGE_DIR])

--- a/recipes/thinc/meta.yaml
+++ b/recipes/thinc/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "thinc" %}
+{% set version = "5.0.8" %}
+{% set sha256sum = "993a12ab10c0af52c1db814fdabeecc591163e76c1fff50857ca9785c7a1841c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [win32 or linux32]
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>34]
+
+# Numpy supported is >=1.7
+requirements:
+  build:
+    - toolchain
+    - msinttypes  # [win and py<35]
+    - python
+    - setuptools
+    - numpy x.x
+    - murmurhash >=0.26,<0.27
+    - cymem >=1.30,<1.32
+    - preshed >=0.46,<0.47
+
+  run:
+    - python
+    - numpy x.x
+    - murmurhash >=0.26,<0.27
+    - cymem >=1.30,<1.32
+    - preshed >=0.46,<0.47
+
+test:
+  requires:
+    - hypothesis
+    - pytest
+
+  imports:
+    - thinc
+    - thinc.linear
+    - thinc.extra
+    - thinc.neural
+
+about:
+  home: https://github.com/explosion/thinc/
+  license: MIT
+  license_file: LICENSE
+  summary: 'thinc: Learn super-sparse multi-class models'
+  description: |
+    thinc is a Cython library for learning models with millions of parameters
+    and dozens of classes. It drives https://spacy.io , a pipeline of very
+    efficient NLP components. I’ve only used thinc from Cython; no real Python
+    API is currently available.
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/thinc/run_test.py
+++ b/recipes/thinc/run_test.py
@@ -1,0 +1,6 @@
+import os
+import pytest
+import thinc
+
+PACKAGE_DIR = os.path.abspath(os.path.dirname(thinc.__file__))
+pytest.main([PACKAGE_DIR])


### PR DESCRIPTION
Notes:

* Some recipes are missing `about/license_file` entry because the
source distribution itself doesn't include the license file.
* Even though some of theses packages exist in anaconda channel, there
is no win-* platform packages.