### PR TITLE
Added recipe for glue-core

### DIFF
--- a/recipes/glue-core/meta.yaml
+++ b/recipes/glue-core/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = "0.10.1" %}
+
+package:
+  name: glue-core
+  version: {{version}}
+
+source:
+  fn: glue-core-{{version}}.tar.gz
+  url: https://pypi.io/packages/source/g/glue-core/glue-core-{{version}}.tar.gz
+  md5: bf0d8d2c2fba069d554aadb9acce5292
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - glue = glue.main:main
+    - glue-config = glue.config_gen:main
+    - glue-deps = glue._deps:main
+  osx_is_app: True
+
+requirements:
+
+  build:
+    - python
+    - setuptools
+    - pyqt 4.11.*
+
+  run:
+
+    # The following is needed to make sure that the package works as a GUI
+    # application (glue needs to be run with python.app, not python)
+    - python.app  # [osx]
+
+    # Required dependencies
+    - python
+    - numpy >=1.9
+    - pandas >=0.14
+    - astropy >=1.3
+    - matplotlib >=1.4
+    - qtpy >=1.1.1
+    - ipython >=4.0
+    - ipykernel
+    - qtconsole
+    - dill >=0.2
+    - xlrd >=1.0
+    - h5py >=2.4
+    - setuptools >=1.0
+    - pyqt 4.11.*
+
+    # Optional dependencies (defined in ``extras_require``)
+    - scipy
+    - scikit-image
+    - plotly
+
+    # Temporary: the scikit-image conda package is missing the dask dependency
+    # so we add it here for now
+    - dask
+
+test:
+  imports:
+    - glue
+    - glue.core
+    - glue.app.qt
+  commands:
+    - glue --version
+    - glue-deps list
+
+# NOTE: we deliberatey do NOT include an app entry here, because we instead do this
+# in the glueviz meta-package (we don't want glue to appear twice in the navigator)
+
+about:
+  home: http://glueviz.org
+  license: BSD 3-Clause
+  license_file: LICENSE
+  summary: Multi-dimensional linked data exploration
+
+extra:
+  recipe-maintainers:
+    - astrofrog


### PR DESCRIPTION
The glueviz package has now been split into glue-core (which is the main package) and glueviz which is going to be a meta-package. Once glue-core is merged and built, I will update the glueviz feedstock.