### PR TITLE
Add pigz (all target platforms)

### DIFF
--- a/recipes/pigz/bld.bat
+++ b/recipes/pigz/bld.bat
@@ -1,9 +1,17 @@
-set "XCFLAGS=/W3 /MT /nologo"
-
-set "CFLAGS=%CFLAGS% -O3 -I%LIBRARY_INC"
-set "LDFLAGS=%LDFLAGS% -L%LIBRARY_LIB"
-nmake /E
-nmake test
-
-copy pigz %LIBRARY_BIN%
-copy unpigz %LIBRARY_BIN%
+:: Trailing semicolon in this variable as set by current (2017/01)
+:: conda-build breaks us. Manual fix:
+set "MSYS2_ARG_CONV_EXCL=/AI;/AL;/OUT;/out"
+:: Delegate to the Unixy script. We need to translate the key path variables
+:: to be Unix-y rather than Windows-y, though.
+set "saved_recipe_dir=%RECIPE_DIR%"
+FOR /F "delims=" %%i IN ('cygpath.exe -u -p "%PATH%"') DO set "PATH_OVERRIDE=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -m "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_M=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%LIBRARY_PREFIX%"') DO set "LIBRARY_PREFIX_U=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PREFIX%"') DO set "PREFIX=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%PYTHON%"') DO set "PYTHON=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%RECIPE_DIR%"') DO set "RECIPE_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SP_DIR%"') DO set "SP_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%SRC_DIR%"') DO set "SRC_DIR=%%i"
+FOR /F "delims=" %%i IN ('cygpath.exe -u "%STDLIB_DIR%"') DO set "STDLIB_DIR=%%i"
+bash -x %saved_recipe_dir%\build.sh
+if errorlevel 1 exit 1

--- a/recipes/pigz/bld.bat
+++ b/recipes/pigz/bld.bat
@@ -1,0 +1,7 @@
+set "XCFLAGS=/W3 /MT /nologo"
+
+nmake
+nmake test
+
+copy pigz %LIBRARY_BIN%
+copy unpigz %LIBRARY_BIN%

--- a/recipes/pigz/bld.bat
+++ b/recipes/pigz/bld.bat
@@ -1,6 +1,8 @@
 set "XCFLAGS=/W3 /MT /nologo"
 
-nmake
+set "CFLAGS=%CFLAGS% -O3 -I%LIBRARY_INC"
+set "LDFLAGS=%LDFLAGS% -L%LIBRARY_LIB"
+nmake /E
 nmake test
 
 copy pigz %LIBRARY_BIN%

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-env
-
 # Adopt a Unix-friendly path if we're on Windows (see bld.bat).
 [ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
 
 LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 CFLAGS="$CFLAGS -O3 -I$PREFIX/include"
 
-make -j$CPU_COUNT LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
+make -j$CPU_COUNT LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS"
 make test
 
 cp pigz unpigz $PREFIX/bin

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+env
+
 # Adopt a Unix-friendly path if we're on Windows (see bld.bat).
 [ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
 

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -6,7 +6,12 @@
 LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 CFLAGS="$CFLAGS -O3 -I$PREFIX/include"
 
-make -j$CPU_COUNT LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS" CPPFLAGS="$CPPFLAGS"
+# The AppVeyor build sets "TARGET_ARCH" to x86 or x64. We need to unset
+# this, as TARGET_ARCH is put on the command line by Make via
+# its default rules for compiling C files.
+export TARGET_ARCH=
+
+make -j$CPU_COUNT LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
 make test
 
 cp pigz unpigz $PREFIX/bin

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 LDFLAGS="$LDFLAGS -L$PREFIX/lib"
+CFLAGS="$CFLAGS -O3 -I$PREFIX/include"
 
-make -j$CPU_COUNT LDFLAGS="$LDFLAGS"
+make -j$CPU_COUNT LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
 make test
 
 cp pigz unpigz $PREFIX/bin

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Adopt a Unix-friendly path if we're on Windows (see bld.bat).
+[ -n "$PATH_OVERRIDE" ] && export PATH="$PATH_OVERRIDE"
+
 LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 CFLAGS="$CFLAGS -O3 -I$PREFIX/include"
 

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+LDFLAGS="$LDFLAGS -L$PREFIX/lib"
+
+make -j$CPU_COUNT LDFLAGS="$LDFLAGS"
+make test
+
+cp pigz unpigz $PREFIX/bin

--- a/recipes/pigz/build.sh
+++ b/recipes/pigz/build.sh
@@ -14,4 +14,9 @@ export TARGET_ARCH=
 make -j$CPU_COUNT LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
 make test
 
-cp pigz unpigz $PREFIX/bin
+# Use different variable to get "binprefix" on win:
+if [ -n "$LIBRARY_BIN" ]; then
+    cp pigz unpigz $LIBRARY_BIN
+else
+    cp pigz unpigz $PREFIX/bin
+fi

--- a/recipes/pigz/meta.yaml
+++ b/recipes/pigz/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "pigz" %}
+{% set version = "2.3.4" %}
+{% set sha256 = "6f031fa40bc15b1d80d502ff91f83ba14f4b079e886bfb83221374f7bf5c8f9a" %}
+{% set am_version = "1.15" %} # keep synchronized with build.sh
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://zlib.net/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python  # [win]
+    - vc 9   # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - pthreads-win32  # [win]
+    - toolchain
+    - zlib 1.2.*
+  run:
+    - vc 9   # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+    - zlib 1.2.*
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
+    - pigz -h
+    - unpigz -h
+
+about:
+  home: https://zlib.net/pigz/
+  license: zlib
+  license_family: other
+  license_file: README
+  summary: Parallel implementation of gzip
+  description: |
+    pigz, which stands for parallel implementation of gzip, is a fully functional
+    replacement for gzip that exploits multiple processors and multiple cores
+    to the hilt when compressing data.
+  doc_url: https://zlib.net/pigz/pigz.pdf
+
+extra:
+  recipe-maintainers:
+    - epruesse

--- a/recipes/pigz/meta.yaml
+++ b/recipes/pigz/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "pigz" %}
 {% set version = "2.3.4" %}
 {% set sha256 = "6f031fa40bc15b1d80d502ff91f83ba14f4b079e886bfb83221374f7bf5c8f9a" %}
-{% set am_version = "1.15" %} # keep synchronized with build.sh
 
 package:
   name: {{ name }}
@@ -14,20 +13,26 @@ source:
 
 build:
   number: 0
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py>=35]
 
 requirements:
   build:
-    - python  # [win]
-    - vc 9   # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
-    - pthreads-win32  # [win]
+    - python           # [win]
+    - vc 9             # [win and py27]
+    - vc 10            # [win and py34]
+    - vc 14            # [win and py>=35]
+    - posix            # [win]
+    - pthreads-win32   # [win]
+    - m2w64-toolchain  # [win]
     - toolchain
     - zlib 1.2.*
   run:
-    - vc 9   # [win and py27]
-    - vc 10  # [win and py34]
-    - vc 14  # [win and py>=35]
+    - vc 9             # [win and py27]
+    - vc 10            # [win and py34]
+    - vc 14            # [win and py>=35]
     - zlib 1.2.*
 
 test:


### PR DESCRIPTION
conda defaults has `pigz`, but only for Linux. It'll work at least on OSX easily; will try briefly to get Win to work as well. 