### PR TITLE
Added recipe for tableschema-py

### DIFF
--- a/recipes/tableschema-py/meta.yaml
+++ b/recipes/tableschema-py/meta.yaml
@@ -1,0 +1,62 @@
+{% set conda_name = "tableschema-py" %}
+{% set name = "tableschema" %}
+{% set version = "1.0.0a5" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "891ff9b3ea4a01de7ef5f9608dd70929106836f9ef49706324040a2082cb7063" %}
+{% set build = 0 %}
+
+package:
+  name: {{ conda_name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  entry_points:
+    - tableschema = tableschema.cli:main
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six >=1.9,<2.0
+    - click >=3.3,<7.0
+    - requests >=2.5,<3.0
+    - python-dateutil >=2.4,<3.0
+    - jsonschema >=2.5,<3.0
+    - rfc3986 >=0.4,<1.0
+    - future >=0.15,<1.0
+    - unicodecsv >=0.14,<1.0
+    - isodate >=0.5.4,<1.0
+    - tabulator >=1.0.0a5,<2.0
+
+test:
+  imports:
+    - tableschema
+    - tableschema.constraints
+    - tableschema.plugins
+    - tableschema.types
+
+  commands:
+    - tableschema --help
+
+about:
+  home: https://github.com/frictionlessdata/tableschema-py
+  license_file: LICENSE.md
+  license: MIT
+  license_family: MIT
+  summary: 'A utility library for working with Table Schema in Python'
+  dev_url: https://github.com/frictionlessdata/tableschema-py
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/tableschema-py/meta.yaml
+++ b/recipes/tableschema-py/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - future >=0.15,<1.0
     - unicodecsv >=0.14,<1.0
     - isodate >=0.5.4,<1.0
-    - tabulator >=1.0.0a5,<2.0
+    - tabulator-py >=1.0.0a5,<2.0
 
 test:
   imports:


### PR DESCRIPTION
`tableschema` is a python module for working with the Frictionless Data's [TableSchema](http://specs.frictionlessdata.io/table-schema/) format. I've added a `-py` suffix because there are also Java and JavaScript libraries with the same name, intended for the same purpose.