### PR TITLE
Batch of Bioconda R recipes (01)

### DIFF
--- a/recipes/r-speedglm/bld.bat
+++ b/recipes/r-speedglm/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-speedglm/build.sh
+++ b/recipes/r-speedglm/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-speedglm/meta.yaml
+++ b/recipes/r-speedglm/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = '0.3-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-speedglm
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: speedglm_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/speedglm_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/speedglm/speedglm_{{ version }}.tar.gz
+  sha256: 5fcaf18324dc754152f528a44894944063303f780d33e58569ea7c306bfc45ac
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r-base
+    - r-mass
+    - r-matrix
+
+  run:
+    - r-base
+    - r-mass
+    - r-matrix
+
+test:
+  commands:
+    - $R -e "library('speedglm')"  # [not win]
+    - "\"%R%\" -e \"library('speedglm')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=speedglm
+  license: GPL
+  summary: Fitting linear models and generalized linear models to large data sets by updating
+    algorithms.
+  license_family: GPL
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-statmod/bld.bat
+++ b/recipes/r-statmod/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-statmod/build.sh
+++ b/recipes/r-statmod/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-statmod/meta.yaml
+++ b/recipes/r-statmod/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '1.4.30' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-statmod
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: statmod_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/statmod_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/statmod/statmod_{{ version }}.tar.gz
+  sha256: 9d2c1722a85f53623a9ee9f73d835119ae22ae2b8ec7b50d675401e314ea641f
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('statmod')"  # [not win]
+    - "\"%R%\" -e \"library('statmod')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=statmod
+  license: GPL-2 | GPL-3
+  summary: A collection of algorithms and functions to aid statistical modeling. Includes growth
+    curve comparisons, limiting dilution analysis (aka ELDA), mixed linear models, heteroscedastic
+    regression, inverse-Gaussian probability calculations, Gauss quadrature and a secure
+    convergence algorithm for nonlinear models.  Includes advanced generalized linear
+    model functions that implement secure convergence, dispersion modeling and Tweedie
+    power-law families.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-tiff/bld.bat
+++ b/recipes/r-tiff/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-tiff/build.sh
+++ b/recipes/r-tiff/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-tiff/meta.yaml
+++ b/recipes/r-tiff/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = '0.1-5' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tiff
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: tiff_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/tiff_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/tiff/tiff_{{ version }}.tar.gz
+  sha256: 9514e6a9926fcddc29ce1dd12b1072ad8265900373f738de687ef4a1f9124e2b
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r-base
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('tiff')"  # [not win]
+    - "\"%R%\" -e \"library('tiff')\""  # [win]
+
+about:
+  home: http://www.rforge.net/tiff/
+  license: GPL-2 | GPL-3
+  summary: This package provides an easy and simple way to read, write and display bitmap images
+    stored in the TIFF format. It can read and write both files and in-memory raw vectors.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-tsne/bld.bat
+++ b/recipes/r-tsne/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-tsne/build.sh
+++ b/recipes/r-tsne/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-tsne/meta.yaml
+++ b/recipes/r-tsne/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = '0.1-3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tsne
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: tsne_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/tsne_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/tsne/tsne_{{ version }}.tar.gz
+  sha256: 66fdf5d73e69594af529a9c4f261d972872b9b7bffd19f85c1adcd66afd80c69
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('tsne')"  # [not win]
+    - "\"%R%\" -e \"library('tsne')\""  # [win]
+
+about:
+  home: https://github.com/jdonaldson/rtsne/
+  license: GPL
+  summary: A "pure R" implementation of the t-SNE algorithm.
+  license_family: GPL
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-upsetr/bld.bat
+++ b/recipes/r-upsetr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-upsetr/build.sh
+++ b/recipes/r-upsetr/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-upsetr/meta.yaml
+++ b/recipes/r-upsetr/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '1.3.3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-upsetr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: UpSetR_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/UpSetR_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/UpSetR/UpSetR_{{ version }}.tar.gz
+  sha256: 1f567fd542e727e1a8c8bb2b72b27fd08f09aba014eaceb1c7d7a125123d7223
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-ggplot2
+    - r-gridextra
+    - r-plyr
+    - r-scales
+
+  run:
+    - r-base
+    - r-ggplot2
+    - r-gridextra
+    - r-plyr
+    - r-scales
+
+test:
+  commands:
+    - $R -e "library('UpSetR')"  # [not win]
+    - "\"%R%\" -e \"library('UpSetR')\""  # [win]
+
+about:
+  home: http://github.com/hms-dbmi/UpSetR
+  license: MIT
+  summary: Creates visualizations of intersecting sets using a novel matrix design, along with
+    visualizations of several common set, element and attribute related tasks.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-venn/bld.bat
+++ b/recipes/r-venn/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-venn/build.sh
+++ b/recipes/r-venn/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-venn/meta.yaml
+++ b/recipes/r-venn/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = '1.2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-venn
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: venn_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/venn_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/venn/venn_{{ version }}.tar.gz
+  sha256: c01de6fbc62f5c6a8028542082e912b751f9efe5d5b063426d22dd11220a34a2
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('venn')"  # [not win]
+    - "\"%R%\" -e \"library('venn')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=venn
+  license: GPL (>= 2)
+  summary: Draws and displays Venn diagrams up to 7 sets, and any Boolean union of set intersections.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-waveslim/bld.bat
+++ b/recipes/r-waveslim/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-waveslim/build.sh
+++ b/recipes/r-waveslim/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-waveslim/meta.yaml
+++ b/recipes/r-waveslim/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '1.7.5' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-waveslim
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: waveslim_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/waveslim_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/waveslim/waveslim_{{ version }}.tar.gz
+  sha256: 31b698f7b19aadcdc02068ee69bf7676cd9dea2913420ce3caa7e507e3a41a53
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('waveslim')"  # [not win]
+    - "\"%R%\" -e \"library('waveslim')\""  # [win]
+
+about:
+  home: http://waveslim.blogspot.com, http://www2.imperial.ac.uk/~bwhitche/book
+  license: BSD_3_clause
+  summary: Basic wavelet routines for time series (1D), image (2D)  and array (3D) analysis.  The
+    code provided here is based on wavelet methodology developed in Percival and Walden
+    (2000); Gencay, Selcuk and Whitcher (2001); the dual-tree complex wavelet transform
+    (DTCWT) from Kingsbury (1999, 2001) as implemented by Selesnick; and Hilbert wavelet
+    pairs (Selesnick 2001, 2002).  All figures in chapters 4-7 of GSW (2001) are reproducible
+    using this  package and R code available at the book website(s) below.
+  license_family: BSD
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-wrassp/bld.bat
+++ b/recipes/r-wrassp/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-wrassp/build.sh
+++ b/recipes/r-wrassp/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-wrassp/meta.yaml
+++ b/recipes/r-wrassp/meta.yaml
@@ -1,0 +1,57 @@
+{% set version = '0.1.4' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-wrassp
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: wrassp_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/wrassp_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/wrassp/wrassp_{{ version }}.tar.gz
+  sha256: f6853cba00cd8350b2fb9d140f8cd385ff6e14dee6f7de260c93023079ff3070
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('wrassp')"  # [not win]
+    - "\"%R%\" -e \"library('wrassp')\""  # [win]
+
+about:
+  home: https://github.com/IPS-LMU/wrassp
+  license: GPL (>= 3)
+  summary: A wrapper around Michel Scheffers's libassp (Advanced Speech Signal Processor). The
+    libassp library aims at providing functionality for handling speech signal files
+    in most common audio formats and for performing analyses common in phonetic science/speech
+    science. This includes the calculation of formants, fundamental frequency, root
+    mean square, auto correlation, a variety of spectral analyses, zero crossing rate,
+    filtering etc. This wrapper provides R with a large subset of libassp's signal processing
+    functions and provides them to the user in a (hopefully) user-friendly manner.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-writexls/bld.bat
+++ b/recipes/r-writexls/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-writexls/build.sh
+++ b/recipes/r-writexls/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-writexls/meta.yaml
+++ b/recipes/r-writexls/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = '4.0.0' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-writexls
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: WriteXLS_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/WriteXLS_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/WriteXLS/WriteXLS_{{ version }}.tar.gz
+  sha256: a0541da45e16bc4bf994cdf3f07a0e202c38d52386460c64e27fe6c1cd889d5b
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('WriteXLS')"  # [not win]
+    - "\"%R%\" -e \"library('WriteXLS')\""  # [win]
+
+about:
+  home: https://github.com/marcschwartz/WriteXLS
+  license: GPL (>= 2)
+  summary: Cross-platform Perl based R function to create Excel 2003 (XLS) and Excel 2007 (XLSX)
+    files from one or more data frames. Each data frame will be written to a separate
+    named worksheet in the Excel spreadsheet. The worksheet name will be the name of
+    the data frame it contains or can be specified by the user.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler


### PR DESCRIPTION
cc @daler @bgruening 

This PR contains the recipes for 9 Bioconda R packages from https://github.com/bioconda/bioconda-recipes/issues/5582:

* r-speedglm
* r-statmod
* r-tiff
* r-tsne
* r-upsetr
* r-venn
* r-waveslim
* r-wrassp
* r-writexls

Notes:

* I used [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper) to create the recipes
* The CI builds for CircleCI and Travis passed on my fork. The Appveyor build on my fork has failed multiple times, but the errors do not appear to be directly related to the recipes