### PR TITLE
add python-seabreeze to conda-forge

### DIFF
--- a/recipes/python-seabreeze/bld.bat
+++ b/recipes/python-seabreeze/bld.bat
@@ -1,0 +1,31 @@
+REM download and compile libseabreeze
+cd extra\libseabreeze\SeaBreeze
+if %ARCH% == 32 (
+  set SBARCH=Win32
+  set WDDKSBPATH="C:\\WinDDK\\7600.16385.1\\lib\\wxp\\i386"
+  set SBPATH="os-support\\windows\\VisualStudio2008\\VSProj\\"
+) else (
+  set SBARCH=x64
+  set WDDKSBPATH="C:\\WinDDK\\7600.16385.1\\lib\\wlh\\amd64"
+  set SBPATH="os-support\\windows\\VisualStudio2008\\VSProj\\x64\\"
+)
+REM update the old project files
+if %VS_MAJOR% == 9 (
+  REM py27
+  vcbuild.exe /platform:%SBARCH% "os-support\\windows\\VisualStudio2008\\VSProj\\SeaBreeze.vcproj" Release
+  cp "%SBPATH%Release\\SeaBreeze.dll" %LIBRARY_BIN%
+  cp "%SBPATH%Release\\SeaBreeze.lib" %LIBRARY_LIB%
+) else (
+  REM py35 py36
+  msbuild.exe /t:SeaBreeze /p:Configuration=Release /p:Platform=%SBARCH% "os-support\\windows\\VisualStudio2015\\SeaBreeze.sln"
+  cp lib\SeaBreeze.dll %LIBRARY_BIN%
+  cp lib\SeaBreeze.lib %LIBRARY_LIB%
+)
+cd ../../..
+REM at this stage it needs to be in 
+"%PYTHON%" setup.py build_ext --library-dirs="%LIBRARY_LIB%;%WDDKSBPATH%"
+if errorlevel 1 exit 1
+"%PYTHON%" setup.py build
+if errorlevel 1 exit 1
+"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
+if errorlevel 1 exit 1

--- a/recipes/python-seabreeze/build.sh
+++ b/recipes/python-seabreeze/build.sh
@@ -1,0 +1,15 @@
+# download and compile libseabreeze
+cd extra/libseabreeze/SeaBreeze
+if [ "$(uname)" == "Darwin" ]; then
+    echo "Platform: Mac"
+    make logger=0 install_name="${PREFIX}/lib/libseabreeze${SHLIB_EXT}" lib/libseabreeze${SHLIB_EXT}
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    echo "Platform: Linux"
+    # we need libusb headers on circleci
+    yum install -y libusb-devel
+    make logger=0 lib/libseabreeze${SHLIB_EXT}
+fi
+cd ../../..
+cp extra/libseabreeze/SeaBreeze/lib/libseabreeze${SHLIB_EXT} ${PREFIX}/lib
+# the shared object should have been copied to "${PREFIX}/lib"
+python setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/python-seabreeze/meta.yaml
+++ b/recipes/python-seabreeze/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "python-seabreeze" %}
+{% set version = "0.6.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/ap--/python-seabreeze.git
+  git_rev: python-seabreeze-v{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+    - cython
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - seabreeze
+    - seabreeze.cseabreeze
+
+about:
+  home: http://github.com/ap--/python-seabreeze
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: 'Python module for Ocean Optics spectrometer'
+
+extra:
+  recipe-maintainers:
+    - ap--


### PR DESCRIPTION
This adds python-seabreeze to conda-forge and tries to include the c-backend library into the same conda package.