### PR TITLE
Add containerpilot to conda-forge

### DIFF
--- a/recipes/containerpilot/meta.yaml
+++ b/recipes/containerpilot/meta.yaml
@@ -17,10 +17,6 @@ build:
     - cp {{ name }} $PREFIX/bin
   skip: True  # [ not linux ]
 
-requirements:
-  build:
-  run:
-
 test:
   commands:
     - containerpilot -version

--- a/recipes/containerpilot/meta.yaml
+++ b/recipes/containerpilot/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "containerpilot" %}
+{% set version = "2.7.8" %}
+{% set sha1= "09158be44c3e887244581d4d019748df9fcfa93c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/joyent/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
+  sha1: {{ sha1 }}
+
+build:
+  number: 0
+  script:
+    - cp {{ name }} $PREFIX/bin
+  skip: True  # [ not linux ]
+
+requirements:
+  build:
+  run:
+
+test:
+  commands:
+    - containerpilot -version
+
+about:
+  home: https://www.joyent.com/containerpilot
+  license: MPL-2.0
+  license_family: OTHER
+  summary: 'A service for autodiscovery and configuration of applications running in containers'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+      ContainerPilot is an init system designed to live inside the container. It acts as a
+      process supervisor, reaps zombies, run health checks, registers the app in the service
+      catalog, watches the service catalog for changes, and runs your user-specified code at
+      events in the lifecycle of the container to make it all work right. ContainerPilot uses
+      Consul to coordinate global state among the application containers.
+  doc_url: https://www.joyent.com/containerpilot/docs
+  dev_url: https://github.com/joyent/containerpilot
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/containerpilot/meta.yaml
+++ b/recipes/containerpilot/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "containerpilot" %}
 {% set version = "2.7.8" %}
 {% set sha1= "09158be44c3e887244581d4d019748df9fcfa93c" %}
+{% set sha256= "cd8d31ea953ea9b558fd4169ed1be9edd70d4ab4e289d4d7e17124e39c0fbb18" %}
 
 package:
   name: {{ name|lower }}
@@ -10,6 +11,7 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/joyent/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha1: {{ sha1 }}
+  sha256: {{ sha256 }}
 
 build:
   number: 0


### PR DESCRIPTION
ContainerPilot is an init system designed to live inside the container. It acts as a
process supervisor, reaps zombies, run health checks, registers the app in the service
catalog, watches the service catalog for changes, and runs your user-specified code at
events in the lifecycle of the container to make it all work right. ContainerPilot uses
Consul to coordinate global state among the application containers.