### PR TITLE
Add new recipe for metaphone

### DIFF
--- a/recipes/metaphone/meta.yaml
+++ b/recipes/metaphone/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "Metaphone" %}
+{% set version = "0.6" %}
+{% set hashtype = "sha256" %}
+{% set hash = "ad0beadca66cb7ec6ede71ef72bb02da097c493ddf159930d6340bc83f53da27" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hashtype }}: {{ hash }}
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - metaphone
+
+about:
+    home: https://github.com/oubiwann/metaphone
+    license: BSD 3-clause
+    license_file: LICENSE
+    license_family: BSD
+    summary: A Python implementation of the double metaphone algorithms
+
+extra:
+    recipe-maintainers:
+        - wyseguy7
+        - ericdill
+        - marshall245


### PR DESCRIPTION
So here's a somewhat annoying problem...

We perhaps unknowingly packaged a fork of metaphone (called metafone) on [conda forge](https://github.com/conda-forge/metafone-feedstock) a few months back. Our package points at the metafone tarball on pypi. That page now says that Metafone was "a temporary fork until the related Metaphone package was updated." Well now Metaphone has been updated and a new release (0.6) is available.

is the appropriate course of action here to:

1. Rename metafone-feedstock to metaphone-feedstock and rerender it?
2. Submit a new recipe (like the one in this PR) that has updated names and let the conda-forge tooling handle the new name and mark the metafone-feedstock as deprecated?

cc @ocefpaf @jakirkham 