### PR TITLE
Add ldaptor package

### DIFF
--- a/recipes/ldaptor/meta.yaml
+++ b/recipes/ldaptor/meta.yaml
@@ -1,15 +1,19 @@
+{% set name = "ldaptor" %}
+{% set version = "16.0.1" %}
+{% set sha256 = "6b9ebe5814e9e7091703c4e3bfeae73b46508b4678e2ff403cddaedf8213815d" %}
+
 package:
-  name: ldaptor
-  version: "16.0.1"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  fn: ldaptor-16.0.1.tar.gz
-  url: https://pypi.python.org/packages/d9/76/a25321b8941bf02e24b4923273caaf531890fb092a06f14d62c1683b11a2/ldaptor-16.0.1.tar.gz
-  md5: 2bda97c508c4fa3a269f40209f6e5311
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 build:
   number: 0
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:

--- a/recipes/ldaptor/meta.yaml
+++ b/recipes/ldaptor/meta.yaml
@@ -1,0 +1,52 @@
+package:
+  name: ldaptor
+  version: "16.0.1"
+
+source:
+  fn: ldaptor-16.0.1.tar.gz
+  url: https://pypi.python.org/packages/d9/76/a25321b8941bf02e24b4923273caaf531890fb092a06f14d62c1683b11a2/ldaptor-16.0.1.tar.gz
+  md5: 2bda97c508c4fa3a269f40209f6e5311
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pycrypto
+    # FIXME: Build currently against previous twisted version, because of
+    # https://groups.google.com/a/continuum.io/forum/?fromgroups#!topic/anaconda/2_YQ3jGU1RQ 
+    - twisted <17.1.0
+    - pyopenssl
+    - pyparsing
+    - zope.interface
+
+  run:
+    - python
+    - pycrypto
+    # FIXME: see above
+    - twisted <17.1.0
+    - pyopenssl
+    - pyparsing
+    - zope.interface
+
+test:
+  imports:
+    - ldaptor
+    - ldaptor.protocols
+    - ldaptor.protocols.ldap
+    - ldaptor.protocols.ldap.autofill
+    - ldaptor.samba
+    - ldaptor.test
+
+about:
+  home: https://github.com/twisted/ldaptor
+  license: MIT
+  license_family: MIT
+  summary: 'A Pure-Python Twisted library for LDAP'
+
+extra:
+  recipe-maintainers:
+    - stuertz


### PR DESCRIPTION
It currently depends of a twisted Version < 17.1.0, because of a build failure with Automat dependency required by Twisted 17.1.0