### PR TITLE
km.ci R/CRAN package

### DIFF
--- a/recipes/r-km.ci/bld.bat
+++ b/recipes/r-km.ci/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-km.ci/build.sh
+++ b/recipes/r-km.ci/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+$R CMD INSTALL --build .

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
@@ -24,8 +25,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('km.ci')"
-    - "\"%R%\" -e \"library('km.ci')\""
+    - $R -e "library('km.ci')"  # [not win]
+    - "\"%R%\" -e \"library('km.ci')\""  # [win]
 
 about:
   home: https://cran.rstudio.com/web/packages/km.ci/index.html

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: r-km.ci
+  version: "0.5_2"
+
+source:
+  fn: km.ci_0.5-2.tar.gz
+  url: https://cran.rstudio.com/src/contrib/km.ci_0.5-2.tar.gz
+  md5: 9079410df73a8a06ea0405e7faf85ea7
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-survival
+
+  run:
+    - r-base
+    - r-survival
+
+test:
+  commands:
+    - $R -e "library('km.ci')" # [not win]
+    - "\"%R%\" -e \"library('km.ci')\"" # [win]
+
+about:
+  home: https://cran.rstudio.com/web/packages/km.ci/index.html
+  license: GPL-2|GPL-3
+  summary: Computes various confidence intervals for the Kaplan-Meier estimator, namely Petos CI, 
+    Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous 
+    confidence bands by Nair and Hall and Wellner.

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -31,7 +31,7 @@ test:
 about:
   home: https://cran.rstudio.com/web/packages/km.ci/index.html
   license: GPL-2|GPL-3
-  license_family: GPL
+  license_family: GPL2|GPL3
   summary: Computes various confidence intervals for the Kaplan-Meier estimator, namely Petos CI, 
     Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous 
     confidence bands by Nair and Hall and Wellner.

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: https://cran.rstudio.com/web/packages/km.ci/index.html
   license: GPL-2|GPL-3
+  license_family: GPL
   summary: Computes various confidence intervals for the Kaplan-Meier estimator, namely Petos CI, 
     Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous 
     confidence bands by Nair and Hall and Wellner.
@@ -38,3 +39,5 @@ about:
 extra:
   recipe-maintainers:
     - fabio-cumbo
+    - johanneskoester
+    - bgruening

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -1,15 +1,21 @@
+{% set version = '0.5-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
 package:
   name: r-km.ci
-  version: "0.5_2"
+  version: {{ version|replace("-", "_") }}
 
 source:
-  fn: km.ci_0.5-2.tar.gz
-  url: https://cran.rstudio.com/src/contrib/km.ci_0.5-2.tar.gz
-  md5: 9079410df73a8a06ea0405e7faf85ea7
+  fn: km.ci_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/km.ci_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/km.ci/km.ci_{{ version }}.tar.gz
+  sha256: 1bb9c60e27ba42ea773407dcc438b4a630f53877eb16e6054041a97b25e2d3d0
 
 build:
   number: 0
-  skip: true  # [win32]
   rpaths:
     - lib/R/lib/
     - lib/
@@ -29,12 +35,34 @@ test:
     - "\"%R%\" -e \"library('km.ci')\""  # [win]
 
 about:
-  home: https://cran.rstudio.com/web/packages/km.ci/index.html
-  license: GPL-2|GPL-3
-  license_family: GPL
-  summary: Computes various confidence intervals for the Kaplan-Meier estimator, namely Petos CI, 
-    Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous 
-    confidence bands by Nair and Hall and Wellner.
+  home: https://CRAN.R-project.org/package=km.ci
+  license: GPL (>= 2)
+  summary: 'Computes various confidence intervals for the Kaplan-Meier estimator, namely: Petos
+    CI, Rothman CI, CI''s based on Greenwoods variance, Thomas and Grunkemeier CI and
+    the simultaneous confidence bands by Nair and Hall and Wellner.'
+
+  license_family: GPL3
+
+# The original CRAN metadata for this package was:
+
+# Package: km.ci
+# Type: Package
+# Title: Confidence intervals for the Kaplan-Meier estimator
+# Version: 0.5-2
+# Date: 2009-08-30
+# Author: Ralf Strobl <rstrobl@ibe.med.uni-muenchen.de>
+# Maintainer: Tobias Verbeke <tobias.verbeke@openanalytics.be>
+# Depends: R (>= 1.8.0), survival, stats
+# Description: Computes various confidence intervals for the Kaplan-Meier estimator, namely: Petos CI, Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous confidence bands by Nair and Hall and Wellner.
+# License: GPL (>= 2)
+# Packaged: 2009-08-30 12:42:35 UTC; tobias
+# Repository: CRAN
+# Date/Publication: 2009-08-30 14:38:17
+# NeedsCompilation: no
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml
 
 extra:
   recipe-maintainers:

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -24,8 +24,8 @@ requirements:
 
 test:
   commands:
-    - $R -e "library('km.ci')" # [not win]
-    - "\"%R%\" -e \"library('km.ci')\"" # [win]
+    - $R -e "library('km.ci')"
+    - "\"%R%\" -e \"library('km.ci')\""
 
 about:
   home: https://cran.rstudio.com/web/packages/km.ci/index.html
@@ -33,3 +33,7 @@ about:
   summary: Computes various confidence intervals for the Kaplan-Meier estimator, namely Petos CI, 
     Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous 
     confidence bands by Nair and Hall and Wellner.
+
+extra:
+  recipe-maintainers:
+    - fabio-cumbo

--- a/recipes/r-km.ci/meta.yaml
+++ b/recipes/r-km.ci/meta.yaml
@@ -31,7 +31,7 @@ test:
 about:
   home: https://cran.rstudio.com/web/packages/km.ci/index.html
   license: GPL-2|GPL-3
-  license_family: GPL2|GPL3
+  license_family: GPL
   summary: Computes various confidence intervals for the Kaplan-Meier estimator, namely Petos CI, 
     Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous 
     confidence bands by Nair and Hall and Wellner.


### PR DESCRIPTION
Computes various confidence intervals for the Kaplan-Meier estimator, namely: Petos CI, Rothman CI, CI's based on Greenwoods variance, Thomas and Grunkemeier CI and the simultaneous confidence bands by Nair and Hall and Wellner.