### PR TITLE
Drop preemptive creation of feedstock directory

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -146,7 +146,6 @@ if __name__ == '__main__':
         feedstock_dirs = []
         for recipe_dir, name in list_recipes():
             feedstock_dir = os.path.join(feedstocks_dir, name + '-feedstock')
-            os.mkdir(feedstock_dir)
             print('Making feedstock for {}'.format(name))
 
             subprocess.check_call(['conda', 'smithy', 'init', recipe_dir,


### PR DESCRIPTION
As this is already handled by `conda-smithy`, there is no need for the directory to be created in advance by this script. Further this change needs to occur as `conda-smithy` no longer overwrites an existing feedstock when running `init`. Instead the feedstock must not exist for `init` to work.
