### PR TITLE
Add PyStan 2.14 recipe

### DIFF
--- a/recipes/pystan/bld.bat
+++ b/recipes/pystan/bld.bat
@@ -1,0 +1,20 @@
+set "STAN_VER=%PKG_VERSION:~0,-2%"
+
+pushd pystan\\stan\\lib\\stan_math_%STAN_VER%
+if errorlevel 1 exit 1
+
+rd /q /s doc doxygen make test lib\\cpplist_4.45 lib\\gtest_1.7.0
+if errorlevel 1 exit 1
+
+popd
+if errorlevel 1 exit 1
+
+
+:: For VS<10 copy stdint to the pystan directory so models can be compiled.
+if %VS_MAJOR% LSS 10 (
+  robocopy %LIBRARY_INC% pystan\\stan\\src stdint.h
+  if errorlevel GTR 1 exit 1
+)
+
+python setup.py install -q --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/recipes/pystan/build.sh
+++ b/recipes/pystan/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ex
+
+STAN_VER=${PKG_VERSION:0:${#PKG_VERSION}-2}
+INSTALL_LOG=install.log
+
+# These folders are not needed in the build and we don't want to include them
+# in the package. This should be cleaned via MANIFEST.in.
+pushd pystan/stan/lib/stan_math_${STAN_VER}
+rm -fr doc doxygen make test lib/cpplist_* lib/gtest_*
+popd
+
+# Log everything to a file to avoid reaching max output limit in travis.
+touch $INSTALL_LOG
+
+function dump_output() {
+  let N=${1:-"10"}
+  echo "Tailing the last $N lines of output"
+  tail -${N} $INSTALL_LOG
+}
+
+function error_handler() {
+  echo "ERROR: An error was encountered in the build"
+  dump_output 500
+  exit 1
+}
+
+trap 'error_handler' ERR
+
+bash -c "while true; do echo === \$(date) === building ...; sleep 60; done" &
+PING_LOOP_PID=$!
+
+python setup.py install -q --single-version-externally-managed --record=record.txt \
+  >> $INSTALL_LOG 2>&1
+
+# Build finished OK
+dump_output
+
+kill $PING_LOOP_PID

--- a/recipes/pystan/meta.yaml
+++ b/recipes/pystan/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "pystan" %}
+{% set version = "2.14.0.0" %}
+{% set sha256sum = "3bed255ca7d35bbd4ed0d5f30470744d9a71b06c1fa8b88281053dd430b0b1b2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256sum }}
+  patches:
+    - patches/0001-Disable-boost-quadmath.patch
+
+build:
+  number: 0
+  # For now, due to Travis time limit, we restrict the build matrix.
+  skip: True  # [osx and (py36 or np!=111)]
+  features:
+    - vc9   # [win and py27]
+    - vc14  # [win and py35]
+    - vc14  # [win and py36]
+  detect_binary_files_with_prefix: False
+
+requirements:
+  build:
+    - msinttypes  # [win and py27]
+    - python
+    - setuptools
+    - numpy >=1.7
+    - cython >=0.22,!=0.25.1
+
+  run:
+    - python
+    - numpy >=1.7
+    - cython >=0.22,!=0.25.1
+    - matplotlib
+
+test:
+  imports:
+    - pystan
+
+about:
+  home: http://mc-stan.org/interfaces/pystan.html
+  license: GPLv3
+  license_file: LICENSE
+  summary: Python interface to Stan, a package for Bayesian inference
+  description: |
+    PyStan provides a Python interface to Stan, a package for Bayesian
+    inference using the No-U-Turn sampler, a variant of Hamiltonian Monte
+    Carlo.
+  doc_url: https://pystan.readthedocs.org/
+  dev_url: https://github.com/stan-dev/pystan
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/pystan/patches/0001-Disable-boost-quadmath.patch
+++ b/recipes/pystan/patches/0001-Disable-boost-quadmath.patch
@@ -1,0 +1,39 @@
+From 9414eac6365a7773fc8b544b3ea8f34f49b095ac Mon Sep 17 00:00:00 2001
+From: Rolando Espinoza <rndmax84@gmail.com>
+Date: Sun, 5 Mar 2017 14:11:15 -0300
+Subject: [PATCH] Disable boost quadmath
+
+Pystan passes its own flags to compile its models. If we don't disable
+float128 explicitly then boost attempts to load quadmath.h header file.
+---
+ pystan/model.py | 1 +
+ setup.py        | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/pystan/model.py b/pystan/model.py
+index 790920f..5f9661d 100644
+--- a/pystan/model.py
++++ b/pystan/model.py
+@@ -271,6 +271,7 @@ class StanModel:
+             ('BOOST_RESULT_OF_USE_TR1', None),
+             ('BOOST_NO_DECLTYPE', None),
+             ('BOOST_DISABLE_ASSERTS', None),
++            ('BOOST_MATH_DISABLE_FLOAT128', None),
+         ]
+         # compile stan models with optimization (-O2)
+         # (stanc is compiled without optimization (-O0) currently, see #33)
+diff --git a/setup.py b/setup.py
+index d5af24b..88371d1 100644
+--- a/setup.py
++++ b/setup.py
+@@ -107,6 +107,7 @@ stan_macros = [
+     ('BOOST_RESULT_OF_USE_TR1', None),
+     ('BOOST_NO_DECLTYPE', None),
+     ('BOOST_DISABLE_ASSERTS', None),
++    ('BOOST_MATH_DISABLE_FLOAT128', None),
+     ('FUSION_MAX_VECTOR_SIZE', 12),  # for parser, stan-dev/pystan#222
+ ]
+ extra_compile_args = [
+-- 
+2.6.2
+

--- a/recipes/pystan/run_test.py
+++ b/recipes/pystan/run_test.py
@@ -1,0 +1,31 @@
+import pystan
+
+schools_code = """
+data {
+    int<lower=0> J; // number of schools
+    real y[J]; // estimated treatment effects
+    real<lower=0> sigma[J]; // s.e. of effect estimates
+}
+parameters {
+    real mu;
+    real<lower=0> tau;
+    real eta[J];
+}
+transformed parameters {
+    real theta[J];
+    for (j in 1:J)
+        theta[j] = mu + tau * eta[j];
+}
+model {
+    eta ~ normal(0, 1);
+    y ~ normal(theta, sigma);
+}
+"""
+
+schools_dat = {'J': 8,
+               'y': [28,  8, -3,  7, -1,  1, 18, 12],
+               'sigma': [15, 10, 16, 11,  9, 11, 10, 18]}
+
+fit = pystan.stan(model_code=schools_code, data=schools_dat,
+                  iter=1000, chains=4, n_jobs=1)
+print(fit)


### PR DESCRIPTION
This fixes the lack of windows build for PyStan in the default anaconda channel. And this version is the minimum one supported by ``fbprophet``.