### PR TITLE
Added recipe for portend

### DIFF
--- a/recipes/portend/meta.yaml
+++ b/recipes/portend/meta.yaml
@@ -35,7 +35,7 @@ test:
 about:
   home: https://github.com/jaraco/portend
   # license_file: No license or manifest - see https://github.com/jaraco/portend/issues/3
-  license: MIT License
+  license: MIT
   license_family: MIT
   summary: TCP port monitoring utilities
   dev_url: https://github.com/jaraco/portend

--- a/recipes/portend/meta.yaml
+++ b/recipes/portend/meta.yaml
@@ -1,0 +1,45 @@
+{%set name = "portend" %}
+{%set version = "1.8" %}
+{%set compress_type = "tar.gz" %}
+{%set hash_type = "sha256" %}
+{%set hash_val = "7de919b82c4ac60d4768fe80a2557290661aa665b7c427de6249d8cb2fde5561" %}
+{%set build_num = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash_val }}
+
+build:
+  number: {{ build_num }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - setuptools_scm >=1.15.0
+
+  run:
+    - python
+    - tempora
+
+test:
+  imports:
+    - portend
+
+about:
+  home: https://github.com/jaraco/portend
+  # license_file: No license or manifest - see https://github.com/jaraco/portend/issues/3
+  license: MIT License
+  license_family: MIT
+  summary: TCP port monitoring utilities
+  dev_url: https://github.com/jaraco/portend
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
`portend` is required by some of the extras for the latest version of `cherrypy`. (Ref. conda-forge/cherrypy-feedstock#8)