### PR TITLE
WIP: add scram

### DIFF
--- a/recipes/scram/bld.bat
+++ b/recipes/scram/bld.bat
@@ -1,0 +1,17 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "%CMAKE_GENERATOR%" ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DBUILD_GUI=OFF ^
+    -DBUILD_TESTS=OFF ^
+    -DBUILD_SHARED_LIBS=OFF ^
+    -DINSTALL_LIBS=OFF ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    ..
+
+cmake --build . --config Release
+
+cmake --build . --config Release --target install

--- a/recipes/scram/build.sh
+++ b/recipes/scram/build.sh
@@ -1,0 +1,12 @@
+mkdir build && cd build
+cmake \
+    -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DBUILD_GUI=OFF \
+    -DBUILD_TESTS=OFF \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DINSTALL_LIBS=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
+    ..
+
+make -j$CPU_COUNT
+make install

--- a/recipes/scram/meta.yaml
+++ b/recipes/scram/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "scram" %}
+{% set version = "0.13.0" %}
+{% set sha256 = "01c4c3cd98e4a197e2b71b85f3953896e75030f5b70970b65fa5a67dbbdc532a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ version }}.tar.gz
+  url: https://github.com/rakhimov/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  features:
+    - vc14  # [win]
+
+requirements:
+  build:
+    - boost >=1.58.0
+    - libxmlpp >=1.38.1
+    - jemalloc
+    - cmake >=2.8.12
+    - toolchain
+  run:
+    - boost >=1.58.0
+    - libxmlpp >=1.38.1
+    - jemalloc
+
+test:
+  commands:
+    - scram --help
+    - scram --version
+
+about:
+  home: https://github.com/rakhimov/scram
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'Probabilistic Risk Analysis Tool'
+
+  description: |
+    A command line probabilistic risk analysis tool
+    capable of performing event tree analysis,
+    static fault tree analysis,
+    analysis with common cause failure models,
+    probability calculations with importance analysis,
+    and uncertainty analysis with Monte Carlo simulations.
+  doc_url: https://scram-pra.org
+  dev_url: https://github.com/rakhimov/scram
+
+extra:
+  recipe-maintainers:
+    - rakhimov


### PR DESCRIPTION
Does build/run depends detect sub-dependencies automatically or do I have to least 'dependencies of dependencies' manually?
Is it possible to make it so that runtime dependencies are discovered automatically (like with ldd)
without duplicating things in meta.yml?