### PR TITLE
Added conda recipe for travis-encrypt

### DIFF
--- a/recipes/travis-encrypt/meta.yaml
+++ b/recipes/travis-encrypt/meta.yaml
@@ -26,7 +26,6 @@ requirements:
 test:
   imports:
     - travis
-    - travis.tests
 
   commands:
     - travis-encrypt --help

--- a/recipes/travis-encrypt/meta.yaml
+++ b/recipes/travis-encrypt/meta.yaml
@@ -35,6 +35,7 @@ about:
   license: GPL-3.0
   summary: 'A command line application that encrypts passwords for use with Travis CI.'
   license_family: GPL3
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipes/travis-encrypt/meta.yaml
+++ b/recipes/travis-encrypt/meta.yaml
@@ -3,9 +3,10 @@ package:
   version: "0.6.0"
 
 source:
-  fn: https://github.com/mandeep/Travis-Encrypt.git
+  git_url: https://github.com/mandeep/Travis-Encrypt.git
 
 build:
+  number: 0
   noarch: python
   entry_points:
     - travis-encrypt=travis.cli:cli
@@ -37,6 +38,10 @@ test:
     - travis-encrypt --help
 
 about:
+  home: https://www.github.com/mandeep/Travis-Encrypt
   license: GNU General Public License v3 or later (GPLv3+)
   summary: 'A command line application that encrypts passwords for use with Travis CI.'
   license_family: GPL3
+extra:
+  recipe-maintainers:
+   - mandeep

--- a/recipes/travis-encrypt/meta.yaml
+++ b/recipes/travis-encrypt/meta.yaml
@@ -3,9 +3,7 @@ package:
   version: "0.6.0"
 
 source:
-  fn: travis-encrypt-0.6.0.tar.gz
-  url: https://pypi.python.org/packages/8d/f6/8948bd1cd0219c1043f214f2c44f41307142329dc5908d18da82ad90a0d2/travis-encrypt-0.6.0.tar.gz
-  md5: 0799ada090eeaafe63af40ae7d6239e9
+  fn: https://github.com/mandeep/Travis-Encrypt.git
 
 build:
   noarch: python

--- a/recipes/travis-encrypt/meta.yaml
+++ b/recipes/travis-encrypt/meta.yaml
@@ -1,13 +1,12 @@
 package:
   name: travis-encrypt
-  version: "0.6.0"
+  version: "0.7.2"
 
 source:
-  git_url: https://github.com/mandeep/Travis-Encrypt.git
-
+  url: https://files.pythonhosted.org/packages/63/ed/71a981d4aa842fb0ed827bcc0560c09392635210497d425b70452c7f3d14/travis-encrypt-0.7.2.tar.gz
+  sha256: 185a3a8a01be2fa4b88b7b2a0b7bbf8fbbe684f1e154cfbafcd4bd3d1bd01f94
 build:
   number: 0
-  noarch: python
   entry_points:
     - travis-encrypt=travis.cli:cli
   script: python setup.py install --single-version-externally-managed --record record.txt
@@ -16,14 +15,9 @@ requirements:
   build:
     - python
     - setuptools
-    - click >=6.6
-    - cryptography >=1.7.1
-    - pyyaml >=3.12
-    - requests >=2.12.5
 
   run:
     - python
-    - setuptools
     - click >=6.6
     - cryptography >=1.7.1
     - pyyaml >=3.12
@@ -39,9 +33,10 @@ test:
 
 about:
   home: https://www.github.com/mandeep/Travis-Encrypt
-  license: GNU General Public License v3 or later (GPLv3+)
+  license: GPL-3.0
   summary: 'A command line application that encrypts passwords for use with Travis CI.'
   license_family: GPL3
+
 extra:
   recipe-maintainers:
    - mandeep

--- a/recipes/travis-encrypt/meta.yaml
+++ b/recipes/travis-encrypt/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: travis-encrypt
+  version: "0.6.0"
+
+source:
+  fn: travis-encrypt-0.6.0.tar.gz
+  url: https://pypi.python.org/packages/8d/f6/8948bd1cd0219c1043f214f2c44f41307142329dc5908d18da82ad90a0d2/travis-encrypt-0.6.0.tar.gz
+  md5: 0799ada090eeaafe63af40ae7d6239e9
+
+build:
+  noarch: python
+  entry_points:
+    - travis-encrypt=travis.cli:cli
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - click >=6.6
+    - cryptography >=1.7.1
+    - pyyaml >=3.12
+    - requests >=2.12.5
+
+  run:
+    - python
+    - setuptools
+    - click >=6.6
+    - cryptography >=1.7.1
+    - pyyaml >=3.12
+    - requests >=2.12.5
+
+test:
+  imports:
+    - travis
+    - travis.tests
+
+  commands:
+    - travis-encrypt --help
+
+about:
+  license: GNU General Public License v3 or later (GPLv3+)
+  summary: 'A command line application that encrypts passwords for use with Travis CI.'
+  license_family: GPL3


### PR DESCRIPTION
This is a recipe for travis-encrypt. travis-encrypt is an application that encrypts passwords and environmen variables in .travis.yml for use with Travis CI.