### PR TITLE
Add rabbitmq-server 3.6.9 to conda forge.

### DIFF
--- a/recipes/rabbitmq/3a8d7ed.patch
+++ b/recipes/rabbitmq/3a8d7ed.patch
@@ -1,0 +1,10 @@
+diff --git a/sbin/rabbitmq-server b/sbin/rabbitmq-server
+index 77f4bf4..f5430c3 100755
+--- a/sbin/rabbitmq-server
++++ b/sbin/rabbitmq-server
+@@ -1,4 +1,4 @@
+-#!/bin/sh -e
++#!/bin/bash -e
+ ##  The contents of this file are subject to the Mozilla Public License
+ ##  Version 1.1 (the "License"); you may not use this file except in
+ ##  compliance with the License. You may obtain a copy of the License

--- a/recipes/rabbitmq/a2f5620.patch
+++ b/recipes/rabbitmq/a2f5620.patch
@@ -1,0 +1,35 @@
+diff --git a/sbin/rabbitmq-script-wrapper b/sbin/rabbitmq-script-wrapper
+new file mode 100755
+index 0000000..aac880b
+--- /dev/null
++++ b/sbin/rabbitmq-script-wrapper
+@@ -0,0 +1,29 @@
++#!/bin/bash -e
++##  The contents of this file are subject to the Mozilla Public License
++##  Version 1.1 (the "License"); you may not use this file except in
++##  compliance with the License. You may obtain a copy of the License
++##  at http://www.mozilla.org/MPL/
++##
++##  Software distributed under the License is distributed on an "AS IS"
++##  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
++##  the License for the specific language governing rights and
++##  limitations under the License.
++##
++##  The Original Code is RabbitMQ.
++##
++##  The Initial Developer of the Original Code is GoPivotal, Inc.
++##  Copyright (c) 2007-2014 GoPivotal, Inc.  All rights reserved.
++##
++
++cd ${PREFIX}/var/lib/rabbitmq
++
++SCRIPT=`basename $0`
++
++if [ "$SCRIPT" = "rabbitmq-server" ] ; then
++    exec ${PREFIX}/lib/rabbitmq/sbin/rabbitmq-server $*
++else
++    if [ -f $PWD/.erlang.cookie ] ; then
++        export HOME=.
++    fi
++    exec ${PREFIX}/lib/rabbitmq/sbin/${SCRIPT} $*
++fi

--- a/recipes/rabbitmq/build.sh
+++ b/recipes/rabbitmq/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -ef
+
+cp_envsubst()
+{
+	src=$1
+	dst=$2
+	if [ -d $dst ]; then
+		dst="$dst/$(basename $src)"
+	fi
+	cat $src | envsubst '${PREFIX}' > $dst
+}
+
+RABBITMQ_HOME=$PREFIX/lib/rabbitmq
+mkdir -p $RABBITMQ_HOME
+
+# Fix patching level mismatch and mode
+mv b/sbin/rabbitmq-script-wrapper sbin
+chmod 755 sbin/rabbitmq-script-wrapper
+
+# Copy files in place.
+cp -avf ebin include plugins sbin ${RABBITMQ_HOME}
+
+# man pages
+cp -avf share ${PREFIX}
+
+# Render a few files
+cp_envsubst sbin/rabbitmq-script-wrapper $RABBITMQ_HOME/sbin
+cp_envsubst sbin/rabbitmq-defaults $RABBITMQ_HOME/sbin
+
+# Create links to main apps
+for app in ${PREFIX}/bin/rabbitmq{ctl,-server,-plugins}; do
+	ln -s ../lib/rabbitmq/sbin/rabbitmq-script-wrapper $app
+done
+
+# Make empty dirs
+for dir in ${PREFIX}/{etc,var{/lib,/log}}/rabbitmq; do
+	mkdir -p $dir
+	touch $dir/.mkdir
+done

--- a/recipes/rabbitmq/f52bca4.patch
+++ b/recipes/rabbitmq/f52bca4.patch
@@ -1,0 +1,13 @@
+diff --git a/sbin/rabbitmq-defaults b/sbin/rabbitmq-defaults
+index b845f74..95dccce 100755
+--- a/sbin/rabbitmq-defaults
++++ b/sbin/rabbitmq-defaults
+@@ -16,7 +16,7 @@
+ ##
+ 
+ ### next line potentially updated in package install steps
+-SYS_PREFIX=${RABBITMQ_HOME}
++SYS_PREFIX=${PREFIX}
+ 
+ ### next line will be updated when generating a standalone release
+ ERL_DIR=

--- a/recipes/rabbitmq/meta.yaml
+++ b/recipes/rabbitmq/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "rabbitmq-server" %}
+{% set version = "3.6.9" %}
+{% set sha256 = "012e8efbd0f40c086030803c92fea2e3af37b8d1515a553896fb5c1f3960bc40" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  #path: ./rabbitmq_server-3.6.9
+  fn: {{ name }}-{{ version }}.tar.xz
+  url: https://www.rabbitmq.com/releases/{{ name }}/v{{ version }}/{{ name }}-generic-unix-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+  patches:
+    - 3a8d7ed.patch  # merges rabbitmq/rabbitmq-server#1192
+    - a2f5620.patch  # wrapper to fake RABBITMQ_HOME location
+    - f52bca4.patch  # SYS_PREFIX is set to Conda's PREFIX
+
+build:
+  number: 0
+  skip: True  # [win]
+  no_link:
+    - etc/rabbitmq
+    - var/*/rabbitmq
+
+requirements:
+  build:
+    - gettext
+
+  run:
+    - erlang
+
+test:
+  commands:
+    - coproc rabbitmq-server
+    - rabbitmqctl status
+    - rabbitmqctl stop
+
+about:
+  home: http://www.rabbitmq.com
+  license: MPL
+  license_family: OTHER
+  license_file: LICENSE
+  summary: Open source multi-protocol messaging broker
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    RabbitMQ is lightweight and easy to deploy on premise and in the cloud. 
+    It supports multiple messaging protocols. RabbitMQ can be deployed in 
+    distributed and federated configurations to meet high-scale, 
+    high-availability requirements.
+  doc_url: https://www.rabbitmq.com/documentation.html
+  dev_url: https://github.com/rabbitmq/rabbitmq-server
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/rabbitmq/meta.yaml
+++ b/recipes/rabbitmq/meta.yaml
@@ -38,7 +38,7 @@ test:
 
 about:
   home: http://www.rabbitmq.com
-  license: MPL
+  license: MPL 1.1
   license_family: OTHER
   license_file: LICENSE
   summary: Open source multi-protocol messaging broker

--- a/recipes/rabbitmq/meta.yaml
+++ b/recipes/rabbitmq/meta.yaml
@@ -7,7 +7,6 @@ package:
   version: {{ version }}
 
 source:
-  #path: ./rabbitmq_server-3.6.9
   fn: {{ name }}-{{ version }}.tar.xz
   url: https://www.rabbitmq.com/releases/{{ name }}/v{{ version }}/{{ name }}-generic-unix-{{ version }}.tar.xz
   sha256: {{ sha256 }}
@@ -44,7 +43,6 @@ about:
   license_file: LICENSE
   summary: Open source multi-protocol messaging broker
 
-  # The remaining entries in this section are optional, but recommended
   description: |
     RabbitMQ is lightweight and easy to deploy on premise and in the cloud. 
     It supports multiple messaging protocols. RabbitMQ can be deployed in 

--- a/recipes/rabbitmq/meta.yaml
+++ b/recipes/rabbitmq/meta.yaml
@@ -32,8 +32,8 @@ requirements:
 
 test:
   commands:
-    - coproc rabbitmq-server  # [linux]
-    - bash -c 'coproc rabbitmq-server'  # [osx]
+    - rabbitmq-server&
+    - sleep 2
     - rabbitmqctl status
     - rabbitmqctl stop
 

--- a/recipes/rabbitmq/meta.yaml
+++ b/recipes/rabbitmq/meta.yaml
@@ -32,7 +32,8 @@ requirements:
 
 test:
   commands:
-    - coproc rabbitmq-server
+    - coproc rabbitmq-server  # [linux]
+    - bash -c 'coproc rabbitmq-server'  # [osx]
     - rabbitmqctl status
     - rabbitmqctl stop
 


### PR DESCRIPTION
A first attempt at having rabbitmq in conda-forge.