### PR TITLE
python-casacore

### DIFF
--- a/recipes/python-casacore/boost-python.patch
+++ b/recipes/python-casacore/boost-python.patch
@@ -1,0 +1,13 @@
+--- a/setup.py	2017-06-02 17:50:31.048245468 -0400
++++ b/setup.py	2017-06-02 18:06:24.724913541 -0400
+@@ -62,9 +62,7 @@
+     return boost_python
+ 
+ 
+-boost_python = find_boost()
+-if not find_library(boost_python):
+-    raise Exception("can't find boost library")
++boost_python = 'boost_python'
+ 
+ 
+ extension_metas = (

--- a/recipes/python-casacore/build.sh
+++ b/recipes/python-casacore/build.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+set -e
+IFS=$' \t\n' # workaround for conda 4.2.13+toolchain bug
+
+export CFLAGS="-I$PREFIX/include"
+
+python setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/python-casacore/meta.yaml
+++ b/recipes/python-casacore/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "python-casacore" %}
+{% set version = "2.1.2" %}
+{% set sha256 = "b4ea03d1b3d72ddfa67c2b4b572dd92f39f806b090c49b4715f982ac9ecba2b1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/casacore/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - boost-python.patch
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: true
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - gcc  # [osx]
+    - boost 1.63.*  # note this is intentionally NOT the latest version; synced with casacore which has special needs
+    - casacore 2.2.*
+    - numpy
+    - python
+    - setuptools
+  run:
+    - boost 1.63.*  # note this is intentionally NOT the latest version; synced with casacore which has special needs
+    - casacore 2.2.*
+    - numpy
+    - python
+
+test:
+  imports:
+    - casacore
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: http://casacore.github.io/python-casacore/
+  license: GPLv2
+  license_file: LICENSE
+  summary: 'Python bindings for casacore, a library used in radio astronomy'
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/python-casacore/meta.yaml
+++ b/recipes/python-casacore/meta.yaml
@@ -24,13 +24,13 @@ requirements:
     - gcc  # [osx]
     - boost 1.63.*  # note this is intentionally NOT the latest version; synced with casacore which has special needs
     - casacore 2.2.*
-    - numpy
+    - numpy x.x
     - python
     - setuptools
   run:
     - boost 1.63.*  # note this is intentionally NOT the latest version; synced with casacore which has special needs
     - casacore 2.2.*
-    - numpy
+    - numpy x.x
     - python
 
 test:


### PR DESCRIPTION
A set of Python bindings for the [casacore](https://github.com/conda-forge/casacore-feedstock) C++ radio astronomy library.