### PR TITLE
bibtexparser: a module for parsing BibTeX files

### DIFF
--- a/recipes/bibtexparser/meta.yaml
+++ b/recipes/bibtexparser/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "bibtexparser" %}
+{% set version = "0.6.2" %}
+{% set sha256 = "5888219ac5db1c63ae0ad4db52ec7ad87fe7a32bd60e62ee87bceedb8ebf73b8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/b/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script:
+    - python setup.py install --single-version-externally-managed --record files.txt
+
+requirements:
+  build:
+    - pyparsing
+    - python
+    - setuptools
+  run:
+    - pyparsing
+    - python
+
+test:
+  imports:
+    bibtexparser
+
+about:
+  home: https://bibtexparser.readthedocs.org/
+  license: LGPLv3 or BSD
+  # license_file: COPYING -- file not included in the current distribution
+  summary: 'A module for parsing BibTeX files.'
+
+extra:
+  recipe-maintainers:
+    - pkgw


### PR DESCRIPTION
A simple pure-Python package.