### PR TITLE
corrected typo in maintainer name

### DIFF
--- a/recipes/r-bookdown/meta.yaml
+++ b/recipes/r-bookdown/meta.yaml
@@ -49,4 +49,4 @@ extra:
   recipe-maintainers:
     - johanneskoester
     - bgruening
-    - bennblad
+    - bsennblad


### PR DESCRIPTION
Follow-up PR to r-bookdown. Corrected typo in maintianer name that prevented conversion to feedstock. Apologies for inconveniences caused.
Bengt 