### PR TITLE
Add recipe for pytest-forked

### DIFF
--- a/recipes/pytest-forked/dummy_test.py
+++ b/recipes/pytest-forked/dummy_test.py
@@ -1,0 +1,5 @@
+import pytest
+
+@pytest.mark.parametrize('i', range(5))
+def test(i):
+    pass

--- a/recipes/pytest-forked/meta.yaml
+++ b/recipes/pytest-forked/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "pytest-forked" %}
+{% set version = "0.2" %}
+{% set hash_type = "sha256" %}
+{% set hash = "e4500cd0509ec4a26535f7d4112a8cc0f17d3a41c29ffd4eab479d2a55b30805" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pytest >=2.6.0
+    - setuptools_scm
+
+  run:
+    - python
+    - pytest >=2.6.0
+
+test:
+  imports:
+    - pytest_forked
+  files:
+    - dummy_test.py
+  commands:
+    - py.test --forked dummy_test.py  # [not win]
+
+about:
+  home: https://github.com/pytest-dev/pytest-forked
+  license: MIT
+  license_file: LICENSE
+  summary: 'run tests in isolated forked subprocesses'
+  dev_url: https://github.com/pytest-dev/pytest-forked
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
This plugin is now required by pytest-xdist, see conda-forge/pytest-xdist-feedstock#13