### PR TITLE
Added recipe for tempora

### DIFF
--- a/recipes/tempora/meta.yaml
+++ b/recipes/tempora/meta.yaml
@@ -1,0 +1,50 @@
+{%set name = "tempora" %}
+{%set version = "1.6.1" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "1c15b3ec37933192470e7e7f0dcd5fbb372a85f13c86ddb4c306f280a7fc1453" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+
+build:
+  entry_points:
+    - calc-prorate = tempora:calculate_prorated_values
+
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - setuptools_scm >=1.9
+
+  run:
+    - python
+    - six
+    - pytz
+
+test:
+  imports:
+    - tempora
+
+about:
+  home: https://github.com/jaraco/tempora
+  # license_file: No license or manifest - see https://github.com/jaraco/tempora/issues/1
+  license: MIT
+  license_family: MIT
+  summary: Objects and routines pertaining to date and time (tempora)
+  dev_url: https://github.com/jaraco/tempora
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
`tempora` is required by `portend`, which is required by some of the extras for the latest version of `cherrypy`. (Ref. https://github.com/conda-forge/cherrypy-feedstock/pull/8)