### PR TITLE
Adds habanero recipe for CrossRef search

### DIFF
--- a/recipes/habanero/meta.yaml
+++ b/recipes/habanero/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "habanero" %}
+{% set version = "0.2.6" %}
+{% set sha256 = "b2f9ceaa403e5a19a2edf5d42386add283a87358375895cc6fb3a6185f1d23a1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/sckott/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - requests >=2.7.0
+
+test:
+  imports:
+    - habanero
+
+about:
+  home: https://github.com/sckott/habanero
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'CrossRef Search Low-level client for Python'
+
+  description: |
+    This is a low level client for working with Crossref's search API.
+    It's been named to be more generic, as other organizations are/will
+    adopt Crossref's search API, making it possible to interact with all
+    from one client.
+  doc_url: http://habanero.readthedocs.io/
+  dev_url: https://github.com/sckott/habanero
+
+extra:
+  recipe-maintainers:
+    - bryanwweber


### PR DESCRIPTION
This package only has a wheel on PyPI, so I set it to download the tarball from GitHub. Please let me know if I should switch to checking out the tag instead.