### PR TITLE
Added recipe for Flask-Jsonpify

### DIFF
--- a/recipes/flask-jsonpify/LICENSE
+++ b/recipes/flask-jsonpify/LICENSE
@@ -1,0 +1,7 @@
+Copyright (C) 2013 Cory Dolphin, Olin College
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/flask-jsonpify/meta.yaml
+++ b/recipes/flask-jsonpify/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "Flask-Jsonpify" %}
+{% set version = "1.5.0" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "8ac4c732aa5b11d9f6c2de58065d3b669f139518ca8f529bce943817e2fedbfbs" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - flask
+
+test:
+  imports:
+    - flask.ext.jsonpify
+    - flask_jsonpify
+
+about:
+  home: https://github.com/CoryDolphin/flask-jsonpify
+  license_file: {{ RECIPE_DIR }}/LICENSE
+  license: MIT
+  license_family: MIT
+  summary: 'A Flask extension adding a decorator for JSONP support'
+  dev_url: https://github.com/CoryDolphin/flask-jsonpify
+
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/flask-jsonpify/meta.yaml
+++ b/recipes/flask-jsonpify/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.5.0" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "8ac4c732aa5b11d9f6c2de58065d3b669f139518ca8f529bce943817e2fedbfbs" %}
+{% set hash = "8ac4c732aa5b11d9f6c2de58065d3b669f139518ca8f529bce943817e2fedbfb" %}
 {% set build = 0 %}
 
 package:


### PR DESCRIPTION
`Flask-Jsonpify` is a Flask extension that adds a decorator for [JSONP](https://en.wikipedia.org/wiki/JSONP) support. It's used by some of the tools in the [frictionless data](http://frictionlessdata.io/) ecosystem.