### PR TITLE
Add neovim

### DIFF
--- a/recipes/neovim/build.sh
+++ b/recipes/neovim/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+mkdir .deps
+cd .deps
+cmake ../third-party
+make
+cd ..
+
+mkdir build
+cd build
+cmake .. \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DENABLE_BUILD_TYPE=Release
+make -j$CPU_COUNT
+make install

--- a/recipes/neovim/meta.yaml
+++ b/recipes/neovim/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "neovim" %}
+{% set version = "0.1.7" %}
+{% set sha256 = "d8f885d019b1ad608f36ae23b8f1b15b7e33585e16f7514666ab6c9809bb4b7e" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/neovim/neovim/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - autoconf
+    - automake
+    - libtool
+    - cmake
+    - pkgconfig
+    - unzip
+    - libiconv
+  run:
+    - libiconv
+
+test:
+  commands:
+    - nvim --help
+    - nvim --headless -u NONE -i NONE -c ':quit'
+
+about:
+  home: https://neovim.io/
+  license: Apache
+  license_file: LICENSE
+  summary: 'Vim-fork focused on extensibility and usability'
+  doc_url: https://neovim.io/doc/
+  dev_url: https://github.com/neovim/neovim
+
+extra:
+  recipe-maintainers:
+    - mdraw


### PR DESCRIPTION
Just an experiment to see if we can use the integrated third-party libraries via cmake, following the instructions at https://github.com/neovim/neovim/wiki/Building-Neovim#third-party-dependencies.

This could be an alternative to https://github.com/conda-forge/staged-recipes/pull/1677 if the build here actually works on CI and this sort of build process is even allowed on conda-forge (it downloads build dependencies directly from the internet, bypassing conda build requirements).

[Edit: Fixed Link to other neovim PR]