### PR TITLE
The cfortran system as shipped with cfitsio

### DIFF
--- a/recipes/cfortran-cfitsio/build.sh
+++ b/recipes/cfortran-cfitsio/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cfortran=$(find . -name "cfortran.h")
+f77_wrap=$(find . -name "f77_wrap.h")
+
+# Install additional headers
+cp ${cfortran} ${PREFIX}/include
+cp ${f77_wrap} ${PREFIX}/include
+

--- a/recipes/cfortran-cfitsio/build.sh
+++ b/recipes/cfortran-cfitsio/build.sh
@@ -4,6 +4,8 @@ cfortran=$(find . -name "cfortran.h")
 f77_wrap=$(find . -name "f77_wrap.h")
 
 # Install additional headers
+mkdir -p ${PREFIX}/include
+
 cp ${cfortran} ${PREFIX}/include
 cp ${f77_wrap} ${PREFIX}/include
 

--- a/recipes/cfortran-cfitsio/meta.yaml
+++ b/recipes/cfortran-cfitsio/meta.yaml
@@ -19,7 +19,8 @@ build:
 about:
   home: https://heasarc.gsfc.nasa.gov/fitsio/
   license: GPL2
-
+  summary: "The version of cfortran.h and f77_wrap.h developed as part of the CFITSIO development"
+  
 extra:
   recipe-maintainers:
     - giacomov

--- a/recipes/cfortran-cfitsio/meta.yaml
+++ b/recipes/cfortran-cfitsio/meta.yaml
@@ -16,6 +16,11 @@ build:
   number: 0
   skip: true  # [win]
 
+test:
+  commands:
+    - test -f ${PREFIX}/include/cfortran.h
+    - test -f ${PREFIX}/include/f77_wrap.h
+
 about:
   home: https://heasarc.gsfc.nasa.gov/fitsio/
   license: GPL2

--- a/recipes/cfortran-cfitsio/meta.yaml
+++ b/recipes/cfortran-cfitsio/meta.yaml
@@ -1,0 +1,25 @@
+{% set name = "cfortran-cfitsio" %}
+{% set version = "4.4" %}
+{% set cfitsioversion = "3410" %}
+{% set sha256 = "a556ac7ea1965545dcb4d41cfef8e4915eeb8c0faa1b52f7ff70870f8bb5734c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}{{ cfitsioversion }}.tar.gz
+  url: ftp://heasarc.gsfc.nasa.gov/software/fitsio/c/cfitsio{{ cfitsioversion }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+about:
+  home: https://heasarc.gsfc.nasa.gov/fitsio/
+  license: GPL2
+
+extra:
+  recipe-maintainers:
+    - giacomov


### PR DESCRIPTION
Two headers (cfortran.h and f77_wrap.h) needed to bridge C and Fortran, as shipped with the Heasoft CFITSIO library (stand alone version).