### PR TITLE
WIP Add recipe for cxxwrap

### DIFF
--- a/recipes/CxxWrap/bld.bat
+++ b/recipes/CxxWrap/bld.bat
@@ -1,0 +1,8 @@
+cmake -G "NMake Makefiles" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%\deps\src\jlcxx
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/CxxWrap/build.sh
+++ b/recipes/CxxWrap/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cmake -DBUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_INSTALL_LIBDIR=lib $SRC_DIR/deps/src/jlcxx
+make install

--- a/recipes/CxxWrap/meta.yaml
+++ b/recipes/CxxWrap/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "CxxWrap" %}
-{% set version = "0.5.0" %}
-{% set sha256 = "0133224fb11e453e7ac65e13ac9be6f7e6b81ade08d58f4d80d2b21405ec9d62" %}
+{% set version = "0.5.0.post" %}
+{% set commit = "3af673b33ba6f47b00c4ed04f8b5616e54dbc7a2" %}
+{% set sha256 = "19d8c3996e886dc98e1065fef86a244095e0653a40bb3fcaf104f7a1c6a1afdd" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +9,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/JuliaInterop/CxxWrap.jl/archive/v{{ version }}.tar.gz
+  url: https://github.com/SylvainCorlay/CxxWrap.jl/archive/{{ commit }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -28,19 +29,19 @@ test:
     - test -d ${PREFIX}/include/jlcxx  # [unix]
     - test -f ${PREFIX}/include/jlcxx/jlcxx.hpp  # [unix]
     # In the current version:
-    - test -f ${PREFIX}/share/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
-    - test -f ${PREFIX}/share/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
+    # - test -f ${PREFIX}/share/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
+    #- test -f ${PREFIX}/share/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
     # In the next version:
-    #- test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
-    #- test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
+    - test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
+    - test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
 
     - if exist %LIBRARY_PREFIX%\include\JlCxx\jlcxx.hpp (exit 0) else (exit 1)  # [win]
     # In the current version:
-    - if exist %LIBRARY_PREFIX%\share\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
-    - if exist %LIBRARY_PREFIX%\share\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+    #- if exist %LIBRARY_PREFIX%\share\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
+    #- if exist %LIBRARY_PREFIX%\share\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
     # In the next version:
-    #- if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
-    #- if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
 
 about:
   home: https://github.com/JuliaInterop/CxxWrap.jl

--- a/recipes/CxxWrap/meta.yaml
+++ b/recipes/CxxWrap/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "CxxWrap" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "0133224fb11e453e7ac65e13ac9be6f7e6b81ade08d58f4d80d2b21405ec9d62" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/JuliaInterop/CxxWrap.jl/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not linux]
+
+requirements:
+  build:
+    - toolchain
+    - cmake
+    - julia >=0.5,<0.7
+  run:
+    - julia >=0.5,<0.7
+
+test:
+  commands:
+    - test -d ${PREFIX}/include/jlcxx  # [unix]
+    - test -f ${PREFIX}/include/jlcxx/jlcxx.hpp  # [unix]
+    # In the current version:
+    - test -f ${PREFIX}/share/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
+    - test -f ${PREFIX}/share/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
+    # In the next version:
+    #- test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
+    #- test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
+
+    - if exist %LIBRARY_PREFIX%\include\JlCxx\jlcxx.hpp (exit 0) else (exit 1)  # [win]
+    # In the current version:
+    - if exist %LIBRARY_PREFIX%\share\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\share\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+    # In the next version:
+    #- if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
+    #- if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://github.com/JuliaInterop/CxxWrap.jl
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: 'Seamless operability between C++11 and Julia'
+  description: 'Lightweight library that exposes C++ types in Julia and vice versa'
+  doc_url: https://github.com/JuliaInterop/CxxWrap.jl
+  dev_url: https://github.com/JuliaInterop/CxxWrap.jl
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - JohanMabille
+    - barche


### PR DESCRIPTION
The `CxxWrap` package by @barche is to Julia what `boost.python` and `pybind11` are to Python.

The goal of this PR is to explore how Julia native extensions can be packaged for `conda` (and other general-purpose package managers). It is now possible since Julia was packaged for conda-forge (cf https://github.com/conda-forge/staged-recipes/pull/3503) thanks to the hard work of  @dfornika, and others who worked on the massive PR (@bgruening, @tkelman, @acaprez).

This is work in progress, now only packaging the C++ part (jlcxx).

Ideally, I would like the conda package to differ from the julia package in that jlcxx would be installed in the general prefix instead of being vendored under the julia directory.

This poses two questions for CxxWrap:

 - should we add a flag (e.g. with an environment variable) to prevent the CxxWrap Julia package to vendor jlcxx headers.
 - should CxxWrap and jlcxx be two separate packages from a conda viewpoint?

Ping @barche.