### PR TITLE
Add aldjemy recipe

### DIFF
--- a/recipes/aldjemy/meta.yaml
+++ b/recipes/aldjemy/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "aldjemy" %}
+{% set version = "0.6.0"%}
+{% set sha256 = "a0f8e684d5c7b97dff64d0da0d75ca6a1f3062d6eca9e54c188e7babbe2439fa" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - sqlalchemy >0.7.1
+
+  run:
+    - python
+    - sqlalchemy >0.7.1
+
+test:
+  imports:
+    - aldjemy
+
+  commands:
+    # django 1.11 yields
+    # ImportError: No module named test1.urls 
+    - 'cd test_project; python manage.py test'  # [not win]
+
+  requires:
+    - django <1.11
+    - django-extensions
+    - sqlalchemy >0.7.1
+
+  source_files:
+    - test_project
+
+about:
+  home: https://github.com/Deepwalker/aldjemy/
+  license: BSD
+  license_family: BSD
+  summary: 'SQLAlchemy to Django integration library'
+  dev_url: https://github.com/Deepwalker/aldjemy
+
+extra:
+  recipe-maintainers:
+    - ltalirz

--- a/recipes/aldjemy/meta.yaml
+++ b/recipes/aldjemy/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   build:
     - python
     - setuptools
-    - sqlalchemy >0.7.1
 
   run:
     - python
@@ -32,7 +31,7 @@ test:
   commands:
     # django 1.11 yields
     # ImportError: No module named test1.urls 
-    - 'cd test_project; python manage.py test'  # [not win]
+    - 'cd test_project; python manage.py test'
 
   requires:
     - django <1.11

--- a/recipes/aldjemy/meta.yaml
+++ b/recipes/aldjemy/meta.yaml
@@ -29,11 +29,12 @@ test:
     - aldjemy
 
   commands:
-    # django 1.11 yields
-    # ImportError: No module named test1.urls 
-    - 'cd test_project; python manage.py test'
+    - 'cd test_project; python manage.py test'  # [not win]
+    - 'cd test_project & python manage.py test'  # [win]
 
   requires:
+    # django 1.11 yields
+    # ImportError: No module named test1.urls 
     - django <1.11
     - django-extensions
     - sqlalchemy >0.7.1
@@ -45,6 +46,8 @@ about:
   home: https://github.com/Deepwalker/aldjemy/
   license: BSD
   license_family: BSD
+  # To be added https://github.com/Deepwalker/aldjemy/pull/50
+  # license_file: LICENSE
   summary: 'SQLAlchemy to Django integration library'
   dev_url: https://github.com/Deepwalker/aldjemy
 


### PR DESCRIPTION
recipe for the [aldjemy](https://pypi.python.org/pypi/aldjemy/0.6.0) package.

This recipe is for aldjemy 0.6.0, which we need for our materials science package.
I can add another recipe for the latest version 0.7.0 later on.