### PR TITLE
Recipe for latest SCons 2.5.1

### DIFF
--- a/recipes/scons/meta.yaml
+++ b/recipes/scons/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "scons" %}
+{% set version = "2.5.1" %}
+{% set sha256 = "c8de85fc02ed1a687b1f2ac791eaa0c1707b4382a204f17d782b5b111b9fdf07" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [py3k]
+  script: python setup.py install --standard-lib
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - SCons
+    - SCons.Node
+    - SCons.Options
+    - SCons.Platform
+    - SCons.Scanner
+    - SCons.Script
+    - SCons.Tool
+    - SCons.Tool.MSCommon
+    - SCons.Tool.docbook
+    - SCons.Tool.packaging
+    - SCons.Variables
+    - SCons.compat
+
+about:
+  home: http://www.scons.org/
+  license: MIT
+  license_family: MIT
+  summary: 'Open Source next-generation build tool.'
+  description: |
+    SCons is an Open Source software construction tool that is, a
+    next-generation build tool. Think of SCons as an improved, cross-platform
+    substitute for the classic Make utility with integrated functionality
+    similar to autoconf/automake and compiler caches such as ccache. In short,
+    SCons is an easier, more reliable and faster way to build software.
+  doc_url: http://scons.org/documentation.html
+  dev_url: https://bitbucket.org/scons/scons
+
+extra:
+  recipe-maintainers:
+    - stuertz


### PR DESCRIPTION
This version is located in standard lib dir, instead of the scons 2.3.6 version from default