### PR TITLE
Add reentry recipe

### DIFF
--- a/recipes/reentry/meta.yaml
+++ b/recipes/reentry/meta.yaml
@@ -8,26 +8,20 @@ package:
 
 source:
   fn: v{{ version }}.tar.gz
-  url: https://github.com/DropD/reentry/archive/v1.0.2.tar.gz
-  # PyPI version is currently missing a .json file
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://github.com/DropD/reentry/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
-
 
 build:
   number: 0
   entry_points:
     - reentry = reentry.cli:reentry
-
   script: python setup.py install --single-version-externally-managed --record record.txt
-
   skip: True  # [not py27]
 
 requirements:
   build:
     - python
     - setuptools >=18.5
-
   run:
     - python
     - click
@@ -35,14 +29,11 @@ requirements:
 test:
   imports:
     - reentry
-
   commands:
     - reentry --help
     - python -m pytest
-
   requires:
     - pytest
-
   source_files:
     - reentry
 

--- a/recipes/reentry/meta.yaml
+++ b/recipes/reentry/meta.yaml
@@ -21,7 +21,7 @@ build:
 
   script: python setup.py install --single-version-externally-managed --record record.txt
 
-  skip: True  [not py27]
+  skip: True  # [not py27]
 
 requirements:
   build:

--- a/recipes/reentry/meta.yaml
+++ b/recipes/reentry/meta.yaml
@@ -1,22 +1,21 @@
 {% set name = "reentry" %}
 {% set version = "1.0.2"%}
-{% set sha256 = "d981bf90c46a11819ff35bea227e4337019ae3b7719038b51e0e21180321c656"%}
+{% set sha256 = "0fe68f19c7623d500ae0c1ca4e98d627f4d1d9832ae8bb4b00e4e471a5fdcd97"%}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  #fn: {{ name }}-{{ version }}.tar.gz
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/DropD/reentry/archive/v1.0.2.tar.gz
+  # PyPI version is currently missing a .json file
   #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  #sha256: {{ sha256 }}
-  git_url: https://github.com/DropD/reentry.git
-  git_rev: v1.0.2
+  sha256: {{ sha256 }}
 
 
 build:
   number: 0
-  preserve_egg_dir: True
   entry_points:
     - reentry = reentry.cli:reentry
 
@@ -29,7 +28,6 @@ requirements:
 
   run:
     - python
-    - setuptools >=18.5
     - click
 
 test:
@@ -50,6 +48,8 @@ about:
   home: https://github.com/DropD/reentry
   license: MIT
   license_family: MIT
+  # PR for including license file: https://github.com/DropD/reentry/pull/10
+  #license_file: LICENSE
   summary: 'A plugin manager based on setuptools entry points mechanism'
   dev_url: https://github.com/DropD/reentry
 

--- a/recipes/reentry/meta.yaml
+++ b/recipes/reentry/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "reentry" %}
+{% set version = "1.0.2"%}
+{% set sha256 = "d981bf90c46a11819ff35bea227e4337019ae3b7719038b51e0e21180321c656"%}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  #fn: {{ name }}-{{ version }}.tar.gz
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  #sha256: {{ sha256 }}
+  git_url: https://github.com/DropD/reentry.git
+  git_rev: v1.0.2
+
+
+build:
+  number: 0
+  preserve_egg_dir: True
+  entry_points:
+    - reentry = reentry.cli:reentry
+
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools >=18.5
+
+  run:
+    - python
+    - setuptools >=18.5
+    - click
+
+test:
+  imports:
+    - reentry
+
+  commands:
+    - reentry --help
+    - python -m pytest
+
+  requires:
+    - pytest
+
+  source_files:
+    - reentry
+
+about:
+  home: https://github.com/DropD/reentry
+  license: MIT
+  license_family: MIT
+  summary: 'A plugin manager based on setuptools entry points mechanism'
+  dev_url: https://github.com/DropD/reentry
+
+extra:
+  recipe-maintainers:
+    - ltalirz

--- a/recipes/reentry/meta.yaml
+++ b/recipes/reentry/meta.yaml
@@ -21,6 +21,8 @@ build:
 
   script: python setup.py install --single-version-externally-managed --record record.txt
 
+  skip: True  [not py27]
+
 requirements:
   build:
     - python


### PR DESCRIPTION
Adding a recipe for the reentry python package.

Currently, the tests don't pass when using the [archive provided on PyPI](https://pypi.python.org/pypi/reentry/1.0.2) (since a file is missing from the .tar).
I have raised an [issue](https://github.com/DropD/reentry/issues/9) (and a [pull request](https://github.com/DropD/reentry/pull/10) to solve it).

For the moment, I rely on a direct checkout of the github repository.
As far as I am informed, the package author is on leave until end of August.