### PR TITLE
Use gh.get_rate_limit()

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -98,7 +98,7 @@ def print_rate_limiting_info(gh):
     # spending it and how to better optimize it.
 
     # Get GitHub API Rate Limit usage and total
-    gh_api_remaining, gh_api_total = gh.rate_limiting
+    gh_api_remaining, gh_api_total = gh.get_rate_limit()
 
     # Compute time until GitHub API Rate Limit reset
     gh_api_reset_time = gh.rate_limiting_resettime


### PR DESCRIPTION
gh.rate_limiting gives the rate limit from the last github call
if there was one, but the remaining calls is depleted by external
parties like travis-ci and appveyor during the last github call
and the printing of the rate limit.

gh.get_rate_limit() on the other hand makes a github API call
which decreases the remaining number, but gives an accurate number