### PR TITLE
Force removal of recipes after conversion

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -255,7 +255,7 @@ if __name__ == '__main__':
 
             # Remove this recipe from the repo.
             if is_merged_pr:
-                subprocess.check_call(['git', 'rm', '-r', recipe_dir])
+                subprocess.check_call(['git', 'rm', '-rf', recipe_dir])
 
     # Add new conda-forge members to all-members team. Welcome! :)
     if conda_forge:


### PR DESCRIPTION
In case for some reason a converted recipe cannot be removed, use force to ensure it is removed from the staged-recipes repo. This may occur if there are formatting changes due to `.gitattributes` for instance. As the plan is to remove the recipe completely anyways, using force should not be a problem.