### PR TITLE
Added recipe for pyperclip

### DIFF
--- a/recipes/pyperclip/LICENSE.txt
+++ b/recipes/pyperclip/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Al Sweigart
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the {organization} nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/pyperclip/meta.yaml
+++ b/recipes/pyperclip/meta.yaml
@@ -37,6 +37,7 @@ about:
   license_family: BSD
   summary: 'A cross-platform clipboard module for Python. (only handles plain text for now)'
   dev_url: https://github.com/asweigart/pyperclip
+  doc_url: https://pyperclip.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipes/pyperclip/meta.yaml
+++ b/recipes/pyperclip/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "pyperclip" %}
+{% set version = "1.5.27" %}
+{% set bundle = "zip" %}
+{% set hash_type = "sha256" %}
+{% set hash = "a3cb6df5d8f1557ca8fc514d94fabf50dc5a97042c90e5ba4f3611864fed3fc5" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - pyperclip
+
+about:
+  home: https://github.com/asweigart/pyperclip
+  license_file: {{ RECIPE_DIR }}/LICENSE.txt
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: 'A cross-platform clipboard module for Python. (only handles plain text for now)'
+  dev_url: https://github.com/asweigart/pyperclip
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
[`pyperclip`](https://github.com/asweigart/pyperclip) is a cross-platform module for copying and pasting from the clipboard. It's needed for the latest version of `cmd2`. (Ref: https://github.com/conda-forge/cmd2-feedstock/pull/14)