### PR TITLE
Require Python for Windows build of bzip2

### DIFF
--- a/recipes/bzip2/meta.yaml
+++ b/recipes/bzip2/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - python  # [win]
     - toolchain
 
 test:


### PR DESCRIPTION
cc @jschueller