### PR TITLE
Add pstdint

### DIFF
--- a/recipes/pstdint/meta.yaml
+++ b/recipes/pstdint/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "0.1.16.0" %}
+
+package:
+  name: pstdint
+  version: {{ version }}
+
+source:
+  fn: pstdint-{{ version }}.h
+  url: http://www.azillionmonkeys.com/qed/pstdint.h
+  sha256: aed1262c00f5eb645354d00c491236172841cf7728115c39a1f77f305fc7db12
+
+build:
+  number: 0
+  script:
+    - mkdir -p "${PREFIX}/include"                                 # [unix]
+    - if not exist "%LIBRARY_INC%" mkdir "%LIBRARY_INC%"           # [win]
+    - cp "pstdint-{{ version }}.h" "${PREFIX}/include/pstdint.h"   # [unix]
+    - copy "pstdint-{{ version }}.h" "%LIBRARY_INC%\pstdint.h"     # [win]
+
+test:
+  commands:
+    - test -f "${PREFIX}/include/pstdint.h"                        # [unix]
+    - if not exist "%PREFIX%\\Library\\include\\pstdint.h" exit 1  # [win]
+
+about:
+  home: http://www.azillionmonkeys.com/qed/pstdint.h
+  license: BSD 3-Clause
+  summary: A portable stdint.h
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a recipe for portable `stdint.h`. This was a precursor to `msinttypes` and a bit more general (designed for any platform). However, it does not include `inttypes.h`.