### PR TITLE
add pulsewaves recipe

### DIFF
--- a/recipes/pulsewaves/bld.bat
+++ b/recipes/pulsewaves/bld.bat
@@ -1,0 +1,13 @@
+:: Needed so we can find stdint.h from msinttypes.
+set LIB=%LIBRARY_LIB%;%LIB%
+set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
+set INCLUDE=%LIBRARY_INC%;%INCLUDE%
+
+cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -D CMAKE_BUILD_TYPE=Release .
+if errorlevel 1 exit 1
+
+nmake 
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/pulsewaves/build.sh
+++ b/recipes/pulsewaves/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX -D CMAKE_BUILD_TYPE=Release .
+
+make install -j$CPU_COUNT

--- a/recipes/pulsewaves/meta.yaml
+++ b/recipes/pulsewaves/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = "20160127" %}
+
+package:
+  name: pulsewaves
+  version: {{ version }}
+
+source:
+  fn: {{ version }}.tar.gz
+  url: https://github.com/gillins/PulseWaves/archive/20160127.tar.gz
+  sha256: b1c07d45a03711ff5fee1ea1f3dbbf2d9a355e0b9451bd31b0238339beaa4172
+
+build:
+  number: 0
+  skip: True  # [win and py36]
+  features:
+    - vc9     # [win and py27]
+    - vc10    # [win and py34]
+    - vc14    # [win and py35]
+
+requirements:
+  build:
+    - python  # [win]
+    - cmake
+    - toolchain
+    - msinttypes  # [win and py27]
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py35]
+  run:
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py35]
+
+test:
+  commands:
+    - if not exist %LIBRARY_BIN%\\pulsewaves.dll exit 1   # [win]
+    - if not exist %LIBRARY_LIB%\\pulsewaves.lib exit 1   # [win]
+    - if not exist %LIBRARY_INC%\\pulsereader.hpp exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\pulsewriter.hpp exit 1  # [win]
+    - test -f $PREFIX/lib/libpulsewaves.so                # [linux]
+    - test -f $PREFIX/lib/libpulsewaves.dylib             # [osx]
+    - test -f $PREFIX/include/pulsereader.hpp             # [unix]
+    - test -f $PREFIX/include/pulsewriter.hpp             # [unix]
+
+about:
+  home: https://rapidlasso.com/pulsewaves/
+  license: LGPL2.1
+  license_file: COPYING.txt
+  summary: An open source effort for a vendor-neutral exchange format for geo-referenced full waveform LiDAR
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - danclewley
+    - armstonj


### PR DESCRIPTION
This library allows access to PulseWaves format LiDAR files. Similar to https://github.com/conda-forge/staged-recipes/pull/3218, this build is from a fork of the upstream repo that contains a release based on the PULSE_TOOLS_VERSION define in the code. It also has `cmake` support. 

@danclewley @armstonj I assumed you would happy to be in on this one also. Let me know if not ok.