### PR TITLE
Added recipe for furl

### DIFF
--- a/recipes/furl/meta.yaml
+++ b/recipes/furl/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "furl" %}
+{% set version = "1.0.0" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "874dae78a19ec08dcdca83f007824c090501fa95e55e965a64fcff8b8c5e7230" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - six >=1.8.0
+    - orderedmultidict >=0.7.8
+
+test:
+  imports:
+    - furl
+
+about:
+  home: https://github.com/gruns/furl
+  license_file: LICENSE.md
+  license: Unlicense
+  license_family: OTHER
+  summary: 'URL manipulation made simple.'
+  dev_url: https://github.com/gruns/furl
+  doc_url: https://github.com/gruns/furl
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/furl/meta.yaml
+++ b/recipes/furl/meta.yaml
@@ -17,6 +17,7 @@ source:
 build:
   number: {{ build }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
+
 requirements:
   build:
     - python
@@ -34,8 +35,7 @@ test:
 about:
   home: https://github.com/gruns/furl
   license_file: LICENSE.md
-  license: Unlicense
-  license_family: OTHER
+  license: PUBLIC-DOMAIN
   summary: 'URL manipulation made simple.'
   dev_url: https://github.com/gruns/furl
   doc_url: https://github.com/gruns/furl


### PR DESCRIPTION
`furl` is required by `sqlalchemy-utils` Interestingly, `sqlalchemy-utils` itself built fine *without* `furl` in either conda-forge or the default channels. Also weirdly, `sqlalchemy-utils` can sometimes install fine without it despite the missing requirement. Either way, getting `furl` built solves this odd, sometimes-missing-requirement issue.