### PR TITLE
ggthemes R/CRAN package

### DIFF
--- a/recipes/r-ggthemes/bld.bat
+++ b/recipes/r-ggthemes/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-ggthemes/build.sh
+++ b/recipes/r-ggthemes/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+$R CMD INSTALL --build .

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -37,6 +37,7 @@ test:
 about:
   home: https://cran.rstudio.com/web/packages/ggthemes/index.html
   license: GPL-2
+  license_family: GPL2
   summary: 'Some extra themes, geoms, and scales for ggplot2. Provides ggplot2 themes and 
     scales that replicate the look of plots by Edward Tufte, Stephen Few, Fivethirtyeight, 
     The Economist, Stata, Excel, and The Wall Street Journal, among others. Provides 
@@ -45,3 +46,5 @@ about:
 extra:
   recipe-maintainers:
     - fabio-cumbo
+    - johanneskoester
+    - bgruening

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -1,0 +1,41 @@
+package:
+  name: r-ggthemes
+  version: "3.4.0"
+
+source:
+  fn: ggthemes_3.4.0.tar.gz
+  url: https://cran.rstudio.com/src/contrib/ggthemes_3.4.0.tar.gz
+  md5: 075dde101a5415becc790dfbdcf0b862
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertthat
+    - r-colorspace
+    - r-ggplot2 >=2.2.0
+    - r-scales
+
+  run:
+    - r-base
+    - r-assertthat
+    - r-colorspace
+    - r-ggplot2 >=2.2.0
+    - r-scales
+
+test:
+  commands:
+    - $R -e "library('ggthemes')"
+
+about:
+  home: https://cran.rstudio.com/web/packages/ggthemes/index.html
+  license: GPL-2
+  summary: 'Some extra themes, geoms, and scales for ggplot2. Provides ggplot2 themes and 
+    scales that replicate the look of plots by Edward Tufte, Stephen Few, Fivethirtyeight, 
+    The Economist, Stata, Excel, and The Wall Street Journal, among others. Provides 
+    geoms for Tufte s box plot and range frame.'

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
@@ -30,8 +31,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('ggthemes')"
-    - "\"%R%\" -e \"library('ggthemes')\""
+    - $R -e "library('ggthemes')"  # [not win]
+    - "\"%R%\" -e \"library('ggthemes')\""  # [win]
 
 about:
   home: https://cran.rstudio.com/web/packages/ggthemes/index.html

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -30,8 +30,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('ggthemes')" # [not win]
-    - "\"%R%\" -e \"library('ggthemes')\"" # [win]
+    - $R -e "library('ggthemes')"
+    - "\"%R%\" -e \"library('ggthemes')\""
 
 about:
   home: https://cran.rstudio.com/web/packages/ggthemes/index.html
@@ -40,3 +40,7 @@ about:
     scales that replicate the look of plots by Edward Tufte, Stephen Few, Fivethirtyeight, 
     The Economist, Stata, Excel, and The Wall Street Journal, among others. Provides 
     geoms for Tufte s box plot and range frame.'
+
+extra:
+  recipe-maintainers:
+    - fabio-cumbo

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -30,7 +30,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('ggthemes')"
+    - $R -e "library('ggthemes')" # [not win]
+    - "\"%R%\" -e \"library('ggthemes')\"" # [win]
 
 about:
   home: https://cran.rstudio.com/web/packages/ggthemes/index.html

--- a/recipes/r-ggthemes/meta.yaml
+++ b/recipes/r-ggthemes/meta.yaml
@@ -1,19 +1,26 @@
+{% set version = '3.4.0' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
 package:
   name: r-ggthemes
-  version: "3.4.0"
+  version: {{ version|replace("-", "_") }}
 
 source:
-  fn: ggthemes_3.4.0.tar.gz
-  url: https://cran.rstudio.com/src/contrib/ggthemes_3.4.0.tar.gz
-  md5: 075dde101a5415becc790dfbdcf0b862
+  fn: ggthemes_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/ggthemes_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/ggthemes/ggthemes_{{ version }}.tar.gz
+  sha256: 1a1aeb7fe5a60fab0d0b82e959dd7c01d80b6f5984af77674264cc25cfa548ca
 
 build:
   number: 0
-  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
 
+# Suggests: extrafont, knitr, lintr, maps, mapproj, pander, plyr, reshape2, rmarkdown, testthat, tidyverse
 requirements:
   build:
     - r-base
@@ -35,13 +42,41 @@ test:
     - "\"%R%\" -e \"library('ggthemes')\""  # [win]
 
 about:
-  home: https://cran.rstudio.com/web/packages/ggthemes/index.html
+  home: http://github.com/jrnold/ggthemes
   license: GPL-2
+  summary: Some extra themes, geoms, and scales for 'ggplot2'. Provides 'ggplot2' themes and
+    scales that replicate the look of plots by Edward Tufte, Stephen Few, 'Fivethirtyeight',
+    'The Economist', 'Stata', 'Excel', and 'The Wall Street Journal', among others.
+    Provides 'geoms' for Tufte's box plot and range frame.
   license_family: GPL2
-  summary: 'Some extra themes, geoms, and scales for ggplot2. Provides ggplot2 themes and 
-    scales that replicate the look of plots by Edward Tufte, Stephen Few, Fivethirtyeight, 
-    The Economist, Stata, Excel, and The Wall Street Journal, among others. Provides 
-    geoms for Tufte s box plot and range frame.'
+
+# The original CRAN metadata for this package was:
+
+# Package: ggthemes
+# Version: 3.4.0
+# Title: Extra Themes, Scales and Geoms for 'ggplot2'
+# Authors@R: c(person("Jeffrey B.", "Arnold", role = c("aut", "cre"), email = "jeffrey.arnold@gmail.com"), person("Gergely", "Daroczi", role = "ctb"), person("Bo", "Werth", role = "ctb"), person("Brian", "Weitzner", role = "ctb"), person("Joshua", "Kunst", role = "ctb"), person("Baptise", "Auguie", role = "ctb"), person("Bob", "Rudis", role = "ctb"), person("Hadley", "Wickham", role = c("ctb", "cph"), comment = "Code from the ggplot2 package."), person("Justin",  "Talbot", role = "ctb", comment = "Code from the labeling package"), person("Joshua", "London", role = "ctb"))
+# Depends: R (>= 3.0.0),
+# Imports: assertthat, colorspace, ggplot2 (>= 2.2.0), graphics, grid, methods, scales
+# Suggests: extrafont, knitr, lintr, maps, mapproj, pander, plyr, reshape2, rmarkdown, testthat, tidyverse
+# VignetteBuilder: knitr
+# Description: Some extra themes, geoms, and scales for 'ggplot2'. Provides 'ggplot2' themes and scales that replicate the look of plots by Edward Tufte, Stephen Few, 'Fivethirtyeight', 'The Economist', 'Stata', 'Excel', and 'The Wall Street Journal', among others. Provides 'geoms' for Tufte's box plot and range frame.
+# License: GPL-2
+# URL: http://github.com/jrnold/ggthemes
+# BugReports: http://github.com/jrnold/ggthemes
+# Collate: 'banking.R' 'base.R' 'calc.R' 'canva.R' 'colorblind.R' 'economist.R' 'excel.R' 'few.R' 'ggthemes-data.R' 'ggthemes-package.R' 'fivethirtyeight.R' 'gdocs.R' 'geom-rangeframe.R' 'geom-tufteboxplot.R' 'hc.R' 'igray.R' 'pander.R' 'ptol.R' 'scale-tufte.R' 'shapes.R' 'show.R' 'solarized.R' 'stat-fivenumber.R' 'stata.R' 'tableau.R' 'theme-foundation.R' 'theme-map.R' 'theme-solid.R' 'tufte.R' 'utils.R' 'wsj.R'
+# RoxygenNote: 6.0.1
+# LazyData: true
+# NeedsCompilation: no
+# Packaged: 2017-02-19 09:14:16 UTC; jrnold
+# Author: Jeffrey B. Arnold [aut, cre], Gergely Daroczi [ctb], Bo Werth [ctb], Brian Weitzner [ctb], Joshua Kunst [ctb], Baptise Auguie [ctb], Bob Rudis [ctb], Hadley Wickham [ctb, cph] (Code from the ggplot2 package.), Justin Talbot [ctb] (Code from the labeling package), Joshua London [ctb]
+# Maintainer: Jeffrey B. Arnold <jeffrey.arnold@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2017-02-19 10:53:38
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Some extra themes, geoms, and scales for 'ggplot2'. Provides 'ggplot2' themes and scales that replicate the look of plots by Edward Tufte, Stephen Few, 'Fivethirtyeight', 'The Economist', 'Stata', 'Excel', and 'The Wall Street Journal', among others. Provides ‘geoms' for Tufte's box plot and range frame.