### PR TITLE
r-gsw

### DIFF
--- a/recipes/r-gsw/meta.yaml
+++ b/recipes/r-gsw/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "1.0-3" %}
+
+package:
+  name: r-gsw
+  version: {{ version.replace("-", "_") }}
+
+source:
+  fn: gsw_{{ version }}.tar.gz
+  url:
+    - http://cran.r-project.org/src/contrib/gsw_{{ version }}.tar.gz
+    - http://cran.r-project.org/src/contrib/Archive/gsw/gsw_{{ version }}.tar.gz
+  sha256: e24c6802467546d616531499c2a98610fdb5c35c8a1e161b6d6b887c4c814331
+
+build:
+  number: 0
+  script: R CMD INSTALL --build .
+  skip: True  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:  # [not win32]
+  build:  # [not win32]
+    - r-base  # [not win32]
+    - posix  # [win64]
+    - m2w64-toolchain  # [win64]
+    - gcc  # [not win]
+  run:  # [not win32]
+    - r-base  # [not win32]
+
+test:
+  commands:
+    - R -e "library('gsw')"  # [not win]
+    - R -e \"library('gsw')\"  # [win]
+
+about:
+  home: http://teos-10.github.io/GSW-R/index.html
+  license: GPL-3.0
+  license_file: LICENSE
+  summary: 'Provides an interface to the Gibbs SeaWater (TEOS-10) C library, which
+    derives from Matlab and other code written by WG127 (Working Group 127) of
+    SCOR/IAPSO (Scientific Committee on Oceanic Research / International Association
+    for the Physical Sciences of the Oceans).'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
Let's try this again now that we have the new `r-base` package with the headers on Windows.

xref: https://github.com/conda-forge/r-base-feedstock/pull/10