### PR TITLE
Add aws.signature recipe

### DIFF
--- a/recipes/aws.signature/build.bat
+++ b/recipes/aws.signature/build.bat
@@ -1,0 +1,1 @@
+"%R%" CMD INSTALL --build .

--- a/recipes/aws.signature/build.bat
+++ b/recipes/aws.signature/build.bat
@@ -1,1 +1,2 @@
 "%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/aws.signature/build.sh
+++ b/recipes/aws.signature/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -1,19 +1,15 @@
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
-{% set rname = "r-aws.signature" %}
-{% set name = "aws.signature" %}
 {% set version = "0.2.9" %}
 {% set sha256 = "5f11ff63203733d7bae0d8cb8ca2ed0a2ee03f0cdfa5407466062314baf98f13" %}
 
 package:
-  name: {{ rname|lower }}
+  name: r-aws.signature
   version: {{ version }}
 
 source:
-  fn: {{ name }}_{{ version }}.tar.gz
-  url:
-    - https://cran.r-project.org/src/contrib/{{ name }}_{{ version }}.tar.gz
-    - https://cran.r-project.org/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz
+  fn: aws.signature_{{ version }}.tar.gz
+  url: https://cran.r-project.org/src/contrib/aws.signature_{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -27,6 +27,9 @@ requirements:
     - r-base
     - r-digest
     - r-base64enc
+    - posix  # [win]
+    - {{native}}toolchain  # [win]
+    - gcc  # [not win]
 
   run:
     - r-base

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -1,6 +1,5 @@
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
-
 {% set rname = "r-aws.signature" %}
 {% set name = "aws.signature" %}
 {% set version = "0.2.9" %}
@@ -18,7 +17,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  build: 0
+  number: 0
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -35,8 +35,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('aws.signature')" # [not win]
-    - "\"%R%\" -e \"library('aws.signature')\"" # [win]
+    - $R -e "library('aws.signature')"  # [not win]
+    - "\"%R%\" -e \"library('aws.signature')\""  # [win]
 
 about:
   home: https://cran.r-project.org/web/packages/aws.signature/index.html
@@ -49,3 +49,24 @@ about:
 extra:
   recipe-maintainers:
     - benvandyke
+
+# The original CRAN metadata for this package was:
+
+# Package: aws.signature
+# Type: Package
+# Title: Amazon Web Services Request Signatures
+# Version: 0.2.9
+# Date: 2017-04-28
+# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),
+#                    email = "thosjleeper@gmail.com"))
+# Description: Generates request signatures for Amazon Web Services (AWS) APIs.
+# License: GPL (>= 2)
+# Imports:
+#    digest,
+#    base64enc,
+#    aws.ec2metadata
+# Suggests:
+#    testthat
+# URL: https://github.com/cloudyr/aws.signature
+# BugReports: https://github.com/cloudyr/aws.signature/issues
+# RoxygenNote: 6.0.1

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -18,6 +18,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -4,7 +4,7 @@
 {% set sha256 = "5f11ff63203733d7bae0d8cb8ca2ed0a2ee03f0cdfa5407466062314baf98f13" %}
 
 package:
-  name: r-aws.signature
+  name: r-aws-signature
   version: {{ version }}
 
 source:

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -1,0 +1,73 @@
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+{% set rname = "r-aws.signature" %}
+{% set name = "aws.signature" %}
+{% set version = "0.2.9" %}
+{% set sha256 = "5f11ff63203733d7bae0d8cb8ca2ed0a2ee03f0cdfa5407466062314baf98f13" %}
+
+package:
+  name: {{ rname|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/{{ name }}_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/{{ name }}/{{ name }}_{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  build: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-digest
+    - r-base64enc
+
+  run:
+    - r-base
+    - r-digest
+    - r-base64enc
+
+test:
+  commands:
+    - $R -e "library('aws.signature')" # [not win]
+    - "\"%R%\" -e \"library('aws.signature')\"" # [win]
+
+about:
+  home: https://cran.r-project.org/web/packages/aws.signature/index.html
+  license: GPL (>= 2)
+  summary: 'Generates request signatures for Amazon Web Services (AWS) APIs'
+  license_family: GPL2
+  doc_url: https://cran.r-project.org/web/packages/aws.signature/aws.signature.pdf
+  dev_url: https://github.com/cloudyr/aws.signature
+
+extra:
+  recipe-maintainers:
+    - benvandyke
+
+# The original CRAN metadata for this package was:
+
+# Package: aws.signature
+# Type: Package
+# Title: Amazon Web Services Request Signatures
+# Version: 0.2.9
+# Date: 2017-04-28
+# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),
+#                    email = "thosjleeper@gmail.com"))
+# Description: Generates request signatures for Amazon Web Services (AWS) APIs.
+# License: GPL (>= 2)
+# Imports:
+#    digest,
+#    base64enc,
+#    aws.ec2metadata
+# Suggests:
+#    testthat
+# URL: https://github.com/cloudyr/aws.signature
+# BugReports: https://github.com/cloudyr/aws.signature/issues
+# RoxygenNote: 6.0.1

--- a/recipes/aws.signature/meta.yaml
+++ b/recipes/aws.signature/meta.yaml
@@ -49,24 +49,3 @@ about:
 extra:
   recipe-maintainers:
     - benvandyke
-
-# The original CRAN metadata for this package was:
-
-# Package: aws.signature
-# Type: Package
-# Title: Amazon Web Services Request Signatures
-# Version: 0.2.9
-# Date: 2017-04-28
-# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),
-#                    email = "thosjleeper@gmail.com"))
-# Description: Generates request signatures for Amazon Web Services (AWS) APIs.
-# License: GPL (>= 2)
-# Imports:
-#    digest,
-#    base64enc,
-#    aws.ec2metadata
-# Suggests:
-#    testthat
-# URL: https://github.com/cloudyr/aws.signature
-# BugReports: https://github.com/cloudyr/aws.signature/issues
-# RoxygenNote: 6.0.1


### PR DESCRIPTION
Adds the cloudyr aws.signature package for R. This is a prerequisite of the aws.s3 package from the same project. 

https://github.com/cloudyr/aws.signature

This is my first attempt at an R package. I based it off existing recipes in conda-forge. 