### PR TITLE
Added recipe for flup

### DIFF
--- a/recipes/flup/meta.yaml
+++ b/recipes/flup/meta.yaml
@@ -15,6 +15,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
+  skip: True  # [py2k]
   preserve_egg_dir: True
   number: {{ build }}
   script: python setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/flup/meta.yaml
+++ b/recipes/flup/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "flup" %}
+{% set version = "1.0.3.dev20161029" %}
+{% set compress_type = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "3dc5620b77a6a4cd0afb556626eb0ce85708e513f9c50dc5e982190e3d5f9e26" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ compress_type }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ compress_type }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  preserve_egg_dir: True
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - flup
+    - flup.client
+    - flup.server
+    - flup.server.ajp
+    - flup.server.ajp_fork
+    - flup.server.fcgi
+    - flup.server.fcgi_fork
+    - flup.server.scgi
+    - flup.server.scgi_fork
+    - flup.middleware.error
+    - flup.middleware.gzip
+    - flup.middleware.session
+    - flup.publisher
+    - flup.resolver.module
+    - flup.resolver.importingmodule
+    - flup.resolver.objectpath
+
+about:
+  home: http://www.saddi.com/software/flup/
+  # no license file, no dev URL for submitting a pull
+  license: BSD
+  license_family: BSD
+  summary: 'Random assortment of WSGI servers'
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/flup/meta.yaml
+++ b/recipes/flup/meta.yaml
@@ -32,20 +32,25 @@ test:
   imports:
     - flup
     - flup.client
+    - flup.client.fcgi_app
+    - flup.client.scgi_app
     - flup.server
     - flup.server.ajp
+    - flup.server.ajp_base
     - flup.server.ajp_fork
+    - flup.server.cgi
     - flup.server.fcgi
+    - flup.server.fcgi_base
     - flup.server.fcgi_fork
+    - flup.server.fcgi_single
+    - flup.server.paste_factory
+    - flup.server.preforkserver
     - flup.server.scgi
+    - flup.server.scgi_base
     - flup.server.scgi_fork
-    - flup.middleware.error
-    - flup.middleware.gzip
-    - flup.middleware.session
-    - flup.publisher
-    - flup.resolver.module
-    - flup.resolver.importingmodule
-    - flup.resolver.objectpath
+    - flup.server.singleserver
+    - flup.server.threadedserver
+    - flup.server.threadpool
 
 about:
   home: http://www.saddi.com/software/flup/


### PR DESCRIPTION
`flup` is ["a random collection of WSGI modules [Allan Saddi has] written"](https://www.saddi.com/software/flup/), and is a dependency for one cherrypy extra. Not sure how well this build will go, and if it falls apart it might better to just skip the extra instead.