### PR TITLE
Final level - adding r-diagrammer  r-essentials

### DIFF
--- a/recipes/r-diagrammer/bld.bat
+++ b/recipes/r-diagrammer/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-diagrammer/build.sh
+++ b/recipes/r-diagrammer/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-diagrammer/meta.yaml
+++ b/recipes/r-diagrammer/meta.yaml
@@ -16,7 +16,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [win32]
+  # r-igraph is not available for Windows
+  skip: true  # [win]
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/r-diagrammer/meta.yaml
+++ b/recipes/r-diagrammer/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.9.0' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-diagrammer
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: DiagrammeR_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/DiagrammeR_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/DiagrammeR/DiagrammeR_{{ version }}.tar.gz
+  sha256: 8f42964f6a52bfee601297cf03bef99d1568b672426d44d14c0b543ec6814626
+
+build:
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rcolorbrewer >=1.1_2
+    - r-dplyr >=0.5.0
+    - r-htmlwidgets >=0.8
+    - r-igraph >=1.0.1
+    - r-influencer >=0.1.0
+    - r-magrittr >=1.5
+    - r-rgexf >=0.15.3
+    - r-rstudioapi >=0.6
+    - r-scales >=0.4.1
+    - r-stringr >=1.1.0
+    - r-tibble >=1.2
+    - r-viridis >=0.3.4
+    - r-visnetwork >=1.0.2
+  run:
+    - r-base
+    - r-rcolorbrewer >=1.1_2
+    - r-dplyr >=0.5.0
+    - r-htmlwidgets >=0.8
+    - r-igraph >=1.0.1
+    - r-influencer >=0.1.0
+    - r-magrittr >=1.5
+    - r-rgexf >=0.15.3
+    - r-rstudioapi >=0.6
+    - r-scales >=0.4.1
+    - r-stringr >=1.1.0
+    - r-tibble >=1.2
+    - r-viridis >=0.3.4
+    - r-visnetwork >=1.0.2
+
+test:
+  commands:
+    - $R -e "library('DiagrammeR')"  # [not win]
+    - "\"%R%\" -e \"library('DiagrammeR')\""  # [win]
+
+about:
+  home: https://github.com/rich-iannone/DiagrammeR
+  license: MIT
+  summary: Create graph diagrams and flowcharts using R.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening

--- a/recipes/r-essentials/meta.yaml
+++ b/recipes/r-essentials/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "r-essentials" %}
+{% set version = "1.5.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+    string: r3.3.2_0
+
+requirements:
+    build: []
+    run:
+        - r-base
+        - r-recommended >=3.3.2
+        - r-ggplot2 >=2.2.0
+        - r-plyr >=1.8.4
+        - r-reshape2 >=1.4.2
+        - r-dplyr >=0.5.0
+        - r-tidyr >=0.6.0
+        - r-caret >=6.0_73
+        - r-randomforest >=4.6_12
+        - r-data.table >=1.10.0
+        - r-quantmod >=0.4_7
+        - r-shiny >=0.14.2
+        - r-rmarkdown >=1.3
+        - r-glmnet >=2.0_5
+        - r-jsonlite >=1.1
+        - r-zoo >=1.7_13
+        - r-irkernel >=0.7.1
+        - r-rbokeh >=0.5.0
+        - r-formatr >=1.4
+        - notebook >=4.2.3
+        - r-tidyverse >=1.0.0
+        - r-dbi >=0.5_1
+        - r-broom >=0.4.1
+        - r-forcats >=0.1.1
+        - r-haven >=1.0.0
+        - r-hms >=0.3
+        - r-httr >=1.2.1
+        - r-jsonlite >=1.1
+        - r-lubridate >=1.6.0
+        - r-magrittr >=1.5
+        - r-modelr >=0.1.0
+        - r-purrr >=0.2.2
+        - r-readr >=1.0.0
+        - r-readxl >=0.1.1
+        - r-rvest >=0.3.2
+        - r-stringr >=1.1.0
+        - r-tibble >=1.2
+        - r-tidyr >=0.6.0
+        - r-xml2 >=1.0.0
+
+test:
+  commands:
+    - $R -e "library('ggplot2')"  # [not win]
+    - $R -e "library('tibble')"  # [not win]
+    - "\"%R%\" -e \"library('ggplot2')\""  # [win]
+    - "\"%R%\" -e \"library('tibble')\""  # [win]
+
+about:
+    license: Various
+    license_family: Other
+    summary: Some essential packages for working with R. This was migrated from the 'r' channel.
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening

--- a/recipes/r-essentials/meta.yaml
+++ b/recipes/r-essentials/meta.yaml
@@ -6,6 +6,7 @@ package:
   version: {{ version }}
 
 build:
+    number: 0
     string: r3.3.2_0
 
 requirements:
@@ -59,6 +60,7 @@ test:
     - "\"%R%\" -e \"library('tibble')\""  # [win]
 
 about:
+    home: https://github.com/conda-forge/r-essentials
     license: Various
     license_family: Other
     summary: Some essential packages for working with R. This was migrated from the 'r' channel.

--- a/recipes/r-essentials/meta.yaml
+++ b/recipes/r-essentials/meta.yaml
@@ -6,11 +6,11 @@ package:
   version: {{ version }}
 
 build:
-    number: 0
-    string: r3.3.2_0
+  # r-rbokeh is not available under Windows
+  skip: true  # [win]
+  number: 0
 
 requirements:
-    build: []
     run:
         - r-base
         - r-recommended >=3.3.2
@@ -60,7 +60,7 @@ test:
     - "\"%R%\" -e \"library('tibble')\""  # [win]
 
 about:
-    home: https://github.com/conda-forge/r-essentials
+    home: https://github.com/conda-forge/r-essentials-feedstock
     license: Various
     license_family: Other
     summary: Some essential packages for working with R. This was migrated from the 'r' channel.

--- a/recipes/r-gsubfn/bld.bat
+++ b/recipes/r-gsubfn/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-gsubfn/build.sh
+++ b/recipes/r-gsubfn/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-gsubfn/meta.yaml
+++ b/recipes/r-gsubfn/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.6-6' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-gsubfn
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: gsubfn_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/gsubfn_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/gsubfn/gsubfn_{{ version }}.tar.gz
+  sha256: bbc5d29bb48e836407f81880aeb368544a54a5513dacb3411c9838180723dda4
+
+build:
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-proto
+  run:
+    - r-base
+    - r-proto
+
+test:
+  commands:
+    - $R -e "library('gsubfn')"  # [not win]
+    - "\"%R%\" -e \"library('gsubfn')\""  # [win]
+
+about:
+  home: http://gsubfn.googlecode.com
+  license: GPL (>= 2)
+  summary: |
+    gsubfn is like gsub but can take a replacement function or certain other objects instead
+    of the replacement string. Matches and back references are input to the replacement
+    function and  replaced by the function output.   gsubfn can be used to split strings  based
+    on content rather than delimiters and for quasi-perl-style string  interpolation.
+    The package also has facilities for translating formulas  to functions and allowing
+    such formulas in function calls instead of  functions.  This can be used with R
+    functions such as apply, sapply, lapply, optim, integrate, xyplot, Filter and any
+    other function that  expects another function as an input argument or functions
+    like cat or sql calls that may involve strings where substitution is desirable.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening

--- a/recipes/r-rgexf/bld.bat
+++ b/recipes/r-rgexf/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-rgexf/build.sh
+++ b/recipes/r-rgexf/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-rgexf/meta.yaml
+++ b/recipes/r-rgexf/meta.yaml
@@ -1,0 +1,62 @@
+{% set version = '0.15.3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rgexf
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: rgexf_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/rgexf_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/rgexf/rgexf_{{ version }}.tar.gz
+  sha256: 2e8a7978d1fb977318e6310ba65b70a9c8890185c819a7951ac23425c6dc8147
+
+build:
+  number: 0
+  # r-igraph is not available under Windows
+  skip: true  # [win]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rook
+    - r-xml
+    - r-igraph
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+  run:
+    - r-base
+    - r-rook
+    - r-xml
+    - r-igraph
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('rgexf')"  # [not win]
+    - "\"%R%\" -e \"library('rgexf')\""  # [win]
+
+about:
+  home: http://bitbucket.org/gvegayon/rgexf, http://www.ggvega.com
+  license: GPL (>= 3)
+  summary: |
+    Create, read and write GEXF (Graph Exchange XML Format) graph files (used in Gephi
+    and others). Using the XML package, it allows the user to easily build/read graph
+    files including attributes, GEXF viz attributes (such as color, size, and position),
+    network dynamics (for both edges and nodes) and edge weighting. Users can build/handle
+    graphs element-by-element or massively through data-frames, visualize the graph
+    on a web browser through "sigmajs" (a javascript library) and interact with the
+    igraph package.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening

--- a/recipes/r-rook/bld.bat
+++ b/recipes/r-rook/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-rook/build.sh
+++ b/recipes/r-rook/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-rook/meta.yaml
+++ b/recipes/r-rook/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = '1.1-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rook
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: Rook_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/Rook_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/Rook/Rook_{{ version }}.tar.gz
+  sha256: 00f4ecfa4c5c57018acbb749080c07154549a6ecaa8d4130dd9de79427504903
+
+build:
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-brew
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+  run:
+    - r-base
+    - r-brew
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('Rook')"  # [not win]
+    - "\"%R%\" -e \"library('Rook')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=Rook
+  license: GPL-2
+  summary: |
+    This package contains the Rook specification and convenience software for building
+    and running Rook applications. To get started, be sure and read the 'Rook' help
+    file first.
+  license_family: GPL2
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening

--- a/recipes/r-sqldf/bld.bat
+++ b/recipes/r-sqldf/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-sqldf/build.sh
+++ b/recipes/r-sqldf/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-sqldf/meta.yaml
+++ b/recipes/r-sqldf/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '0.4-10' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-sqldf
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: sqldf_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/sqldf_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/sqldf/sqldf_{{ version }}.tar.gz
+  sha256: 0786f09cb14174423c2e624be0f844a23ec8dd717403fcf760ebc9375ede1e59
+
+build:
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-dbi >=0.2_5
+    - r-rsqlite >=1.0.0
+    - r-chron
+    - r-gsubfn >=0.6
+    - r-proto
+
+  run:
+    - r-base
+    - r-dbi >=0.2_5
+    - r-rsqlite >=1.0.0
+    - r-chron
+    - r-gsubfn >=0.6
+    - r-proto
+
+test:
+  commands:
+    - $R -e "library('sqldf')"  # [not win]
+    - "\"%R%\" -e \"library('sqldf')\""  # [win]
+
+about:
+  home: http://sqldf.googlecode.com
+  license: GPL-2
+  summary: |
+    Description: Manipulate R data frames using SQL.
+  license_family: GPL2
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening


### PR DESCRIPTION
This will add the last packages from https://github.com/conda-forge/staged-recipes/issues/2009 and will fix it. With this the migration from the r-channel to conda-forge should be completed.

* r-diagrammer
* r-essentials

![image](https://cloud.githubusercontent.com/assets/469983/25683244/903ec1a0-305b-11e7-9999-3d609069a3c0.png)

As a small bonus this will add `r-gsubfn` and `r-sqldf` for @chambm!