### PR TITLE
Add case 1.5.3 to conda-forge

### DIFF
--- a/recipes/case/meta.yaml
+++ b/recipes/case/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "case" %}
+{% set version = "1.5.3" %}
+{% set sha256 = "48432b01d91913451c3512c5b90e31b0f348f1074b166a3431085eb70d784fb1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - six
+    - nose >=1.3.7
+    - unittest2 >=0.5.1  # [py26]
+    - mock >=2.0.0
+
+test:
+  imports:
+    - case
+
+about:
+  home: http://github.com/celery/case
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python unittest Utilities'
+
+  doc_url: http://case.readthedocs.io/
+  dev_url: https://github.com/celery/case
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
case is a set of python unittest utils.
It is used for running celery unit-tests