### PR TITLE
ENH enable openmp for xgboost on macs

### DIFF
--- a/recipes/xgboost/LICENSE
+++ b/recipes/xgboost/LICENSE
@@ -1,0 +1,13 @@
+Copyright (c) 2016 by Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/xgboost/Makefile.patch
+++ b/recipes/xgboost/Makefile.patch
@@ -1,6 +1,13 @@
-46,47c46,47
-< export CC = $(if $(shell which gcc-5),gcc-5,clang-omp)
-< export CXX = $(if $(shell which g++-5),g++-5,clang-omp++)
----
-> export CC = clang
-> export CXX = clang++
+--- xgboost-0.6a2/xgboost/Makefile	2016-08-09 04:32:24.000000000 -0500
++++ xgboost-0.6a2/xgboost/Makefile	2017-03-10 15:15:39.000000000 -0600
+@@ -43,8 +43,8 @@
+ # it is useful for pip install compiling-on-the-fly
+ OS := $(shell uname)
+ ifeq ($(OS), Darwin)
+-export CC = $(if $(shell which gcc-5),gcc-5,clang-omp)
+-export CXX = $(if $(shell which g++-5),g++-5,clang-omp++)
++export CC = $(if $(shell which gcc),gcc,clang)
++export CXX = $(if $(shell which g++),g++,clang)
+ endif
+ 
+ export LDFLAGS= -pthread -lm $(ADD_LDFLAGS) $(DMLC_LDFLAGS) $(PLUGIN_LDFLAGS)

--- a/recipes/xgboost/Makefile.patch
+++ b/recipes/xgboost/Makefile.patch
@@ -7,7 +7,7 @@
 -export CC = $(if $(shell which gcc-5),gcc-5,clang-omp)
 -export CXX = $(if $(shell which g++-5),g++-5,clang-omp++)
 +export CC = $(if $(shell which gcc),gcc,clang)
-+export CXX = $(if $(shell which g++),g++,clang)
++export CXX = $(if $(shell which g++),g++,clang++)
  endif
  
  export LDFLAGS= -pthread -lm $(ADD_LDFLAGS) $(DMLC_LDFLAGS) $(PLUGIN_LDFLAGS)

--- a/recipes/xgboost/Makefile.patch
+++ b/recipes/xgboost/Makefile.patch
@@ -1,0 +1,6 @@
+46,47c46,47
+< export CC = $(if $(shell which gcc-5),gcc-5,clang-omp)
+< export CXX = $(if $(shell which g++-5),g++-5,clang-omp++)
+---
+> export CC = clang
+> export CXX = clang++

--- a/recipes/xgboost/Makefile.patch
+++ b/recipes/xgboost/Makefile.patch
@@ -1,6 +1,6 @@
---- xgboost-0.6a2/xgboost/Makefile	2016-08-09 04:32:24.000000000 -0500
-+++ xgboost-0.6a2/xgboost/Makefile	2017-03-10 15:15:39.000000000 -0600
-@@ -43,8 +43,8 @@
+--- xgboost/Makefile
++++ xgboost/Makefile
+@@ -43,8 +43,9 @@
  # it is useful for pip install compiling-on-the-fly
  OS := $(shell uname)
  ifeq ($(OS), Darwin)
@@ -8,6 +8,7 @@
 -export CXX = $(if $(shell which g++-5),g++-5,clang-omp++)
 +export CC = $(if $(shell which gcc),gcc,clang)
 +export CXX = $(if $(shell which g++),g++,clang++)
++export ADD_LDFLAGS = -lgcc_eh
  endif
  
  export LDFLAGS= -pthread -lm $(ADD_LDFLAGS) $(DMLC_LDFLAGS) $(PLUGIN_LDFLAGS)

--- a/recipes/xgboost/build-python.patch
+++ b/recipes/xgboost/build-python.patch
@@ -1,0 +1,8 @@
+18c18
+< if make lib/libxgboost.so -j4; then
+---
+> if make lib/libxgboost.so -j4 USE_OPENMP=0; then
+25c25
+<     make lib/libxgboost.so -j4 no_omp=1
+---
+>     make lib/libxgboost.so -j4 USE_OPENMP=0

--- a/recipes/xgboost/build-python.patch
+++ b/recipes/xgboost/build-python.patch
@@ -1,8 +1,19 @@
-18c18
-< if make lib/libxgboost.so -j4; then
----
-> if make lib/libxgboost.so -j4 USE_OPENMP=0; then
-25c25
-<     make lib/libxgboost.so -j4 no_omp=1
----
->     make lib/libxgboost.so -j4 USE_OPENMP=0
+--- xgboost-0.6a2/xgboost/build-python.sh	2016-08-09 04:32:24.000000000 -0500
++++ xgboost-0.6a2/xgboost/build-python.sh	2017-03-10 15:16:18.000000000 -0600
+@@ -15,14 +15,14 @@
+ cd ./xgboost/
+ #remove the pre-compiled .so and trigger the system's on-the-fly compiling
+ make clean
+-if make lib/libxgboost.so -j4; then
++if make lib/libxgboost.so -j4 USE_OPENMP=0; then
+     echo "Successfully build multi-thread xgboost"
+ else
+     echo "-----------------------------"
+     echo "Building multi-thread xgboost failed"
+     echo "Start to build single-thread xgboost"
+     make clean
+-    make lib/libxgboost.so -j4 no_omp=1
++    make lib/libxgboost.so -j4 USE_OPENMP=0
+     echo "Successfully build single-thread xgboost"
+     echo "If you want multi-threaded version"
+     echo "See additional instructions in doc/build.md"

--- a/recipes/xgboost/build-python.patch
+++ b/recipes/xgboost/build-python.patch
@@ -1,11 +1,11 @@
---- xgboost-0.6a2/xgboost/build-python.sh	2016-08-09 04:32:24.000000000 -0500
-+++ xgboost-0.6a2/xgboost/build-python.sh	2017-03-10 15:16:18.000000000 -0600
+--- xgboost-0.6a2/xgboost/build-python.sh
++++ xgboost-0.6a2/xgboost/build-python.sh
 @@ -15,14 +15,14 @@
  cd ./xgboost/
  #remove the pre-compiled .so and trigger the system's on-the-fly compiling
  make clean
 -if make lib/libxgboost.so -j4; then
-+if make lib/libxgboost.so -j4 USE_OPENMP=0; then
++if make lib/libxgboost.so -j4 USE_OPENMP=1; then
      echo "Successfully build multi-thread xgboost"
  else
      echo "-----------------------------"

--- a/recipes/xgboost/build.sh
+++ b/recipes/xgboost/build.sh
@@ -1,0 +1,6 @@
+if [ -n "${OSX_ARCH+x}" ]; then
+  patch xgboost/Makefile $RECIPE_DIR/Makefile.patch
+  patch xgboost/build-python.sh $RECIPE_DIR/build-python.patch
+fi
+cp $RECIPE_DIR/LICENSE LICENSE
+$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/xgboost/build.sh
+++ b/recipes/xgboost/build.sh
@@ -1,6 +1,0 @@
-if [ -n "${OSX_ARCH+x}" ]; then
-  patch xgboost/Makefile $RECIPE_DIR/Makefile.patch
-  patch xgboost/build-python.sh $RECIPE_DIR/build-python.patch
-fi
-cp $RECIPE_DIR/LICENSE LICENSE
-$PYTHON setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - toolchain
     - numpy >=1.12
     - scipy
+
   run:
     - python
     - numpy >=1.12

--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "0.6a2" %}
-{% set md5 = "c486211efa29b95771c74f5d8701ca4a" %}
+{% set sha256 = "ebc4e2bf8c8266212e342ff8ec4f6ae469e8c41a05d099b6778de8424ce32563" %}
 
 package:
   name: {{ name|lower }}
@@ -9,29 +9,31 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  md5: {{ md5 }}
+  sha256: {{ sha256 }}
+  patches:
+    - Makefile.patch  # [osx]
+    - build-python.patch  # [osx]
 
 build:
   number: 0
   skip: True  # [win]
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
     - toolchain
-    - numpy >=1.12
-    - scipy
 
   run:
     - python
-    - numpy >=1.12
+    - numpy
     - scipy
 
 test:
   requires:
-    - scikit-learn >=0.18.1
-    - numpy >=1.12
+    - scikit-learn >=0.18.0
+    - numpy
     - scipy
 
   imports:
@@ -43,7 +45,7 @@ test:
 about:
   home: https://github.com/dmlc/xgboost
   license: Apache-2.0
-  license_file: LICENSE
+  license_file: {{ RECIPE_DIR }}/LICENSE
   summary: |
     Scalable, Portable and Distributed Gradient Boosting (GBDT, GBRT or GBM) Library, for
     Python, R, Java, Scala, C++ and more. Runs on single machine, Hadoop, Spark, Flink

--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "xgboost" %}
+{% set version = "0.6a2" %}
+{% set md5 = "c486211efa29b95771c74f5d8701ca4a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+    - numpy >=1.12
+    - scipy
+  run:
+    - python
+    - numpy >=1.12
+    - scipy
+
+test:
+  requires:
+    - scikit-learn >=0.18.1
+    - numpy >=1.12
+    - scipy
+
+  imports:
+    - xgboost
+    - sklearn.datasets
+    - sklearn.model_selection
+    - sklearn.metrics
+
+about:
+  home: https://github.com/dmlc/xgboost
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: |
+    Scalable, Portable and Distributed Gradient Boosting (GBDT, GBRT or GBM) Library, for
+    Python, R, Java, Scala, C++ and more. Runs on single machine, Hadoop, Spark, Flink
+    and DataFlow
+  description: |
+    XGBoost is an optimized distributed gradient boosting library designed to be highly efficient,
+    flexible and portable. It implements machine learning algorithms under the Gradient Boosting
+    framework. XGBoost provides a parallel tree boosting (also known as GBDT, GBM) that solve many
+    data science problems in a fast and accurate way. The same code runs on major distributed
+    environment (Hadoop, SGE, MPI) and can solve problems beyond billions of examples.
+  doc_url: https://xgboost.readthedocs.io/
+  dev_url: https://github.com/dmlc/xgboost/
+
+extra:
+  recipe-maintainers:
+    - beckermr

--- a/recipes/xgboost/meta.yaml
+++ b/recipes/xgboost/meta.yaml
@@ -24,11 +24,13 @@ requirements:
     - python
     - setuptools
     - toolchain
+    - gcc  # [osx]
 
   run:
     - python
     - numpy
     - scipy
+    - libgcc  # [osx]
 
 test:
   requires:

--- a/recipes/xgboost/run_test.py
+++ b/recipes/xgboost/run_test.py
@@ -1,0 +1,28 @@
+"""
+A simple test for xgboost based on scikit-learn.
+
+Note that xgboost's internal tests are NOT shipped with their
+python package on PyPI. Hence our own test is rolled here.
+"""
+import xgboost
+import sklearn.datasets
+import sklearn.model_selection
+import sklearn.metrics
+
+X, y = sklearn.datasets.load_iris(return_X_y=True)
+Xtrn, Xtst, ytrn, ytst = sklearn.model_selection.train_test_split(
+    X, y, train_size=0.8, random_state=4)
+
+clf = xgboost.XGBClassifier(
+    max_depth=2,
+    learning_rate=1,
+    n_estimators=10,
+    silent=True,
+    objective='multi:softmax',
+    seed=5)
+clf.fit(Xtrn, ytrn)
+ypred = clf.predict(Xtst)
+acc = sklearn.metrics.accuracy_score(ytst, ypred)
+
+print('xgboost accuracy on iris:', acc)
+assert acc > 0.9


### PR DESCRIPTION
@jakirkham, since we have not merged the other xgboost recipe yet, I thought I would take a crack at getting OpenMP to work with Mac OS X. This version works on my mac, but requires `libgcc` as a dependence. 

@mrocklin @jseabold for viz