### PR TITLE
add pytorch and torchvision [not ready yet]

### DIFF
--- a/recipes/pytorch/build.sh
+++ b/recipes/pytorch/build.sh
@@ -1,0 +1,15 @@
+export CMAKE_LIBRARY_PATH="$PREFIX/lib:$PREFIX/include:$CMAKE_LIBRARY_PATH"
+export CMAKE_PREFIX_PATH="$PREFIX"
+
+# static linking of libstdc++
+export PYTORCH_BINARY_BUILD=1
+export TH_BINARY_BUILD=1
+
+export PYTORCH_BUILD_VERSION=$PKG_VERSION
+export PYTORCH_BUILD_NUM=$PKG_BUILDNUM
+
+export NO_CUDA=1
+
+export MAKEFLAGS=-j$CPU_COUNT
+
+python setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/pytorch/meta.yaml
+++ b/recipes/pytorch/meta.yaml
@@ -17,7 +17,6 @@ build:
   number: {{ build }}
   features:
     - blas_{{ blas_variant }}
-  script: NO_CUDA=1 CMAKE_PREFIX_PATH=$PREFIX MAKEFLAGS=-j$CPU_COUNT python setup.py install --single-version-externally-managed --record record.txt
   skip: true  # [win]
 
 requirements:
@@ -33,7 +32,6 @@ requirements:
   run:
     - python
     - numpy >=1.8
-    - pyyaml
     - cffi
     - openblas 0.2.19|0.2.19.*
 

--- a/recipes/pytorch/meta.yaml
+++ b/recipes/pytorch/meta.yaml
@@ -18,6 +18,7 @@ build:
   features:
     - blas_{{ blas_variant }}
   script: NO_CUDA=1 CMAKE_PREFIX_PATH=$PREFIX MAKEFLAGS=-j$CPU_COUNT python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [win]
 
 requirements:
   build:
@@ -35,7 +36,6 @@ requirements:
     - pyyaml
     - cffi
     - openblas 0.2.19|0.2.19.*
-  skip: true  # [win]
 
 test:
   imports:

--- a/recipes/pytorch/meta.yaml
+++ b/recipes/pytorch/meta.yaml
@@ -62,3 +62,4 @@ about:
 extra:
   recipe-maintainers:
     - dougalsutherland
+    - soumith

--- a/recipes/pytorch/meta.yaml
+++ b/recipes/pytorch/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "pytorch" %}
+{% set version = "0.2.0" %}
+{% set build = 0 %}
+{% set sha256 = "22b30638536d20d387e1adff62aa4b9ddebd8ac7ab812a36c699d72df9f7f570" %}
+{% set blas_variant = "openblas" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/pytorch/pytorch/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: {{ build }}
+  features:
+    - blas_{{ blas_variant }}
+  script: NO_CUDA=1 CMAKE_PREFIX_PATH=$PREFIX MAKEFLAGS=-j$CPU_COUNT python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+    - numpy 1.8.*
+    - pyyaml
+    - cmake
+    - cffi
+    - openblas 0.2.19|0.2.19.*
+  run:
+    - python
+    - numpy >=1.8
+    - pyyaml
+    - cffi
+    - openblas 0.2.19|0.2.19.*
+  skip: true  # [win]
+
+test:
+  imports:
+    - torch
+
+about:
+  home: http://pytorch.org
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Tensors and Dynamic neural networks in Python with strong GPU acceleration'
+  description: |
+    PyTorch is a Python package that provides two high-level features:
+    - Tensor computation (like NumPy) with strong GPU acceleration
+    - Deep neural networks built on a tape-based autograd system
+    
+    You can reuse your favorite Python packages such as NumPy, SciPy and Cython
+    to extend PyTorch when needed.
+
+    We are in an early-release beta. Expect some adventures and rough edges. 
+  doc_url: http://pytorch.org/docs/
+  dev_url: https://github.com/pytorch/pytorch
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland

--- a/recipes/torchvision/LICENSE
+++ b/recipes/torchvision/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) Soumith Chintala 2016, 
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/torchvision/meta.yaml
+++ b/recipes/torchvision/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "torchvision" %}
+{% set version = "0.1.9" %}
+{% set wheel_tag = "py2.py3" %}
+{% set fn = "{}-{}-{}-none-any.whl".format(name, version, wheel_tag) %}
+{% set sha256 = "8eb3b60d838188e12cd5f8a8d1ec09910a39f0d6dde712f8eda4079ea093d904" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ fn }}
+  url: https://pypi.io/packages/{{ wheel_tag }}/{{ name[0] }}/{{ name }}/{{ fn }}
+  sha256: {{ sha256 }}
+
+build:
+  number: {{ build }}
+  script: pip install --no-deps {{ fn }}
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - pillow
+    - six
+    - pytorch
+
+test:
+  imports:
+    - torchvision
+    - torchvision.datasets
+    - torchvision.models
+    - torchvision.transforms
+    - torchvision.utils
+
+about:
+  home: http://github.com/pytorch/vision
+  license: BSD-3-Clause
+  license_family: BSD
+  # license file will be in next release: https://github.com/pytorch/vision/pull/229
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: 'image and video datasets and models for torch deep learning'
+  description: |
+    This repository consists of:
+     - vision.datasets : Data loaders for popular vision datasets
+     - vision.models : Definitions for popular model architectures, such as
+       AlexNet, VGG, and ResNet and pre-trained models.
+     - vision.transforms : Common image transformations such as random crop,
+       rotations etc.
+     - vision.utils : Useful stuff such as saving tensor (3 x H x W) as image
+       to disk, given a mini-batch creating a grid of images, etc.
+  doc_url: https://github.com/pytorch/vision
+  dev_url: https://github.com/pytorch/vision
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland

--- a/recipes/torchvision/meta.yaml
+++ b/recipes/torchvision/meta.yaml
@@ -59,3 +59,4 @@ about:
 extra:
   recipe-maintainers:
     - dougalsutherland
+    - soumith


### PR DESCRIPTION
Adds a CPU-only version of pytorch, and the pure-python torchvision, package.

- `defaults` has `pytorch` and `pytorch-gpu` packages, but they don't have the newest 0.2.0 release (~3 weeks old). It also has `torchvision` and `torchvision-gpu` (which I think differ only in that they depend on `pytorch` or `pytorch-gpu`...hopefully that'll be fixed with features eventually).
- `soumith`'s channel is the officially recommended way to install the `pytorch` and `torchvision` packages, but it's a separate channel / uses MKL / includes CUDA binaries / ....

I would very much like to have a CUDA version too as this becomes possible on conda-forge (related: https://github.com/conda-forge/tensorflow-feedstock/issues/10, https://github.com/conda-forge/caffe-feedstock/issues/27).

@soumith, if you'd like yourself (or some other pytorch person) to be added as a maintainer here, let me know.