### PR TITLE
Add OOMMFODT recipe

### DIFF
--- a/recipes/oommfodt/meta.yaml
+++ b/recipes/oommfodt/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = "0.7.1" %}
+{% set name = "oommfodt" %}
+{% set sha256 = "ec21c2878c79a562498117bf2d5a5e3e9157daf933c60fde0cbbf4a0976aa110" %}
+
+package:
+  name: {{ name | lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: pip install --no-deps .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - pandas
+
+test:
+  imports:
+    - oommfodt
+
+about:
+  home: http://joommf.github.io/
+  license: BSD 3-clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Reading and analysing OOMMF odt files
+  # license_file: LICENSE
+  doc_url: http://oommfodt.readthedocs.io
+  dev_url: https://github.com/joommf/oommfodt
+
+  description: |
+    oommfodt provides tools to read Ooommf Data Table files (ODT)
+    files.
+    It is part of the Jupyter-OOMMF project (https://github.com/joommf
+    and http://joommf.github.io).
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - fangohr
+    - mb1a15
+    - takluyver
+    - davidcortesortuno

--- a/recipes/oommfodt/meta.yaml
+++ b/recipes/oommfodt/meta.yaml
@@ -31,9 +31,8 @@ about:
   home: http://joommf.github.io/
   license: BSD 3-clause
   license_family: BSD
-  license_file: LICENSE
-  summary: Reading and analysing OOMMF odt files
   # license_file: LICENSE
+  summary: Reading and analysing OOMMF odt files
   doc_url: http://oommfodt.readthedocs.io
   dev_url: https://github.com/joommf/oommfodt
 

--- a/recipes/oommfodt/meta.yaml
+++ b/recipes/oommfodt/meta.yaml
@@ -44,8 +44,6 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - fangohr
     - mb1a15
     - takluyver

--- a/recipes/oommfodt/meta.yaml
+++ b/recipes/oommfodt/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "0.7.1" %}
+{% set version = "0.7.2" %}
 {% set name = "oommfodt" %}
-{% set sha256 = "ec21c2878c79a562498117bf2d5a5e3e9157daf933c60fde0cbbf4a0976aa110" %}
+{% set sha256 = "4a578871c4ee2aa9fa6f77fd98c0afae566147d2d47be77ff15b46e379d7a8dd" %}
 
 package:
   name: {{ name | lower }}
@@ -31,7 +31,7 @@ about:
   home: http://joommf.github.io/
   license: BSD 3-clause
   license_family: BSD
-  # license_file: LICENSE
+  license_file: LICENSE
   summary: Reading and analysing OOMMF odt files
   doc_url: http://oommfodt.readthedocs.io
   dev_url: https://github.com/joommf/oommfodt
@@ -48,3 +48,4 @@ extra:
     - mb1a15
     - takluyver
     - davidcortesortuno
+    - rpep


### PR DESCRIPTION
`oommfodt` provides tools to read Oommf Data Table files (ODT) files. It is part of the Jupyter-OOMMF project (https://github.com/joommf and http://joommf.github.io), and we like to use conda to distribute it.

OOMMF is a simulation code for magnetic materials research, and in this project, we provide access to it through the Jupyter Notebook. 

The list of all conda packages from Jupyter-OOMMF is visible at https://github.com/joommf/conda-recipes, and we hope to get all of those 11 merged into conda forge.
