### PR TITLE
Adding natsort in v4.0.4

### DIFF
--- a/recipes/natsort/meta.yaml
+++ b/recipes/natsort/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "natsort" %}
+{% set version = "4.0.4" %}
+{% set sha256 = "c76ba3e85fba78f276ac06e4d47f2230d1070f9c19413b2a0bfe7de6af311839" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - natsort
+
+about:
+  home: https://github.com/SethMMorton/natsort
+  license: MIT
+  license_file: LICENSE
+  summary: 'Sort lists naturally'
+
+  doc_url: http://pythonhosted.org/natsort/
+  dev_url: https://github.com/SethMMorton/natsort
+
+extra:
+  recipe-maintainers:
+    - holtgrewe


### PR DESCRIPTION
I need to package a software into Bioconda that has a hard-coded dependency on `natsort==4.0.4`. I don't want to patch that software, so here is the recipe for v4.0.4 for conda-forge.

I hope that's OK.