### PR TITLE
Add tini

### DIFF
--- a/recipes/tini/build.sh
+++ b/recipes/tini/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+mkdir build && cd build
+cmake .. \
+      -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+      -DCMAKE_PREFIX_PATH="${PREFIX}"
+make
+make install
+
+####################################################
+# We don't want tini statically link to GLIBC.     #
+# So we just remove the static build. Have asked   #
+# upstream for an option to disable the static     #
+# build of tini.                                   #
+#                                                  #
+# xref: https://github.com/krallin/tini/issues/93  #
+####################################################
+rm "${PREFIX}/bin/tini-static"

--- a/recipes/tini/meta.yaml
+++ b/recipes/tini/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "tini" %}
+{% set version = "0.14.0" %}
+{% set sha256 = "d624bb6fba3bc02701977813b7bdac9dfc9bdeedf88aff67066cf8948d2ec6ab" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/krallin/tini/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not (linux and py27)]
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - python
+
+test:
+  commands:
+    - tini -h
+
+about:
+  home: https://github.com/krallin/tini
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A tiny but valid `init` for containers
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/tini/yum_requirements.txt
+++ b/recipes/tini/yum_requirements.txt
@@ -1,0 +1,3 @@
+glibc-devel
+glibc-static
+vim-common


### PR DESCRIPTION
Adds a recipe to build [`tini`]( https://github.com/krallin/tini ). A small `init` process designed for Docker containers.