### PR TITLE
Added recipe for zopfli

### DIFF
--- a/recipes/zopfli/meta.yaml
+++ b/recipes/zopfli/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "zopfli" %}
+{% set version = "0.1.1" %}
+{% set bundle = "zip" %}
+{% set hash_type = "sha256" %}
+{% set hash = "54f1fe2580f7142cd3e76720916e3e343a3280c4605aa12387077ebc5b845cd3" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+
+  run:
+    - python
+
+test:
+  imports:
+    - zopfli
+
+about:
+  home: https://github.com/obp/zopfli
+  license_file: COPYING
+  license: Apache 2.0
+  license_family: Apache
+  summary: 'Zopfli module for python'
+  dev_url: https://github.com/obp/zopfli
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
cPython bindings for Google's [`zopfli`](https://developers.googleblog.com/2013/02/compress-data-more-densely-with-zopfli.html). Used by [`fonttools`](https://github.com/fonttools/fonttools).