### PR TITLE
Added recipe for routes

### DIFF
--- a/recipes/routes/meta.yaml
+++ b/recipes/routes/meta.yaml
@@ -34,6 +34,7 @@ test:
 
 about:
   home: https://routes.readthedocs.io/
+  license_file: LICENSE.txt
   license: MIT
   license_family: MIT
   summary: Routing Recognition and Generation Tools

--- a/recipes/routes/meta.yaml
+++ b/recipes/routes/meta.yaml
@@ -1,0 +1,45 @@
+{%set name = "Routes" %}
+{%set version = "2.4.1" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "26ee43340fca5a32769ffe0c58edcb396ccce6bc1dfa689ddf844d50877355fd" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six
+    - repoze.lru >=0.3
+
+test:
+  imports:
+    - routes
+
+about:
+  home: https://routes.readthedocs.io/
+  license: MIT
+  license_family: MIT
+  summary: Routing Recognition and Generation Tools
+  dev_url: https://github.com/bbangert/routes
+  doc_url: https://routes.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Adding a recipe for `routes`, since it's required for the extras in the latest `cherrypy`. (ref. https://github.com/conda-forge/cherrypy-feedstock/pull/8)