### PR TITLE
Add astro-gala to conda-forge

### DIFF
--- a/recipes/astro-gala/meta.yaml
+++ b/recipes/astro-gala/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "astro-gala" %}
+{% set version = "0.2.1" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "83b319d1e05dbe0453671a3d28cadacb7f57bcf17e3f7e24441410b4cd1ff134" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: python setup.py install --offline --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+  run:
+    - python
+    - astropy
+    - six
+    - pyyaml
+    - scipy
+
+test:
+  imports:
+    - gala
+    - gala.coordinates
+    - gala.dynamics
+    - gala.dynamics._genfunc
+    - gala.dynamics.lyapunov
+    - gala.dynamics.mockstream
+    - gala.integrate
+    - gala.integrate.cyintegrators
+    - gala.integrate.cyintegrators.dopri
+    - gala.integrate.pyintegrators
+    - gala.potential
+    - gala.potential.frame
+    - gala.potential.frame.builtin
+    - gala.potential.hamiltonian
+    - gala.potential.potential
+    - gala.potential.potential.builtin
+
+about:
+  home: http://gala.adrian.pw/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Galactic and gravitational dynamics in Python
+  description: |
+    Gala is a Python package for Galactic astronomy and gravitational
+    dynamics. The bulk of the package centers around implementations of
+    gravitational potentials, numerical integration, and nonlinear dynamics.
+  doc_url: http://gala.adrian.pw
+  dev_url: https://github.com/adrn/gala
+
+extra:
+  recipe-maintainers:
+    - mwcraig
+    - bsipocz
+    - adrn


### PR DESCRIPTION
There is already a package called gala on conda-forge and PyPI, so this one is called `astro-gala`.