### PR TITLE
Added recipe for a stackless meta package

### DIFF
--- a/recipes/stackless/LICENSE.txt
+++ b/recipes/stackless/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2017 Anselm Kruis
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/stackless/meta.yaml
+++ b/recipes/stackless/meta.yaml
@@ -1,12 +1,6 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
-{% set name = "stackless" %}
-{% set version = "1.0" %}
-
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: stackless
+  version: '1.0'
 
 build:
   entry_points: []
@@ -29,21 +23,14 @@ test:
 
 about:
   home: http://www.stackless.com
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
   license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
   license_family: MIT
+  license_file: '{{ RECIPE_DIR }}/LICENSE.txt'
   summary: 'meta package, which tracks the feature "stackless".'
-
-  # The remaining entries in this section are optional, but recommended
   description: |
     stackless is a meta packages, which tracks the feature "stackless".
     If you install this package, conda will install Stackless Python instead of regular C-Python.
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - akruis

--- a/recipes/stackless/meta.yaml
+++ b/recipes/stackless/meta.yaml
@@ -1,0 +1,49 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+{% set name = "stackless" %}
+{% set version = "1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  entry_points: []
+  features: []
+  number: 0
+  string: ''
+  track_features:
+    - stackless
+
+requirements:
+  build: []
+  conflicts: []
+  run: []
+
+test:
+  commands: []
+  files: []
+  imports: []
+  requires: []
+
+about:
+  home: http://www.stackless.com
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
+  license_family: MIT
+  summary: 'meta package, which tracks the feature "stackless".'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    stackless is a meta packages, which tracks the feature "stackless".
+    If you install this package, conda will install Stackless Python instead of regular C-Python.
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - akruis

--- a/recipes/stackless/meta.yaml
+++ b/recipes/stackless/meta.yaml
@@ -3,8 +3,6 @@ package:
   version: '1.0'
 
 build:
-  entry_points: []
-  features: []
   number: 0
   string: ''
   track_features:
@@ -12,14 +10,10 @@ build:
 
 requirements:
   build: []
-  conflicts: []
   run: []
 
 test:
-  commands: []
-  files: []
   imports: []
-  requires: []
 
 about:
   home: http://www.stackless.com


### PR DESCRIPTION
This pull request adds a recipe for a meta package, which tracks the feature "stackless". 

I created another pull request (https://github.com/conda-forge/python-feedstock/pull/131) to package Stackless Python as a "python" with the feature "stackless". Because Stackless Python is a complete Python and conflicts with regular C-Python the feature-mechanism is used to select it over regular C-Python.
