### PR TITLE
Add recipe for elektronn2

### DIFF
--- a/recipes/elektronn2/meta.yaml
+++ b/recipes/elektronn2/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "elektronn2" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "87484e4ef199144e0959a0574c4340d71800419ce99f24e106d04142bb1e9238" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/e/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: True  # [not linux64]
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - theano <0.10
+    - numpy
+    - scipy
+    - matplotlib
+    - scikit-learn
+    - scikit-image
+    - h5py
+    - future
+    - tqdm
+    - numba
+    - colorlog
+    - pydotplus
+    - seaborn
+    - prompt_toolkit
+    - jedi
+    - psutil
+    - ipython
+
+test:
+  imports:
+    - elektronn2
+    - elektronn2.data
+    - elektronn2.neuromancer
+    - elektronn2.training
+    - elektronn2.utils
+  commands:
+    - elektronn2-train --help
+
+about:
+  home: http://elektronn2.readthedocs.io/en/latest/elektronn2.html
+  license: GPLv3
+  license_file: LICENSE.txt
+  summary: 'A highly configurable toolkit for training 3d/2d CNNs and general Neural Networks'
+  doc_url: http://elektronn2.readthedocs.io/en/latest/
+  dev_url: https://github.com/ELEKTRONN/ELEKTRONN2
+
+extra:
+  recipe-maintainers:
+    - mdraw


### PR DESCRIPTION
ELEKTRONN2 is a flexible and extensible Python toolkit that facilitates design, training and application of neural networks. It can be used for general machine learning tasks, but its main focus is on convolutional neural networks (CNNs) for high-throughput 3D and 2D image analysis.

ELEKTRONN2 is a complete rewrite with a much more flexible API and many more features than ELEKTRONN 1.0 (legacy), which  already [is in conda-forge](https://github.com/conda-forge/elektronn-feedstock).