### PR TITLE
Feedstock creation: don't error out if rerendering produces no changes

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -199,7 +199,8 @@ if __name__ == '__main__':
                 continue
 
             subprocess.check_call(['conda', 'smithy', 'rerender'], cwd=feedstock_dir)
-            subprocess.check_call(['git', 'commit', '-am', "Re-render the feedstock after CI registration."], cwd=feedstock_dir)
+            subprocess.check_call(['git', 'commit', '--allow-empty',
+                                   '-am', "Re-render the feedstock after CI registration."], cwd=feedstock_dir)
             for i in range(5):
                 try:
                     # Capture the output, as it may contain the GH_TOKEN.


### PR DESCRIPTION
By default Git will exit with an error if you try to make an empty commit. This behavior could cause feedstock registration to abort if the `conda smithy rerender` step had no changes to make. But in our system that's really not an error, so let's use Git's `--allow-empty` option to signal that.

[ci skip]