### PR TITLE
Add a pyspark 2.1.0 recipe

### DIFF
--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -20,10 +20,10 @@ build:
 requirements:
   build:
     - python
-    - setuptools
+    - pip
     - pypandoc
     - py4j 0.10.4
-    - wheel
+    - setuptools
 
   run:
     - python

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pyspark" %}
+{% set version = "2.1.0" %}
+{% set hadoop_version = "2.7" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: http://www.apache.org/dist/spark/spark-{{ version }}/spark-{{ version }}-bin-hadoop{{ hadoop_version }}.tgz
+  sha256: 0834c775f38473f67cb122e0ec21074f800ced50c1ff1b9e37e222a0069dc5c7
+
+build:
+  number: 0
+  script: >
+    cd python &&
+    python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pypandoc
+    - py4j 0.10.4
+
+  run:
+    - python
+    - numpy >=1.7
+    - pandas
+    - py4j 0.10.4
+
+test:
+  imports:
+    - pyspark
+    # - pyspark.mllib # Subpackages of this missing in 2.1.0 release
+    # - pyspark.ml    # Ditto
+    - pyspark.sql
+    - pyspark.streaming
+
+about:
+  home: http://spark.apache.org/
+  license: Apache License
+  license_file: LICENSE
+  summary: 'Apache Spark'
+  description: Apache Spark is a fast and general engine for large-scale data processing.
+
+extra:
+  recipe-maintainers:
+    - parente
+    - ericdill

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - setuptools
     - pypandoc
     - py4j 0.10.4
+    - wheel
 
   run:
     - python

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -41,7 +41,7 @@ test:
 
 about:
   home: http://spark.apache.org/
-  license: Apache
+  license: Apache 2.0
   license_file: LICENSE
   summary: 'Apache Spark'
   description: Apache Spark is a fast and general engine for large-scale data processing.

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "pyspark" %}
 {% set version = "2.1.0" %}
 {% set hadoop_version = "2.7" %}
+{% set sha256 = "0834c775f38473f67cb122e0ec21074f800ced50c1ff1b9e37e222a0069dc5c7" %}
 
 package:
   name: {{ name }}
@@ -8,7 +9,7 @@ package:
 
 source:
   url: http://www.apache.org/dist/spark/spark-{{ version }}/spark-{{ version }}-bin-hadoop{{ hadoop_version }}.tgz
-  sha256: 0834c775f38473f67cb122e0ec21074f800ced50c1ff1b9e37e222a0069dc5c7
+  sha256: {{ sha256 }}
 
 build:
   number: 0

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -10,8 +10,11 @@ package:
 source:
   url: http://www.apache.org/dist/spark/spark-{{ version }}/spark-{{ version }}-bin-hadoop{{ hadoop_version }}.tgz
   sha256: {{ sha256 }}
+  patches:
+    - setup.py.patch
 
 build:
+  skip: True  # [py36]
   number: 0
   script: >
     cd python &&
@@ -34,8 +37,12 @@ requirements:
 test:
   imports:
     - pyspark
-    # - pyspark.mllib # Subpackages of this missing in 2.1.0 release
-    # - pyspark.ml    # Ditto
+    - pyspark.ml
+    - pyspark.ml.linalg
+    - pyspark.ml.param
+    - pyspark.mllib
+    - pyspark.mllib.linalg
+    - pyspark.mllib.stat
     - pyspark.sql
     - pyspark.streaming
 

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: http://spark.apache.org/
-  license: Apache License
+  license: Apache
   license_file: LICENSE
   summary: 'Apache Spark'
   description: Apache Spark is a fast and general engine for large-scale data processing.

--- a/recipes/pyspark/meta.yaml
+++ b/recipes/pyspark/meta.yaml
@@ -57,3 +57,4 @@ extra:
   recipe-maintainers:
     - parente
     - ericdill
+    - quasiben

--- a/recipes/pyspark/setup.py.patch
+++ b/recipes/pyspark/setup.py.patch
@@ -1,0 +1,17 @@
+diff --git a/python/setup.py b/python/setup.py
+index bc2eb4c..f500354 100644
+--- a/python/setup.py
++++ b/python/setup.py
+@@ -162,7 +162,11 @@ try:
+         url='https://github.com/apache/spark/tree/master/python',
+         packages=['pyspark',
+                   'pyspark.mllib',
++                  'pyspark.mllib.linalg',
++                  'pyspark.mllib.stat',
+                   'pyspark.ml',
++                  'pyspark.ml.linalg',
++                  'pyspark.ml.param',
+                   'pyspark.sql',
+                   'pyspark.streaming',
+                   'pyspark.bin',
+


### PR DESCRIPTION
This recipe pulls the Apache Spark tarball and uses the newly included setup.py file to build a conda package. The result is ~180 MB but provides a fully functional pyspark library once installed.

Does it make sense as a conda package? If so, anyone else want to help maintain it?

cc'ing a few folks to start a discussion: @holdenk, @rgbkrk, @jakirkham, @ericdill