### PR TITLE
Add jsonapi-client 0.9.3 to conda-forge.

### DIFF
--- a/recipes/aiohttp/meta.yaml
+++ b/recipes/aiohttp/meta.yaml
@@ -32,7 +32,7 @@ test:
     - aiohttp
 
 about:
-  home: http://github.com/simplejson/simplejson
+  home: https://github.com/aio-libs/aiohttp
   license: Apache 2.0
   license_file: LICENSE.txt
   summary: 'Async http client/server framework (asyncio)'

--- a/recipes/aiohttp/meta.yaml
+++ b/recipes/aiohttp/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "aiohttp" %}
+{% set version = "2.0.7" %}
+{% set sha256 = "76bfd47ee7fbda115cff486c3944fcb237ecbf6195bf2943fae74052fb40c4fe" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [py2k]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - chardet
+    - multidict >=2.1.4
+    - async-timeout >=1.2.0
+    - yarl >=0.10.0,<0.11
+
+test:
+  imports:
+    - aiohttp
+
+about:
+  home: http://github.com/simplejson/simplejson
+  license: Apache 2.0
+  license_file: LICENSE.txt
+  summary: 'Async http client/server framework (asyncio)'
+
+  doc_url: http://aiohttp.readthedocs.io/
+  dev_url: https://github.com/aio-libs/aiohttp
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/async-timeout/meta.yaml
+++ b/recipes/async-timeout/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "async-timeout" %}
+{% set version = "1.2.1" %}
+{% set sha256 = "380e9bfd4c009a14931ffe487499b0906b00b3378bb743542cfd9fbb6d8e4657" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [py2k]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - async_timeout
+
+about:
+  home: http://github.com/aio-libs/async_timeout
+  license: Apache 2.0
+  license_file: LICENSE
+  summary: 'Timeout context manager for asyncio programs'
+
+  dev_url: http://github.com/aio-libs/async_timeout
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/jsonapi-client/meta.yaml
+++ b/recipes/jsonapi-client/meta.yaml
@@ -37,7 +37,7 @@ test:
 
 about:
   home: https://github.com/qvantel/jsonapi-client
-  license: BSD
+  license: BSD 3-Clause
   license_family: BSD
   license_file: LICENSE.txt
   summary: 'Comprehensive, yet easy-to-use, pythonic, ORM-like access to JSON API services'

--- a/recipes/jsonapi-client/meta.yaml
+++ b/recipes/jsonapi-client/meta.yaml
@@ -27,8 +27,13 @@ requirements:
     - aiohttp
 
 test:
-  imports:
-    - jsonapi_client
+  source_files:
+    - tests
+  requires:
+    - pytest
+    - pytest-mock
+  commands:
+    - py.test tests
 
 about:
   home: https://github.com/qvantel/jsonapi-client

--- a/recipes/jsonapi-client/meta.yaml
+++ b/recipes/jsonapi-client/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "jsonapi-client" %}
+{% set version = "0.9.3" %}
+{% set sha256 = "7e8563b59f408429ac943e9b6d060f2dfae1c61b774aefd1c456bac189da0b68" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/qvantel/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [py < 36]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - requests
+    - jsonschema
+    - aiohttp
+
+test:
+  imports:
+    - jsonapi_client
+
+about:
+  home: https://github.com/qvantel/jsonapi-client
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Comprehensive, yet easy-to-use, pythonic, ORM-like access to JSON API services'
+
+  dev_url: https://github.com/qvantel/jsonapi-client
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/multidict/meta.yaml
+++ b/recipes/multidict/meta.yaml
@@ -24,8 +24,12 @@ requirements:
     - python
 
 test:
-  imports:
-    - multidict
+  source_files:
+    - tests
+  requires:
+    - pytest
+  commands:
+    - py.test tests
 
 about:
   home: http://github.com/aio-libs/multidict

--- a/recipes/multidict/meta.yaml
+++ b/recipes/multidict/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "multidict" %}
+{% set version = "2.1.4" %}
+{% set sha256 = "a77aa8c9f68846c3b5db43ff8ed2a7a884dbe845d01f55113a3fba78518c4cd7" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [py2k]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - multidict
+
+about:
+  home: http://github.com/aio-libs/multidict
+  license: Apache 2.0
+  license_file: LICENSE
+  summary: 'multidict implementation'
+
+  description: |
+    Multidicts are useful for working with HTTP headers, URL query args etc.
+  doc_url: http://simplejson.readthedocs.io/
+  dev_url: http://github.com/aio-libs/multidict
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - HomerSimpson
+    - LukeSkywalker

--- a/recipes/multidict/meta.yaml
+++ b/recipes/multidict/meta.yaml
@@ -39,12 +39,9 @@ about:
 
   description: |
     Multidicts are useful for working with HTTP headers, URL query args etc.
-  doc_url: http://simplejson.readthedocs.io/
+  doc_url: http://multidict.readthedocs.io/
   dev_url: http://github.com/aio-libs/multidict
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
-    - HomerSimpson
-    - LukeSkywalker
+    - sodre

--- a/recipes/pytest-asyncio/meta.yaml
+++ b/recipes/pytest-asyncio/meta.yaml
@@ -1,6 +1,6 @@
-{% set name = "yarl" %}
-{% set version = "0.10.0" %}
-{% set sha256 = "d92947434946bf47e3ee2123f4ea785ea4c7d5ba37c93fd2142470868dc2a01b" %}
+{% set name = "pytest-asyncio" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "ce457148d9a8337679b19742d37f77c5e4eb53a48b626e3ce19464fa1cc25d0f" %}
 
 package:
   name: {{ name|lower }}
@@ -14,7 +14,6 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: true  # [py2k]
 
 requirements:
   build:
@@ -22,24 +21,19 @@ requirements:
     - setuptools
   run:
     - python
-    - multidict >=2.0
+    - pytest >=3.0.2
 
 test:
-  source_files:
-    - tests
-  requires:
-    - pytest
-  commands:
-    - py.test tests
+    imports:
+      - pytest_asyncio
 
 about:
-  home: http://github.com/simplejson/simplejson
+  home: http://github.com/pytest-dev/pytest-asyncio
   license: Apache 2.0
-  license_file: LICENSE
-  summary: 'Yet another URL library'
+  #license_file: LICENSE # License file is missing in package
+  summary: 'Pytest support for asyncio'
 
-  doc_url: http://yarl.readthedocs.io/
-  dev_url: https://github.com/aio-libs/yarl
+  dev_url: https://github.com/pytest-dev/pytest-asyncio
 
 extra:
   recipe-maintainers:

--- a/recipes/yarl/meta.yaml
+++ b/recipes/yarl/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "yarl" %}
+{% set version = "0.10.0" %}
+{% set sha256 = "d92947434946bf47e3ee2123f4ea785ea4c7d5ba37c93fd2142470868dc2a01b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [py2k]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - multidict >=2.0
+
+test:
+  imports:
+    - yarl
+
+about:
+  home: http://github.com/simplejson/simplejson
+  license: Apache 2.0
+  license_file: LICENSE
+  summary: 'Yet another URL library'
+
+  doc_url: http://yarl.readthedocs.io/
+  dev_url: https://github.com/aio-libs/yarl
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/yarl/meta.yaml
+++ b/recipes/yarl/meta.yaml
@@ -33,7 +33,7 @@ test:
     - py.test tests
 
 about:
-  home: http://github.com/simplejson/simplejson
+  home: https://github.com/aio-libs/yarl
   license: Apache 2.0
   license_file: LICENSE
   summary: 'Yet another URL library'


### PR DESCRIPTION
Includes dependencies:
  - aiohttp
  - async-timeout
  - multidict
  - yarl