### PR TITLE
Add conda-exec 0.1.0 to conda-forge

### DIFF
--- a/recipes/conda-exec/meta.yaml
+++ b/recipes/conda-exec/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "conda-exec" %}
 {% set version = "0.1.0" %}
+{% set sha256 = "f0da795feb521269935f819127cf1f54f49316808db3d2d1feb56520a65afec7" %}
 
 package:
-    name: {{ name }}
+    name: {{ name|lower }}
     version: {{ version }}
 
 source:
-    fn: {{ version }}.tar.gz
+    fn: {{ name }}-{{ version }}.tar.gz
     url: https://github.com/nomr/{{ name }}/archive/{{ version }}.tar.gz
+    sha256: {{ sha256 }}
 
 build:
     number: 0

--- a/recipes/conda-exec/meta.yaml
+++ b/recipes/conda-exec/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "conda-exec" %}
+{% set version = "0.1.0" %}
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+source:
+    fn: {{ version }}.tar.gz
+    url: https://github.com/nomr/{{ name }}/archive/{{ version }}.tar.gz
+
+build:
+    number: 0
+    skip: True  # [win]
+    script:
+        - install conda-exec.sh ${PREFIX}/bin/conda-exec
+
+requirements:
+    run:
+        - conda
+
+test:
+    commands:
+        - conda exec -h
+
+about:
+    home: https://github.com/nomr/conda-exec
+    license: BSD 3-Clause
+    license_family: BSD
+    license_file: LICENSE
+    summary: Executes a command inside a conda environment after activating it.
+
+    dev_url: https://github.com/nomr/conda-exec
+
+extra:
+    recipe-maintainers:
+        - sodre


### PR DESCRIPTION
conda-exec lets a user execute a conda program inside a conda environment
without having to activate it first. This is useful for executing
programs that have variables that depend on "activate.d" scripts.