### PR TITLE
Fix maintainer list of libsakura

### DIFF
--- a/recipes/libsakura/meta.yaml
+++ b/recipes/libsakura/meta.yaml
@@ -42,4 +42,4 @@ about:
 
 extra:
   recipe-maintainers:
-    pkgw
+    - pkgw


### PR DESCRIPTION
Did not previously have the maintainer's handle as a list element. So it appears scripts treated it as a list of characters instead. This fixes that so the appropriate maintainer will be added.

Somehow this recipe is still in `master` at staged-recipes. Likely due to the issues we experienced as fallout from S3 today. Hence why we are fixing this here in addition to the feedstock.