### PR TITLE
Adds orcid recipe for ORCID API access

### DIFF
--- a/recipes/orcid/LICENSE
+++ b/recipes/orcid/LICENSE
@@ -1,0 +1,28 @@
+Copyright (c) 2014, 2015 CERN
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of python-orcid nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/recipes/orcid/meta.yaml
+++ b/recipes/orcid/meta.yaml
@@ -33,6 +33,7 @@ about:
   home: https://github.com/ORCID/python-orcid
   license: BSD-3-Clause
   license_family: BSD
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
   summary: 'Python wrapper around ORCID API'
 
   description: |

--- a/recipes/orcid/meta.yaml
+++ b/recipes/orcid/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "orcid" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "299ba93143b2e212fb44cf035b8c43bb4893075edcd3f5fb3c66ebf23d566c05" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - beautifulsoup4
+    - simplejson
+    - requests
+
+test:
+  imports:
+    - orcid
+
+about:
+  home: https://github.com/ORCID/python-orcid
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: 'Python wrapper around ORCID API'
+
+  description: |
+    ORCID is an open, non-profit, community-based effort to provide a registry
+    of unique researcher identifiers and a transparent method of linking research
+    activities and outputs to these identifiers. ORCID is unique in its ability to
+    reach across disciplines, research sectors, and national boundaries and its
+    cooperation with other identifier systems. orcid is a Python wrapper around
+    the ORCID API
+  dev_url: https://github.com/ORCID/python-orcid
+
+extra:
+  recipe-maintainers:
+    - bryanwweber


### PR DESCRIPTION
The LICENSE file for this package is available in the repository (https://github.com/ORCID/python-orcid/blob/master/LICENSE) but is not distributed in the tarball on pypi.io (https://pypi.org/project/orcid/#files)