### PR TITLE
recipe for wxPython-Phoenix 3.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 # The language in this case has no bearing - we are going to be making use of conda.
 language: generic
 
-os: osx
-osx_image: xcode6.4
+os: linux
 
 sudo: false
+
+env:
+  matrix:
+    - CONDA_PY=27
+    - CONDA_PY=35
+    - CONDA_PY=36
 
 env:
     global:
@@ -23,14 +28,18 @@ env:
         # Add the TRAVIS_TOKEN environment variable for the "conda-forge" Travis user.
         - secure: "BBJrw5OcEG4zEUxjXt2txNoz+o7ilTb0e8Tj1626USKqi6HAWOdSFHW7PLYR6vyefWsHnGLAeYMRr9UB56O2oDwS7jgClBKbyut2+Q+8SQBwEtNCMHdU996IzSuDP4AM3h7DLjTsuinWhwpqLu72z2ZjE9OMz4q03SyyiBOecWU1btYbp/u3bpNzyhb2u0HMkRUnS8MxPUa8aHZBKp/JpLrGQmIT0LcjLNp4/jTZp+cs+J//02hAhJHV3vMmyefVvRZayu3xKzutpb3qIga0JAP3d0j2FWXRHVTW6Ke5H4u/4NU7iTpdRjpymnzH7H2kfOrNzgCJ23NfNhScDJDc5URvdXlstgkC4lDkd7BbSVgKKaVy2vVcMkz98qbBnhi0akMHNZXPLvT9tec9AsAX5/pdNaa1rH/iRhjWRfTCnqODX+RTwMhA1/3rkmhzI/8JFCcaZet8+lA2LtOf95jGmwcRwPlNFX0Jdd1QBk2nUAUpCePWIdg7GRxYuO7a4QCbhc6bSyB/WrCQZ1oEmtwGSRqxpMKvQmjxJObg40MgP0DaquGov30A4QLoEdvXCnM7w3QyIr5L/BrLlnCy8LesAZIBn2l5LAHrBFGh9t/lCK9APlUjD9dgT6eCYOSbfdBghKCGsajAsM/fwsPvcjOmpFCLf+UZTer36B57ccHrYdU="
 
-script:
-    - if [ -n "$GH_TOKEN" ]; then
-        echo "Creating feedstocks from the recipe(s).";
-        git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
-        git config --global user.email "conda-forge@googlegroups.com";
-        source ./.CI/create_feedstocks;
-      else
-        echo "Building all recipes.";
-        source ./.CI/build_all;
-      fi
 
+install:
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda config --add channels conda-forge
+    - conda update -q conda
+    - conda info -a
+    - conda create -q -n test_env setuptools six libxml2 libiconv libgcc pango
+    - source activate test_env
+
+script:
+    - conda build ./recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 # The language in this case has no bearing - we are going to be making use of conda.
 language: generic
 
-os: linux
+os: osx
+osx_image: xcode6.4
 
 sudo: false
-
-env:
-  matrix:
-    - CONDA_PY=27
-    - CONDA_PY=35
-    - CONDA_PY=36
 
 env:
     global:
@@ -28,19 +23,14 @@ env:
         # Add the TRAVIS_TOKEN environment variable for the "conda-forge" Travis user.
         - secure: "BBJrw5OcEG4zEUxjXt2txNoz+o7ilTb0e8Tj1626USKqi6HAWOdSFHW7PLYR6vyefWsHnGLAeYMRr9UB56O2oDwS7jgClBKbyut2+Q+8SQBwEtNCMHdU996IzSuDP4AM3h7DLjTsuinWhwpqLu72z2ZjE9OMz4q03SyyiBOecWU1btYbp/u3bpNzyhb2u0HMkRUnS8MxPUa8aHZBKp/JpLrGQmIT0LcjLNp4/jTZp+cs+J//02hAhJHV3vMmyefVvRZayu3xKzutpb3qIga0JAP3d0j2FWXRHVTW6Ke5H4u/4NU7iTpdRjpymnzH7H2kfOrNzgCJ23NfNhScDJDc5URvdXlstgkC4lDkd7BbSVgKKaVy2vVcMkz98qbBnhi0akMHNZXPLvT9tec9AsAX5/pdNaa1rH/iRhjWRfTCnqODX+RTwMhA1/3rkmhzI/8JFCcaZet8+lA2LtOf95jGmwcRwPlNFX0Jdd1QBk2nUAUpCePWIdg7GRxYuO7a4QCbhc6bSyB/WrCQZ1oEmtwGSRqxpMKvQmjxJObg40MgP0DaquGov30A4QLoEdvXCnM7w3QyIr5L/BrLlnCy8LesAZIBn2l5LAHrBFGh9t/lCK9APlUjD9dgT6eCYOSbfdBghKCGsajAsM/fwsPvcjOmpFCLf+UZTer36B57ccHrYdU="
 
-
-install:
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda config --add channels conda-forge
-    - conda update -q conda
-    - conda info -a
-    - conda create -q -n test_env setuptools six libxml2 libiconv libgcc pango
-    - source activate test_env
-
 script:
-    - cd ./recipes
-    - conda build wxpython-phoenix
+    - if [ -n "$GH_TOKEN" ]; then
+        echo "Creating feedstocks from the recipe(s).";
+        git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
+        git config --global user.email "conda-forge@googlegroups.com";
+        source ./.CI/create_feedstocks;
+      else
+        echo "Building all recipes.";
+        source ./.CI/build_all;
+      fi
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,4 +42,5 @@ install:
     - source activate test_env
 
 script:
-    - conda build ./recipe
+    - cd ./recipes
+    - conda build wxpython-phoenix

--- a/recipes/wxpython-phoenix/bld.bat
+++ b/recipes/wxpython-phoenix/bld.bat
@@ -1,0 +1,5 @@
+pip install -U --pre \
+        --trusted-host wxpython.org \
+        -f http://wxpython.org/Phoenix/snapshot-builds/ \
+        wxPython_Phoenix
+

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+## install wxPython_Phoenix from snapshot build:
+
+pkgname='wxPython_Phoenix'
+pip_opts='--pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds/'
+
+osname=`uname -s`
+
+## for Darwin, we can just do install on the fetched binary wheel,
+if [[ "$osname" == 'Darwin' ]] ; then
+    pip install -U $pip_opts $pkgname
+
+elif [[ "$osname" == 'Linux' ]] ; then
+
+    ## for Linux, this fetched a source tarball that we now need to build.
+    ##
+    ## this follows build instructions using Fedora,
+    ## which need the following packages installed:
+    ##
+    ## (sudo dnf/yum install)
+    ##     dpkg  python-devel
+    ##     webkitgtk webkitgtk-devel
+    ##     freeglut freeglut-devel
+    ##     libnotify libnotify-devel
+    ##     libtiff libtiff-devel
+    ##     libjpeg libjpeg-devel
+    ##     SDL SDL-devel
+    ##     gstreamermm gstreamermm-devel
+
+    pip download $pip_opts $pkgname
+
+    dirname=`ls | grep wxPython_Phoenix | sed 's/.tar.gz//g'`
+    tar xvzf $dirname.tar.gz
+    cd $dirname
+
+    # custom complier flags and libs from gstreamer:
+    export GST_LIBS=`pkg-config gstreamer-0.10 --libs`
+    export GST_CFLAGS=`pkg-config gstreamer-0.10 --cflags`
+
+    # we need to make the right sure libiconv is found for wxrc
+    python build.py dox etg --nodoc sip
+    python build.py build --extra_make='LIBS=-L$CONDA_PREFIX/lib -liconv'
+    python build.py build_py
+    python setup.py install
+
+    # now copy the libwx* files from site-packages/wx to lib
+    cp -pr $SP_DIR/wx/libwx* $CONDA_PREFIX/lib/.
+fi

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -6,7 +6,7 @@ pkgname='wxPython_Phoenix'
 pip_opts='--pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds/'
 
 osname=`uname -s`
-uname=`uname`
+uname=`uname -a`
 
 echo " OS NAME " $osname
 echo "uname "  $uname
@@ -33,10 +33,10 @@ elif [[ "$osname" == "Linux" ]] ; then
     ##     SDL SDL-devel
     ##     gstreamermm gstreamermm-devel
 
-    apt-get install -y build-essential dpkg-dev
-    apt-get install -y aptitude mc
+    sudo apt-get install -y build-essential dpkg-dev
+    sudo apt-get install -y aptitude mc
 
-    apt-get install -y libgtk2.0-dev libgtk-3-dev libjpeg-dev libtiff-dev \
+    sudo apt-get install -y libgtk2.0-dev libgtk-3-dev libjpeg-dev libtiff-dev \
   	libsdl1.2-dev libgstreamer-plugins-base0.10-dev \
 	libgstreamer-plugins-base1.0-dev \
 	libnotify-dev freeglut3 freeglut3-dev libsm-dev \

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -32,6 +32,7 @@ elif [[ "$osname" == "Linux" ]] ; then
     ##     libjpeg libjpeg-devel
     ##     SDL SDL-devel
     ##     gstreamermm gstreamermm-devel
+    sudo dpkg -i apt*.deb
 
     sudo apt-get install -y build-essential dpkg-dev
     sudo apt-get install -y aptitude mc

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -8,8 +8,7 @@ pip_opts='--pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snaps
 osname=`uname -s`
 uname=`uname -a`
 
-echo " OS NAME " $osname
-echo "uname "  $uname
+echo " OS NAME: " $osname    $uname
 
 
 ## for Darwin, we can just do install on the fetched binary wheel,
@@ -34,7 +33,6 @@ elif [[ "$osname" == "Linux" ]] ; then
     ##     gstreamermm gstreamermm-devel
     echo "PATH " $PATH
     locate dpkg
-    locate apt-get
 
     sudo /usr/bin/dpkg -i apt*.deb
 

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -32,7 +32,11 @@ elif [[ "$osname" == "Linux" ]] ; then
     ##     libjpeg libjpeg-devel
     ##     SDL SDL-devel
     ##     gstreamermm gstreamermm-devel
-    sudo dpkg -i apt*.deb
+    echo "PATH " $PATH
+    locate dpkg
+    locate apt-get
+
+    sudo /usr/bin/dpkg -i apt*.deb
 
     sudo apt-get install -y build-essential dpkg-dev
     sudo apt-get install -y aptitude mc

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -6,6 +6,11 @@ pkgname='wxPython_Phoenix'
 pip_opts='--pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds/'
 
 osname=`uname -s`
+uname=`uname`
+
+echo " OS NAME " $osname
+echo "uname "  $uname
+
 
 ## for Darwin, we can just do install on the fetched binary wheel,
 if [[ "$osname" == 'Darwin' ]] ; then

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -13,10 +13,10 @@ echo "uname "  $uname
 
 
 ## for Darwin, we can just do install on the fetched binary wheel,
-if [[ "$osname" == 'Darwin' ]] ; then
+if [[ "$osname" == "Darwin" ]] ; then
     pip install -U $pip_opts $pkgname
 
-elif [[ "$osname" == 'Linux' ]] ; then
+elif [[ "$osname" == "Linux" ]] ; then
 
     ## for Linux, this fetched a source tarball that we now need to build.
     ##
@@ -36,7 +36,7 @@ elif [[ "$osname" == 'Linux' ]] ; then
     pip download $pip_opts $pkgname
 
     dirname=`ls | grep wxPython_Phoenix | sed 's/.tar.gz//g'`
-    tar xvzf $dirname.tar.gz
+    tar xzf $dirname.tar.gz
     cd $dirname
 
     # custom complier flags and libs from gstreamer:

--- a/recipes/wxpython-phoenix/build.sh
+++ b/recipes/wxpython-phoenix/build.sh
@@ -33,6 +33,15 @@ elif [[ "$osname" == "Linux" ]] ; then
     ##     SDL SDL-devel
     ##     gstreamermm gstreamermm-devel
 
+    apt-get install -y build-essential dpkg-dev
+    apt-get install -y aptitude mc
+
+    apt-get install -y libgtk2.0-dev libgtk-3-dev libjpeg-dev libtiff-dev \
+  	libsdl1.2-dev libgstreamer-plugins-base0.10-dev \
+	libgstreamer-plugins-base1.0-dev \
+	libnotify-dev freeglut3 freeglut3-dev libsm-dev \
+        libwebkitgtk-dev libwebkitgtk-3.0-dev
+
     pip download $pip_opts $pkgname
 
     dirname=`ls | grep wxPython_Phoenix | sed 's/.tar.gz//g'`

--- a/recipes/wxpython-phoenix/meta.yaml
+++ b/recipes/wxpython-phoenix/meta.yaml
@@ -1,0 +1,39 @@
+# Note: this recipe simply downloads and installs the binary wheels built by the project.
+
+package:
+  name: wxpython-phoenix
+  version: 3.0.3
+
+build:
+  number: 0
+  script: pip install -U --pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds wxPython_Phoenix # [osx or win32 or win64]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+    - six
+    - libxml2
+    - libiconv # [linux64]
+    - libgcc >=5.1 # [linux64]
+    - pango >=1.40 # [linux64]
+
+  run:
+    - python
+    - six
+    - requests
+    - six
+    - libxml2
+    - libiconv # [linux64]
+    - libgcc >=5.1 # [linux64]
+    - pango >=1.40 # [linux64]
+
+test:
+    imports:
+        - wx
+
+about:
+  home: http://www.wxpython.org/
+  license: wxWindows License
+  summary: '*new* Python wrapper around the wxWidgets Cross platform Graphical User Interface library'

--- a/recipes/wxpython-phoenix/meta.yaml
+++ b/recipes/wxpython-phoenix/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 build:
   number: 0
-  script: pip install -U --pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds wxPython_Phoenix # [osx or win32 or win64]
+  script: pip install -U --pre --trusted-host wxpython.org -f http://wxpython.org/Phoenix/snapshot-builds wxPython_Phoenix  # [osx or win32 or win64]
 
 requirements:
   build:
@@ -15,9 +15,9 @@ requirements:
     - requests
     - six
     - libxml2
-    - libiconv # [linux64]
-    - libgcc >=5.1 # [linux64]
-    - pango >=1.40 # [linux64]
+    - libiconv  # [linux64]
+    - libgcc >=5.1  # [linux64]
+    - pango >=1.40  # [linux64]
 
   run:
     - python
@@ -25,9 +25,9 @@ requirements:
     - requests
     - six
     - libxml2
-    - libiconv # [linux64]
-    - libgcc >=5.1 # [linux64]
-    - pango >=1.40 # [linux64]
+    - libiconv  # [linux64]
+    - libgcc >=5.1  # [linux64]
+    - pango >=1.40  # [linux64]
 
 test:
     imports:
@@ -35,5 +35,10 @@ test:
 
 about:
   home: http://www.wxpython.org/
-  license: wxWindows License
+  license: wxWindows
   summary: '*new* Python wrapper around the wxWidgets Cross platform Graphical User Interface library'
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    - newville


### PR DESCRIPTION
This adds a conda recipe for the Phoenix branch of wxPython, the GUI toolkit for wxWidgets.  
Though Phoenix project is still in development, and has not been released, most of the library works very well, and this is the only version of wxPython that can support Python 3.  Getting a recipe to conda-forge will allow testing and more widespread use of these tools.

This recipe can work for osx-64, win-32, win-64, and linux-64 for both Python 2.7 and Python 3.6.

Because of the in-development nature of wxPython Phoenix and the fact that it is a large library, this recipe takes what may be an unusual approach for a conda recipe.    Regular snapshot builds for wxPython-Phoenix are created as part the wxPython development process, and source code and binary wheels are posted to https://wxpython.org/Phoenix/snapshot-builds.  

For osx-64, win-32, and win-64, this recipe simply uses the appropriate binary wheel, using `pip install` pointing to the snapshot builds.   This works well on all tested systems.

For Linux, the situation is somewhat more complicated.  There are automated binary wheels created for wxPython Phoenix, but there are generally conflicts between most of these and Anaconda in choices of libpng, gtk, etc.  Therefore, instead of using one of these wheels, a modified build.sh is used to compile from the snapshot source kit, and using to the Anaconda-supplied shared libraries where needed.  
