### PR TITLE
Revert "Pin conda to 4.2.13 for feedstock creation"

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -24,8 +24,6 @@ conda install --yes --quiet conda-smithy
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-conda install --yes --quiet conda=4.2.13
-
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 


### PR DESCRIPTION
Revert PR ( https://github.com/conda-forge/staged-recipes/pull/3121 ).

Now that `conda-smithy` has releases that support `conda` 4.3, it makes sense to unpin this.