### PR TITLE
add clickclick and swagger-spec-validator

### DIFF
--- a/recipes/clickclick/bld.bat
+++ b/recipes/clickclick/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install 
+if errorlevel 1 exit 1

--- a/recipes/clickclick/build.sh
+++ b/recipes/clickclick/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install 

--- a/recipes/clickclick/meta.yaml
+++ b/recipes/clickclick/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "1.2.1" %}
+
+package:
+  name: clickclick
+  version: {{ version }}
+
+source:
+  fn: {{ version }}.tar.gz
+  url: https://github.com/zalando/python-clickclick/archive/{{ version }}.tar.gz
+  sha256: f29b1af9cf5a388e56e2c2aab6bafb4e1bec6f0424a53fa77ba83f4646f09910
+  
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - click >=4.0
+    - pyyaml >=3.11
+    - flake8
+    - six
+
+  run:
+    - python
+    - click >=4.0
+    - pyyaml >=3.11
+
+test:
+  imports:
+    - clickclick
+
+  requires:
+    - pytest
+    - pytest-cov
+
+about:
+  home: https://github.com/zalando/python-clickclick
+  license: Apache Software License
+  summary: 'Click utility functions'
+  license_family: APACHE
+
+extra:
+  recipe-maintainers:
+    - rvalieris

--- a/recipes/swagger-spec-validator/bld.bat
+++ b/recipes/swagger-spec-validator/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install 
+if errorlevel 1 exit 1

--- a/recipes/swagger-spec-validator/build.sh
+++ b/recipes/swagger-spec-validator/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON setup.py install 

--- a/recipes/swagger-spec-validator/meta.yaml
+++ b/recipes/swagger-spec-validator/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "2.1.0" %}
+
+package:
+  name: swagger-spec-validator
+  version: {{ version }}
+
+source:
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/Yelp/swagger_spec_validator/archive/v{{ version }}.tar.gz
+  sha256: bf3a816e3f44edca2e30ed3af68826e84037ed69d2e985406ba3a5a9e0c0b3a0
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - jsonschema
+    - six
+
+  run:
+    - python
+    - jsonschema
+    - six
+
+test:
+  imports:
+    - swagger_spec_validator
+
+about:
+  home: http://github.com/Yelp/swagger_spec_validator
+  license: Apache License, Version 2.0
+  summary: 'Validation of Swagger specifications'
+  license_family: APACHE
+
+extra:
+  recipe-maintainers:
+    - rvalieris


### PR DESCRIPTION
these are missing dependencies for the [connexion](https://github.com/zalando/connexion) recipe, which I will add later.