### PR TITLE
Added recipe for pyldap

### DIFF
--- a/recipes/pyldap/meta.yaml
+++ b/recipes/pyldap/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "pyldap" %}
+{% set version = "2.4.37" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "ba402b013696d7cb39ed20b38ae8f8be0461f837d3a2818e67f3bdf0cc16987f" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  preserve_egg_dir: True
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - pyldap
+
+about:
+  home: https://github.com/pyldap/pyldap/
+  license_file: LICENSE
+  license: PSF
+  license_family: OTHER
+  summary: 'Python modules for implementing LDAP clients'
+  dev_url: https://github.com/pyldap/pyldap/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
`pyldap` is a python 3-compatible version of `python-ldap`, and is used by the latest version of `girder`