### PR TITLE
added lastools receipe

### DIFF
--- a/recipes/lastools/bld.bat
+++ b/recipes/lastools/bld.bat
@@ -1,0 +1,9 @@
+
+cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release .
+if errorlevel 1 exit 1
+
+nmake 
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/lastools/build.sh
+++ b/recipes/lastools/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX -D CMAKE_BUILD_TYPE=Release .
+
+make install -j$CPU_COUNT

--- a/recipes/lastools/build.sh
+++ b/recipes/lastools/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-cmake -D CMAKE_INSTALL_PREFIX=$PREFIX -D CMAKE_BUILD_TYPE=Release .
+# prevent conflict between "LASzip" dir and 'laszip' executeable on OSX
+# do doing build in a different directory
+mkdir build
+cd build
+
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX -D CMAKE_BUILD_TYPE=Release ..
 
 make install -j$CPU_COUNT

--- a/recipes/lastools/meta.yaml
+++ b/recipes/lastools/meta.yaml
@@ -55,7 +55,7 @@ about:
   home: http://www.cs.unc.edu/~isenburg/lastools/
   license: LGPL2.1
   license_file: LICENSE.txt
-  summary: award-winning software for efficient LiDAR processing (with LASzip)
+  summary: LASlib and LASzip libraries plus open source utilities from LAStools for manipulating LiDAR data in LAS format
 
 extra:
   recipe-maintainers:

--- a/recipes/lastools/meta.yaml
+++ b/recipes/lastools/meta.yaml
@@ -1,0 +1,64 @@
+{% set version = "20170625" %}
+
+package:
+  name: lastools
+  version: {{ version }}
+
+source:
+  fn: {{ version }}.tar.gz
+  url: https://github.com/gillins/LAStools/archive/{{ version }}.tar.gz
+  sha256: f2f2b9a798ce7642a820aa90e3cbd8550a2ed0d2d50d5422a16483a944b605ff
+
+build:
+  number: 0
+  skip: True  # [win and py36]
+  features:
+    - vc9     # [win and py27]
+    - vc10    # [win and py34]
+    - vc14    # [win and py35]
+
+requirements:
+  build:
+    - python  # [win]
+    - cmake
+    - toolchain
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py35]
+
+  run:
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py35]
+
+test:
+  commands:
+    - if not exist %LIBRARY_BIN%\\las.dll exit 1        # [win]
+    - if not exist %LIBRARY_LIB%\\las.lib exit 1        # [win]
+    - if not exist %LIBRARY_INC%\\lasreader.hpp exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\laswriter.hpp exit 1  # [win]
+    - test -f $PREFIX/lib/liblas.so                     # [linux]
+    - test -f $PREFIX/lib/liblas.dylib                  # [osx]
+    - test -f $PREFIX/include/lasreader.hpp             # [unix]
+    - test -f $PREFIX/include/laswriter.hpp             # [unix]
+    - lasdiff -h
+    - las2txt -h
+    - lasindex -h
+    - lasmerge -h
+    - txt2las -h
+    - lasprecision -h
+    - las2las -h
+    - laszip -h
+    - lasinfo -h
+
+about:
+  home: http://www.cs.unc.edu/~isenburg/lastools/
+  license: LGPL2.1
+  license_file: LICENSE.txt
+  summary: award-winning software for efficient LiDAR processing (with LASzip)
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - danclewley
+    - armstonj


### PR DESCRIPTION
This adds the `lastools` package for reading and writing .las LiDAR files. Upstream does not provide releases so I have made this recipe from my fork which does provide releases when the LAS_TOOLS_VERSION define is updated. My fork also provides `cmake` support. Let me know if this is ok or not.

@danclewley are you ok to be a maintainer? I spoke to @armstonj on the phone, he was happy to be a maintainer also.

