### PR TITLE
Do not mention conda skeleton in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,7 @@ This repo is a holding area for recipes destined for a conda-forge feedstock rep
 
 ### 1. **How do I start editing the recipe?**
 
-There are two ways to get started:
-
-a. If it is a python package you can generate a skeleton as a starting point with
-`conda skeleton pypi your_package_name`. You do *not* have to use skeleton, and the
-recipes produced by skeleton will need to be edited.
-
-b. Look at one of [these examples](https://github.com/conda-forge/staged-recipes/tree/master/recipes)
+Look at one of [these examples](https://github.com/conda-forge/staged-recipes/tree/master/recipes)
 in this repository and modify it as necessary.
 
 Your final recipe should have no comments and follow the order in the example.


### PR DESCRIPTION
While nice in theory, conda skeleton produces a recipe that will need to be modified a lot (it does not use template variables, puts all dependencies in both build and run, uses md5 hash, uses build scripts for simple python packages, ...). It might be a better idea to just start with the example recipe and change where change is needed.

Most of the comments in #2289 referred to the lines generated by `conda skeleton`.