### PR TITLE
Add statistics 1.0.3.5

### DIFF
--- a/recipes/statistics/meta.yaml
+++ b/recipes/statistics/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "statistics" %}
+{% set version = "1.0.3.5" %}
+{% set sha256 = "2dc379b80b07bf2ddd5488cad06b2b9531da4dd31edb04dc9ec0dc226486c138" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [py3k]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - statistics
+
+about:
+  home: https://pypi.python.org/pypi/statistics
+  license: Apache-2.0
+  license_family: Apache
+  summary: 'A Python 2.* port of 3.4 Statistics Module'
+  description: |
+    A port of Python 3.4 statistics module to Python 2.*, initially
+    done through the 3to2 tool.
+
+    This module provides functions for calculating mathematical
+    statistics of numeric (Real-valued) data.
+  doc_url: https://docs.python.org/3/library/statistics.html
+  dev_url: https://github.com/digitalemagine/py-statistics
+
+extra:
+  recipe-maintainers:
+    - danring


### PR DESCRIPTION
(This package is required to fix pytest-benchmark-feedstock for py2k -- see https://github.com/danring/pytest-benchmark-feedstock.)