### PR TITLE
Colormath (PyPI)

### DIFF
--- a/recipes/colormath/meta.yaml
+++ b/recipes/colormath/meta.yaml
@@ -19,11 +19,10 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy x.x
 
   run:
     - python
-    - numpy x.x
+    - numpy
     - networkx
 
 test:

--- a/recipes/colormath/meta.yaml
+++ b/recipes/colormath/meta.yaml
@@ -1,0 +1,47 @@
+
+{% set name = "colormath" %}
+{% set version = "2.1.1" %}
+{% set sha256 = "003a2b2d9c1f43aa7d90addf1863fb2d822463c839b1166ae3092950792f9707" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+    - networkx
+
+  run:
+    - python
+    - numpy x.x
+    - networkx
+
+test:
+  imports:
+    - colormath
+
+about:
+  home: https://github.com/gtaylor/python-colormath
+  summary: 'Color math and conversion library.'
+  description: |
+    This module implements a large number of different
+    color operations such as color space conversions,
+    Delta E, and density to spectral.
+  license: BSD
+  license_family: BSD
+
+extra:
+  recipe-maintainers:
+    - ewels

--- a/recipes/colormath/meta.yaml
+++ b/recipes/colormath/meta.yaml
@@ -1,4 +1,3 @@
-
 {% set name = "colormath" %}
 {% set version = "2.1.1" %}
 {% set sha256 = "003a2b2d9c1f43aa7d90addf1863fb2d822463c839b1166ae3092950792f9707" %}
@@ -21,7 +20,6 @@ requirements:
     - python
     - setuptools
     - numpy x.x
-    - networkx
 
   run:
     - python
@@ -41,6 +39,9 @@ about:
     Delta E, and density to spectral.
   license: BSD
   license_family: BSD
+  license_file: LICENSE.txt
+  dev_url: https://github.com/gtaylor/python-colormath
+  doc_url: http://python-colormath.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Package for [colormath](https://github.com/gtaylor/python-colormath) - a python module that abstracts common color math operations. For example, converting from CIE L*a*b to XYZ, or from RGB to CMYK