### PR TITLE
added appveyor retry on conda update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,8 +69,8 @@ install:
     - cmd: conda config --set show_channel_urls true
     - cmd: appveyor-retry conda update --yes --quiet conda
 
-    - cmd: conda install --yes --quiet conda-build-all
-    - cmd: conda install --yes --quiet conda-forge-build-setup
+    - cmd: appveyor-retry conda install --yes --quiet conda-build-all
+    - cmd: appveyor-retry conda install --yes --quiet conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,7 @@ install:
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: conda config --add channels conda-forge
     - cmd: conda config --set show_channel_urls true
-    - cmd: conda update --yes --quiet conda
+    - cmd: appveyor-retry conda update --yes --quiet conda
 
     - cmd: conda install --yes --quiet conda-build-all
     - cmd: conda install --yes --quiet conda-forge-build-setup

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,7 @@ install:
 
     - cmd: appveyor-retry conda install --yes --quiet conda-build-all
     - cmd: appveyor-retry conda install --yes --quiet conda-forge-build-setup
-    - cmd: run_conda_forge_build_setup
+    - cmd: appveyor-retry run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off


### PR DESCRIPTION
Appveyor builds repeatedly fail due to transient network errors.  This patches fixes that by adding retries.