### PR TITLE
Drop BINSTAR_TOKEN from CircleCI script

### DIFF
--- a/scripts/run_docker_build.sh
+++ b/scripts/run_docker_build.sh
@@ -46,10 +46,6 @@ pushd /staged-recipes/recipes > /dev/null
 git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf ~/conda-recipes/{} && echo Removing recipe: {}"
 popd > /dev/null
 
-if [ "${BINSTAR_TOKEN}" ];then
-    export BINSTAR_TOKEN=${BINSTAR_TOKEN}
-fi
-
 # Unused, but needed by conda-build currently... :(
 export CONDA_NPY='19'
 


### PR DESCRIPTION
We are not using the BINSTAR_TOKEN at all on CircleCI. Nor do we have any need of it. So this drops the setting of the BINSTAR_TOKEN on CircleCI.