### PR TITLE
Added recipe for deprecation

### DIFF
--- a/recipes/deprecation/meta.yaml
+++ b/recipes/deprecation/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "deprecation" %}
+{% set version = "1.0.1" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "b9bff5cc91f601ef2a8a0200bc6cde3f18a48c2ed3d1ecbfc16076b14b3ad935" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  noarch: python
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - deprecation
+
+about:
+  home: http://deprecation.readthedocs.io/
+  license_file: LICENSE
+  license: Apache 2.0
+  license_family: Apache
+  summary: 'A library to handle automated deprecations'
+  dev_url: https://github.com/briancurtin/deprecation
+  doc_url: http://deprecation.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
We need `deprecation` for the latest version of `openstacksdk` (See [pull](https://github.com/conda-forge/openstacksdk-feedstock/pull/3))