### PR TITLE
Add dask-core recipe

### DIFF
--- a/recipes/dask/meta.yaml
+++ b/recipes/dask/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.15.2" %}
+
+package:
+  name: dask-core
+  version: "{{ version }}"
+
+source:
+  fn: dask-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/d/dask/dask-{{ version }}.tar.gz
+  sha256: abe6758540fdbc260f14ee71cebc3ab88682e24ff147afa89375b7006f57d3ed
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - dask
+
+about:
+  home: http://github.com/dask/dask/
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
+  summary: 'Parallel Python with task scheduling'
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - jcrist
+    - martindurant
+    - mrocklin
+    - pitrou
+    - shoyer
+    - sinhrks
+    - tomaugspurger


### PR DESCRIPTION
We're converting the dask package to a metapackage with all
dependencies.  

This dask-core package will just have the dask package
without dependencies which will make it a more suitable dependency
target for other downstream packages.