### PR TITLE
Add python-mimeparse recipe

### DIFF
--- a/recipes/python-mimeparse/meta.yaml
+++ b/recipes/python-mimeparse/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "python-mimeparse" %}
+{% set version = "1.6.0"%}
+{% set sha256 = "76e4b03d700a641fd7761d3cd4fdbbdcd787eade1ebfac43f877016328334f78" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  commands:
+    - python mimeparse_test.py
+
+  source_files:
+      - mimeparse_test.py
+      - testdata.json
+
+about:
+  home: https://github.com/dbtsai/python-mimeparse
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Basic functions for handling mime-types in python'
+  dev_url: https://github.com/dbtsai/python-mimeparse
+
+extra:
+  recipe-maintainers:
+    - ltalirz


### PR DESCRIPTION
Recipe for the [python-mimeparse](https://pypi.python.org/pypi/python-mimeparse) package.
I will be adding a handful more dependencies of our materials science package AiiDA.