### PR TITLE
Readd hiredis

### DIFF
--- a/recipes/hiredis/bld.bat
+++ b/recipes/hiredis/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
+if errorlevel 1 exit 1

--- a/recipes/hiredis/meta.yaml
+++ b/recipes/hiredis/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "0.2.0" %}
+
+package:
+    name: hiredis
+    version: {{ version }}
+
+source:
+    fn: hiredis-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/h/hiredis/hiredis-{{ version }}.tar.gz
+    md5: b410cf2f2062d87ab841c33d8345761e
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+
+test:
+    imports:
+        - hiredis
+
+about:
+    home: https://github.com/redis/hiredis-py
+    license: BSD
+    summary: Python wrapper for hiredis
+
+extra:
+    recipe-maintainers:
+        - kwilcox


### PR DESCRIPTION
(Possibly) fixes https://github.com/conda-forge/hiredis-feedstock/issues/7

The SSH key used to checkout the feedstock is expired. To fix this, we are readding the feedstock through staged-recipes as it is in `master`.

cc @conda-forge/hiredis @sannykr