### PR TITLE
Adds the opt_einsum package

### DIFF
--- a/recipes/opt_einsum/meta.yaml
+++ b/recipes/opt_einsum/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "opt_einsum" %}
 {% set version = "1.0.1" %}
-{% set sha256 = "6e8a09a86ce02be16f07a0090de064fa56d0db0ba91541244f9eb680d157d241" %}
+{% set sha256 = "247794e7f97ab451ea8f24245fd84174197bec76bd96a4a42b5678884e19e147" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/opt_einsum/meta.yaml
+++ b/recipes/opt_einsum/meta.yaml
@@ -1,0 +1,95 @@
+{% set name = "opt_einsum" %}
+{% set version = "1.0.1" %}
+{% set sha256 = "6e8a09a86ce02be16f07a0090de064fa56d0db0ba91541244f9eb680d157d241" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/dgasmith/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+  commands:
+    - "py.test -v"
+
+about:
+  home: http://github.com/dgasmith/opt_einsum
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A contraction optimizer for the NumPy Einsum function.'
+
+  description: >
+    Einsum is a very powerful function for contracting tensors of arbitrary dimension and index.
+    However, it is only optimized to contract two terms at a time resulting in non-optimal scaling.
+    
+    For example, let us examine the following index transformation:
+    `M_{pqrs} = C_{pi} C_{qj} I_{ijkl} C_{rk} C_{sl}`
+    
+    We can then develop two seperate implementations that produce the same result:
+    ```python
+    N = 10
+    C = np.random.rand(N, N)
+    I = np.random.rand(N, N, N, N)
+    
+    def naive(I, C):
+        # N^8 scaling
+        return np.einsum('pi,qj,ijkl,rk,sl->pqrs', C, C, I, C, C)
+    
+    def optimized(I, C):
+        # N^5 scaling
+        K = np.einsum('pi,ijkl->pjkl', C, I)
+        K = np.einsum('qj,pjkl->pqkl', C, K)
+        K = np.einsum('rk,pqkl->pqrl', C, K)
+        K = np.einsum('sl,pqrl->pqrs', C, K)
+        return K
+    ```
+    
+    The einsum function does not consider building intermediate arrays; therefore, helping einsum out by building these intermediate arrays can result in a considerable cost savings even for small N (N=10):
+    
+    ```python
+    np.allclose(naive(I, C), optimized(I, C))
+    True
+    
+    %timeit naive(I, C)
+    1 loops, best of 3: 934 ms per loop
+    
+    %timeit optimized(I, C)
+    1000 loops, best of 3: 527 µs per loop
+    ```
+    
+    A 2000 fold speed up for 4 extra lines of code!
+    This contraction can be further complicated by considering that the shape of the C matrices need not be the same, in this case the ordering in which the indices are transformed matters greatly.
+    Logic can be built that optimizes the ordering; however, this is a lot of time and effort for a single expression.
+    The opt_einsum package is a drop in replacement for the np.einsum function and can handle all of this logic for you:
+    
+    ```python
+    from opt_einsum import contract
+    
+    %timeit contract('pi,qj,ijkl,rk,sl->pqrs', C, C, I, C, C)
+    1000 loops, best of 3: 324 µs per loop
+    ```
+    
+    The above will automatically find the optimal contraction order, in this case identical to that of the optimized function above, and compute the products for you. In this case, it even uses `np.dot` under the hood to exploit any vendor BLAS functionality that your NumPy build has!
+  dev_url: https://github.com/dgasmith/opt_einsum
+
+extra:
+  recipe-maintainers:
+    - dgasmith
+    - loriab

--- a/recipes/opt_einsum/meta.yaml
+++ b/recipes/opt_einsum/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - numpy
 
 test:
-  src_files:
+  source_files:
     - test
   requires:
     - python

--- a/recipes/opt_einsum/meta.yaml
+++ b/recipes/opt_einsum/meta.yaml
@@ -21,12 +21,16 @@ requirements:
     - setuptools
   run:
     - python
+    - numpy
 
 test:
+  src_files:
+    - test
   requires:
+    - python
     - pytest
   commands:
-    - "py.test -v"
+    - py.test -v ./test
 
 about:
   home: http://github.com/dgasmith/opt_einsum


### PR DESCRIPTION
This package extends the `np.einsum` function to both take advantage of contraction path optimization and BLAS utilization, i.e., it makes `np.einsum` really fast.

Upstream can be found [here](https://github.com/dgasmith/opt_einsum). 