### PR TITLE
add rgdal

### DIFF
--- a/recipes/r-rgdal/build.sh
+++ b/recipes/r-rgdal/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export LD_LIBRARY_PATH=$PREFIX/lib/:${LD_LIBRARY_PATH}
+
+$R CMD INSTALL --build .

--- a/recipes/r-rgdal/meta.yaml
+++ b/recipes/r-rgdal/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '1.2-8' %}
+
+package:
+  name: r-rgdal
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: rgdal_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/rgdal_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/rgdal/rgdal_{{ version }}.tar.gz
+  sha256: b87cc7e70eeb10091890c9cb8e07a8f7f5e1a358473dea40dc272da252e4aa25
+
+build:
+  number: 0
+  skip: True  # [win]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-sp
+    - posix  # [win]
+    - m2w64-toolchain  # [win]
+    - gcc  # [not win]
+    - libgdal 2.1.*
+  run:
+    - r-base
+    - r-sp
+    - libgcc  # [not win]
+    - libgdal 2.1.*
+
+test:
+  commands:
+    - R -e "library('rgdal')"  # [not win]
+    - R -e \"library('rgdal')\"  # [win]
+    - conda inspect linkages -p $PREFIX r-rgdal  # [not win]
+    - conda inspect objects -p $PREFIX r-rgdal  # [osx]
+
+about:
+  home: http://www.gdal.org, https://r-forge.r-project.org/projects/rgdal/
+  license: GPL-3.0
+  summary: 'Provides bindings to Frank Warmerdam''s Geospatial Data Abstraction Library (GDAL)
+    (>= 1.6.3) and access to projection/transformation operations from the PROJ.4 library.
+    The GDAL and PROJ.4 libraries are external to the package, and, when installing
+    the package from source, must be correctly installed first. Both GDAL raster and
+    OGR vector map data can be imported into R, and GDAL raster data and OGR vector
+    data exported. Use is made of classes defined in the sp package. Windows and Mac
+    Intel OS X binaries (including GDAL, PROJ.4 and Expat) are provided on CRAN. '
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
Ping @daf

Note to self: add more tests beyond just loading the library.

PS: the instructions mention
    SystemRequirements: | for building from source: GDAL >= 1.6.3

But I am not sure we can use `libgdal 2.2.*`  or even `2.1.*` here. Version `1.6.3` is too old and a lot has changed since then.