### PR TITLE
conda-build-all subcommand

### DIFF
--- a/.CI/build_all
+++ b/.CI/build_all
@@ -42,4 +42,4 @@ popd > /dev/null
 echo ""
 
 # We just want to build all of the recipes.
-conda-build-all ./recipes --matrix-condition "numpy >=1.11" "python >=2.7,<3|>=3.5" "r-base >=3.3.2"
+conda build-all ./recipes --matrix-condition "numpy >=1.11" "python >=2.7,<3|>=3.5" "r-base >=3.3.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ install:
 build: off
 
 test_script:
-    - conda-build-all recipes --matrix-conditions "numpy >=1.11" "%PY_CONDITION%" "r-base >=3.3.2"
+    - conda build-all recipes --matrix-conditions "numpy >=1.11" "%PY_CONDITION%" "r-base >=3.3.2"
     # copy any newly created conda packages into the conda_packages dir
     - cmd: mkdir conda_packages
     # Uncomment the following two lines to make any conda packages created

--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -68,5 +68,5 @@ find ~/conda-recipes -mindepth 2 -maxdepth 2 -type f -name "yum_requirements.txt
     | xargs -n1 cat | grep -v -e "^#" -e "^$" | \
     xargs -r /usr/bin/sudo -n yum install -y
 
-conda-build-all ~/conda-recipes --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.5" "r-base >=3.3.2"
+conda build-all ~/conda-recipes --matrix-conditions "numpy >=1.11" "python >=2.7,<3|>=3.5" "r-base >=3.3.2"
 EOF


### PR DESCRIPTION
Uses `conda-build-all` as a `conda` subcommand.