### PR TITLE
Add recipe for itk

### DIFF
--- a/recipes/itk/bld.bat
+++ b/recipes/itk/bld.bat
@@ -1,0 +1,7 @@
+set POST=.post1
+set PYPI_VER=%PY_VER:~0,1%%PY_VER:~2,1%
+
+FOR %%D IN (core,io,filtering,numerics,registration) DO (
+  %PYTHON% -m pip install --no-deps https://pypi.org/packages/cp%PYPI_VER%/i/itk-%%D/itk_%%D-%PKG_VERSION%%POST%-cp%PYPI_VER%-cp%PYPI_VER%m-win_amd64.whl
+)
+if errorlevel 1 exit 1

--- a/recipes/itk/build.sh
+++ b/recipes/itk/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# install using pip from the whl files on PyPI
+
+POST=".post1"
+PYPI_VER="${PY_VER:0:1}${PY_VER:2:3}"
+
+for DEP_PACKAGE in core io filtering numerics registration segmentation; do
+  if [ `uname` == Darwin ]; then
+      WHL_FILE=https://pypi.org/packages/cp${PYPI_VER}/i/itk-${DEP_PACKAGE}/itk_${DEP_PACKAGE}-${PKG_VERSION}${POST}-cp${PYPI_VER}-cp${PYPI_VER}m-macosx_10_6_x86_64.whl
+  fi
+
+  if [ `uname` == Linux ]; then
+      if [ "$PY_VER" == "2.7" ]; then
+          WHL_FILE=https://pypi.org/packages/cp${PYPI_VER}/i/itk-${DEP_PACKAGE}/itk_${DEP_PACKAGE}-${PKG_VERSION}${POST}-cp${PYPI_VER}-cp${PYPI_VER}mu-manylinux1_x86_64.whl
+      else
+          WHL_FILE=https://pypi.org/packages/cp${PYPI_VER}/i/itk-${DEP_PACKAGE}/itk_${DEP_PACKAGE}-${PKG_VERSION}${POST}-cp${PYPI_VER}-cp${PYPI_VER}m-manylinux1_x86_64.whl
+      fi
+  fi
+  pip install --no-deps $WHL_FILE
+done

--- a/recipes/itk/meta.yaml
+++ b/recipes/itk/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: itk
+  version: "4.12.0"
+
+build:
+  number: 0
+  skip: True  # [win32]
+
+requirements:
+  build:
+    - python
+    - pip
+    - wheel
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - itk
+
+about:
+  home: http://www.itk.org/
+  license: Apache 2.0
+  summary: ITK is an open-source toolkit for multidimensional image analysis
+  doc_url: https://itk.org/ITK/help/documentation.html
+  dev_url: https://github.com/InsightSoftwareConsortium/ITK
+
+extra:
+  recipe-maintainers:
+    - thewtex
+    - ericdill


### PR DESCRIPTION
This re-uses the PyPI packages that wrap the Insight Toolkit (ITK). The
infrastructure is based off the tensorflow conda recipe.

Currently a monolithic package for "itk" in created. In the future, it is
possible to splite it into an itk metapackage and multiple dependent packages,
itk-core, itk-io, itk-segmentation, etc.

Co-authored-by: Eric Dill <thedizzle@gmail.com>

This is a re-submission of #3263 since the feedstock did not get created the first time around due to the existing repository.

CC: @blowekamp @ericdill @jjhelmus @msarahan 