### PR TITLE
Add cluster-lensing to conda-forge

### DIFF
--- a/recipes/cluster-lensing/meta.yaml
+++ b/recipes/cluster-lensing/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "cluster-lensing" %}
+{% set version = "0.1.2" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "ed1474701aac80648c4483f8e66af2663c2be1493e7a003e08e4a9f594dfa6b9" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy
+    - astropy
+    - scipy
+    - pandas
+
+test:
+  imports:
+    - clusterlensing
+
+about:
+  home: http://github.com/jesford/cluster-lensing
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: Galaxy Cluster and Weak Lensing Tools
+  description: |
+    This package includes tools for calculating a variety of galaxy cluster
+    properties, as well as mass-richness and mass-concentration scaling
+    relations, and weak lensing profiles. These include surface mass density
+    (Sigma) and differential surface mass density (DeltaSigma) for NFW halos,
+    both with and without the effects of cluster miscentering.
+  doc_url: http://jesford.github.io/cluster-lensing/
+  dev_url: http://github.com/jesford/cluster-lensing
+
+extra:
+  recipe-maintainers:
+    - mwcraig
+    - bsipocz
+    - jesford

--- a/recipes/cluster-lensing/meta.yaml
+++ b/recipes/cluster-lensing/meta.yaml
@@ -50,4 +50,3 @@ extra:
   recipe-maintainers:
     - mwcraig
     - bsipocz
-    - jesford


### PR DESCRIPTION
@jesford -- do you mind being listed here as a maintainer? Being a maintainer doesn't entail much work. Once this PR is merged, a new repo is created at https://github.com/conda-forge/cluster-lensing-feedstock, which needs to be updated only when a new version is released. We are moving building of packages for the astropy conda channel over to conda-forge. The astropy channel will continue, copying builds from conda-forge.