### PR TITLE
Add dirent

### DIFF
--- a/recipes/dirent/meta.yaml
+++ b/recipes/dirent/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "dirent" %}
+{% set version = "1.21" %}
+{% set sha256 = "b5214abdd138056f893bad41e6f15081cb454304df9432c1d233e5a68eddf839" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://softagalleria.net/download/dirent/dirent-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not win]
+  script:
+    - if not exist "%LIBRARY_INC%" mkdir "%LIBRARY_INC%"  # [win]
+    - copy "include\\dirent.h" "%LIBRARY_INC%\\"          # [win]
+
+test:
+  commands:
+    - if not exist "%LIBRARY_INC%\\dirent.h" exit 1       # [win]
+
+about:
+  home: https://softagalleria.net/dirent.php
+  license: MIT
+  # No license file, unfortunately.
+  summary: Dirent interface for Microsoft Visual Studio
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a package for the Windows compatible copy of `dirent.h`. Seems to be needed to build `libcxx` on Windows as seen on this [log line]( https://ci.appveyor.com/project/jakirkham/libcxx-feedstock/build/1.0.14/job/hp8w4mit5s7nmnad#L851 ).

cc @inducer @SylvainCorlay