### PR TITLE
Readd netaddr

### DIFF
--- a/recipes/netaddr/meta.yaml
+++ b/recipes/netaddr/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "netaddr" %}
+{% set version = "0.7.18" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a1f5c9fcf75ac2579b9995c843dade33009543c04f218ff7c007b3c81695bd19
+
+build:
+  number: 0
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - netaddr
+    - netaddr.eui
+    - netaddr.ip
+    - netaddr.strategy
+
+about:
+  home: http://github.com/drkjam/netaddr
+  license: BSD 3-clause
+  summary: 'Pythonic manipulation of IPv4, IPv6, CIDR, EUI and MAC network addresses'
+
+extra:
+  recipe-maintainers:
+    - anguslees
+    - mariusvniekerk
+    - drkjam


### PR DESCRIPTION
Should fix the expired checkout key issue that the `netaddr` feedstock is experiencing.