### PR TITLE
add seapy

### DIFF
--- a/recipes/seapy/meta.yaml
+++ b/recipes/seapy/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: seapy
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/ocefpaf/seapy.git
+  git_tag: packaging
+
+build:
+  number: 0
+  skip: True  # [osx or win or py2k]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+    - gcc  # [not win]
+  run:
+    - python
+    - numpy x.x
+    - scipy
+    - joblib
+    - netcdf4
+    - matplotlib
+    - basemap
+    - numpy_groupies
+    - libgcc  # [not win]
+
+test:
+  imports:
+    - seapy
+    - seapy.seawater
+    - seapy.roms
+    - seapy.model
+    - seapy.external.oalib
+    - seapy.external.hindices
+  commands:
+    - conda inspect linkages -p $PREFIX seapy  # [not win]
+    - conda inspect objects -p $PREFIX seapy  # [osx]
+
+about:
+  home: https://github.com/powellb/seapy/
+  license: MIT
+  license_file: LICENSE.txt
+  summary: 'State Estimation and Analysis in PYthon'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
@rsignell-usgs I decided to bite the bullet and rewrite `seapy` a little bit to be more packaging friendly.

All the changes are in my [branch](https://github.com/ocefpaf/seapy/tree/packaging).
I will send a PR upstream once we can test this package.

This PR is pending the creation of the packages for [`numpy_groupies`](https://github.com/conda-forge/numpy_groupies-feedstock).