### PR TITLE
Added recipe for python-memcached

### DIFF
--- a/recipes/python-memcached/meta.yaml
+++ b/recipes/python-memcached/meta.yaml
@@ -1,0 +1,44 @@
+{%set name = "python-memcached" %}
+{%set version = "1.58" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "2775829cb54b9e4c5b3bbd8028680f0c0ab695db154b9c46f0f074ff97540eb6" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six >=1.4.0
+
+test:
+  imports:
+    - memcache
+
+about:
+  home: http://www.tummy.com/Community/software/python-memcached/
+  license_file: PSF.LICENSE
+  license: PSF 2.0
+  license_family: PSF
+  summary: Pure python memcached client
+  dev_url: https://github.com/linsomniac/python-memcached
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
The latest version of `python-memcached` is required for the extras in the most recent version of `CherryPy`. (Ref. https://github.com/conda-forge/cherrypy-feedstock/pull/8)