### PR TITLE
Batch of Bioconda R recipes (02)

### DIFF
--- a/recipes/r-docopt/bld.bat
+++ b/recipes/r-docopt/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-docopt/build.sh
+++ b/recipes/r-docopt/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-docopt/meta.yaml
+++ b/recipes/r-docopt/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = '0.4.5' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-docopt
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: docopt_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/docopt_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/docopt/docopt_{{ version }}.tar.gz
+  sha256: b6c3bf69b129f09c1adeeabebfd91519eb7fb9f448af82ce84405314807996df
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-stringr
+
+  run:
+    - r-base
+    - r-stringr
+
+test:
+  commands:
+    - $R -e "library('docopt')"  # [not win]
+    - "\"%R%\" -e \"library('docopt')\""  # [win]
+
+about:
+  home: https://github.com/docopt/docopt.R
+  license: MIT
+  summary: Define a command-line interface by just giving it a description in the specific format.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - jdblischak
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-openxlsx/bld.bat
+++ b/recipes/r-openxlsx/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-openxlsx/build.sh
+++ b/recipes/r-openxlsx/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-openxlsx/meta.yaml
+++ b/recipes/r-openxlsx/meta.yaml
@@ -1,0 +1,57 @@
+{% set version = '4.0.17' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-openxlsx
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: openxlsx_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/openxlsx_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/openxlsx/openxlsx_{{ version }}.tar.gz
+  sha256: 116b9829c5a85ab1b7368d9f7f34a2248436f54bbf6ad635186c8a70b5a204d7
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rcpp
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-rcpp
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('openxlsx')"  # [not win]
+    - "\"%R%\" -e \"library('openxlsx')\""  # [win]
+
+about:
+  home: https://github.com/awalker89/openxlsx
+  license: GPL-3
+  summary: Simplifies the creation of Excel .xlsx files by providing a high level interface to
+    writing, styling and editing worksheets. Through the use of 'Rcpp', read/write times
+    are comparable to the 'xlsx' and 'XLConnect' packages with the added benefit of
+    removing the dependency on Java.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - jdblischak
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-pscl/bld.bat
+++ b/recipes/r-pscl/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-pscl/build.sh
+++ b/recipes/r-pscl/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-pscl/meta.yaml
+++ b/recipes/r-pscl/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = '1.4.9' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-pscl
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: pscl_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/pscl_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/pscl/pscl_{{ version }}.tar.gz
+  sha256: 0e3a08a5d1ab73b84e4a3b3bb1893d6bf534eb4e53e5ffe80d3ec341ac91d195
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-mass
+    - r-lattice
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-mass
+    - r-lattice
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('pscl')"  # [not win]
+    - "\"%R%\" -e \"library('pscl')\""  # [win]
+
+about:
+  home: http://pscl.stanford.edu/
+  license: GPL-2
+  summary: Bayesian analysis of item-response theory (IRT) models, roll call analysis; computing
+    highest density regions; maximum likelihood estimation of zero-inflated and hurdle
+    models for count data; goodness-of-fit measures for GLMs; data sets used in writing and
+    teaching at the Political Science Computational Laboratory; seats-votes curves.
+  license_family: GPL2
+
+extra:
+  recipe-maintainers:
+    - jdblischak
+    - johanneskoester
+    - bgruening
+    - daler

--- a/recipes/r-truncnorm/bld.bat
+++ b/recipes/r-truncnorm/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-truncnorm/build.sh
+++ b/recipes/r-truncnorm/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-truncnorm/meta.yaml
+++ b/recipes/r-truncnorm/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = '1.0-7' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-truncnorm
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: truncnorm_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/truncnorm_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/truncnorm/truncnorm_{{ version }}.tar.gz
+  sha256: c7d775d09e2dcbcc543c03a207b4407b8548b5fdfeb4c017f12818507e014ce1
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r-base
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - {{native}}gcc-libs   # [win]
+    - libgcc               # [not win]
+
+test:
+  commands:
+    - $R -e "library('truncnorm')"  # [not win]
+    - "\"%R%\" -e \"library('truncnorm')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=truncnorm
+  license: GPL-2
+  summary: r/d/p/q functions for the truncated normal distribution
+  license_family: GPL2
+
+extra:
+  recipe-maintainers:
+    - jdblischak
+    - johanneskoester
+    - bgruening
+    - daler


### PR DESCRIPTION
cc @daler @bgruening 

This PR contains the recipes for 4 Bioconda R packages from https://github.com/bioconda/bioconda-recipes/issues/5582:

* r-docopt
* r-openxlsx
* r-pscl
* r-truncnorm

Notes:

* I used [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper) to create the recipes
* The CI builds passed on my fork