### PR TITLE
Added recipe for zeo

### DIFF
--- a/recipes/zdaemon/meta.yaml
+++ b/recipes/zdaemon/meta.yaml
@@ -40,13 +40,6 @@ test:
   commands:
     - zdaemon --help
 
-  requires:
-    - manuel
-    - mock
-    - zc.customdoctests
-    - zope.testing
-    - zope.testrunner
-
 about:
   home: https://github.com/zopefoundation/zdaemon
   license_file: LICENSE.txt

--- a/recipes/zdaemon/meta.yaml
+++ b/recipes/zdaemon/meta.yaml
@@ -50,7 +50,7 @@ test:
 about:
   home: https://github.com/zopefoundation/zdaemon
   license_file: LICENSE.txt
-  license: Zope Public License
+  license: ZPL 2.1
   license_family: OTHER
   summary: 'Daemon process control library and tools for Unix-based systems'
   dev_url: https://github.com/zopefoundation/zdaemon

--- a/recipes/zdaemon/meta.yaml
+++ b/recipes/zdaemon/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "zdaemon" %}
+{% set version = "4.2.0" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "ee7b118069e7e6a5ea93df8aabaa0b6549dff4414fda259d0efc036c5c73e1bf" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  preserve_egg_dir: True
+  entry_points:
+    - zdaemon=zdaemon.zdctl:main
+
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+    - zconfig
+
+test:
+  imports:
+    - zdaemon
+    - zdaemon.tests
+
+  commands:
+    - zdaemon --help
+
+  requires:
+    - manuel
+    - mock
+    - zc.customdoctests
+    - zope.testing
+    - zope.testrunner
+
+about:
+  home: https://github.com/zopefoundation/zdaemon
+  license_file: LICENSE.txt
+  license: Zope Public License
+  license_family: OTHER
+  summary: 'Daemon process control library and tools for Unix-based systems'
+  dev_url: https://github.com/zopefoundation/zdaemon
+  doc_url: https://github.com/zopefoundation/zdaemon
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/zeo/meta.yaml
+++ b/recipes/zeo/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   run:
     - python
     - setuptools
+    - trollius  # [py2k]
     - futures  # [py<32]
     - zodb >=5.1.1
     - six

--- a/recipes/zeo/meta.yaml
+++ b/recipes/zeo/meta.yaml
@@ -55,7 +55,7 @@ test:
     - ZEO.tests.ZEO4.zrpc
 
   commands:
-    - zeopack --help
+    # no --help option for zeopack: - zeopack --help
     - runzeo --help
     - zeoctl --help
     - zeo-nagios --help

--- a/recipes/zeo/meta.yaml
+++ b/recipes/zeo/meta.yaml
@@ -1,0 +1,73 @@
+{% set name = "ZEO" %}
+{% set version = "5.1.0" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "142edf8fcabaeec8c438319d71a12a1d4461befa9111a073c362b75e481e7522" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  preserve_egg_dir: True
+  entry_points:
+    - zeopack=ZEO.scripts.zeopack:main
+    - runzeo=ZEO.runzeo:main
+    - zeoctl=ZEO.zeoctl:main
+    - zeo-nagios=ZEO.nagios:main
+
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+    - futures  # [py<32]
+    - zodb >=5.1.1
+    - six
+    - transaction >=2.0.3
+    - persistent >=4.1.0
+    - zc.lockfile
+    - zconfig
+    - zdaemon
+    - zope.interface
+
+test:
+  imports:
+    - ZEO
+    - ZEO.asyncio
+    - ZEO.scripts
+    - ZEO.tests
+    - ZEO.tests.ZEO4
+    - ZEO.tests.ZEO4.auth
+    - ZEO.tests.ZEO4.zrpc
+
+  commands:
+    - zeopack --help
+    - runzeo --help
+    - zeoctl --help
+    - zeo-nagios --help
+
+about:
+  home: https://github.com/zopefoundation/ZEO
+  license_file: LICENSE.txt
+  license: ZPL 2.1
+  license_family: OTHER
+  summary: 'ZEO - Single-server client-server database server for ZODB'
+  dev_url: https://github.com/zopefoundation/ZEO
+  doc_url: https://github.com/zopefoundation/ZEO
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Take two!

[ZEO](http://www.zodb.org/en/latest/articles/old-guide/zeo.html), or Zope Enterprise Objects, extends the ZODB machinery to provide access to objects over a network. It's also a requirement for updating to the next version of `zodburi`.

This version strips out the `sarge` recipe, which really shouldn't have been there.