### PR TITLE
add cyflann recipe

### DIFF
--- a/recipes/cyflann/meta.yaml
+++ b/recipes/cyflann/meta.yaml
@@ -14,9 +14,8 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip:
-    # Windows should work, but flann recipe isn't built there yet.
-    - True  # [win]
+  # Windows should work, but flann recipe isn't built there yet.
+  skip: true  # [win]
 
 requirements:
   build:

--- a/recipes/cyflann/meta.yaml
+++ b/recipes/cyflann/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "cyflann" %}
+{% set version = "0.2.3" %}
+{% set sha256 = "a38cfdbaf7b4005f1f6ba417186f485483f78219bec5aa95f479f38551d234ae" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  skip:
+    # Windows should work, but flann recipe isn't built there yet.
+    - True  # [win]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+    - numpy x.x
+    - flann >=1.9.1,<1.10
+    - cython
+  run:
+    - python
+    - numpy x.x
+    - flann >=1.9.1,<1.10
+
+test:
+  imports:
+    - cyflann
+  commands:
+    - nosetests --exe cyflann
+  requires:
+    - pyflann
+    - cython
+    - nose
+
+about:
+  home: http://github.com/dougalsutherland/cyflann
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'A Cython interface to FLANN'
+  description: |
+    cyflann is a Cython interface to the FLANN library. Compared to
+    the default pyflann interface, it allows you to run lots of independent
+    searches without the GIL.
+  dev_url: https://github.com/dougalsutherland/cyflann
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland

--- a/recipes/cyflann/meta.yaml
+++ b/recipes/cyflann/meta.yaml
@@ -24,12 +24,13 @@ requirements:
     - setuptools
     - toolchain
     - numpy x.x
-    - flann >=1.9.1,<1.10
+    - flann 1.9.*
     - cython
+    - pkg-config
   run:
     - python
     - numpy x.x
-    - flann >=1.9.1,<1.10
+    - flann 1.9.*
 
 test:
   imports:

--- a/recipes/cyflann/meta.yaml
+++ b/recipes/cyflann/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - python
     - numpy x.x
     - flann 1.9.*
+    - pkg-config
 
 test:
   imports:


### PR DESCRIPTION
[cyflann](https://github.com/dougalsutherland/cyflann) is my alternative interface to [flann](https://github.com/conda-forge/flann-feedstock/), rather than the default [pyflann](https://github.com/conda-forge/pyflann-feedstock/). It's not incredibly widely-used but I think it would be worthwhile to have in conda-forge.