### PR TITLE
Add simhash-py recipe

### DIFF
--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -35,7 +35,6 @@ about:
   home: http://github.com/seomoz/simhash-py/
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
   summary: 'Simhash and near-duplicate detection'
   description: |
      This library enables the efficient identification of 

--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -1,13 +1,16 @@
 {% set name = "simhash-py" %}
-{% set version = "0.3.0" %}
+{% set version = "0.4.0" %}
+{% set sha256 = "c83e20cfac873ba9067c564135c293db635cbd7372f126e9bcfb0fabf9fd0234" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  git_url: https://github.com/seomoz/simhash-py/
-  git_tag: v{{ version }}
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/27/42/fc4203f6881e98a744765f7911d783bbd67d5c85706e7e66d1c06e6c6534/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
 
 build:
   number: 0

--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   number: 0
   skip: True  # [win]
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python setup.py install
 
 requirements:
   build:

--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/27/42/fc4203f6881e98a744765f7911d783bbd67d5c85706e7e66d1c06e6c6534/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 
@@ -20,7 +20,6 @@ build:
 requirements:
   build:
     - python
-    - setuptools
     - cython
     - toolchain
   run:
@@ -35,6 +34,9 @@ about:
   home: http://github.com/seomoz/simhash-py/
   license: MIT
   license_family: MIT
+  # the licence file was excluded from PyPi's .tar.gz in v0.4.0 by accident
+  # but it will be included in the following releases
+  # license_file: LICENSE
   summary: 'Simhash and near-duplicate detection'
   description: |
      This library enables the efficient identification of 

--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "simhash-py" %}
+{% set version = "1.7.1" %}
+{% set sha256 = "434811eb975e8888bb1e872fc8d532c3ca1b4c6475f5fb1a4456c0b2562e73c0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+  run:
+    - python
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - simplejson
+    - simplejson.tests
+
+about:
+  home: http://github.com/simplejson/simplejson
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
+  license_family: MIT
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
+  license_file: LICENSE.txt
+  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    simplejson is a simple, fast, complete, correct and extensible
+    JSON <http://json.org> encoder and decoder for Python 2.5+ and
+    Python 3.3+. It is pure Python code with no dependencies, but includes
+    an optional C extension for a serious speed boost.
+  doc_url: http://simplejson.readthedocs.io/
+  dev_url: https://github.com/simplejson/simplejson
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - HomerSimpson
+    - LukeSkywalker

--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True # [win]
+  skip: True  # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipes/simhash-py/meta.yaml
+++ b/recipes/simhash-py/meta.yaml
@@ -1,61 +1,45 @@
 {% set name = "simhash-py" %}
-{% set version = "1.7.1" %}
-{% set sha256 = "434811eb975e8888bb1e872fc8d532c3ca1b4c6475f5fb1a4456c0b2562e73c0" %}
+{% set version = "0.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  git_url: https://github.com/seomoz/simhash-py/
+  git_tag: v{{ version }}
 
 build:
   number: 0
+  skip: True # [win]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
+    - cython
     - toolchain
   run:
     - python
+    - six
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
-    - simplejson
-    - simplejson.tests
+    - simhash
 
 about:
-  home: http://github.com/simplejson/simplejson
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
+  home: http://github.com/seomoz/simhash-py/
   license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
   license_family: MIT
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
   license_file: LICENSE.txt
-  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
-
-  # The remaining entries in this section are optional, but recommended
+  summary: 'Simhash and near-duplicate detection'
   description: |
-    simplejson is a simple, fast, complete, correct and extensible
-    JSON <http://json.org> encoder and decoder for Python 2.5+ and
-    Python 3.3+. It is pure Python code with no dependencies, but includes
-    an optional C extension for a serious speed boost.
-  doc_url: http://simplejson.readthedocs.io/
-  dev_url: https://github.com/simplejson/simplejson
+     This library enables the efficient identification of 
+     near-duplicate documents using simhash using a C++ extension.
+  doc_url: https://github.com/seomoz/simhash-py
+  dev_url: https://github.com/seomoz/simhash-py
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
-    - HomerSimpson
-    - LukeSkywalker
+    - rth


### PR DESCRIPTION
This adds a recipe for the [simhash-py](https://github.com/seomoz/simhash-py) package.

~~I'm aware that it is preferable to have a fixed tarbar download rather than cloning the github repository, however this repository includes a git submodule which is not included in [github releases](https://github.com/seomoz/simhash-py/releases) and this version is not yet uploaded to PyPi.~~
**Edit:** The package is now downloaded from PyPi.

Currently Windows builds are skipped as compilation  with VisualStudio doesn't work yet.

**Edit:** appveyor builds failing due to https://github.com/conda-forge/conda-smithy/pull/489