### PR TITLE
Added recipe for colour

### DIFF
--- a/recipes/colour/meta.yaml
+++ b/recipes/colour/meta.yaml
@@ -15,6 +15,7 @@ source:
   {{ hash_type }}: {{ hash }}
 
 build:
+  noarch: python
   number: {{ build }}
   script: python setup.py install --single-version-externally-managed --record=record.txt
 

--- a/recipes/colour/meta.yaml
+++ b/recipes/colour/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.1.4" %}
 {% set bundle = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash = "insert-real-hash" %}
+{% set hash = "1357f37ddfd0d7c0e770f0772901635b3a38025a2480a44280510faca30fb509" %}
 {% set build = 0 %}
 
 package:

--- a/recipes/colour/meta.yaml
+++ b/recipes/colour/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "colour" %}
+{% set version = "0.1.4" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "insert-real-hash" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - d2to1
+
+  run:
+    - python
+
+test:
+  imports:
+    - colour
+
+about:
+  home: https://github.com/vaab/colour
+  summary: 'Python color representations manipulation library (RGB, HSL, web, ...)'
+  license_file: LICENSE
+  license: BSD 2-Clause
+  license_family: BSD
+  dev_url: https://github.com/vaab/colour
+  doc_url: https://github.com/vaab/colour
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/d2to1/LICENSE
+++ b/recipes/d2to1/LICENSE
@@ -1,0 +1,28 @@
+Copyright (C) 2013 Association of Universities for Research in Astronomy (AURA)
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    3. The name of AURA and its representatives may not be used to
+       endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL AURA BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipes/d2to1/meta.yaml
+++ b/recipes/d2to1/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "d2to1" %}
+{% set version = "0.2.12.post1" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "49ef2d16862b3efdc81fc5c32eac373b984945cde5fc02bb01a0a11ff03dd825" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+
+build:
+  noarch: python
+  preserve_egg_dir: True
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - d2to1
+    - d2to1.extern
+
+about:
+  home: https://github.com/embray/d2to1
+  license_file: {{ recipe_dir }}/LICENSE
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: "Allows using distutils2-like setup.cfg files for a package's metadata with a distribute/setuptools setup.py"
+  dev_url: https://github.com/embray/d2to1
+  doc_url: https://github.com/embray/d2to1
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
Includes both a recipe for `colour` and a recipe for `d2to1`, which is required to install the package. (It's worth noting here that `colour` and `colour-science` both install a module called `colour`. There's nothing wrong with this, but builders will need to be careful in the future.)