### PR TITLE
Add pygpu

### DIFF
--- a/recipes/pygpu/meta.yaml
+++ b/recipes/pygpu/meta.yaml
@@ -1,0 +1,68 @@
+#
+# All noted sections must be uncommented in the next release.
+# Also a re-rendering will be required after committing the
+# uncommented portions
+#
+# ref: https://github.com/conda-forge/conda-smithy#re-rendering-an-existing-feedstock
+#
+
+
+{% set version = "0.6.5" %}
+
+package:
+  name: pygpu
+  version: {{ version }}
+
+source:
+  fn: libgpuarray-{{ version }}.tar.gz
+  url: https://github.com/Theano/libgpuarray/archive/v{{ version }}.tar.gz
+  sha256: 29f44957a826083954d01de7009083fec4acb904bc51b48d3c667ef52c1f2c0b
+
+build:
+  number: 0
+  ###############################
+  # Uncomment on next release.  #
+  ###############################
+  # script:
+  #  - export CFLAGS="${CFLAGS} -I${PREFIX}/include -L${PREFIX}/lib"  # [unix]
+  #  - python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    ###############################
+    # Uncomment on next release.  #
+    ###############################
+    # - toolchain
+    # - python
+    # - cython >=0.25
+    # - numpy x.x
+    # - mako
+    # - setuptools
+    - libgpuarray =={{ version }}
+
+  run:
+    ###############################
+    # Uncomment on next release.  #
+    ###############################
+    # - python
+    # - numpy x.x
+    # - mako
+    # - six
+    - libgpuarray =={{ version }}
+
+test:
+  imports:
+    - pygpu
+    - pygpu.gpuarray
+
+about:
+  home: http://github.com/Theano/libgpuarray
+  license: ISC
+  license_file: LICENSE
+  summary: 'Library to manipulate arrays on GPU'
+  doc_url: http://deeplearning.net/software/libgpuarray/
+  dev_url: http://github.com/Theano/libgpuarray
+
+extra:
+  recipe-maintainers:
+    - abergeron


### PR DESCRIPTION
Part of an attempt to address issue ( https://github.com/conda-forge/libgpuarray-feedstock/issues/2 ).

Creates a fancy metapackage, which will later become a full fledged package. For now it is stand-in for `pygpu` at `conda-forge` as all the content is already in `libgpuarray`. However with the next release of `libgpuarray`, we can fix `libgpuarray` to not contain the Python content. Then the install step can be uncommented and this will become a full-fledged package.

cc @abergeron