### PR TITLE
Add hdf5storage

### DIFF
--- a/recipes/hdf5storage/meta.yaml
+++ b/recipes/hdf5storage/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "hdf5storage" %}
+{% set version = "0.1.14" %}
+{% set sha256 = "180593f91325c952346010dde32b359563f69d2760b6e7d25a8d2d851b93b1ab" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - h5py >=2.3
+    - numpy
+    - scipy
+
+test:
+  imports:
+    - hdf5storage
+
+about:
+  home: https://github.com/frejanordsiek/hdf5storage
+  license: BSD 2-Clause
+  license_file: COPYING.txt
+  summary: Utilities to read/write Python types to/from HDF5 files, including MATLAB v7.3 MAT files.
+  doc_url: http://pythonhosted.org/hdf5storage
+  dev_url: https://github.com/frejanordsiek/hdf5storage
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a package for `hdf5storage`. This allows reading MATLAB files (both old and new formats) into Python seamlessly using the same API that SciPy uses for the old format of MATLAB files.