### PR TITLE
[WIP] Add airflow extras to conda-forge.

### DIFF
--- a/recipes/airflow-with-celery/meta.yaml
+++ b/recipes/airflow-with-celery/meta.yaml
@@ -1,0 +1,31 @@
+{% set name = "airflow-with-celery" %}
+{% set version = "1.8.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: True  # [py3k or win]
+
+requirements:
+  run:
+    - airflow 1.8.0
+    - celery >=3.1.17
+    - flower >=0.7.3
+
+test:
+  commands:
+    - true
+
+about:
+  home: http://github.com/conda-forge/airflow-feedstock
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'airflow[celery] extra'
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
This PR will bring the first wave of airflow extras (conda metapackages) that can be resolved without adding additional packages to conda-forge. This was promised in PR #2882