### PR TITLE
Add pre-commit tool and requirements

### DIFF
--- a/recipes/aspy.yaml/meta.yaml
+++ b/recipes/aspy.yaml/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "aspy.yaml" %}
+{% set version = "0.3.0" %}
+{% set hash_type = "sha256" %}
+{% set hash = "f59ec8f43a96be234c2a589097312e5787e68ba716a2f2ce6c7df5c7c5bb008a" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/asottile/aspy.yaml/archive/v{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - pyyaml
+
+test:
+  imports:
+    - aspy
+    - aspy.yaml
+  requires:
+    - pytest
+  source_files:
+    - tests
+  commands:
+    - pytest tests
+
+about:
+  home: http://github.com/asottile/aspy.yaml
+  license: MIT License
+  summary: 'A few extensions to pyyaml.'
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - nicoddemus

--- a/recipes/aspy.yaml/meta.yaml
+++ b/recipes/aspy.yaml/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: http://github.com/asottile/aspy.yaml
-  license: MIT License
+  license: MIT
   summary: 'A few extensions to pyyaml.'
   license_family: MIT
   license_file: LICENSE

--- a/recipes/identify/meta.yaml
+++ b/recipes/identify/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "identify" %}
+{% set version = "1.0.5" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "cfe1487d9fa28fdb59f52306b8465021864d1bb8b580d63f31e379ded3f2b21c" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://github.com/chriskuehl/identify/archive/v{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  entry_points:
+    - identify-cli=identify.cli:main
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - identify
+  requires:
+    - pytest
+  source_files:
+    - tests
+  commands:
+    - identify-cli --help
+    - pytest tests
+
+about:
+  home: https://github.com/chriskuehl/identify
+  license: MIT License
+  license_family: MIT
+  license_file: LICENSE
+  summary: File identification library for Python
+
+extra:
+  recipe-maintainers:
+    - nicoddemus

--- a/recipes/identify/meta.yaml
+++ b/recipes/identify/meta.yaml
@@ -14,10 +14,10 @@ source:
 
 build:
   number: 0
-  entry_points:
-    - identify-cli=identify.cli:main
   script: python setup.py install  --single-version-externally-managed --record=record.txt
   noarch: python
+  entry_points:
+    - identify-cli = identify.cli:main
 
 requirements:
   build:

--- a/recipes/identify/meta.yaml
+++ b/recipes/identify/meta.yaml
@@ -33,6 +33,7 @@ test:
     - pytest
   source_files:
     - tests
+    - setup.py
   commands:
     - identify-cli --help
     - pytest tests

--- a/recipes/identify/meta.yaml
+++ b/recipes/identify/meta.yaml
@@ -39,7 +39,7 @@ test:
 
 about:
   home: https://github.com/chriskuehl/identify
-  license: MIT License
+  license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: File identification library for Python

--- a/recipes/nodeenv/meta.yaml
+++ b/recipes/nodeenv/meta.yaml
@@ -41,7 +41,7 @@ test:
 
 about:
   home: https://github.com/ekalinin/nodeenv
-  license: BSD
+  license: BSD 3-Clause
   license_family: BSD
   license_file: ''
   summary: Node.js virtual environment builder

--- a/recipes/nodeenv/meta.yaml
+++ b/recipes/nodeenv/meta.yaml
@@ -38,7 +38,7 @@ test:
 
 about:
   home: https://github.com/ekalinin/nodeenv
-  license: BSD License
+  license: BSD
   license_family: BSD
   license_file: ''
   summary: Node.js virtual environment builder

--- a/recipes/nodeenv/meta.yaml
+++ b/recipes/nodeenv/meta.yaml
@@ -29,7 +29,9 @@ requirements:
 test:
   commands:
     - nodeenv --help
-    - pytest tests
+    # skip test_predeactivate_hook test because it fails on py36
+    # See: https://github.com/ekalinin/nodeenv/pull/200
+    - pytest tests -k-test_predeactivate_hook
   requires:
     - pytest
     - mock

--- a/recipes/nodeenv/meta.yaml
+++ b/recipes/nodeenv/meta.yaml
@@ -33,6 +33,7 @@ test:
   requires:
     - pytest
     - mock
+    - coverage
   source_files:
     - tests
 

--- a/recipes/nodeenv/meta.yaml
+++ b/recipes/nodeenv/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "nodeenv" %}
+{% set version = "1.2.0" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "11bb8e8c4001f0394616bc2649c090b998b700784dd7d7f1420be6fc59f3d592" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://github.com/ekalinin/nodeenv/archive/{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  entry_points:
+    - nodeenv = nodeenv:main
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  commands:
+    - nodeenv --help
+    - pytest tests
+  requires:
+    - pytest
+    - mock
+  source_files:
+    - tests
+
+about:
+  home: https://github.com/ekalinin/nodeenv
+  license: BSD License
+  license_family: BSD
+  license_file: ''
+  summary: Node.js virtual environment builder
+
+extra:
+  recipe-maintainers:
+    - nicoddemus

--- a/recipes/pre_commit/meta.yaml
+++ b/recipes/pre_commit/meta.yaml
@@ -55,7 +55,7 @@ test:
 
 about:
   home: http://pre-commit.com/
-  license: MIT License
+  license: MIT
   license_file: LICENSE
   summary: 'A framework for managing and maintaining multi-language pre-commit hooks.'
   license_family: MIT

--- a/recipes/pre_commit/meta.yaml
+++ b/recipes/pre_commit/meta.yaml
@@ -41,17 +41,10 @@ test:
     - pre_commit
     - pre_commit.commands
     - pre_commit.languages
-  requires:
-    - pytest
-    - mock
-  source_files:
-    - tests
-    - testing
   commands:
     - pre-commit --help
     - pre-commit-validate-config --help
     - pre-commit-validate-manifest --help
-    - pytest tests
 
 about:
   home: http://pre-commit.com/

--- a/recipes/pre_commit/meta.yaml
+++ b/recipes/pre_commit/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "pre_commit" %}
+{% set version = "1.1.0" %}
+{% set hash_type = "sha256" %}
+{% set hash = "105a9a941c48e0f90ef4f429e8dbabe2411e1eb74fbda44ff5ed3f31d637a69d" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-v{{ version }}.tar.gz
+  url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  noarch: python
+  entry_points:
+    - pre-commit = pre_commit.main:main
+    - pre-commit-validate-config = pre_commit.clientlib:validate_config_main
+    - pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - aspy.yaml
+    - cached-property
+    - identify >=1.0.0
+    - nodeenv >=0.11.1
+    - pyyaml
+    - six
+    - virtualenv
+
+test:
+  imports:
+    - pre_commit
+    - pre_commit.commands
+    - pre_commit.languages
+  requires:
+    - pytest
+    - mock
+  source_files:
+    - tests
+    - testing
+  commands:
+    - pre-commit --help
+    - pre-commit-validate-config --help
+    - pre-commit-validate-manifest --help
+    - pytest tests
+
+about:
+  home: http://pre-commit.com/
+  license: MIT License
+  license_file: LICENSE
+  summary: 'A framework for managing and maintaining multi-language pre-commit hooks.'
+  license_family: MIT
+  dev_url: https://github.com/pre-commit/pre-commit
+  doc_url: https://github.com/pre-commit/pre-commit
+
+extra:
+  recipe-maintainers:
+    - nicoddemus

--- a/recipes/pre_commit/meta.yaml
+++ b/recipes/pre_commit/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - identify >=1.0.0
     - nodeenv >=0.11.1
     - pyyaml
+    - setuptools
     - six
     - virtualenv
 

--- a/recipes/pytest-env/meta.yaml
+++ b/recipes/pytest-env/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pytest-env" %}
+{% set version = "0.6.2" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools
+    - pytest >=2.6.0
+
+test:
+  imports:
+    - pytest_env
+  commands:
+    - pytest --help
+
+about:
+  home: https://github.com/MobileDynasty/pytest-env
+  license: MIT
+  license_family: MIT
+  # license file is missing from sdist: https://github.com/MobileDynasty/pytest-env/issues/6
+  summary: py.test plugin that allows you to add environment variables.
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
Packages added:

- pre_commit
- aspy.yaml
- identify
- nodeenv
- pytest-env

Decided to use tarballs from GitHub because they include tests and LICENSE
file, so all packages run their full test suite *except* for `pre-commit` itself because it needs all source files and even a git checkout of the repository to run its own tests, which I think will be too much trouble to replicate on the recipe itself.

Note: all the recipes are noarch:python, so we only need to wait for CircleCI.