### PR TITLE
Added recipe for datadotworld-py

### DIFF
--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - certifi >=2017.04.17
     - click >=6.0,<7.0a
     - configparser >=3.5.0,<4.0a  # [py<34]
-    - datapackage >=0.8.8,<1.0a
+    - datapackage-py >=0.8.8,<1.0a
     - jsontableschema >=0.10.0,<1.0a
     - python-dateutil >=2.6.0,<3.0a
     - requests >=2.0.0,<3.0a

--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ pkg_name }}-{{ version }}.{{ bundle }}
+  fn: {{ name }}-{{ version }}.{{ bundle }}
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
   {{ hash_type }}: {{ hash }}
 

--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -1,5 +1,5 @@
-{% set name = "datadotworld-py" %}
-{% set pkg_name = "datadotworld" %}
+{% set conda_name = "datadotworld-py" %}
+{% set name = "datadotworld" %}
 {% set version = "1.2.5" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
@@ -7,12 +7,12 @@
 {% set build = 0 %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ conda_name }}
   version: {{ version }}
 
 source:
   fn: {{ pkg_name }}-{{ version }}.{{ bundle }}
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ pkg_name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
   {{ hash_type }}: {{ hash }}
 
 build:

--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -26,7 +26,7 @@ requirements:
   build:
     - python
     - setuptools
-    - pytest-runner>=2.11,<3.0a
+    - pytest-runner >=2.11,<3.0a
 
   run:
     - python

--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "datadotworld-py" %}
+{% set pkg_name = "datadotworld" %}
+{% set version = "1.2.5" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "484eaed3e44563274634daf67d134268668fa08fd4b7e72b1a151fe24ca5f531" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ pkg_name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ pkg_name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  entry_points:
+    - dw=datadotworld.cli:cli
+
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - certifi >=2017.04.17
+    - click >=6.0,<7.0a
+    - configparser >=3.5.0,<4.0a  # [py<34]
+    - datapackage >=0.8.8,<1.0a
+    - jsontableschema >=0.10.0,<1.0a
+    - python-dateutil >=2.6.0,<3.0a
+    - requests >=2.0.0,<3.0a
+    - six >=1.5.0,<2.0a
+    - tabulator-py <2.0a
+    - urllib3 >=1.15,<2.0a
+
+test:
+  imports:
+    - datadotworld
+    - datadotworld.client
+    - datadotworld.client._swagger
+    - datadotworld.client._swagger.apis
+    - datadotworld.client._swagger.models
+    - datadotworld.models
+
+  commands:
+    - dw --help
+
+about:
+  home: http://github.com/datadotworld/data.world-py
+  license_file: LICENSE.txt
+  license: Apache 2.0
+  license_family: Apache
+  summary: 'Python library for data.world'
+  dev_url: http://github.com/datadotworld/data.world-py
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - six >=1.5.0,<2.0a
     - tabulator-py <2.0a
     - urllib3 >=1.15,<2.0a
-    - pandas<1.0a
+    - pandas <1.0a
 
 test:
   imports:

--- a/recipes/datadotworld-py/meta.yaml
+++ b/recipes/datadotworld-py/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   build:
     - python
     - setuptools
+    - pytest-runner>=2.11,<3.0a
 
   run:
     - python
@@ -39,6 +40,7 @@ requirements:
     - six >=1.5.0,<2.0a
     - tabulator-py <2.0a
     - urllib3 >=1.15,<2.0a
+    - pandas<1.0a
 
 test:
   imports:


### PR DESCRIPTION
`datadotworld` is a python module for accessing [data.world's](https://data.world/) API. I've added a `-py` suffix because there's a corresponding R package we might want to bundle at some point.