### PR TITLE
Download fast finish script with PowerShell

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,7 +51,7 @@ platform:
 install:
     # If there is a newer build queued for the same PR, cancel this one.
     - cmd: |
-        curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py > ff_ci_pr_build.py
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
         ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
         del ff_ci_pr_build.py
 


### PR DESCRIPTION
It appears `curl` has moved off of the path on AppVeyor. While it is possible to move `curl` back onto the path, there are a couple of concerns. First this may result in including other things on the path that we don't intend to. Second those other things may get involved in builds corrupting packages we are trying to deploy. Third there was never any guarantee that `curl` would be included on Windows nor is there any guarantee it will still be there. So this changes the download command to make use of PowerShell to perform the download. This is something we can rely on. Therefore PowerShell should be a safe choice for long term usage.

Edit: A similar change has been proposed at conda-smithy ( https://github.com/conda-forge/conda-smithy/pull/489 ).