### PR TITLE
cdecimal: add recipy (py2k only)

### DIFF
--- a/recipes/cdecimal/meta.yaml
+++ b/recipes/cdecimal/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [not py2k]
+  skip: True  # [py3k]
   script: python setup.py install
 
 requirements:
@@ -27,10 +27,13 @@ requirements:
 test:
   imports:
     - cdecimal
+  commands:
+    - conda inspect linkages -p $PREFIX cdecimal  # [not win]
+    - conda inspect objects -p $PREFIX cdecimal  # [osx]
 
 about:
   home: http://www.bytereef.org/mpdecimal/index.html
-  license: BSD
+  license: BSD 2-Clause
   summary: 'Fast arbitrary precision correctly-rounded decimal floating point arithmetic.'
   license_family: BSD
   license_file: LICENSE.txt

--- a/recipes/cdecimal/meta.yaml
+++ b/recipes/cdecimal/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "cdecimal" %}
+{% set version = "2.3" %}
+{% set sha256 = "d737cbe43ed1f6ad9874fb86c3db1e9bbe20c0c750868fde5be3f379ade83d8b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://www.bytereef.org/software/mpdecimal/releases/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not py2k]
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+    - toolchain
+
+  run:
+    - python
+
+test:
+  imports:
+    - cdecimal
+
+about:
+  home: http://www.bytereef.org/mpdecimal/index.html
+  license: BSD
+  summary: 'Fast arbitrary precision correctly-rounded decimal floating point arithmetic.'
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Fast drop-in replacement for decimal.py
+  description: |
+    Cdecimal is a fast drop-in replacement for the decimal module in
+    Python's standard library. Typical performance gains are between 30x
+    for I/O heavy benchmarks and 80x for numerical programs.
+  doc_url: http://www.bytereef.org/mpdecimal/doc/cdecimal/index.html
+
+extra:
+  recipe-maintainers:
+    - nehaljwani


### PR DESCRIPTION
cdecimal is a fast drop-in replacement for the decimal module in Python’s standard library for Python versions 2.5 up to 3.2. It provides a complete implementation of Mike Cowlishaw/IBM’s General Decimal Arithmetic Specification.

Why only py2k?:
cdecimal has been integrated into CPython 3.3, where it supersedes the pure Python version: import decimal will automatically import the C version. Performance has been improved further, so the cdecimal version shipped with CPython 3.3 is significantly faster for numerical workload than cdecimal-2.3. If you need maximum decimal computing performance, you should solely use that Python version.