### PR TITLE
Push HEAD to upstream in all cases

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -203,7 +203,7 @@ if __name__ == '__main__':
             for i in range(5):
                 try:
                     # Capture the output, as it may contain the GH_TOKEN.
-                    out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'master:master'], cwd=feedstock_dir,
+                    out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'HEAD:master'], cwd=feedstock_dir,
                                                   stderr=subprocess.STDOUT)
                     break
                 except subprocess.CalledProcessError:


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/2775 )

In the event that the branch is not `master` as we would expect or is even undefined, simply push the contents from `HEAD` to upstream's `master`. This should work reliably regardless of how we handle branches before this point.