### PR TITLE
Update comment

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -21,8 +21,8 @@ source:
 build:
   number: 0
   # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for Python 2.7, 3.4, and above, for all major OSs.
-  # Add the line "skip: True  # [py<34]" (for example) to limit to Python 3.4 and newer, or "skip: True  # [not win]" to limit to Windows.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
This change is to avoid confusion. Some people go the impression that Python 3.4 was still supported b/c of that comment.