### PR TITLE
[WIP] Added libminizinc recipe

### DIFF
--- a/recipes/libminizinc/bld.bat
+++ b/recipes/libminizinc/bld.bat
@@ -1,0 +1,4 @@
+mkdir build
+cd build
+cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ..
+cmake --build . --target install

--- a/recipes/libminizinc/build.sh
+++ b/recipes/libminizinc/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir build
+cd build
+cmake .. \
+	-DCMAKE_INSTALL_PREFIX:PATH="$PREFIX"
+cmake --build . --target install

--- a/recipes/libminizinc/meta.yaml
+++ b/recipes/libminizinc/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  fn: minizinc-{{ version }}-linux64.tar.gz
+  fn: {{ version }}.tar.gz
   url: https://github.com/MiniZinc/libminizinc/archive/{{ version }}.tar.gz
   sha256: 173a42189f0fa447d04d63b27afdd10af9c5035061db00ba1e2b390622b49803
 

--- a/recipes/libminizinc/meta.yaml
+++ b/recipes/libminizinc/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.1.5" %}
 
 package:
-  name: minizinc
+  name: libminizinc
   version: {{ version }}
 
 source:

--- a/recipes/libminizinc/meta.yaml
+++ b/recipes/libminizinc/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "2.1.5" %}
+
+package:
+  name: minizinc
+  version: {{ version }}
+
+source:
+  fn: minizinc-{{ version }}-linux64.tar.gz
+  url: https://github.com/MiniZinc/libminizinc/archive/{{ version }}.tar.gz
+  sha256: 173a42189f0fa447d04d63b27afdd10af9c5035061db00ba1e2b390622b49803
+
+build:
+  number: 0
+  msvc_compiler: 14.0
+  features:
+    - vc14             # [win]
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - bison
+    - flex
+    - vc 14            # [win]
+    - python
+  run:
+    - vc 14            # [win]
+    - python
+
+test:
+  imports:
+    - mngzn
+
+about:
+  home: https://www.minizinc.org
+  license: MPL-2.0
+  license_file: LICENSE.txt
+  summary: 'The MiniZinc Compiler'
+
+extra:
+  recipe-maintainers:
+    - moorepants

--- a/recipes/libminizinc/meta.yaml
+++ b/recipes/libminizinc/meta.yaml
@@ -25,12 +25,6 @@ requirements:
   run:
     - vc 14            # [win]
 
-about:
-  home: https://www.minizinc.org
-  license: MPL-2.0
-  license_file: LICENSE.txt
-  summary: 'The MiniZinc Compiler'
-
 test:
   commands:
     - test -f $PREFIX/bin/mzn-fzn                                     # [unix]
@@ -45,6 +39,12 @@ test:
     - if not exist %LIBRARY_BIN%\\mzn2doc.exe exit 1                  # [win]
     - test -f $PREFIX/include/minizinc/gc.hh                          # [unix]
     - if not exist %LIBRARY_INC%\\gc.hh exit 1                        # [win]
+
+about:
+  home: https://www.minizinc.org
+  license: MPL-2.0
+  license_file: LICENSE.txt
+  summary: 'The MiniZinc Compiler'
 
 extra:
   recipe-maintainers:

--- a/recipes/libminizinc/meta.yaml
+++ b/recipes/libminizinc/meta.yaml
@@ -31,6 +31,21 @@ about:
   license_file: LICENSE.txt
   summary: 'The MiniZinc Compiler'
 
+test:
+  commands:
+    - test -f $PREFIX/bin/mzn-fzn                                     # [unix]
+    - test -f $PREFIX/bin/mzn2fzn                                     # [unix]
+    - test -f $PREFIX/bin/mzn2fzn_test                                # [unix]
+    - test -f $PREFIX/bin/solns2out                                   # [unix]
+    - test -f $PREFIX/bin/mzn2doc                                     # [unix]
+    - if not exist %LIBRARY_BIN%\\mzn-fzn.exe exit 1                  # [win]
+    - if not exist %LIBRARY_BIN%\\mzn2fzn.exe exit 1                  # [win]
+    - if not exist %LIBRARY_BIN%\\mzn2fzn_test.exe exit 1             # [win]
+    - if not exist %LIBRARY_BIN%\\solns2out.exe exit 1                # [win]
+    - if not exist %LIBRARY_BIN%\\mzn2doc.exe exit 1                  # [win]
+    - test -f $PREFIX/include/minizinc/gc.hh                          # [unix]
+    - if not exist %LIBRARY_INC%\\gc.hh exit 1                        # [win]
+
 extra:
   recipe-maintainers:
     - moorepants

--- a/recipes/libminizinc/meta.yaml
+++ b/recipes/libminizinc/meta.yaml
@@ -22,14 +22,8 @@ requirements:
     - bison
     - flex
     - vc 14            # [win]
-    - python
   run:
     - vc 14            # [win]
-    - python
-
-test:
-  imports:
-    - mngzn
 
 about:
   home: https://www.minizinc.org


### PR DESCRIPTION
This is a basic build of minizinc. Here are some things I need to think about:

- Should I build the python wrappers in this recipe or make a separate one called `python-minizinc` that depends on this package?
- investigate this python package: https://github.com/paolodragone/pymzn/
- I need to figure out all of the cmake options that should be enabled.
- minizinc has it's own ide (https://github.com/MiniZinc/MiniZincIDE), maybe this should be the `minizinc` package which depends on `libminizinc`, or should I put all this together in one package?
- Make [various solvers](http://www.minizinc.org/software.html#flatzinc) dependencies, e.g.:
  - http://www.gecode.org/ (biconda has a package: https://anaconda.org/bioconda/gecode and recipe https://github.com/gwcbi/bioconda-recipes/tree/master/recipes/gecode)
    - Started this: https://github.com/conda-forge/staged-recipes/pull/3206
  - or-tools https://github.com/conda-forge/staged-recipes/pull/2878
  - ?
- The debian package has this set of deps:
  - minizinc: `libc6 (>= 2.23), libgcc1 (>= 1:3.0), libstdc++6 (>= 5.2), flatzinc`
  - flatzinc: `libc6 (>= 2.14), libgcc1 (>= 1:4.1.1), libgecode41v5, libgecodeflatzinc41v5, libgecodegist41v5, libstdc++6 (>= 5.2)`
  - libgecode41v5: `libc6 (>= 2.15), libgcc1 (>= 1:4.1.1), libmpfr4 (>= 3.1.3), libstdc++6 (>= 5.2)`
  - libgecodeflatzinc41v5: `libc6 (>= 2.14), libgcc1 (>= 1:4.1.1), libgecode41v5, libgecodegist41v5, libqt5core5a (>= 5.0.2), libstdc++6 (>= 5.2)`

My main goal is getting a build with the Python wrappers on conda for easy python use of the package.