### PR TITLE
Add lancet recipe

### DIFF
--- a/recipes/lancet/meta.yaml
+++ b/recipes/lancet/meta.yaml
@@ -13,12 +13,11 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python setup.py install
 
 requirements:
   build:
     - python
-    - setuptools
   run:
     - python
     - param

--- a/recipes/lancet/meta.yaml
+++ b/recipes/lancet/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "lancet" %}
+{% set version = "0.9.0" %}
+{% set sha256 = "1fff606e0b4b00b3c5e411bd6b42d495a151842aeca29f158a5e452770a0f4f6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/ioam/lancet/archive/v{{version}}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - param
+
+test:
+  imports:
+    - lancet
+
+about:
+  home: https://ioam.github.io/lancet/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Launch jobs, organize the output, and dissect the results.'
+  description: |
+    Lancet is designed to help you organize the output of your research
+    tools, store it, and dissect the data you have collected. The output
+    of a single simulation or analysis rarely contains all the data you
+    need; Lancet helps you generate data from many runs and analyse it
+    using your own Python code.
+  doc_url: https://ioam.github.io/param/
+  dev_url: https://github.com/ioam/lancet
+
+extra:
+  recipe-maintainers:
+    - jlstevens
+    - philippjfr
+    - basnijholt


### PR DESCRIPTION
@jlstevens and @philippjfr I noticed that installing `holoviews` from `conda-forge` currently installs `param` v1.4.2, I think this is due to `lancet` only being on the `defaults` channel.