### PR TITLE
New conda-forge recipe for climlab

### DIFF
--- a/recipes/climlab/build.sh
+++ b/recipes/climlab/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#  Based on conda-forge recipe for scipy
+export LIBRARY_PATH="${PREFIX}/lib"
+export C_INCLUDE_PATH="${PREFIX}/include"
+export CPLUS_INCLUDE_PATH="${PREFIX}/include"
+
+# Depending on our platform, shared libraries end with either .so or .dylib
+if [[ `uname` == 'Darwin' ]]; then
+    # Also, included a workaround so that `-stdlib=c++` doesn't go to
+    # `gfortran` and cause problems.
+    #
+    # https://github.com/conda-forge/toolchain-feedstock/pull/8
+    export CFLAGS="${CFLAGS} -stdlib=libc++ -lc++"
+    export LDFLAGS="-headerpad_max_install_names -undefined dynamic_lookup -bundle -Wl,-search_paths_first -lc++"
+else
+    unset LDFLAGS
+fi
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "climlab" %}
-{% set version = "0.5.3" %}
-{% set sha256 = "ecd81c84af291e83cebfacd096cb13e7c6d1fa45401e969900f5934c2dd2fb9f" %}
+{% set version = "0.5.4.dev0" %}
+{% set sha256 = "8395ca6313914e75fb415372c2093f2bef5908851a15b026db1ad607db63c34f" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - numpy x.x
     - toolchain
-    - gcc
+    - gcc       # [osx]
     - libgfortran
 
   run:

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: climlab
+  version: '0.5.1.dev1'
+
+source:
+  path: ../climlab
+
+requirements:
+  build:
+    - python
+    - numpy
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - netcdf4
+    - pytest
+
+build:
+  script:
+    - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
+    - python setup.py install
+
+test:
+  requires:
+    - pytest
+  imports:
+    - climlab
+  commands:
+    - pytest -v --pyargs climlab
+
+about:
+  home: https://github.com/brian-rose/climlab
+  license: MIT
+  license_file: LICENSE
+  summary: Python package for process-oriented climate modeling

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
     - python setup.py install
@@ -22,6 +22,8 @@ requirements:
     - python
     - numpy x.x
     - toolchain
+    - gcc
+    - libgfortran
 
   run:
     - python
@@ -29,6 +31,7 @@ requirements:
     - scipy
     - netcdf4
     - pytest
+    - libgfortran
 
 test:
   requires:

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "climlab" %}
-{% set version = "0.5.4" %}
-{% set sha256 = "af907691ed43941b772dc6815a6c96e6e28ecbc8972e874ec4f8b0528b4c72b7" %}
+{% set version = "0.5.5" %}
+{% set sha256 = "c2b55061f1600829d117286299051880571d56541e9efb0a9db4f7686d75c511" %}
 
 package:
   name: {{ name|lower }}
@@ -13,17 +13,16 @@ source:
 
 build:
   number: 0
-  skip: true  # [win or not py2k or linux]
-  script:
-    - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
-    - python setup.py install
+  skip: true  # [win or not py2k]
 
 requirements:
   build:
-    - python
-    - numpy x.x
     - toolchain
-    - gcc
+    - gcc  # [osx]
+    - python
+    - setuptools
+    - libgfortran  # [linux]
+    - numpy x.x
 
   run:
     - python 2.7*

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -10,6 +10,7 @@ requirements:
   build:
     - python
     - numpy x.x
+    - gcc
 
   run:
     - python
@@ -17,8 +18,10 @@ requirements:
     - scipy
     - netcdf4
     - pytest
+    - libgfortran
 
 build:
+  number: 1
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
     - python setup.py install

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,16 +1,27 @@
+{% set name = "climlab" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "38636608903ed54dea33b5c3ddedbf8d98b38504af9ed27fed64042a45e09279" %}
+
 package:
-  name: climlab
-  version: '0.5.1.dev1'
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  git_url: https://github.com/brian-rose/climlab.git
-  git_tag: devel
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script:
+    - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
+    - python setup.py install
 
 requirements:
   build:
     - python
     - numpy x.x
-    - gcc
+    - toolchain
 
   run:
     - python
@@ -18,13 +29,6 @@ requirements:
     - scipy
     - netcdf4
     - pytest
-    - libgfortran
-
-build:
-  number: 1
-  script:
-    - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
-    - python setup.py install
 
 test:
   requires:
@@ -37,5 +41,12 @@ test:
 about:
   home: https://github.com/brian-rose/climlab
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Python package for process-oriented climate modeling
+  doc_url: http://climlab.readthedocs.io/
+  dev_url: https://github.com/brian-rose/climlab
+
+extra:
+  recipe-maintainers:
+    - brian-rose

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win or not py2k]
+  skip: true  # [win or not py2k or linux]
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
     - python setup.py install

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -38,7 +38,7 @@ test:
   imports:
     - climlab
   commands:
-    - pytest -v --pyargs climlab
+    - pytest -v --pyargs climlab.tests.test_rrtm
 
 about:
   home: https://github.com/brian-rose/climlab

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "climlab" %}
-{% set version = "0.5.2" %}
-{% set sha256 = "7ff27199a065aa70db9b32fa81cc83a37a7195f097689bd3dd06a92730ab9e62" %}
+{% set version = "0.5.3" %}
+{% set sha256 = "ecd81c84af291e83cebfacd096cb13e7c6d1fa45401e969900f5934c2dd2fb9f" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
@@ -22,9 +22,9 @@ requirements:
   build:
     - python
     - numpy x.x
-    - toolchain  # [osx]
-    - gcc  # [osx]
-    - libgfortran  # [osx]
+    - toolchain
+    - gcc
+    - libgfortran
 
   run:
     - python

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "climlab" %}
-{% set version = "0.5.4.dev0" %}
-{% set sha256 = "8395ca6313914e75fb415372c2093f2bef5908851a15b026db1ad607db63c34f" %}
+{% set version = "0.5.4" %}
+{% set sha256 = "af907691ed43941b772dc6815a6c96e6e28ecbc8972e874ec4f8b0528b4c72b7" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 1
+  skip: true  # [win]
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
     - python setup.py install
@@ -21,9 +22,9 @@ requirements:
   build:
     - python
     - numpy x.x
-    - toolchain
+    - toolchain # [osx]
     - gcc       # [osx]
-    - libgfortran
+    - libgfortran # [osx]
 
   run:
     - python

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "climlab" %}
-{% set version = "0.5.1" %}
-{% set sha256 = "38636608903ed54dea33b5c3ddedbf8d98b38504af9ed27fed64042a45e09279" %}
+{% set version = "0.5.2" %}
+{% set sha256 = "7ff27199a065aa70db9b32fa81cc83a37a7195f097689bd3dd06a92730ab9e62" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -20,14 +20,14 @@ build:
 
 requirements:
   build:
-    - python
+    - python 2.7*
     - numpy x.x
     - toolchain
     - gcc
     - libgfortran
 
   run:
-    - python
+    - python 2.7*
     - numpy x.x
     - scipy
     - netcdf4

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -3,7 +3,8 @@ package:
   version: '0.5.1.dev1'
 
 source:
-  path: ../climlab
+  git_url: https://github.com/brian-rose/climlab.git
+  git_tag: devel
 
 requirements:
   build:

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -9,11 +9,11 @@ source:
 requirements:
   build:
     - python
-    - numpy
+    - numpy x.x
 
   run:
     - python
-    - numpy
+    - numpy x.x
     - scipy
     - netcdf4
     - pytest

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -13,18 +13,17 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  skip: true  # [win or not py2k]
   script:
     - export LDFLAGS="-undefined dynamic_lookup -bundle"  # [osx]
     - python setup.py install
 
 requirements:
   build:
-    - python 2.7*
+    - python
     - numpy x.x
     - toolchain
     - gcc
-    - libgfortran
 
   run:
     - python 2.7*

--- a/recipes/climlab/meta.yaml
+++ b/recipes/climlab/meta.yaml
@@ -22,9 +22,9 @@ requirements:
   build:
     - python
     - numpy x.x
-    - toolchain # [osx]
-    - gcc       # [osx]
-    - libgfortran # [osx]
+    - toolchain  # [osx]
+    - gcc  # [osx]
+    - libgfortran  # [osx]
 
   run:
     - python

--- a/recipes/climlab/yum_requirements.txt
+++ b/recipes/climlab/yum_requirements.txt
@@ -1,0 +1,1 @@
+devtoolset-2-gcc-gfortran


### PR DESCRIPTION
This is a recipe for the [climlab](https://github.com/brian-rose/climlab) packge, which is a climate modeling toolkit written in Python with some underlying numerics in Fortran.

climlab builds against numpy using `numpy.distutils` to compile Fortran extension modules.

I have tested this recipe on OSX and linux and posted the resulting binaries to <https://anaconda.org/brian-rose/climlab>. 

I would love to get `climlab` integrated into conda-forge going forward for easier deployment.

Thanks.