### PR TITLE
discretisedfield

### DIFF
--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   build:
     - python
     - pip
-    - numpy
+    - numpy >=1.11
     - pandas
     - matplotlib
     - pyvtk
@@ -27,7 +27,7 @@ requirements:
 
   run:
     - python
-    - numpy
+    - numpy  >=1.11
     - pandas
     - matplotlib
     - pyvtk

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py27]
   number: 0
   script: pip install --no-deps .
 

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -39,7 +39,7 @@ test:
     - discretisedfield
     - discretisedfield.util
     - discretisedfield.mesh
-    - discretisedfield.test
+    - discretisedfield.tests
 
 about:
   home: http://joommf.github.io/

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -1,0 +1,65 @@
+{% set version = "0.7.2" %}
+{% set name = "discretisedfield" %}
+{% set sha256 = "120db86c46cbaaa8149f2e380b442642" %}
+
+package:
+  name: {{ name | lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: pip install --no-deps .
+
+requirements:
+  build:
+    - python
+    - pip
+    - joommfutil
+    - numpy
+    - pandas
+    - matplotlib
+    - pyvtk
+
+  run:
+    - python
+    - numpy
+    - pandas
+    - matplotlib
+    - pyvtk
+    - joommfutil
+
+test:
+  imports:
+    - discretisedfield
+    - discretisedfield.util
+    - discretisedfield.mesh
+    - discretisedfield.test
+
+about:
+  home: http://joommf.github.io/
+  license: BSD 3-clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Reading and analysing OOMMF odt files
+  doc_url: http://discretisedfield.readthedocs.io
+  dev_url: https://github.com/joommf/discretisedfield
+
+  description: |
+    discretisedfield provides a class to represent (finite difference)
+    discretisation of a field (in the continuum field theory context).
+
+    It is part of the Jupyter-OOMMF project (https://github.com/joommf
+    and http://joommf.github.io).
+
+extra:
+  recipe-maintainers:
+    - fangohr
+    - mb1a15
+    - takluyver
+    - davidcortesortuno
+    - rpep

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "0.7.2" %}
 {% set name = "discretisedfield" %}
-{% set sha256 = "120db86c46cbaaa8149f2e380b442642" %}
+{% set sha256 = "e52c78f72f181edd328872e541564e0a4bee17d73d575111360574032fdf992c" %}
 
 package:
   name: {{ name | lower }}

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -39,7 +39,6 @@ test:
     - discretisedfield
     - discretisedfield.util
     - discretisedfield.mesh
-    - discretisedfield.tests
 
 about:
   home: http://joommf.github.io/

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -19,11 +19,11 @@ requirements:
   build:
     - python
     - pip
-    - joommfutil
     - numpy
     - pandas
     - matplotlib
     - pyvtk
+    - joommfutil
 
   run:
     - python

--- a/recipes/discretisedfield/meta.yaml
+++ b/recipes/discretisedfield/meta.yaml
@@ -20,11 +20,6 @@ requirements:
   build:
     - python
     - pip
-    - numpy >=1.11
-    - pandas
-    - matplotlib
-    - pyvtk
-    - joommfutil
 
   run:
     - python


### PR DESCRIPTION
`discretisedfield` provides a (Python) class to represent (finite difference)  discretisation of a field (in the continuum field theory context).

It is part of the Jupyter-OOMMF project (https://github.com/joommf and http://joommf.github.io).