### PR TITLE
Recipe for pytest-datadir

### DIFF
--- a/recipes/pytest-datadir/meta.yaml
+++ b/recipes/pytest-datadir/meta.yaml
@@ -23,10 +23,8 @@ requirements:
     - python
 
 test:
-  requires:
-    - pytest
-  commands:
-    - pytest tests
+  imports:
+    pytest_datadir
 
 about:
   home: https://github.com/gabrielcnr/pytest-datadir

--- a/recipes/pytest-datadir/meta.yaml
+++ b/recipes/pytest-datadir/meta.yaml
@@ -32,7 +32,6 @@ about:
   home: https://github.com/gabrielcnr/pytest-datadir
   license: MIT
   license_family: MIT
-  license_file: LICENSE
   summary: 'pytest plugin for manipulating test data directories and files'
 
 extra:

--- a/recipes/pytest-datadir/meta.yaml
+++ b/recipes/pytest-datadir/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "pytest-datadir" %}
+{% set version = "1.0.1" %}
+{% set sha256 = "3e5d1892c68d0dfb6863e87d6a1f683e67be60802fee798a3ccae5dbda1ab378" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+  commands:
+    - pytest tests
+
+about:
+  home: https://github.com/gabrielcnr/pytest-datadir
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'pytest plugin for manipulating test data directories and files'
+
+extra:
+  recipe-maintainers:
+    - IgorTG
+    - Nicoddemus

--- a/recipes/pytest-datadir/meta.yaml
+++ b/recipes/pytest-datadir/meta.yaml
@@ -32,7 +32,7 @@ about:
   home: https://github.com/gabrielcnr/pytest-datadir
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  license_file: LICENSE
   summary: 'pytest plugin for manipulating test data directories and files'
 
 extra:


### PR DESCRIPTION
Recipe for pytest-datadir package. A pytest plugin for manipulating test data directories and files.