### PR TITLE
Drop Obvious CI compiler activation on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,6 @@ skip_commits:
 
 environment:
 
-  # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-  # /E:ON and /V:ON options are not enabled in the batch script interpreter
-  # See: http://stackoverflow.com/a/13751649/163740
-  CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
-
   # Workaround for https://github.com/conda/conda-build/issues/636
   PYTHONIOENCODING: "UTF-8"
 
@@ -74,7 +69,7 @@ install:
     - cmd: conda config --set show_channel_urls true
     - cmd: conda update --yes --quiet conda
 
-    - cmd: conda install --yes --quiet obvious-ci conda-build-all
+    - cmd: conda install --yes --quiet conda-build-all
     - cmd: conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
@@ -82,7 +77,7 @@ install:
 build: off
 
 test_script:
-    - '%CMD_IN_ENV% conda-build-all recipes --matrix-conditions "numpy >=1.11" "%PY_CONDITION%" "r-base >=3.3.2"'
+    - conda-build-all recipes --matrix-conditions "numpy >=1.11" "%PY_CONDITION%" "r-base >=3.3.2"
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
     # Uncomment the following two lines to make any conda packages created


### PR DESCRIPTION
Same change as PR ( https://github.com/conda-forge/conda-smithy/pull/392 ) except for `staged-recipes`.

cc @conda-forge/core