### PR TITLE
Add recipe for google-auth-oauthlib

### DIFF
--- a/recipes/google-auth-oauthlib/meta.yaml
+++ b/recipes/google-auth-oauthlib/meta.yaml
@@ -30,14 +30,14 @@ test:
     - google_auth_oauthlib
 
 about:
-  home: https://github.com/GoogleCloudPlatform/google-auth-library-python
+  home: https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: 'Google Authentication Library, oauthlib integration with google-auth'
   description: This library provides oauthlib integration with google-auth.
-  doc_url: https://google-auth.readthedocs.io/en/latest/
-  dev_url: https://github.com/GoogleCloudPlatform/google-auth-library-python
+  doc_url: http://google-auth-oauthlib.readthedocs.io/en/latest/
+  dev_url: https://github.com/GoogleCloudPlatform/google-auth-library-python-oauthlib
 
 extra:
   recipe-maintainers:

--- a/recipes/google-auth-oauthlib/meta.yaml
+++ b/recipes/google-auth-oauthlib/meta.yaml
@@ -44,4 +44,3 @@ extra:
     - parthea
     - jreback
     - tswast
-

--- a/recipes/google-auth-oauthlib/meta.yaml
+++ b/recipes/google-auth-oauthlib/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "google-auth-oauthlib" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "8e05ec997a946aed1fa82f7f360d835e4c031f13413962c29b7329cc10b91e5f" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - google-auth
+    - requests-oauthlib >=0.7.0,<1dev
+
+test:
+  imports:
+    - google_auth_oauthlib
+
+about:
+  home: https://github.com/GoogleCloudPlatform/google-auth-library-python
+  license: Apache
+  license_family: Apache
+  summary: 'Google Authentication Library, oauthlib integration with google-auth'
+  description: This library provides oauthlib integration with google-auth.
+  doc_url: https://google-auth.readthedocs.io/en/latest/
+  dev_url: https://github.com/GoogleCloudPlatform/google-auth-library-python
+
+extra:
+  recipe-maintainers:
+    - parthea
+    - jreback
+    - tswast
+

--- a/recipes/google-auth-oauthlib/meta.yaml
+++ b/recipes/google-auth-oauthlib/meta.yaml
@@ -31,8 +31,9 @@ test:
 
 about:
   home: https://github.com/GoogleCloudPlatform/google-auth-library-python
-  license: Apache
+  license: Apache-2.0
   license_family: Apache
+  license_file: LICENSE
   summary: 'Google Authentication Library, oauthlib integration with google-auth'
   description: This library provides oauthlib integration with google-auth.
   doc_url: https://google-auth.readthedocs.io/en/latest/


### PR DESCRIPTION
For https://pypi.python.org/pypi/google-auth-oauthlib/0.1.0

This is waiting on conda-forge/staged-recipes#3099. Nothing to do here until conda-forge/staged-recipes#3099 is ready.