### PR TITLE
Add airflow 1.8.0 recipe to conda-forge.

### DIFF
--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: True  # [py36]
 
 requirements:
   build:

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: True  # [py36]
+  skip: True  # [py36 or win]
 
 requirements:
   build:
@@ -54,8 +54,6 @@ requirements:
 
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - airflow
     - airflow.api

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -27,10 +27,10 @@ requirements:
     - flask >=0.11,<0.12
     - flask-admin >=1.4.1,<2
     - flask-cache >=0.13.1,<0.14
-    - flask-login ==0.2.11
-    - flask-swagger ==0.2.13
+    - flask-login >=0.4.0,<0.5
+    - flask-swagger >=0.2.13,<0.3
     - flask-wtf ==0.12
-    - funcsigs ==1.0.0
+    - funcsigs 1.0.*
     - future >=0.15.0,<0.16
     - gitpython >=2.0.2
     - gunicorn >=19.3.0,<20
@@ -42,7 +42,7 @@ requirements:
     - pygments >=2.0.1,<3.0
     - python-daemon >=2.1.1,<2.2
     - python-dateutil >=2.3,<3
-    - python-nvd3 ==0.14.2
+    - python-nvd3 >=0.14.2,<0.15
     - requests >=2.5.1,<3
     - setproctitle >=1.1.8,<2
     - sqlalchemy >=0.9.8

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -1,0 +1,119 @@
+{% set name = "airflow" %}
+{% set version = "1.8.0" %}
+{% set sha256 = "86a3099447e2f3e2c1a166f38996d5756c74c758aa3a87dc2a546aca80a91e7f" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/apache/incubator-{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - alembic >=0.8.3,<0.9
+    - croniter >=0.3.8,<0.4
+    - dill >=0.2.2,<0.3
+    - flask >=0.11,<0.12
+    - flask-admin >=1.4.1,<2
+    - flask-cache >=0.13.1,<0.14
+    - flask-login ==0.2.11
+    - flask-swagger ==0.2.13
+    - flask-wtf ==0.12
+    - funcsigs ==1.0.0
+    - future >=0.15.0,<0.16
+    - gitpython >=2.0.2
+    - gunicorn >=19.3.0,<20
+    - jinja2 >=2.7.3,<2.9.0
+    - lxml >=3.6.0,<4.0
+    - markdown >=2.5.2,<3.0
+    - pandas >=0.17.1,<1.0.0
+    - psutil >=4.2.0,<5.0.0
+    - pygments >=2.0.1,<3.0
+    - python-daemon >=2.1.1,<2.2
+    - python-dateutil >=2.3,<3
+    - python-nvd3 ==0.14.2
+    - requests >=2.5.1,<3
+    - setproctitle >=1.1.8,<2
+    - sqlalchemy >=0.9.8
+    - tabulate >=0.7.5,<0.8.0
+    - thrift >=0.9.2,<0.10
+    - zope.deprecation >=4.0,<5.0
+
+
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - airflow
+    - airflow.api
+    - airflow.api.auth
+    - airflow.api.auth.backend
+    - airflow.api.client
+    - airflow.api.common
+    - airflow.api.common.experimental
+    - airflow.bin
+    - airflow.contrib
+    - airflow.contrib.auth
+    - airflow.contrib.auth.backends
+    - airflow.contrib.executors
+    - airflow.contrib.hooks
+    - airflow.contrib.operators
+    - airflow.contrib.sensors
+    - airflow.contrib.task_runner
+    - airflow.dag
+    - airflow.example_dags
+    - airflow.example_dags.subdags
+    - airflow.executors
+    - airflow.hooks
+    - airflow.macros
+    - airflow.migrations
+    - airflow.migrations.versions
+    - airflow.operators
+    - airflow.security
+    - airflow.task_runner
+    - airflow.ti_deps
+    - airflow.ti_deps.deps
+    - airflow.utils
+    - airflow.www
+    - airflow.www.api
+    - airflow.www.api.experimental
+
+  commands:
+    - airflow initdb
+    - airflow webserver -p 8080 &
+
+about:
+  home: http://airflow.apache.org 
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Airflow is a platform to programmatically author, schedule and monitor workflows'
+
+  description: |
+      Use airflow to author workflows as directed acyclic graphs (DAGs) of tasks. The airflow
+      scheduler executes your tasks on an array of workers while following the specified
+      dependencies. Rich command line utilities make performing complex surgeries on DAGs a
+      snap. The rich user interface makes it easy to visualize pipelines running in
+      production, monitor progress, and troubleshoot issues when needed.
+
+      When workflows are defined as code, they become more maintainable, versionable,
+      testable, and collaborative.
+
+  doc_url: http://pythonhosted.org/airflow/profiling.html
+  dev_url: https://github.com/apache/incubating-{{ name }}
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -26,15 +26,15 @@ requirements:
     - croniter >=0.3.8,<0.4
     - dill >=0.2.2,<0.3
     - flask >=0.11,<0.12
-    - flask-admin >=1.4.1,<2
+    - flask-admin ==1.4.1
     - flask-cache >=0.13.1,<0.14
-    - flask-login >=0.4.0,<0.5
-    - flask-swagger >=0.2.13,<0.3
+    - flask-login ==0.3.2
+    - flask-swagger ==0.2.13
     - flask-wtf ==0.12
-    - funcsigs 1.0.*
+    - funcsigs ==1.0.0
     - future >=0.15.0,<0.16
     - gitpython >=2.0.2
-    - gunicorn >=19.3.0,<20
+    - gunicorn >=19.3.0,<19.4.0
     - jinja2 >=2.7.3,<2.9.0
     - lxml >=3.6.0,<4.0
     - markdown >=2.5.2,<3.0
@@ -96,7 +96,6 @@ test:
 about:
   home: http://airflow.apache.org 
   license: Apache 2.0
-  license_family: Apache
   license_file: LICENSE
   summary: 'Airflow is a platform to programmatically author, schedule and monitor workflows'
 

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: True  # [py36 or win]
+  skip: True  # [py3k or win]
 
 requirements:
   build:

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -89,7 +89,6 @@ test:
 
   commands:
     - airflow initdb
-    - airflow webserver -p 8080 &
 
 about:
   home: http://airflow.apache.org 
@@ -108,7 +107,7 @@ about:
       testable, and collaborative.
 
   doc_url: http://pythonhosted.org/airflow/profiling.html
-  dev_url: https://github.com/apache/incubating-{{ name }}
+  dev_url: https://github.com/apache/incubating-airflow
 
 extra:
   recipe-maintainers:

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -51,26 +51,6 @@ requirements:
     - thrift >=0.9.2,<0.10
     - zope.deprecation >=4.0,<5.0
 
-    # async
-    # - greenlet >=0.4.9
-    # - eventlet >=0.9.7
-    # - gevent >= 0.13
-    #
-    # azure
-    # - azure-storage >=0.34.0
-    #
-    # celery
-    # - celery >= 3.1.17
-    # - flower >= 0.7.3
-    #
-    # cgroups
-    # - cgroupspy >=0.1.4
-    #
-    # crypto
-    # - cryptography >=0.9.3
-
-
-
 test:
   imports:
     - airflow

--- a/recipes/airflow/meta.yaml
+++ b/recipes/airflow/meta.yaml
@@ -51,6 +51,24 @@ requirements:
     - thrift >=0.9.2,<0.10
     - zope.deprecation >=4.0,<5.0
 
+    # async
+    # - greenlet >=0.4.9
+    # - eventlet >=0.9.7
+    # - gevent >= 0.13
+    #
+    # azure
+    # - azure-storage >=0.34.0
+    #
+    # celery
+    # - celery >= 3.1.17
+    # - flower >= 0.7.3
+    #
+    # cgroups
+    # - cgroupspy >=0.1.4
+    #
+    # crypto
+    # - cryptography >=0.9.3
+
 
 
 test:

--- a/recipes/airflow/scripts/extras.py
+++ b/recipes/airflow/scripts/extras.py
@@ -1,0 +1,130 @@
+#/usr/bin/env python
+# This code was lifted from airflow's setup.py
+
+async = [
+    'greenlet>=0.4.9',
+    'eventlet>= 0.9.7',
+    'gevent>=0.13'
+]
+celery = [
+    'celery>=3.1.17',
+    'flower>=0.7.3'
+]
+cgroups = [
+    'cgroupspy>=0.1.4',
+]
+crypto = ['cryptography>=0.9.3']
+datadog = ['datadog>=0.14.0']
+doc = [
+    'sphinx>=1.2.3',
+    'sphinx-argparse>=0.1.13',
+    'sphinx-rtd-theme>=0.1.6',
+    'Sphinx-PyPI-upload>=0.2.1'
+]
+docker = ['docker-py>=1.6.0']
+druid = ['pydruid>=0.2.1']
+emr = ['boto3>=1.0.0']
+gcp_api = [
+    'httplib2',
+    'google-api-python-client>=1.5.0, <1.6.0',
+    'oauth2client>=2.0.2, <2.1.0',
+    'PyOpenSSL',
+]
+hdfs = ['snakebite>=2.7.8']
+webhdfs = ['hdfs[dataframe,avro,kerberos]>=2.0.4']
+jira = ['JIRA>1.0.7']
+hive = [
+    'hive-thrift-py>=0.0.1',
+    'pyhive>=0.1.3',
+    'impyla>=0.13.3',
+    'unicodecsv>=0.14.1'
+]
+jdbc = ['jaydebeapi>=0.2.0']
+mssql = ['pymssql>=2.1.1', 'unicodecsv>=0.14.1']
+mysql = ['mysqlclient>=1.3.6']
+rabbitmq = ['librabbitmq>=1.6.1']
+oracle = ['cx_Oracle>=5.1.2']
+postgres = ['psycopg2>=2.6']
+salesforce = ['simple-salesforce>=0.72']
+s3 = [
+    'boto>=2.36.0',
+    'filechunkio>=1.6',
+]
+samba = ['pysmbclient>=0.1.3']
+slack = ['slackclient>=1.0.0']
+statsd = ['statsd>=3.0.1, <4.0']
+vertica = ['vertica-python>=0.5.1']
+ldap = ['ldap3>=0.9.9.1']
+kerberos = ['pykerberos>=1.1.13',
+            'requests_kerberos>=0.10.0',
+            'thrift_sasl>=0.2.0',
+            'snakebite[kerberos]>=2.7.8',
+            'kerberos>=1.2.5']
+password = [
+    'bcrypt>=2.0.0',
+    'flask-bcrypt>=0.7.1',
+]
+github_enterprise = ['Flask-OAuthlib>=0.9.1']
+qds = ['qds-sdk>=1.9.0']
+cloudant = ['cloudant>=0.5.9,<2.0'] # major update coming soon, clamp to 0.x
+
+all_dbs = postgres + mysql + hive + mssql + hdfs + vertica + cloudant
+devel = [
+    'click',
+    'freezegun',
+    'jira',
+    'lxml>=3.3.4',
+    'mock',
+    'moto',
+    'nose',
+    'nose-ignore-docstring==0.2',
+    'nose-parameterized',
+]
+devel_minreq = devel + mysql + doc + password + s3 + cgroups
+devel_hadoop = devel_minreq + hive + hdfs + webhdfs + kerberos
+devel_all = devel + all_dbs + doc + samba + s3 + slack + crypto + oracle + docker
+
+require={
+            'all': devel_all,
+            'all_dbs': all_dbs,
+            'async': async,
+            'celery': celery,
+            'cgroups': cgroups,
+            'cloudant': cloudant,
+            'crypto': crypto,
+            'datadog': datadog,
+            'devel': devel_minreq,
+            'devel_hadoop': devel_hadoop,
+            'doc': doc,
+            'docker': docker,
+            'druid': druid,
+            'emr': emr,
+            'gcp_api': gcp_api,
+            'github_enterprise': github_enterprise,
+            'hdfs': hdfs,
+            'hive': hive,
+            'jdbc': jdbc,
+            'kerberos': kerberos,
+            'ldap': ldap,
+            'mssql': mssql,
+            'mysql': mysql,
+            'oracle': oracle,
+            'password': password,
+            'postgres': postgres,
+            'qds': qds,
+            'rabbitmq': rabbitmq,
+            's3': s3,
+            'salesforce': salesforce,
+            'samba': samba,
+            'slack': slack,
+            'statsd': statsd,
+            'vertica': vertica,
+            'webhdfs': webhdfs,
+            'jira': jira,
+        }
+
+for e in sorted(require.keys(), key=lambda x: (len(require[x]), x)):
+    print('{}:'.format(e))
+    for r in sorted(require[e]):
+        print('    - {}'.format(r))
+


### PR DESCRIPTION
The recipe currently does not build pass the test because
- [x] flask-swagger 
- [x] python-nvd3
  - [x] update python-slugify-feedstock
- [x] dependency on flask-login =0.2.11 (conda-forge/flask-login-feedstock#5, conda-forge/flask-login-feedstock#6)
- [x] dependency on gunicorn >=19.3.0,<19.4.0 (conda-forge/gunicorn-feedstock#6)
- [x] dependency on flask-admin =1.4.1 (conda-forge/flask-admin-feedstock#3)
- [x] Decision from @conda-forge/core on how to handle the extra features/requirements. 

I will be working to create additional packages for those.