### PR TITLE
Fix yaml issue in recipe rebound

### DIFF
--- a/recipes/rebound/meta.yaml
+++ b/recipes/rebound/meta.yaml
@@ -46,6 +46,6 @@ about:
 
 extra:
   recipe-maintainers:
-    -ACBlock
-    -mwcraig
-    -hannorein
+    - ACBlock
+    - mwcraig
+    - hannorein


### PR DESCRIPTION
Was missing a space after the `-`s in the `recipe-maintainer`'s list. This adds that missing space to correct the recipe and make it parsable.

xref: https://github.com/conda-forge/staged-recipes/pull/3024
xref: https://github.com/conda-forge/staged-recipes/pull/3024#discussion_r118967539

cc @mwcraig @isuruf @ACBlock