### PR TITLE
Package xeus-cling

### DIFF
--- a/recipes/xeus-cling/bld.bat
+++ b/recipes/xeus-cling/bld.bat
@@ -1,0 +1,8 @@
+cmake -G "NMake Makefiles" -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% -DXEXTRA_JUPYTER_DATA_DIR=%PREFIX%\\share\\jupyter %SRC_DIR%
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/xeus-cling/build.sh
+++ b/recipes/xeus-cling/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cmake -DCMAKE_BUILD_TYPE=Release     \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib     \
+      -DDISABLE_ARCH_NATIVE=ON       \
+      $SRC_DIR
+
+make install

--- a/recipes/xeus-cling/build.sh
+++ b/recipes/xeus-cling/build.sh
@@ -2,6 +2,7 @@
 
 cmake -DCMAKE_BUILD_TYPE=Release     \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_PREFIX_PATH=$PREFIX    \
       -DCMAKE_INSTALL_LIBDIR=lib     \
       -DDISABLE_ARCH_NATIVE=ON       \
       $SRC_DIR

--- a/recipes/xeus-cling/conda_build_config.yaml
+++ b/recipes/xeus-cling/conda_build_config.yaml
@@ -1,0 +1,9 @@
+channel_sources:
+- conda-forge/label/gcc7,defaults   # [unix]
+- conda-forge,defaults              # [win]
+channel_targets:
+- conda-forge gcc7                  # [unix]
+- conda-forge main                  # [win]
+cxx_compiler:
+- gxx      # [linux]
+- clangxx  # [osx]

--- a/recipes/xeus-cling/meta.yaml
+++ b/recipes/xeus-cling/meta.yaml
@@ -13,7 +13,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [win and vc<14]
+  # cling has not been built for windows yet
+  skip: true  # [win]
   {% if 'toolchain' in compiler('cxx') %}skip: True{% endif %}  # Only build with modern compilers.
 
 requirements:

--- a/recipes/xeus-cling/meta.yaml
+++ b/recipes/xeus-cling/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "xeus-cling" %}
+{% set version = "0.4.10" %}
+{% set sha256 = "e4e2651fc0522938dbe246131103d36dd997b07b45ed3940fb8478c446c98c8c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/QuantStack/xeus-cling/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win and vc<14]
+  {% if 'toolchain' in compiler('cxx') %}skip: True{% endif %}  # Only build with modern compilers.
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+  host:
+    - cppzmq >=4.3.0,<4.4.0
+    - zeromq >=4.2.5,<4.4.0
+    - cling >=0.5,<0.6
+    - xeus >=0.18.1,<0.19
+    - xtl >=0.5.2,<0.6
+    - pugixml
+    - cxxopts >=2.1.1,<3.0
+    - nlohmann_json >=3.3.0,<4.0
+    - dirent >=1.21,<2.0  # [win]
+  run:
+    # Cling misses a run_exports section
+    - {{ pin_compatible('cling', max_pin='x.x') }}
+    # Even though cppzmq, xtl and nlohmann_json are header-only,
+    # they are used at runtime by the interpreted c++
+    - {{ pin_compatible('cppzmq', max_pin='x.x.x') }}
+    - {{ pin_compatible('xtl', max_pin='x.x.x') }}
+    - {{ pin_compatible('nlohmann_json', max_pin='x.x.x') }}
+
+test:
+  commands:
+    - test -f ${PREFIX}/bin/xeus-cling  # [unix]
+    - if exist %LIBRARY_PREFIX%\bin\xeus-cling.exe (exit 0) else (exit 1)  # [win]
+
+about:
+  home: http://quantstack.net/xeus-cling
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Cling-based C++ kernel for Jupyter based on xeus'
+  description: 'Jupyter kernel for the C++ programming language'
+  doc_url: http://xeus-cling.readthedocs.io
+  dev_url: https://github.com/QuantStack/xeus-cling
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - JohanMabille
+    - gouarin
+    - martinRenou

--- a/recipes/xeus-cling/meta.yaml
+++ b/recipes/xeus-cling/meta.yaml
@@ -34,6 +34,7 @@ requirements:
     - dirent >=1.21,<2.0  # [win]
     - clangdev={{ clang_version }}
     - clang_variant * cling
+    - zlib
   run:
     # Cling misses a run_exports section
     - {{ pin_compatible('cling', max_pin='x.x') }}

--- a/recipes/xeus-cling/meta.yaml
+++ b/recipes/xeus-cling/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "xeus-cling" %}
 {% set version = "0.4.10" %}
 {% set sha256 = "e4e2651fc0522938dbe246131103d36dd997b07b45ed3940fb8478c446c98c8c" %}
+{% set clang_version = "5.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -31,6 +32,8 @@ requirements:
     - cxxopts >=2.1.1,<3.0
     - nlohmann_json >=3.3.0,<4.0
     - dirent >=1.21,<2.0  # [win]
+    - clangdev={{ clang_version }}
+    - clang_variant * cling
   run:
     # Cling misses a run_exports section
     - {{ pin_compatible('cling', max_pin='x.x') }}


### PR DESCRIPTION
This still depends on versions of xeus that are not on conda-forge but only in QuantStack because of the lack of a recent GCC in conda-forge.