### PR TITLE
Add recipe for google-cloud-core

### DIFF
--- a/recipes/google-cloud-core/meta.yaml
+++ b/recipes/google-cloud-core/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "google-cloud-core" %}
+{% set version = "0.24.1" %}
+{% set sha256 = "fe73253dd98965bdd02ac6951afabe9e09bda203fc8065bf285d8d13172afc9c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six
+    - protobuf >=3.0.0
+    - httplib2 >=0.9.1
+    - googleapis-common-protos >=1.3.4
+    - google-auth-httplib2
+    - google-auth >=0.4.0,<2dev
+
+test:
+  imports:
+    - google.cloud.client
+
+about:
+  home: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/core
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'API Client library for Google Cloud: Core Helpers'
+  description: This library is not meant to stand-alone. Instead it defines common helpers
+    (e.g. base Client and Connection classes) used by all of the  google-cloud-*.
+  doc_url: https://googlecloudplatform.github.io/google-cloud-python/stable/google-cloud-api.html
+  dev_url: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/core
+
+extra:
+  recipe-maintainers:
+    - parthea


### PR DESCRIPTION
For https://pypi.python.org/pypi/google-cloud-core/0.24.1 . 


I'm planning to add a recipe for [google-cloud-bigquery](https://pypi.python.org/pypi/google-cloud-bigquery) once this is merged.