### PR TITLE
add recipe for pdb++ (pdbpp)

### DIFF
--- a/recipes/pdbpp/meta.yaml
+++ b/recipes/pdbpp/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "pdbpp" %}
+{% set version = "0.9.1" %}
+{% set sha256 = "4a8099079150bbd6b6eedcd6cc42573871bec7d7e7e094feeaca01a62f65959c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - fancycompleter >=0.2
+    - wmctrl
+    - pygments
+
+test:
+  # pdbpp replaces built-in pdb module and makes it available as pdb.pdb
+  # if pdbpp was properly dropped in as pdb replacement the following import should work
+  # on the other hand the built-in pdb does not have pdb.pdb
+  commands:
+    - python -c "from pdb import pdb" 
+
+about:
+  home: http://github.com/antocuni/pdb
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  # n.b. as of 2017-06-28 pdbpp package only specifies license to be "BSD"
+  license: BSD
+  license_family: BSD
+  summary: 'pdb++, a drop-in replacement for pdb'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    This module is an extension of the pdb module of the standard library. It
+    is meant to be fully compatible with its predecessor, yet it introduces a
+    number of new features to make your debugging experience as nice as
+    possible.
+  doc_url: https://github.com/antocuni/pdb
+  dev_url: https://github.com/antocuni/pdb
+
+extra:
+  recipe-maintainers:
+    - megies

--- a/recipes/pdbpp/meta.yaml
+++ b/recipes/pdbpp/meta.yaml
@@ -19,6 +19,9 @@ requirements:
   build:
     - python
     - setuptools
+    - fancycompleter >=0.2
+    - wmctrl
+    - pygments
   run:
     - python
     - fancycompleter >=0.2


### PR DESCRIPTION
This PR is trying to get pdb++ (plain name: pdbpp) packaged for conda. Not sure if it'll work as it's replacing the built-in pdb but since all dependencies are already packaged I thought I'd give it a shot..