### PR TITLE
Pin conda to 4.2.13 for feedstock creation

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -24,6 +24,8 @@ conda install --yes --quiet conda-smithy
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
+conda install --yes --quiet conda=4.2.13
+
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 


### PR DESCRIPTION
Currently `conda-smithy` raises an error and exits if used with `conda` 4.3. This is mainly because there has been no testing with `conda` 4.3 given that `conda-build-all` did not work with `conda` 4.3. So we need to pin to `conda` 4.2 until we can test (and fix) `conda-smithy` to work with `conda` 4.3. Then do a subsequent patch release of `conda-smithy`.