### PR TITLE
Add the lzstring package, which will be needed by multiQC

### DIFF
--- a/recipes/lzstring/bld.bat
+++ b/recipes/lzstring/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install 
+if errorlevel 1 exit 1

--- a/recipes/lzstring/build.sh
+++ b/recipes/lzstring/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON setup.py install 

--- a/recipes/lzstring/meta.yaml
+++ b/recipes/lzstring/meta.yaml
@@ -10,7 +10,10 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash_val }}
+  md5: {{ hash_val }}
+
+build:
+  number: 0
 
 requirements:
   build:
@@ -28,7 +31,7 @@ test:
 
 about:
   home: https://github.com/gkovacs/lz-string-python
-  license: MIT License
+  license: MIT
   summary: 'lz-string for python'
   license_family: MIT
 

--- a/recipes/lzstring/meta.yaml
+++ b/recipes/lzstring/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: lzstring
+  version: "1.0.3"
+
+source:
+  fn: lzstring-1.0.3.tar.gz
+  url: https://pypi.python.org/packages/2b/e0/06231b1114cae946b6d3505ab8157f7308b207e3f8e3eb58334769dab6c0/lzstring-1.0.3.tar.gz
+  md5: 1c636543484629020a26432740f81443
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - future
+
+  run:
+    - python
+    - future
+
+test:
+  imports:
+    - lzstring
+
+about:
+  home: https://github.com/gkovacs/lz-string-python
+  license: MIT License
+  summary: 'lz-string for python'
+  license_family: MIT

--- a/recipes/lzstring/meta.yaml
+++ b/recipes/lzstring/meta.yaml
@@ -1,11 +1,16 @@
+{%set name = "lzstring" %}
+{%set version = "1.0.3" %}
+{%set hash_type = "md5sum" %}
+{%set hash_val = "1c636543484629020a26432740f81443" %}
+
 package:
-  name: lzstring
-  version: "1.0.3"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  fn: lzstring-1.0.3.tar.gz
-  url: https://pypi.python.org/packages/2b/e0/06231b1114cae946b6d3505ab8157f7308b207e3f8e3eb58334769dab6c0/lzstring-1.0.3.tar.gz
-  md5: 1c636543484629020a26432740f81443
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash_val }}
 
 requirements:
   build:
@@ -26,3 +31,7 @@ about:
   license: MIT License
   summary: 'lz-string for python'
   license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - dpryan79


### PR DESCRIPTION
This adds the lzstring package from pypi. This will be needed as a dependency for a few packages (e.g., multiQC).

The files are essentially the output of `conda skeleton pypi`.