### PR TITLE
cram: add recipe

### DIFF
--- a/recipes/cram/meta.yaml
+++ b/recipes/cram/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "cram" %}
+{% set version = "0.7" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "7da7445af2ce15b90aad5ec4792f857cef5786d71f14377e9eb994d8b8337f2f" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - cram
+
+  commands:
+    - cram -h
+
+about:
+  home: https://bitheap.org/cram/
+  license: GPL-2.0
+  license_file: COPYING.txt
+  summary: 'A simple testing framework for command line applications'
+  license_family: GPL2
+  dev_url: https://github.com/brodie/cram
+
+extra:
+  recipe-maintainers:
+    - nehaljwani


### PR DESCRIPTION
Required by https://github.com/conda-forge/staged-recipes/pull/3110 for running tests.