### PR TITLE
Adding confluent-kafka

### DIFF
--- a/recipes/confluent-kafka/build.sh
+++ b/recipes/confluent-kafka/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export CFLAGS="${CFLAGS} -I${PREFIX}/include"
+export CXXFLAGS="${CXXFLAGS} -I${PREFIX}/include"
+export CPPFLAGS="${CXXFLAGS}"
+export LDFLAGS="${LDFLAGS} -Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
+export LIBS="$LIBS -lrdkafka -lz -lpthread -lrt"
+
+python setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/confluent-kafka/meta.yaml
+++ b/recipes/confluent-kafka/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "confluent-kafka" %}
+{% set version = "0.9.4" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/confluentinc/confluent-kafka-python.git
+  git_rev: 421bf9e2eae68f63e58add72d7f6beb580c3c3d9
+
+build:
+  number: {{ build }}
+  skip: True  # [win]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - librdkafka ==0.9.4
+
+  run:
+    - python
+    - setuptools
+    - requests
+    - fastavro
+    - librdkafka ==0.9.4
+    - python-avro
+
+test:
+  imports:
+    - confluent_kafka
+    - confluent_kafka.avro
+
+about:
+  home: https://github.com/confluentinc/confluent-kafka-python
+  license: Apache 2.0
+  license_family: Apache
+  summary: "Confluent's Apache Kafka client for Python"
+
+extra:
+  recipe-maintainers:
+    - kwilcox


### PR DESCRIPTION
I'm using a git commit here because the 0.9.4 release was botched.
https://github.com/confluentinc/confluent-kafka-python/releases.
Will move to the github release tarballs with 0.9.5.