### PR TITLE
Add zstandard recipe.

### DIFF
--- a/recipes/zstandard/bld.bat
+++ b/recipes/zstandard/bld.bat
@@ -1,0 +1,6 @@
+
+:: Existing egg_info directory causes failure in windows.
+rd /s /q zstandard.egg-info
+
+%PYTHON% setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/recipes/zstandard/build.sh
+++ b/recipes/zstandard/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/recipes/zstandard/meta.yaml
+++ b/recipes/zstandard/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "zstandard" %}
+{% set version = "0.8.1" %}
+{% set sha256hash = "d8df3b40fed5c0a5d15b36e698b0286323170086b2034e5d52465fa3c1ce2429" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256hash }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - toolchain  # [unix]
+    - python
+    - setuptools
+    - cffi >=1.8
+  run:
+    - python
+    - cffi >=1.8
+
+about:
+  home: https://github.com/indygreg/python-zstandard
+  license: BSD 3-Clause
+  summary: "Zstandard bindings for Python"
+  description: |
+    This project provides Python bindings for interfacing with the
+    Zstandard compression library. A C extension and CFFI interface are
+    provided.
+  doc_url: https://github.com/indygreg/python-zstandard/blob/master/README.rst#python-zstandard
+  dev_url: https://github.com/indygreg/python-zstandard
+
+extra:
+  recipe-maintainers:
+    - rolando

--- a/recipes/zstandard/run_test.py
+++ b/recipes/zstandard/run_test.py
@@ -1,0 +1,8 @@
+import zstd
+
+data = b'foo'
+
+compress = zstd.ZstdCompressor(write_checksum=True, write_content_size=True).compress
+decompress = zstd.ZstdDecompressor().decompress
+
+assert decompress(compress(data)) == data


### PR DESCRIPTION
Notes: license file and tests are missing from the source distribution, see https://github.com/indygreg/python-zstandard/pull/22