### PR TITLE
Added recipe for docrep v0.1.2

### DIFF
--- a/recipes/docrep/meta.yaml
+++ b/recipes/docrep/meta.yaml
@@ -18,6 +18,7 @@ build:
 requirements:
   build:
     - python
+    - setuptools
   run:
     - python
     - six

--- a/recipes/docrep/meta.yaml
+++ b/recipes/docrep/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "docrep" %}
+{% set version = "0.1.1" %}
+{% set sha256 = "ede2317a6caa63b04197b69b0b511237236d9c27c962d0dfcd6ff7290b165d45" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - six
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - docrep
+
+about:
+  home: https://github.com/Chilipp/docrep
+  license: GNU General Public License v2 (GPLv2)
+  license_family: GPL2
+  license_file: LICENSE
+  summary: 'Python package for docstring repetition'
+
+  description: |
+    The documentation repetition module (docrep) targets developpers that
+    develop complex and nested Python APIs and helps them to create a
+    well-documented software.
+  doc_url: http://docrep.readthedocs.io/
+  dev_url: https://github.com/Chilipp/docrep
+
+extra:
+  recipe-maintainers:
+    - Chilipp

--- a/recipes/docrep/meta.yaml
+++ b/recipes/docrep/meta.yaml
@@ -18,8 +18,6 @@ build:
 requirements:
   build:
     - python
-    - setuptools
-    - six
   run:
     - python
     - six

--- a/recipes/docrep/meta.yaml
+++ b/recipes/docrep/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "docrep" %}
-{% set version = "0.1.1" %}
-{% set sha256 = "ede2317a6caa63b04197b69b0b511237236d9c27c962d0dfcd6ff7290b165d45" %}
+{% set version = "0.1.2" %}
+{% set sha256 = "bd88bd864c04c5db84e65648f53816a5bc695632d5d87a389be8bafcfa1cf407" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/docrep/meta.yaml
+++ b/recipes/docrep/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 about:
   home: https://github.com/Chilipp/docrep
-  license: GNU General Public License v2 (GPLv2)
+  license: GPLv2
   license_family: GPL2
   license_file: LICENSE
   summary: 'Python package for docstring repetition'


### PR DESCRIPTION
The docrep [python package](https://pypi.python.org/pypi/docrep/0.1.1) is hosted on [github](https://github.com/Chilipp/docrep) with a documentation on [readthedocs.org](http://docrep.readthedocs.io/en/latest/).
This module targets developpers that develop complex and nested Python APIs and helps them to create a well-documented piece of software.

This pull request was restarted due to the AWS outage the day before.