### PR TITLE
Add r-ncdf4, r-rerddap, and r-xtractomatic

### DIFF
--- a/recipes/r-ncdf4/meta.yaml
+++ b/recipes/r-ncdf4/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [win32]
+  # ncdf.c:3:20: fatal error: netcdf.h: No such file or directory
+  skip: True  # [win]
   script: R CMD INSTALL --configure-args="--with-nc-config={{ PREFIX }}/bin/nc-config" --build .
   rpaths:
     - lib/R/lib/

--- a/recipes/r-ncdf4/meta.yaml
+++ b/recipes/r-ncdf4/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '1.15' %}
+
+package:
+  name: r-ncdf4
+  version: {{ version }}
+
+source:
+  fn: ncdf4_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/ncdf4_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/ncdf4/ncdf4_{{ version }}.tar.gz
+  sha256: d58298f4317c6c80a041a70216126492fd09ba8ecde9da09d5145ae26f324d4d
+
+build:
+  number: 0
+  skip: True  # [win32]
+  script: R CMD INSTALL --configure-args="--with-nc-config={{ PREFIX }}/bin/nc-config" --build .
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - posix  # [win64]
+    - m2w64-toolchain  # [win64]
+    - gcc  # [not win]
+    - libnetcdf 4.4.*
+  run:
+    - r-base
+    - libnetcdf 4.4.*
+
+test:
+  commands:
+    - R -e "library('ncdf4')"  # [not win]
+    - R -e \"library('ncdf4')\"  # [win]
+
+about:
+  home: http://cirrus.ucsd.edu/~pierce/ncdf
+  license: GPL-3.0
+  summary: "Provides a high-level R interface to  data files written using Unidata's netCDF library
+    (version 4 or earlier), which are binary data files that are portable  across platforms
+    and include metadata information in addition to the data sets.   Using this package,
+    netCDF files (either version 4  or 'classic' version 3) can be opened and data sets
+    read in easily. It is also easy to create new netCDF dimensions, variables, and
+    files, in either version 3 or 4 format, and manipulate existing netCDF files. This
+    package replaces the former ncdf package, which only worked with netcdf version
+    3 files.  For various reasons the names of the functions have had to be changed
+    from the names in the ncdf package.  The old ncdf package is still available at
+    the URL given below, if you need to have backward compatibility. It should be possible
+    to have both the ncdf and ncdf4 packages installed simultaneously without a problem.
+    However, the ncdf package does not provide an interface for netcdf version 4 files."
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/r-rerddap/meta.yaml
+++ b/recipes/r-rerddap/meta.yaml
@@ -1,0 +1,57 @@
+{% set version = '0.3.4' %}
+
+package:
+  name: r-rerddap
+  version: {{ version }}
+
+source:
+  fn: rerddap-{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/rerddap_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/rerddap/rerddap_{{ version }}.tar.gz
+  sha256: 60acdd2a551e9737c2c5edabbee71e9d88a03b66fa081472c169b41904c5cce5
+
+build:
+  number: 0
+  skip: True  # [win32]
+  script: R CMD INSTALL --build .
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-data.table
+    - r-digest
+    - r-dplyr
+    - r-httr >=1.0.0
+    - r-jsonlite >=0.9.17
+    - r-ncdf4
+    - r-xml2
+  run:
+    - r-base
+    - r-data.table
+    - r-digest
+    - r-dplyr
+    - r-httr >=1.0.0
+    - r-jsonlite >=0.9.17
+    - r-ncdf4
+    - r-xml2
+
+test:
+  commands:
+    - R -e "library('rerddap')"  # [not win]
+    - R -e \"library('rerddap')\"  # [win]
+
+about:
+  home: https://github.com/ropensci/rerddap
+  license: MIT
+  license_file: LICENSE
+  summary: "General purpose R client for 'ERDDAP' servers. Includes functions to search for
+    'datasets', get summary information on 'datasets', and fetch 'datasets', in
+    either 'csv' or 'netCDF' format. 'ERDDAP' information: http://upwell.pfeg.noaa.gov/erddap/information.html."
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/r-rerddap/meta.yaml
+++ b/recipes/r-rerddap/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [win32]
+  # No r-ncdf4 on Windows yet.
+  skip: True  # [win]
   script: R CMD INSTALL --build .
   rpaths:
     - lib/R/lib/

--- a/recipes/r-xtractomatic/meta.yaml
+++ b/recipes/r-xtractomatic/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = '3.2.0' %}
+
+package:
+  name: r-xtractomatic
+  version: {{ version }}
+
+source:
+  fn: xtractomatic_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/xtractomatic_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/xtractomatic/xtractomatic_{{ version }}.tar.gz
+  sha256: a0679f32e77279a6ecf0526c2139eb00ba3194dcc91d73a4dfce00733c7af611
+
+build:
+  number: 0
+  skip: True  # [win32]
+  script: R CMD INSTALL --build .
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-httr
+    - r-ncdf4
+    - r-sp
+  run:
+    - r-base
+    - r-httr
+    - r-ncdf4
+    - r-sp
+
+test:
+  commands:
+    - R -e "library('xtractomatic')"  # [not win]
+    - R -e \"library('xtractomatic')\"  # [win]
+
+about:
+  home: https://github.com/rmendels/xtractomatic
+  license: CC0
+  summary: "Contains three functions that access environmental data from ERD's ERDDAP service
+    <http://coastwatch.pfeg.noaa.gov/erddap>. The xtracto() function extracts data along
+    a trajectory for a given 'radius' around the point. The xtracto_3D() function extracts
+    data in a box. The xtractogon() function extracts data in a polygon. There are also
+    two helper functions to obtain information about available data."
+  license_family: OTHER
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/r-xtractomatic/meta.yaml
+++ b/recipes/r-xtractomatic/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [win32]
+  # No r-ncdf4 on Windows yet.
+  skip: True  # [win]
   script: R CMD INSTALL --build .
   rpaths:
     - lib/R/lib/


### PR DESCRIPTION
Note to self: skipping Windows because I could not make `r-ncdf4` find the netcdf headers:

```
** libs
C:/bld/r-ncdf4_1494001584063/_b_env/R/../Library/mingw-w64/bin/gcc  -I"C:/bld/r-ncdf4_1494001584063/_b_env/R/include" -DNDEBUG     -I"C:/bld/r-ncdf4_1494001584063/_b_env/R/../Library/mingw-w64/include"     -O2 -Wall  -std=gnu99 -march=x86-64 -mtune=generic -c ncdf.c -o ncdf.o
ncdf.c:3:20: fatal error: netcdf.h: No such file or directory
compilation terminated.
C:/bld/r-ncdf4_1494001584063/_b_env/R/etc/x64/Makeconf:181: recipe for target 'ncdf.o' failed
make: *** [ncdf.o] Error 1
Warning: running command 'make -f "Makevars.win" -f "C:/bld/r-ncdf4_1494001584063/_b_env/R/etc/x64/Makeconf" -f "C:/bld/r-ncdf4_1494001584063/_b_env/R/share/make/winshlib.mk" SHLIB="ncdf4.dll" WIN=64 TCLBIN=64 OBJECTS="ncdf.o ncdf2.o ncdf3.o src_ncdf4.o"' had status 2
ERROR: compilation failed for package 'ncdf4'
* removing 'C:/bld/r-ncdf4_1494001584063/_b_env/R/library/ncdf4'
```

full log: https://ci.appveyor.com/project/ocefpaf/staged-recipes/build/1.0.376/job/svx1et65m0l8awb4

@mingwandroid any advice on how to help `r-ncdf4` to find `netcdf.h`? Not sure how to specify that in the Windows `script` call. (Maybe exporting `LIBRARY_INC`?)