### PR TITLE
Add recipe for cached-property

### DIFF
--- a/recipes/cached-property/meta.yaml
+++ b/recipes/cached-property/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "cached-property" %}
+{% set version = "1.3.0" %}
+{% set sha256 = "458e78b1c7286ece887d92c9bee829da85717994c5e3ddd253a40467f488bc81" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - cached_property
+
+about:
+  home: https://github.com/pydanny/cached-property
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: 'A decorator for caching properties in classes.'
+
+extra:
+  recipe-maintainers:
+    - mvdbeek


### PR DESCRIPTION
This is a tiny python package that adds the cached_property decorator.
I find myself using this quite frequently, so it would be nice if it could be included in conda-forge.