### PR TITLE
adding haskell compiler ghc

### DIFF
--- a/recipes/ghc/build.sh
+++ b/recipes/ghc/build.sh
@@ -1,0 +1,2 @@
+CFLAGS="-L${PREFIX}/lib" ./configure --prefix=$PREFIX
+make install

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -1,11 +1,15 @@
+{% set name = "ghc" %}
+{% set version = "6.8.3" %}
+{% set sha256 = "07d06efa9222638c80b72ceda957d3c7bcbdc2665a9738dd6ef6c0751a05e8ed" %}
+
 package:
-  name: ghc
-  version: 8.2.1
+  name: {{ name }}
+  version: {{ version }}
 
 source:
-  fn: ghc-8.2.1.-src.tar.xz
-  url: https://downloads.haskell.org/~ghc/8.2.1/ghc-8.2.1-src.tar.xz
-  md5: 8942b6fb393984aeb8304d09bc326851
+  fn: {{ name }}-{{ version }}-x86_64-unknown-linux.tar.bz2  # [linux and x86_64]
+  url: https://downloads.haskell.org/{{ name }}/dist/{{ version }}/{{ name }}-{{ version }}-x86_64-unknown-linux.tar.bz2  # [linux and x86_64]
+  sha256: {{ sha256 }}
 
 build:
   number: 0
@@ -14,6 +18,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - gmp
   run:
     - gmp
@@ -30,4 +35,4 @@ about:
 extra:
   recipe-maintainers:
     - notestaff
-  
+  notes: "ghc 6.8.3 is outdated but needed to bootstrap the building of later versions"

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: ghc-8.2.1.-src.tar.xz
-  url: https://www.haskell.org/ghc/dist/6.8.3/ghc-6.8.3-x86_64-unknown-linux.tar.bz2
+  url: https://downloads.haskell.org/~ghc/8.2.1/ghc-8.2.1-src.tar.xz
   md5: 8942b6fb393984aeb8304d09bc326851
 
 build:
@@ -26,3 +26,8 @@ about:
   home: https://www.haskell.org/ghc/
   license: BSD
   summary: "GHC is a state-of-the-art, open source, compiler and interactive environment for the functional language Haskell."
+
+extra:
+  recipe-maintainers:
+    - notestaff
+  

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: ghc
+  version: 8.2.1
+
+source:
+  fn: ghc-8.2.1.-src.tar.xz
+  url: https://www.haskell.org/ghc/dist/6.8.3/ghc-6.8.3-x86_64-unknown-linux.tar.bz2
+  md5: 8942b6fb393984aeb8304d09bc326851
+
+build:
+  number: 0
+  skip: True # [osx]
+  skip: True # [win]
+
+requirements:
+  build:
+    - gmp
+  run:
+    - gmp
+
+test:
+  commands:
+    - ghc --help > /dev/null
+
+about:
+  home: https://www.haskell.org/ghc/
+  license: BSD
+  summary: "GHC is a state-of-the-art, open source, compiler and interactive environment for the functional language Haskell."

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -9,8 +9,8 @@ source:
 
 build:
   number: 0
-  skip: True # [osx]
-  skip: True # [win]
+  skip: True  # [osx]
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - toolchain
+    - perl
     - gmp
   run:
     - gmp

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}-x86_64-unknown-linux.tar.bz2  # [linux and x86_64]
-  url: https://downloads.haskell.org/{{ name }}/dist/{{ version }}/{{ name }}-{{ version }}-x86_64-unknown-linux.tar.bz2  # [linux and x86_64]
+  url: https://www.haskell.org/{{ name }}/dist/{{ version }}/{{ name }}-{{ version }}-x86_64-unknown-linux.tar.bz2  # [linux and x86_64]
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/ghc/meta.yaml
+++ b/recipes/ghc/meta.yaml
@@ -19,9 +19,12 @@ build:
 requirements:
   build:
     - toolchain
+    - pkg-config
     - perl
+    - readline
     - gmp
   run:
+    - readline
     - gmp
 
 test:


### PR DESCRIPTION
Adding Haskell compiler ghc.  The ghc version added by this PR is old, but is necessary to bootstrap the building of later versions.