### PR TITLE
Add mysql-connector-python

### DIFF
--- a/recipes/mysql-connector-python/meta.yaml
+++ b/recipes/mysql-connector-python/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "mysql-connector-python" %}
+{% set version = "2.2.2" %}
+{% set sha256 = "fe46832fa4007c81c5aff6574f2852f301f105bf1e351d5cc69e012309116fa1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/mysql/mysql-connector-python/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - mysql.connector
+
+about:
+  home: https://dev.mysql.com/doc/connector-python/en/
+  license: GPL-2.0
+  license_family: GPL
+  license_file: LICENSE.txt
+  summary: 'Python driver for communicating with MySQL servers'
+
+  description: |
+    MySQL Connector/Python is a standardized database driver for Python
+    platforms and development.  
+  doc_url: http://dev.mysql.com/doc/connector-python/en/index.html
+  dev_url: https://github.com/mysql/mysql-connector-python
+
+extra:
+  recipe-maintainers:
+    - synapticarbors


### PR DESCRIPTION
As of v2.1.1 this package can optionally be compiled against the mysql-connector-c package. Since that's not built for Windows on conda-forge yet, for now, I'm not including that. 