### PR TITLE
add POT recipe

### DIFF
--- a/recipes/pot/LICENSE
+++ b/recipes/pot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Rémi Flamary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pot/meta.yaml
+++ b/recipes/pot/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "POT" %}
+{% set version = "0.3.1" %}
+{% set sha256 = "1c226e359e81ca08e593012b9022d64041318d0bd7aafcb30185f1c4f02304af" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+    - cython
+    - numpy x.x
+  run:
+    - python
+    - numpy x.x
+    - scipy
+    - matplotlib
+
+test:
+  imports:
+    - ot
+  requirements:
+    - numpy x.x
+
+about:
+  home: http://github.com/rflamary/POT
+  license: MIT
+  license_family: MIT
+  # license file not yet packaged: https://github.com/rflamary/POT/pull/14
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: 'Python Optimal Transport library'
+  description: |
+    This open source Python library provide several solvers for optimization
+    problems related to Optimal Transport for signal, image processing and
+    machine learning.
+  doc_url: http://pot.readthedocs.io/
+  dev_url: https://github.com/rflamary/pot
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland

--- a/recipes/pot/run_test.py
+++ b/recipes/pot/run_test.py
@@ -1,0 +1,12 @@
+import numpy as np
+import ot
+
+n = 5
+a, b = np.random.dirichlet([1] * n, size=2)
+M = ot.dist(np.random.randn(n, 5), metric='canberra')
+
+W = ot.emd2(a, b, M)
+W_reg = ot.sinkhorn2(a, b, M, .1)
+
+T = ot.emd(a, b, M)
+T_reg = ot.sinkhorn(a, b, M, .1)


### PR DESCRIPTION
Adds a recipe for the Python Optimal Transport package.

@rflamary, if you'd like to be a maintainer here (or any other changes), let me know.