### PR TITLE
Add xorg-libxrandr

### DIFF
--- a/recipes/xorg-libxrandr/bld.bat
+++ b/recipes/xorg-libxrandr/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/xorg-libxrandr/build.sh
+++ b/recipes/xorg-libxrandr/build.sh
@@ -1,0 +1,56 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+fi
+
+export PKG_CONFIG_LIBDIR=$uprefix/lib/pkgconfig:$uprefix/share/pkgconfig
+configure_args=(
+    --prefix=$mprefix
+    --disable-dependency-tracking
+    --disable-selective-werror
+    --disable-silent-rules
+)
+
+./configure "${configure_args[@]}"
+make -j$CPU_COUNT
+make install
+make check
+rm -rf $uprefix/share/man $uprefix/share/doc/${PKG_NAME#xorg-}
+
+# Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
+if [ -z "VS_MAJOR" ] ; then
+    for lib_ident in Xrender; do
+        rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
+    done
+fi

--- a/recipes/xorg-libxrandr/build.sh
+++ b/recipes/xorg-libxrandr/build.sh
@@ -50,7 +50,7 @@ rm -rf $uprefix/share/man $uprefix/share/doc/${PKG_NAME#xorg-}
 
 # Non-Windows: prefer dynamic libraries to static, and dump libtool helper files
 if [ -z "VS_MAJOR" ] ; then
-    for lib_ident in Xrender; do
+    for lib_ident in Xrandr; do
         rm -f $uprefix/lib/lib${lib_ident}.la $uprefix/lib/lib${lib_ident}.a
     done
 fi

--- a/recipes/xorg-libxrandr/meta.yaml
+++ b/recipes/xorg-libxrandr/meta.yaml
@@ -1,0 +1,75 @@
+{% set xorg_name = "libXrandr" %}
+{% set xorg_category = "lib" %}
+{% set name = "xorg-" ~ xorg_name %}
+{% set version = "1.5.1" %}
+{% set sha256 = "1ff9e7fa0e4adea912b16a5f0cfa7c1d35b0dcda0e216831f7715c8a3abcf51a" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.bz2
+  url: https://www.x.org/releases/individual/{{ xorg_category }}/{{ xorg_name }}-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py35]
+    - vc14  # [win and py36]
+
+requirements:
+  build:
+    - m2-autoconf  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool  # [win]
+    - m2w64-pkg-config  # [win]
+    - m2w64-toolchain  # [win]
+    - pkg-config  # [not win]
+    - posix  # [win]
+    - pthread-stubs
+    - python  # [win]
+    - toolchain
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py35]
+    - vc 14  # [win and py36]
+    - xorg-libx11 1.6.*
+    - xorg-libxrender
+    - xorg-libxext
+    - xorg-randrproto
+    - xorg-xextproto
+    - xorg-renderproto
+    - xorg-util-macros
+  run:
+    - vc 9  # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py35]
+    - vc 14  # [win and py36]
+    - xorg-libx11 1.6.*
+    - xorg-libxrender
+    - xorg-libxext
+    - xorg-randrproto
+    - xorg-xextproto
+    - xorg-renderproto
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'The X.org Xrandr library'
+
+extra:
+  recipe-maintainers:
+    - Xarthisius

--- a/recipes/xorg-libxrandr/meta.yaml
+++ b/recipes/xorg-libxrandr/meta.yaml
@@ -73,3 +73,4 @@ about:
 extra:
   recipe-maintainers:
     - Xarthisius
+    - pkgw


### PR DESCRIPTION
It's a dependency for packages I'm planning to add, but also for packages already in conda-forge (e.g. freeglut). Not sure, why the latter compiles without it...