### PR TITLE
privy

### DIFF
--- a/recipes/privy/meta.yaml
+++ b/recipes/privy/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "privy" %}
+{% set version = "6.0.0" %}
+{% set wheel_tag = "py2.py3" %}
+{% set fn = "{}-{}-{}-none-any.whl".format(name, version, wheel_tag) %}
+{% set sha256 = "e68679bb4006ce83206d9a7af1158cf4d56a2ed6861ee39276907be618dfb8d9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # privy only uploads wheels to PyPI
+  fn: {{ fn }}
+  url: https://pypi.io/packages/{{ wheel_tag }}/{{ name[0] }}/{{ name }}/{{ fn }}
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: pip install --no-deps {{ fn }}
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - cryptography
+    - argon2_cffi
+
+test:
+  imports:
+    - privy
+
+about:
+  home: https://github.com/ofek/privy
+  # privy is actually dual-licensed Apache 2.0 and MIT
+  # can anaconda.org express that?
+  license: MIT
+  license_family: MIT
+  # license_files are not in the wheel, but they are on GitHub
+  # license_file: LICENSE-MIT
+  summary: 'Password-protected data made easy.'
+
+  description: |
+    Privy is a small and fast utility for password-protecting secret data
+    such as API keys, cryptocurrency wallets, or seeds for digital signatures.
+
+extra:
+  recipe-maintainers:
+    - minrk

--- a/recipes/privy/run_test.py
+++ b/recipes/privy/run_test.py
@@ -1,0 +1,6 @@
+# basic smoke test of privy
+import privy
+password = b'password'
+data = b'secret'
+encrypted = privy.hide(data, password)
+assert privy.peek(encrypted, password) == data


### PR DESCRIPTION
privy only uploads wheels, but is pure Python.

Follow flit recipe for installing a conda package from a wheel.