### PR TITLE
Added recipe for jsonlines

### DIFF
--- a/recipes/jsonlines/meta.yaml
+++ b/recipes/jsonlines/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "jsonlines" %}
+{% set version = "1.1.0" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "7cd2cce7415861cfe5cdcf6bb484c93bed35e23447e8f338c1bd150f766c0f1b" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - jsonlines
+
+about:
+  home: https://github.com/wbolster/jsonlines
+  # license_file: No license in repository - see https://github.com/wbolster/jsonlines/issues/27
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: 'Library with helpers for the jsonlines file format'
+  dev_url: https://github.com/wbolster/jsonlines
+  doc_url: https://jsonlines.readthedocs.org/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
`jsonlines` is an interface for working with `jsonlines` and is used, far upstream, by `datadotworld`