### PR TITLE
Added recipe for scikit-garden

### DIFF
--- a/recipes/scikit-garden/LICENSE.txt
+++ b/recipes/scikit-garden/LICENSE.txt
@@ -1,0 +1,32 @@
+New BSD License
+
+Copyright (c) 2016 - scikit-garden developers.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  a. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  b. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  c. Neither the name of the scikit-garden developers nor the names of
+     its contributors may be used to endorse or promote products
+     derived from this software without specific prior written
+     permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipes/scikit-garden/meta.yaml
+++ b/recipes/scikit-garden/meta.yaml
@@ -23,14 +23,17 @@ requirements:
     - python
     - setuptools
     - cython
-    - numpy
+    - numpy 1.7.*   # [py27]
+    - numpy 1.9.*   # [py35]
+    - numpy 1.11.*  # [py36]
 
   run:
     - python
-    - numpy
+    - numpy >=1.7   # [py27]
+    - numpy >=1.9   # [py35]
+    - numpy >=1.11  # [py36]
     - scipy
     - scikit-learn >=0.18
-    - cython
 
 test:
   imports:

--- a/recipes/scikit-garden/meta.yaml
+++ b/recipes/scikit-garden/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "scikit-garden" %}
+{% set version = "0.1.3" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "d6fe65205f39633f17c181f552a0fc56e2f05bb2096be63f38c160fe20718d9d" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - cython
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - scikit-learn >=0.18
+    - cython
+
+test:
+  imports:
+    - skgarden
+    - skgarden.mondrian
+    - skgarden.quantile
+
+about:
+  home: https://scikit-garden.github.io/
+  license_file: {{ RECIPE_DIR }}/LICENSE.txt
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: 'A garden for scikit-learn compatible trees'
+  dev_url: https://github.com/scikit-garden/scikit-garden
+  doc_url: https://scikit-garden.github.io/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/scikit-garden/meta.yaml
+++ b/recipes/scikit-garden/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - python
     - setuptools
     - cython
+    - numpy
 
   run:
     - python


### PR DESCRIPTION
`skgarden` is a module bundling up different kinds of `sklearn`-compatible trees.