### PR TITLE
Add xorg-*proto (for XQuartz #2587)

### DIFF
--- a/recipes/xorg-applewmproto/bld.bat
+++ b/recipes/xorg-applewmproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-applewmproto/build.sh
+++ b/recipes/xorg-applewmproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-applewmproto/meta.yaml
+++ b/recipes/xorg-applewmproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "applewmproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.4.2" %}
+{% set sha256 = "fcc7de3ad614dd4c56f061c45af4a7e072d6397df5910b0698559a5b0fb824fe" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/applewmproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-bigreqsproto/bld.bat
+++ b/recipes/xorg-bigreqsproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-bigreqsproto/build.sh
+++ b/recipes/xorg-bigreqsproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-bigreqsproto/meta.yaml
+++ b/recipes/xorg-bigreqsproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "bigreqsproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.1.2" %}
+{% set sha256 = "462116ab44e41d8121bfde947321950370b285a5316612b8fce8334d50751b1e" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/bigreqsproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-compositeproto/bld.bat
+++ b/recipes/xorg-compositeproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-compositeproto/build.sh
+++ b/recipes/xorg-compositeproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-compositeproto/meta.yaml
+++ b/recipes/xorg-compositeproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "compositeproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "0.4.2" %}
+{% set sha256 = "049359f0be0b2b984a8149c966dd04e8c58e6eade2a4a309cf1126635ccd0cfc" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/compositeproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-damageproto/bld.bat
+++ b/recipes/xorg-damageproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-damageproto/build.sh
+++ b/recipes/xorg-damageproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-damageproto/meta.yaml
+++ b/recipes/xorg-damageproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "damageproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.2.1" %}
+{% set sha256 = "5c7c112e9b9ea8a9d5b019e5f17d481ae20f766cb7a4648360e7c1b46fc9fc5b" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/damageproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-dmxproto/bld.bat
+++ b/recipes/xorg-dmxproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-dmxproto/build.sh
+++ b/recipes/xorg-dmxproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-dmxproto/meta.yaml
+++ b/recipes/xorg-dmxproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "dmxproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "2.3.1" %}
+{% set sha256 = "e72051e6a3e06b236d19eed56368117b745ca1e1a27bdc50fd51aa375bea6509" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/dmxproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-evieext/bld.bat
+++ b/recipes/xorg-evieext/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-evieext/build.sh
+++ b/recipes/xorg-evieext/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-evieext/meta.yaml
+++ b/recipes/xorg-evieext/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "evieext" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.1.1" %}
+{% set sha256 = "1cf74114436d99f56577a90b6438a32ba31b8128c9e63842bb179aba592733fe" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/evieproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-fontcacheproto/bld.bat
+++ b/recipes/xorg-fontcacheproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-fontcacheproto/build.sh
+++ b/recipes/xorg-fontcacheproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-fontcacheproto/meta.yaml
+++ b/recipes/xorg-fontcacheproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "fontcacheproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "0.1.3" %}
+{% set sha256 = "1dcaa659d416272ff68e567d1910ccc1e369768f13b983cffcccd6c563dbe3cb" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/fontcachstr.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-fontsproto/bld.bat
+++ b/recipes/xorg-fontsproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-fontsproto/build.sh
+++ b/recipes/xorg-fontsproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-fontsproto/meta.yaml
+++ b/recipes/xorg-fontsproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "fontsproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "2.1.3" %}
+{% set sha256 = "259046b0dd9130825c4a4c479ba3591d6d0f17a33f54e294b56478729a6e5ab8" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/fonts/FSproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-glproto/bld.bat
+++ b/recipes/xorg-glproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-glproto/build.sh
+++ b/recipes/xorg-glproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-glproto/meta.yaml
+++ b/recipes/xorg-glproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "glproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.4.17" %}
+{% set sha256 = "adaa94bded310a2bfcbb9deb4d751d965fcfe6fb3a2f6d242e2df2d6589dbe40" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/GL/glxproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-presentproto/bld.bat
+++ b/recipes/xorg-presentproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-presentproto/build.sh
+++ b/recipes/xorg-presentproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-presentproto/meta.yaml
+++ b/recipes/xorg-presentproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "presentproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.1" %}
+{% set sha256 = "f69b23a8869f78a5898aaf53938b829c8165e597cda34f06024d43ee1e6d26b9" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/presentproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-randrproto/bld.bat
+++ b/recipes/xorg-randrproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-randrproto/build.sh
+++ b/recipes/xorg-randrproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-randrproto/meta.yaml
+++ b/recipes/xorg-randrproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "randrproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.5.0" %}
+{% set sha256 = "4c675533e79cd730997d232c8894b6692174dce58d3e207021b8f860be498468" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/randrproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-recordproto/bld.bat
+++ b/recipes/xorg-recordproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-recordproto/build.sh
+++ b/recipes/xorg-recordproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-recordproto/meta.yaml
+++ b/recipes/xorg-recordproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "recordproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.14.2" %}
+{% set sha256 = "a777548d2e92aa259f1528de3c4a36d15e07a4650d0976573a8e2ff5437e7370" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/recordproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-resourceproto/bld.bat
+++ b/recipes/xorg-resourceproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-resourceproto/build.sh
+++ b/recipes/xorg-resourceproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-resourceproto/meta.yaml
+++ b/recipes/xorg-resourceproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "resourceproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.2.0" %}
+{% set sha256 = "3c66003a6bdeb0f70932a9ed3cf57cc554234154378d301e0c5cfa189d8f6818" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/XResproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-scrnsaverproto/bld.bat
+++ b/recipes/xorg-scrnsaverproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-scrnsaverproto/build.sh
+++ b/recipes/xorg-scrnsaverproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-scrnsaverproto/meta.yaml
+++ b/recipes/xorg-scrnsaverproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "scrnsaverproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.2.2" %}
+{% set sha256 = "8bb70a8da164930cceaeb4c74180291660533ad3cc45377b30a795d1b85bcd65" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/saverproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-trapproto/bld.bat
+++ b/recipes/xorg-trapproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-trapproto/build.sh
+++ b/recipes/xorg-trapproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-trapproto/meta.yaml
+++ b/recipes/xorg-trapproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "trapproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "3.4.3" %}
+{% set sha256 = "ff32a0d3bc696cadc3457be9c85e9818af2b6daa2f159188bb01aad7e932a0e1" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xtrapdi.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-videoproto/bld.bat
+++ b/recipes/xorg-videoproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-videoproto/build.sh
+++ b/recipes/xorg-videoproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-videoproto/meta.yaml
+++ b/recipes/xorg-videoproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "videoproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "2.3.3" %}
+{% set sha256 = "c7803889fd08e6fcaf7b68cc394fb038b2325d1f315e571a6954577e07cca702" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/Xvproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-windowswmproto/bld.bat
+++ b/recipes/xorg-windowswmproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-windowswmproto/build.sh
+++ b/recipes/xorg-windowswmproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-windowswmproto/meta.yaml
+++ b/recipes/xorg-windowswmproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "windowswmproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.0.4" %}
+{% set sha256 = "c05bb0edb627554fe97aa1516aed44accf6566b1db0e50332689a24afcebd26b" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/windowswm.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xcmiscproto/bld.bat
+++ b/recipes/xorg-xcmiscproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xcmiscproto/build.sh
+++ b/recipes/xorg-xcmiscproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xcmiscproto/meta.yaml
+++ b/recipes/xorg-xcmiscproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xcmiscproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.2.2" %}
+{% set sha256 = "b13236869372256c36db79ae39d54214172677fb79e9cdc555dceec80bd9d2df" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xcmiscproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xf86bigfontproto/bld.bat
+++ b/recipes/xorg-xf86bigfontproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xf86bigfontproto/build.sh
+++ b/recipes/xorg-xf86bigfontproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xf86bigfontproto/meta.yaml
+++ b/recipes/xorg-xf86bigfontproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xf86bigfontproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.2.0" %}
+{% set sha256 = "ba9220e2c4475f5ed2ddaa7287426b30089e4d29bd58d35fad57ba5ea43e1648" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xf86bigfproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xf86dgaproto/bld.bat
+++ b/recipes/xorg-xf86dgaproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xf86dgaproto/build.sh
+++ b/recipes/xorg-xf86dgaproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xf86dgaproto/meta.yaml
+++ b/recipes/xorg-xf86dgaproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xf86dgaproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "2.1" %}
+{% set sha256 = "ac5ef65108e1f2146286e53080975683dae49fc94680042e04bd1e2010e99050" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xf86dgaproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xf86driproto/bld.bat
+++ b/recipes/xorg-xf86driproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xf86driproto/build.sh
+++ b/recipes/xorg-xf86driproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xf86driproto/meta.yaml
+++ b/recipes/xorg-xf86driproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xf86driproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "2.1.1" %}
+{% set sha256 = "9c4b8d7221cb6dc4309269ccc008a22753698ae9245a398a59df35f1404d661f" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/dri/xf86driproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xf86miscproto/bld.bat
+++ b/recipes/xorg-xf86miscproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xf86miscproto/build.sh
+++ b/recipes/xorg-xf86miscproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xf86miscproto/meta.yaml
+++ b/recipes/xorg-xf86miscproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xf86miscproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "0.9.3" %}
+{% set sha256 = "45b8ec6a4a8ca21066dce117e09dcc88539862e616e60fb391de05b36f63b095" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xf86mscstr.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xf86rushproto/bld.bat
+++ b/recipes/xorg-xf86rushproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xf86rushproto/build.sh
+++ b/recipes/xorg-xf86rushproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xf86rushproto/meta.yaml
+++ b/recipes/xorg-xf86rushproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xf86rushproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.1.2" %}
+{% set sha256 = "07d9b237541f2d6313b5b28f5335d987a766b36c87b133f77cc48f31d969a3ae" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xf86rushstr.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xf86vidmodeproto/bld.bat
+++ b/recipes/xorg-xf86vidmodeproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xf86vidmodeproto/build.sh
+++ b/recipes/xorg-xf86vidmodeproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xf86vidmodeproto/meta.yaml
+++ b/recipes/xorg-xf86vidmodeproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xf86vidmodeproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "2.3.1" %}
+{% set sha256 = "45d9499aa7b73203fd6b3505b0259624afed5c16b941bd04fcf123e5de698770" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/xf86vmproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xineramaproto/bld.bat
+++ b/recipes/xorg-xineramaproto/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xineramaproto/build.sh
+++ b/recipes/xorg-xineramaproto/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xineramaproto/meta.yaml
+++ b/recipes/xorg-xineramaproto/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xineramaproto" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.2.1" %}
+{% set sha256 = "977574bb3dc192ecd9c55f59f991ec1dff340be3e31392c95deff423da52485b" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/extensions/panoramiXproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw

--- a/recipes/xorg-xproxymanagementprotocol/bld.bat
+++ b/recipes/xorg-xproxymanagementprotocol/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-xproxymanagementprotocol/build.sh
+++ b/recipes/xorg-xproxymanagementprotocol/build.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-silent-rules
+)
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+
+# remove all docs

--- a/recipes/xorg-xproxymanagementprotocol/meta.yaml
+++ b/recipes/xorg-xproxymanagementprotocol/meta.yaml
@@ -1,0 +1,47 @@
+{% set xorg_name = "xproxymanagementprotocol" %}
+{% set xorg_category = "proto" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.0.3" %}
+{% set sha256 = "7382acd8c76fa577beb622cab86cc07fafdcecbbd9b4f209bfa72976c4fd26c2" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - toolchain
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -e $PREFIX/include/X11/PM/PMproto.h  # [not win]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Print extension headers'
+
+extra:
+  recipe-maintainers:
+    - epruesse
+    - pkgw


### PR DESCRIPTION
This adds all but two of the 28 missing xorg protocol packages. The two missing ones are dri2proto and dri3proto, which lack license files. 