### PR TITLE
Add source_files hint to example

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -41,6 +41,11 @@ test:
     - simplejson
     - simplejson.tests
 
+  # Some packages provide tests but don't install them.
+  # To copy a 'tests' folder from the package source into the test environment do
+  # source_files:
+  #  - tests
+
 about:
   home: http://github.com/simplejson/simplejson
   # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.


### PR DESCRIPTION
Hi, 
I'm new to conda-forge (and conda in general) and I was very positively surprised by how easy it was to get into it simply by adjusting the conda-forge example recipe.

One thing I stumbled upon, however, was how to run tests for packages that don't install them (see 'Test' section in [this blog post](https://www.continuum.io/blog/developer-blog/whats-old-and-new-conda-build)).
I believe a hint in the example meta.yaml would make it even better.