### PR TITLE
Add SimpleITK libraries and headers

### DIFF
--- a/recipes/libsimpleitk/bld.bat
+++ b/recipes/libsimpleitk/bld.bat
@@ -1,0 +1,27 @@
+set BUILD_DIR=%SRC_DIR%\bld
+mkdir %BUILD_DIR%
+cd %BUILD_DIR%
+
+REM Configure Step
+cmake -G "Ninja" ^
+    -D SimpleITK_BUILD_DISTRIBUTE:BOOL=ON ^
+    -D BUILD_SHARED_LIBS:BOOL=ON ^
+    -D BUILD_TESTING:BOOL=OFF ^
+    -D BUILD_EXAMPLES:BOOL=OFF ^
+    -D WRAP_DEFAULT:BOOL=OFF ^
+    -D SimpleITK_EXPLICIT_INSTANTIATION:BOOL=ON ^
+    -D "CMAKE_SYSTEM_PREFIX_PATH:PATH=%LIBRARY_PREFIX%" ^
+    -D "CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%" ^
+    "%SRC_DIR%/SuperBuild"
+
+if errorlevel 1 exit 1
+
+REM Build step
+cmake --build  . --config Release
+if errorlevel 1 exit 1
+
+REM Install step
+cmake -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -P %BUILD_DIR%\cmake_install.cmake
+if errorlevel 1 exit 1
+
+

--- a/recipes/libsimpleitk/build.sh
+++ b/recipes/libsimpleitk/build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# When building 32-bits on 64-bit system this flags is not automatically set by conda-build
+if [ $ARCH == 32 -a "${OSX_ARCH:-notosx}" == "notosx" ]; then
+    export CFLAGS="${CFLAGS} -m32"
+    export CXXFLAGS="${CXXFLAGS} -m32"
+fi
+
+if [ -z "${OSX_ARCH+x}" ]; then
+    export CXXFLAGS="${CXXFLAGS} -std=c++11"
+fi
+
+BUILD_DIR=${SRC_DIR}/build
+mkdir ${BUILD_DIR}
+cd ${BUILD_DIR}
+
+cmake \
+    -G Ninja \
+    -D "CMAKE_CXX_FLAGS:STRING=-fvisibility=hidden -fvisibility-inlines-hidden ${CXXFLAGS}" \
+    -D "CMAKE_C_FLAGS:STRING=-fvisibility=hidden ${CFLAGS}" \
+    -D "CMAKE_EXE_LINKER_FLAGS:STRING=${LDFLAGS}" \
+    -D "CMAKE_MODULE_LINKER_FLAGS:STRING=${LDFLAGS}" \
+    -D "CMAKE_SHARED_LINKER_FLAGS:STRING=${LDFLAGS}" \
+    -D "CMAKE_STATIC_LINKER_FLAGS:STRING=${LDFLAGS}" \
+    ${CMAKE_ARGS} \
+    -D SimpleITK_BUILD_DISTRIBUTE:BOOL=ON \
+    -D CMAKE_BUILD_TYPE:STRING=RELEASE \
+    -D BUILD_SHARED_LIBS:BOOL=ON \
+    -D BUILD_TESTING:BOOL=OFF \
+    -D BUILD_EXAMPLES:BOOL=OFF \
+    -D WRAP_DEFAULT:BOOL=OFF \
+    -D SimpleITK_EXPLICIT_INSTANTIATION:BOOL=OFF \
+    -D "CMAKE_SYSTEM_PREFIX_PATH:FILEPATH=${PREFIX}" \
+    -D "CMAKE_INSTALL_PREFIX=$PREFIX" \
+    ..
+
+
+ninja -j $((${CPU_COUNT}))
+cmake \
+    -D CMAKE_INSTALL_DO_STRIP:BOOL=1 \
+    -D CMAKE_INSTALL_PREFIX=$PREFIX \
+    -P ${BUILD_DIR}/cmake_install.cmake

--- a/recipes/libsimpleitk/meta.yaml
+++ b/recipes/libsimpleitk/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "1.1.0" %}
+
+package:
+  name: libsimpleitk
+  version: "{{version}}"
+
+source:
+  url: https://github.com/SimpleITK/SimpleITK/releases/download/v{{version}}/SimpleITK-{{version}}.tar.gz
+  sha256: f5fddcc813e677fdf82739a310bf361eb0c07eb9183991235eca135ec7d1c807
+
+build:
+    number: 0
+    # Lets first get Linux and OSX working...
+    skip: True # [win and py27]
+    features:
+    - vc9  # [win and py27]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - cmake   >=3.3
+    - ninja
+    - lua     5.1.*
+    - libitk  4.13.*
+    - python  # [win]
+    - vc 9  # [win and py27]
+    - vc 14  # [win and py35>=35]
+  run:
+    - libitk 4.13.*
+    - vc 9  # [win and py27]
+    - vc 14  # [win and py35>=35]
+
+test:
+  commands:
+    - echo "TODO Testing..."
+
+about:
+  home: http::/www.simpleitk.org
+  license: Apache 2.0
+  summary: Development headers and libraries for SimpleITK a simplified interface to the Insight Toolkit.
+
+extra:
+    recipe-maintainers:
+      - blowekamp
+      - zivy


### PR DESCRIPTION
A standalone recipe for SimpleITK for Python would rebuild the same
ITK and SimpleITK repeatedly for each version of python. This package
is a separates the compiled libraries into a separate package which
can be reused by difference versions of Python ( Lua, R ).

This is expected to reduce the compilation to a reasonable time.