### PR TITLE
Add libidn11

### DIFF
--- a/recipes/libidn/bld.bat
+++ b/recipes/libidn/bld.bat
@@ -1,0 +1,17 @@
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/libidn/build.sh
+++ b/recipes/libidn/build.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
+# On Windows we want $LIBRARY_PREFIX in both "mixed" (C:/Conda/...) and Unix
+# (/c/Conda) forms, but Unix form is often "/" which can cause problems.
+if [ -n "$LIBRARY_PREFIX_M" ] ; then
+    mprefix="$LIBRARY_PREFIX_M"
+    if [ "$LIBRARY_PREFIX_U" = / ] ; then
+        uprefix=""
+    else
+        uprefix="$LIBRARY_PREFIX_U"
+    fi
+else
+    mprefix="$PREFIX"
+    uprefix="$PREFIX"
+fi
+
+# On Windows we need to regenerate the configure scripts.
+if [ -n "$VS_MAJOR" ] ; then
+    am_version=1.15 # keep sync'ed with meta.yaml
+    export ACLOCAL=aclocal-$am_version
+    export AUTOMAKE=automake-$am_version
+    autoreconf_args=(
+        --force
+        --install
+        -I "$mprefix/share/aclocal"
+        -I "$mprefix/mingw-w64/share/aclocal" # note: this is correct for win32 also!
+    )
+    autoreconf "${autoreconf_args[@]}"
+
+    # And we need to add the search path that lets libtool find the
+    # msys2 stub libraries for ws2_32.
+    platlibs=$(cd $(dirname $(gcc --print-prog-name=ld))/../lib && pwd -W)
+    export LDFLAGS="$LDFLAGS -L$platlibs"
+fi
+
+./configure \
+    --prefix=$PREFIX \
+    --with-sysroot=$PREFIX \
+    --disable-dependency-tracking \
+    --disable-gtk-doc-html
+
+make -j$CPU_COUNT
+make check -j$CPU_COUNT
+make install
+

--- a/recipes/libidn/meta.yaml
+++ b/recipes/libidn/meta.yaml
@@ -52,3 +52,6 @@ about:
   doc_url: https://www.gnu.org/software/libidn/#documentation
   dev_url: https://savannah.gnu.org/projects/libidn
 
+extra:
+  recipe-maintainers:
+    - epruesse

--- a/recipes/libidn/meta.yaml
+++ b/recipes/libidn/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "libidn" %}
+{% set soversion = "11" %}
+{% set version = "1.33" %}
+{% set sha256 = "44a7aab635bb721ceef6beecc4d49dfd19478325e1b47f3196f7d2acc4930e19" %}
+
+package:
+  name: {{ name|lower }}{{ soversion }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
+
+requirements:
+  build:
+    - m2-autoconf                  # [win]
+    - m2-automake{{ am_version }}  # [win]
+    - m2-libtool                   # [win]
+    - m2w64-toolchain              # [win]
+    - posix                        # [win]
+    - python                       # [win]
+    - toolchain
+    - libiconv
+  run:
+    - vc 9   # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
+
+about:
+  home: https://www.gnu.org/software/libidn/
+  license: LGPLv3
+  license_family: GPL
+  license_file: COPYING.LESSERv3
+  summary: "Library for internationalized domain name support"
+  description: |
+    Libidn is a package for internationalized string handling based on the
+    Stringprep, Punycode, IDNA and TLD specifications.  Libidn is a GNU
+    project.  See the file COPYING for licensing information.
+  doc_url: https://www.gnu.org/software/libidn/#documentation
+  dev_url: https://savannah.gnu.org/projects/libidn
+

--- a/recipes/libidn/meta.yaml
+++ b/recipes/libidn/meta.yaml
@@ -2,6 +2,7 @@
 {% set soversion = "11" %}
 {% set version = "1.33" %}
 {% set sha256 = "44a7aab635bb721ceef6beecc4d49dfd19478325e1b47f3196f7d2acc4930e19" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
 
 package:
   name: {{ name|lower }}{{ soversion }}


### PR DESCRIPTION
    Libidn is a package for internationalized string handling based on the
    Stringprep, Punycode, IDNA and TLD specifications.

 - It's in bioconda, but missing in conda.
 - Using `libidn11` as package name to reflect so-version and avoid run-time binding issues at a later time.
 - Name also avoids override by weirdly versioned bioconda package (7.x).