### PR TITLE
Recipe for pygmo_plugins_nonfree, a pygmo affiliated package

### DIFF
--- a/recipes/pygmo_plugins_nonfree/bld.bat
+++ b/recipes/pygmo_plugins_nonfree/bld.bat
@@ -1,0 +1,15 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "%CMAKE_GENERATOR%" ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DPAGMO_PLUGINS_NONFREE_BUILD_PYTHON=yes ^
+    -DPAGMO_PLUGINS_NONFREE_BUILD_TESTS=no ^
+    ..
+
+cmake --build . --config Release
+
+cmake --build . --config Release --target install
+

--- a/recipes/pygmo_plugins_nonfree/build.sh
+++ b/recipes/pygmo_plugins_nonfree/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+mkdir build
+cd build
+
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DPAGMO_PLUGINS_NONFREE_BUILD_PYTHON=yes \
+    -DPAGMO_PLUGINS_NONFREE_BUILD_TESTS=no \
+    ..
+
+make
+
+make install

--- a/recipes/pygmo_plugins_nonfree/meta.yaml
+++ b/recipes/pygmo_plugins_nonfree/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/esa/pagmo_plugins_nonfree/archive/v{{ version }}.tar.gz
-  sha256: 541e53e8bc026065a04e4dc2c5e289479c7fc69e79271d336b338e025aec841b
+  sha256: 66a6793598653f33fb331e8ed2e9e582fcf44b3bfb23229ebd81bb892542bb6a
 
 build:
   number: 0

--- a/recipes/pygmo_plugins_nonfree/meta.yaml
+++ b/recipes/pygmo_plugins_nonfree/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.3" %}
+
+package:
+  name: pygmo_plugins_nonfree
+  version: {{ version }}
+
+source:
+  url: https://github.com/esa/pagmo_plugins_nonfree/archive/v{{ version }}.tar.gz
+  sha256: 541e53e8bc026065a04e4dc2c5e289479c7fc69e79271d336b338e025aec841b
+
+build:
+  number: 0
+  skip: true  # [(win and py27) or win32]
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - pagmo     2.4
+    - pygmo     2.4
+    - boost     1.63.*
+    - numpy     x.x
+    - cloudpickle
+    - ipyparallel
+    - python
+  run:
+    - pagmo     2.4
+    - boost     1.63.*
+    - numpy     x.x
+    - cloudpickle
+    - ipyparallel
+    - python
+
+about:
+  home: https://github.com/esa/pagmo_plugins_nonfree/
+  license: GPL v3 and LGPL v3
+  license_file: COPYING.lgpl3
+  summary: 'A package affiliated to pagmo/pygmo and providing additional solvers in the form of plugins (i.e. loading the third party libraries at run time)'
+
+extra:
+  recipe-maintainers:
+    - bluescarni
+    - darioizzo

--- a/recipes/pygmo_plugins_nonfree/meta.yaml
+++ b/recipes/pygmo_plugins_nonfree/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [(win  and py27) or win32]
+  skip: true  #[(win  and py27) or win32]
 
 requirements:
   build:

--- a/recipes/pygmo_plugins_nonfree/meta.yaml
+++ b/recipes/pygmo_plugins_nonfree/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - python
   run:
     - pagmo     2.4
+    - pygmo     2.4
     - boost     1.63.*
     - numpy     x.x
     - cloudpickle

--- a/recipes/pygmo_plugins_nonfree/meta.yaml
+++ b/recipes/pygmo_plugins_nonfree/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  #[(win  and py27) or win32]
+  skip: true  # [(win  and py27) or win32]
 
 requirements:
   build:

--- a/recipes/pygmo_plugins_nonfree/meta.yaml
+++ b/recipes/pygmo_plugins_nonfree/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [(win and py27) or win32]
+  skip: true  # [(win  and py27) or win32]
 
 requirements:
   build:

--- a/recipes/pygmo_plugins_nonfree/run_test.bat
+++ b/recipes/pygmo_plugins_nonfree/run_test.bat
@@ -1,0 +1,5 @@
+start /b ipcluster start
+
+timeout 20
+
+python -c "import pygmo_plugins_nonfree; pygmo_plugins_nonfree.test.run_test_suite()"

--- a/recipes/pygmo_plugins_nonfree/run_test.sh
+++ b/recipes/pygmo_plugins_nonfree/run_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+ipcluster start --daemonize=True;
+
+# Give some time for the cluster to start up.
+sleep 20;
+
+# Run the test suite
+python -c "import pygmo_plugins_nonfree; pygmo_plugins_nonfree.test.run_test_suite()"
+
+# Stop the cluster.
+ipcluster stop


### PR DESCRIPTION
I am not super expert on this, its my first PR to staged-recipes.

 [pygmo](https://esa.github.io/pagmo2/index.html) is an AI toolbox for evolutionary optimization as well as deterministic optimization and is already available in conda-forge. This recipe is for  [pygmo_plugins_nonfree](https://esa.github.io/pagmo_plugins_nonfree/index.html) which adds as plugins a number of commercial solvers to pygmo's parallelization capabilities. In its 0.3 version SNOPT is made available, in the future there are plans for WORHP and others.