### PR TITLE
pyaudio

### DIFF
--- a/recipes/jack/build.sh
+++ b/recipes/jack/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export LDFLAGS="-L${PREFIX}/lib $LDFLAGS"
+export CPPFLAGS="-I${PREFIX}/include $CPPFLAGS"
+export CFLAGS="-fPIC $CFLAGS"
+
+./configure --prefix=$PREFIX
+
+make -j$CPU_COUNT
+make check -j$CPU_COUNT
+make install -j$CPU_COUNT
+
+
+# Conda uses only /lib for everything.
+mkdir -p $PREFIX/lib
+mv $PREFIX/lib64/* $PREFIX/lib
+
+cd $PREFIX
+find . -type f -name "*.la" -exec rm -rf '{}' \; -print

--- a/recipes/jack/meta.yaml
+++ b/recipes/jack/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "0.125.0" %}
+
+package:
+  name: jack
+  version: {{ version }}
+
+source:
+  url: http://jackaudio.org/downloads/jack-audio-connection-kit-{{ version }}.tar.gz
+  sha256: 3517b5bff82139a76b2b66fe2fd9a3b34b6e594c184f95a988524c575b11d444
+
+build:
+  number: 0
+  skip: True  # [win or osx]
+
+requirements:
+  build:
+    - libdb
+  run:
+    - libdb
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX jack  # [not win]
+    - conda inspect objects -p $PREFIX jack  # [osx]
+
+about:
+  home: http://www.portaudio.com/
+  license: LGLP-2.0
+  license_file: COPYING.LGPL
+  summary: 'Audio connection kit.'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/jack/meta.yaml
+++ b/recipes/jack/meta.yaml
@@ -24,7 +24,7 @@ test:
     - conda inspect objects -p $PREFIX jack  # [osx]
 
 about:
-  home: http://www.portaudio.com/
+  home: http://jackaudio.org/
   license: LGLP-2.0
   license_file: COPYING.LGPL
   summary: 'Audio connection kit.'

--- a/recipes/jack/meta.yaml
+++ b/recipes/jack/meta.yaml
@@ -32,3 +32,4 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - scopatz

--- a/recipes/libdb/build.sh
+++ b/recipes/libdb/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [[ $(uname) == Darwin ]]; then
+  export CC=clang
+  export CXX=clang++
+  export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib -headerpad_max_install_names $LDFLAGS"
+  export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+  export MACOSX_DEPLOYMENT_TARGET="10.9"
+  export CXXFLAGS="-stdlib=libc++ $CXXFLAGS"
+fi
+
+cd build_unix
+../dist/configure --prefix=$PREFIX \
+                  --enable-shared \
+                  --disable-static \
+                  --enable-cxx
+
+make -j$CPU_COUNT
+make check -j$CPU_COUNT
+make install -j$CPU_COUNT
+
+cd $PREFIX
+find . -type f -name "*.la" -exec rm -rf '{}' \; -print

--- a/recipes/libdb/meta.yaml
+++ b/recipes/libdb/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "6.1.26" %}
+
+package:
+  name: libdb
+  version: {{ version }}
+
+source:
+  url: http://download.oracle.com/berkeley-db/db-{{ version }}.tar.gz
+  sha256: dd1417af5443f326ee3998e40986c3c60e2a7cfb5bfa25177ef7cadb2afb13a6
+
+build:
+  number: 0
+  skip: True  # [win]
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: http://www.oracle.com/technology/software/products/berkeley-db/index.html
+  license: AGPL-3.0
+  license_file: LICENSE
+  summary: 'The Berkeley DB embedded database system.'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/libdb/meta.yaml
+++ b/recipes/libdb/meta.yaml
@@ -26,3 +26,4 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - scopatz

--- a/recipes/portaudio/bld.bat
+++ b/recipes/portaudio/bld.bat
@@ -1,0 +1,10 @@
+copy "%RECIPE_DIR%\build.sh" .
+set PREFIX=%PREFIX:\=/%
+set SRC_DIR=%SRC_DIR:\=/%
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
+bash -lc "./build.sh"
+if errorlevel 1 exit 1
+
+exit 0

--- a/recipes/portaudio/build.sh
+++ b/recipes/portaudio/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+export LDFLAGS="-L${PREFIX}/lib $LDFLAGS"
+export CPPFLAGS="-I${PREFIX}/include $CPPFLAGS"
+export CFLAGS="-fPIC $CFLAGS"
+
+./configure --prefix=$PREFIX
+
+make -j$CPU_COUNT
+make tests -j$CPU_COUNT
+make install -j$CPU_COUNT
+
+cd $PREFIX
+find . -type f -name "*.la" -exec rm -rf '{}' \; -print

--- a/recipes/portaudio/build.sh
+++ b/recipes/portaudio/build.sh
@@ -2,7 +2,7 @@
 
 export LDFLAGS="-L${PREFIX}/lib $LDFLAGS"
 export CPPFLAGS="-I${PREFIX}/include $CPPFLAGS"
-export CFLAGS="-fPIC $CFLAGS"
+export CFLAGS="-I${PREFIX}/include -fPIC $CFLAGS"
 
 ./configure --prefix=$PREFIX
 

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "190600_20161030" %}
+
+package:
+  name: portaudio
+  version:  {{ version }}
+
+source:
+  url: http://www.portaudio.com/archives/pa_stable_v{{ version }}.tgz
+  sha256: f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - posix  # [win]
+    - m2w64-toolchain  # [win]
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: http://www.portaudio.com/
+  license: PortAudio
+  license_file: LICENSE.txt
+  summary: 'PortAudio is a free, cross-platform, open-source, audio I/O library.'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -16,8 +16,10 @@ requirements:
     - posix  # [win]
     - m2w64-toolchain  # [win]
     - alsa-lib  # [linux]
+    - gcc
   run:
     - alsa-lib  # [linux]
+    - libgcc
 
 test:
   commands:

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/lib/libportaudio$SHLIB_EXT
+    - test -f $PREFIX/lib/libportaudio$SHLIB_EXT  # [not win]
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: portaudio
-  version:  {{ version }}
+  version: 19.6.0
 
 source:
   url: http://www.portaudio.com/archives/pa_stable_v{{ version }}.tgz

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -10,16 +10,17 @@ source:
 
 build:
   number: 0
+  skip: True  # [osx]
 
 requirements:
   build:
     - posix  # [win]
     - m2w64-toolchain  # [win]
     - alsa-lib  # [linux]
-    - gcc
+    - gcc  # [linux]
   run:
     - alsa-lib  # [linux]
-    - libgcc
+    - libgcc  # [linux]
 
 test:
   commands:

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -15,6 +15,9 @@ requirements:
   build:
     - posix  # [win]
     - m2w64-toolchain  # [win]
+    - alsa-lib  # [linux]
+  run:
+    - alsa-lib  # [linux]
 
 test:
   commands:

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -17,10 +17,8 @@ requirements:
     - posix  # [win]
     - m2w64-toolchain  # [win]
     - alsa-lib  # [linux]
-    - gcc  # [linux]
   run:
     - alsa-lib  # [linux]
-    - libgcc  # [linux]
 
 test:
   commands:

--- a/recipes/portaudio/meta.yaml
+++ b/recipes/portaudio/meta.yaml
@@ -21,6 +21,7 @@ requirements:
 
 test:
   commands:
+    - test -f $PREFIX/lib/libportaudio$SHLIB_EXT
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
@@ -33,3 +34,4 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - scopatz

--- a/recipes/pyaudio/lib.patch
+++ b/recipes/pyaudio/lib.patch
@@ -1,0 +1,11 @@
+--- PyAudio-0.2.11.orig/setup.py	2017-03-18 20:29:01.000000000 -0300
++++ PyAudio-0.2.11/setup.py	2017-07-15 17:04:58.411856212 -0300
+@@ -79,7 +79,7 @@
+ else:
+     include_dirs = [os.path.join(portaudio_path, 'include/')]
+     extra_link_args = [
+-        os.path.join(portaudio_path, 'lib/.libs/libportaudio.a')
++        os.path.join(portaudio_path, 'lib/libportaudio.a')
+         ]
+
+     # platform specific configuration

--- a/recipes/pyaudio/meta.yaml
+++ b/recipes/pyaudio/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "0.2.11" %}
+
+package:
+  name: pyaudio
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/P/PyAudio/PyAudio-{{ version }}.tar.gz
+  sha256: 93bfde30e0b64e63a46f2fd77e85c41fd51182a4a3413d9edfaf9ffaa26efb74
+  patches:
+    # Find the libs in the right directory.
+    - lib.patch
+
+build:
+  number: 0
+  # py2k needs alsa-lib-devel
+  skip: True  # [win or py2k or osx]
+  script:
+    - export PORTAUDIO_PATH=$PREFIX  # [not win]
+    - python setup.py install --static-link
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+    - portaudio  # [not win]
+    - jack  # [linux]
+  run:
+    - python
+    - setuptools
+    - portaudio  # [not win]
+    - jack  # [linux]
+
+test:
+  imports:
+    - pyaudio
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: http://people.csail.mit.edu/hubert/pyaudio/
+  license: MIT
+  summary: 'PortAudio Python Bindings.'
+
+extra:
+  recipe-maintainers:
+    - chiranthsiddappa
+    - ocefpaf

--- a/recipes/pyaudio/meta.yaml
+++ b/recipes/pyaudio/meta.yaml
@@ -48,3 +48,4 @@ extra:
   recipe-maintainers:
     - chiranthsiddappa
     - ocefpaf
+    - scopatz

--- a/recipes/pyaudio/meta.yaml
+++ b/recipes/pyaudio/meta.yaml
@@ -17,7 +17,7 @@ build:
   skip: True  # [win or py2k or osx]
   script:
     - export PORTAUDIO_PATH=$PREFIX  # [not win]
-    - python setup.py install --static-link
+    - python setup.py install
 
 requirements:
   build:


### PR DESCRIPTION
Add `pyaudio` and its dependencies.

@chiranthsiddappa these recipes were in my to do list since SciPy. I still need to figure out why `pyaudio` does not compiled without `alsa` on Python 2.7 but it fails if `alsa` is available on `Python 3`.

I also could not get it to work on `OS X` yet.