### PR TITLE
Pin git to earlier version

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -19,7 +19,7 @@ echo ""
 echo "Configuring conda."
 conda config --set show_channel_urls true
 conda config --add channels conda-forge
-conda install --yes --quiet git
+conda install --yes --quiet git=2.12.2
 conda install --yes --quiet conda-smithy
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup


### PR DESCRIPTION
Would probably fix https://github.com/conda-forge/staged-recipes/issues/3365
I have no idea why the new git version fails.