### PR TITLE
downloader R/CRAN package

### DIFF
--- a/recipes/r-downloader/bld.bat
+++ b/recipes/r-downloader/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-downloader/build.sh
+++ b/recipes/r-downloader/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+$R CMD INSTALL --build .

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -23,7 +23,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('downloader')"
+    - $R -e "library('downloader')" # [not win]
+    - "\"%R%\" -e \"library('downloader')\"" # [win]
 
 about:
   home: https://cran.rstudio.com/web/packages/downloader/index.html

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: r-downloader
+  version: 0.0.4
+
+source:
+  fn: downloader_0.4.tar.gz
+  url: https://cran.rstudio.com/src/contrib/downloader_0.4.tar.gz
+  md5: f26daf8fbeb29a1882bf102f62008594
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-digest
+  run:
+    - r-base
+    - r-digest
+
+test:
+  commands:
+    - $R -e "library('downloader')"
+
+about:
+  home: https://cran.rstudio.com/web/packages/downloader/index.html
+  license: GPL-2
+  summary: 'Provides a wrapper for the download.file function, making it possible to download 
+    files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The RCurl package 
+    provides this functionality (and much more) but can be difficult to install because it must 
+    be compiled with external dependencies. This package has no external dependencies, so it is 
+    much easier to install.'

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
@@ -23,8 +24,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('downloader')"
-    - "\"%R%\" -e \"library('downloader')\""
+    - $R -e "library('downloader')"  # [not win]
+    - "\"%R%\" -e \"library('downloader')\""  # [win]
 
 about:
   home: https://cran.rstudio.com/web/packages/downloader/index.html

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -30,6 +30,7 @@ test:
 about:
   home: https://cran.rstudio.com/web/packages/downloader/index.html
   license: GPL-2
+  license_family: GPL2
   summary: 'Provides a wrapper for the download.file function, making it possible to download 
     files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The RCurl package 
     provides this functionality (and much more) but can be difficult to install because it must 

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -23,8 +23,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('downloader')" # [not win]
-    - "\"%R%\" -e \"library('downloader')\"" # [win]
+    - $R -e "library('downloader')"
+    - "\"%R%\" -e \"library('downloader')\""
 
 about:
   home: https://cran.rstudio.com/web/packages/downloader/index.html

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -34,3 +34,7 @@ about:
     provides this functionality (and much more) but can be difficult to install because it must 
     be compiled with external dependencies. This package has no external dependencies, so it is 
     much easier to install.'
+
+extra:
+  recipe-maintainers:
+    - fabio-cumbo

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -1,23 +1,31 @@
+{% set version = '0.4' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
 package:
   name: r-downloader
-  version: 0.0.4
+  version: {{ version|replace("-", "_") }}
 
 source:
-  fn: downloader_0.4.tar.gz
-  url: https://cran.rstudio.com/src/contrib/downloader_0.4.tar.gz
-  md5: f26daf8fbeb29a1882bf102f62008594
+  fn: downloader_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/downloader_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/downloader/downloader_{{ version }}.tar.gz
+  sha256: 1890e75b028775154023f2135cafb3e3eed0fe908138ab4f7eff1fc1b47dafab
 
 build:
   number: 0
-  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
 
+# Suggests: testthat
 requirements:
   build:
     - r-base
     - r-digest
+
   run:
     - r-base
     - r-digest
@@ -28,14 +36,36 @@ test:
     - "\"%R%\" -e \"library('downloader')\""  # [win]
 
 about:
-  home: https://cran.rstudio.com/web/packages/downloader/index.html
+  home: https://github.com/wch/downloader
   license: GPL-2
+  summary: Provides a wrapper for the download.file function, making it possible to download
+    files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The 'RCurl'
+    package provides this functionality (and much more) but can be difficult to install
+    because it must be compiled with external dependencies. This package has no external
+    dependencies, so it is much easier to install.
   license_family: GPL2
-  summary: 'Provides a wrapper for the download.file function, making it possible to download 
-    files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The RCurl package 
-    provides this functionality (and much more) but can be difficult to install because it must 
-    be compiled with external dependencies. This package has no external dependencies, so it is 
-    much easier to install.'
+
+# The original CRAN metadata for this package was:
+
+# Package: downloader
+# Maintainer: Winston Chang <winston@stdout.org>
+# Author: Winston Chang <winston@stdout.org>
+# Version: 0.4
+# License: GPL-2
+# Title: Download Files over HTTP and HTTPS
+# Description: Provides a wrapper for the download.file function, making it possible to download files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The 'RCurl' package provides this functionality (and much more) but can be difficult to install because it must be compiled with external dependencies. This package has no external dependencies, so it is much easier to install.
+# URL: https://github.com/wch/downloader
+# Imports: utils, digest
+# Suggests: testthat
+# BugReports: https://github.com/wch/downloader/issues
+# NeedsCompilation: no
+# Packaged: 2015-07-09 01:22:22 UTC; winston
+# Repository: CRAN
+# Date/Publication: 2015-07-09 14:47:41
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml
 
 extra:
   recipe-maintainers:

--- a/recipes/r-downloader/meta.yaml
+++ b/recipes/r-downloader/meta.yaml
@@ -40,3 +40,5 @@ about:
 extra:
   recipe-maintainers:
     - fabio-cumbo
+    - johanneskoester
+    - bgruening


### PR DESCRIPTION
Provides a wrapper for the download.file function, making it possible to download files over HTTPS on Windows, Mac OS X, and other Unix-like platforms. The 'RCurl' package provides this functionality (and much more) but can be difficult to install because it must be compiled with external dependencies. This package has no external dependencies, so it is much easier to install.