### PR TITLE
Coastline data for the Generic Mapping Tools

### DIFF
--- a/recipes/gshhg-gmt/bld.bat
+++ b/recipes/gshhg-gmt/bld.bat
@@ -1,0 +1,7 @@
+set DATADIR="%LIBRARY_PREFIX%\share\gshhg-gmt"
+
+if not exist %DATADIR% mkdir %DATADIR%
+
+xcopy %SRC_DIR%\*.nc %DATADIR% /s /e || exit 1
+xcopy %SRC_DIR%\*.TXT %DATADIR% /s /e || exit 1
+xcopy %SRC_DIR%\COPYING* %DATADIR% /s /e || exit 1

--- a/recipes/gshhg-gmt/build.sh
+++ b/recipes/gshhg-gmt/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DATADIR="$PREFIX/share/gshhg-gmt"
+
+mkdir -p $DATADIR
+
+cp $SRC_DIR/*.nc $DATADIR/
+cp $SRC_DIR/*.TXT $DATADIR/
+cp $SRC_DIR/COPYING* $DATADIR/

--- a/recipes/gshhg-gmt/meta.yaml
+++ b/recipes/gshhg-gmt/meta.yaml
@@ -17,7 +17,9 @@ build:
 test:
   commands:
       - test -f $PREFIX/share/{{ name }}/binned_river_l.nc                            # [unix]
+      - test -f $PREFIX/share/{{ name }}/binned_GSHHS_f.nc                            # [unix]
       - if not exist %PREFIX%\\Library\\share\\{{ name }}\\binned_river_l.nc exit 1   # [win]
+      - if not exist %PREFIX%\\Library\\share\\{{ name }}\\binned_GSHHS_f.nc exit 1   # [win]
 
 about:
   home: http://www.soest.hawaii.edu/wessel/gshhg

--- a/recipes/gshhg-gmt/meta.yaml
+++ b/recipes/gshhg-gmt/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "gshhg-gmt" %}
+{% set version = "2.3.7" %}
+{% set sha256 = "9bb1a956fca0718c083bef842e625797535a00ce81f175df08b042c2a92cfe7f" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: ftp://ftp.iag.usp.br/pub/gmt/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+test:
+  commands:
+      - test -f $PREFIX/share/{{ name }}/binned_river_l.nc                            # [unix]
+      - if not exist %PREFIX%\\Library\\share\\{{ name }}\\binned_river_l.nc exit 1   # [win]
+
+about:
+  home: http://www.soest.hawaii.edu/wessel/gshhg
+  license: LGPL-3.0
+  license_family: GPL
+  license_file: LICENSE.TXT
+  summary: 'A Global Self-consistent, Hierarchical, High-resolution Geography Database'
+  description: |
+      This is the version used by the Generic Mapping Tools (GMT). We present
+      a high-resolution geography data set amalgamated from three data bases in
+      the public domain: 1. World Vector Shorelines (WVS). 2. CIA World Data
+      Bank II (WDBII). 3. Atlas of the Cryosphere (AC).
+  doc_url: http://www.soest.hawaii.edu/wessel/gshhg
+  dev_url: http://www.soest.hawaii.edu/wessel/gshhg
+
+extra:
+  recipe-maintainers:
+      - leouieda
+      - mhearne-usgs


### PR DESCRIPTION
This package contains the coastlines used by the `gmt` package. We're separating it into a different package.