### PR TITLE
rename feedstocks

### DIFF
--- a/recipes/decorator/meta.yaml
+++ b/recipes/decorator/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "4.1.2" %}
+
+package:
+  name: decorator
+  version: {{ version }}
+
+source:
+  fn: decorator-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/d/decorator/decorator-{{ version }}.tar.gz
+  sha256: 7cb64d38cb8002971710c8899fbdfb859a23a364b7c99dab19d1f719c2ba16b5
+
+build:
+  number: 0
+  script: python -m pip install --no-deps .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - decorator
+
+about:
+  home: https://github.com/micheles/decorator
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
+  summary: 'Better living through Python with decorators.'
+
+extra:
+  recipe-maintainers:
+    - msarahan
+    - pelson
+    - ocefpaf
+    - scopatz

--- a/recipes/pathlib2/meta.yaml
+++ b/recipes/pathlib2/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "2.3.0" %}
+
+package:
+  name: pathlib2
+  version: {{ version }}
+
+source:
+  fn: pathlib2-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/p/pathlib2/pathlib2-{{ version }}.tar.gz
+  sha256: d32550b75a818b289bd4c1f96b60c89957811da205afcceab75bc8b4857ea5b3
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - six
+    - scandir  # [py27]
+
+test:
+  imports:
+    - pathlib2
+
+about:
+  home: https://github.com/mcmtroffaes/pathlib2
+  license: MIT
+  license_file: LICENSE.rst
+  summary: "Fork of pathlib aiming to support the full stdlib Python API."
+
+extra:
+  recipe-maintainers:
+    - pelson
+    - takluyver

--- a/recipes/simplegeneric/meta.yaml
+++ b/recipes/simplegeneric/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "0.8.1" %}
+
+package:
+  name: simplegeneric
+  version: {{ version }}
+
+source:
+  fn: simplegeneric-{{ version }}.zip
+  url: https://pypi.python.org/packages/source/s/simplegeneric/simplegeneric-{{ version }}.zip
+  md5: f9c1fab00fd981be588fc32759f474e3
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - simplegeneric
+
+about:
+  home: http://cheeseshop.python.org/pypi/simplegeneric
+  license: Zope Public
+  summary: "Simple generic functions (similar to Python's own len(), pickle.dump(), etc.)"
+
+extra:
+  recipe-maintainers:
+    - minrk
+    - msarahan
+    - pelson


### PR DESCRIPTION
@conda-forge/python-pathlib2, @conda-forge/python-pathlib2, and @conda-forge/python-simplegeneric 

@conda-forge/core agreed in our last meeting that the current feedstocks, containing the recipes for `decorator`, `pathlib2`, and `simplegeneric`, will be removed. This PR re-adds them with the names used in the `meta.yaml` file (without the `python-` prefix).

All you have to do is to fork the new feedstock, once this PR is merged, and remove your old forks. Sorry for the inconvincente but this will help us integrate better with the default channel.

@jjhelmus we though we had only two but I found a third one, let me know if you find more.
