### PR TITLE
Drop additions of maintainers

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -14,9 +14,8 @@ from conda_build.metadata import MetaData
 from conda_smithy.github import gh_token
 from contextlib import contextmanager
 from datetime import datetime
-from github import Github, GithubException, Team
+from github import Github, GithubException
 import os.path
-from random import choice
 import shutil
 import subprocess
 import sys
@@ -26,12 +25,6 @@ import traceback
 
 # Enable DEBUG to run the diagnostics, without actually creating new feedstocks.
 DEBUG = False
-
-
-superlative = ['awesome', 'slick', 'formidable', 'awe-inspiring', 'breathtaking',
-               'magnificent', 'wonderous', 'stunning', 'astonishing', 'superb',
-               'splendid', 'impressive', 'unbeatable', 'excellent', 'top', 'outstanding',
-               'exalted', 'standout', 'smashing']
 
 
 recipe_directory_name = 'recipes'
@@ -72,22 +65,6 @@ def repo_exists(organization, name):
             return False
         raise
 
-
-def create_team(org, name, description, repo_names):
-    # PyGithub creates secret teams, and has no way of turning that off! :(
-    post_parameters = {
-        "name": name,
-        "description": description,
-        "privacy": "closed",
-        "permission": "push",
-        "repo_names": repo_names
-    }
-    headers, data = org._requester.requestJsonAndCheck(
-        "POST",
-        org.url + "/teams",
-        input=post_parameters
-    )
-    return Team.Team(org._requester, headers, data, completed=True)
 
 def print_rate_limiting_info(gh):
     # Compute some info about our GitHub API Rate Limit.
@@ -173,17 +150,8 @@ if __name__ == '__main__':
             else:
                 subprocess.check_call(['conda', 'smithy', 'register-github', feedstock_dir] + owner_info)
 
-        conda_forge = None
-        teams = None
-        if gh:
-            # Only get the org and teams if there is stuff to add.
-            if feedstock_dirs:
-                conda_forge = gh.get_organization('conda-forge')
-                teams = {team.name: team for team in conda_forge.get_teams()}
-
         # Break the previous loop to allow the TravisCI registering to take place only once per function call.
         # Without this, intermittent failures to synch the TravisCI repos ensue.
-        all_maintainers = set()
         # Hang on to any CI registration errors that occur and raise them at the end.
         for feedstock_dir, name, recipe_dir in feedstock_dirs:
             # Try to register each feedstock with CI.
@@ -220,67 +188,9 @@ if __name__ == '__main__':
                     subprocess.check_call(['git', 'checkout', 'master', '--', '.'], cwd=feedstock_dir)
                     subprocess.check_call(['git', 'rebase', '--continue'], cwd=feedstock_dir)
 
-            # Add team members as maintainers.
-            if conda_forge:
-                meta = MetaData(recipe_dir)
-                maintainers = set(meta.meta.get('extra', {}).get('recipe-maintainers', []))
-                all_maintainers.update(maintainers)
-                team_name = name.lower()
-                repo_name = 'conda-forge/{}-feedstock'.format(name)
-
-                # Try to get team or create it if it doesn't exist.
-                team = teams.get(team_name)
-                if not team:
-                    team = create_team(
-                        conda_forge,
-                        team_name,
-                        'The {} {} contributors!'.format(choice(superlative), team_name),
-                        repo_names=[repo_name]
-                    )
-                    teams[team_name] = team
-                    current_maintainers = []
-                else:
-                    current_maintainers = team.get_members()
-
-                # Add only the new maintainers to the team.
-                current_maintainers_handles = set([each_maintainers.login.lower() for each_maintainers in current_maintainers])
-                for new_maintainer in maintainers - current_maintainers_handles:
-                    headers, data = team._requester.requestJsonAndCheck(
-                        "PUT",
-                        team.url + "/memberships/" + new_maintainer
-                    )
-                # Mention any maintainers that need to be removed (unlikely here).
-                for old_maintainer in current_maintainers_handles - maintainers:
-                    print("AN OLD MEMBER ({}) NEEDS TO BE REMOVED FROM {}".format(old_maintainer, repo_name))
-
             # Remove this recipe from the repo.
             if is_merged_pr:
                 subprocess.check_call(['git', 'rm', '-rf', recipe_dir])
-
-    # Add new conda-forge members to all-members team. Welcome! :)
-    if conda_forge:
-        team_name = 'all-members'
-        team = teams.get(team_name)
-        if not team:
-            team = create_team(
-                conda_forge,
-                team_name,
-                'All of the awesome conda-forge contributors!',
-                []
-            )
-            teams[team_name] = team
-            current_members = []
-        else:
-            current_members = team.get_members()
-
-        # Add only the new members to the team.
-        current_members_handles = set([each_member.login.lower() for each_member in current_members])
-        for new_member in all_maintainers - current_members_handles:
-            print("Adding a new member ({}) to conda-forge. Welcome! :)".format(new_member))
-            headers, data = team._requester.requestJsonAndCheck(
-                "PUT",
-                team.url + "/memberships/" + new_member
-            )
 
     # Update status based on the remote.
     subprocess.check_call(['git', 'stash', '--keep-index', '--include-untracked'])

--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -173,6 +173,7 @@ if __name__ == '__main__':
                     # Capture the output, as it may contain the GH_TOKEN.
                     out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'HEAD:master'], cwd=feedstock_dir,
                                                   stderr=subprocess.STDOUT)
+                    subprocess.check_call(['conda', 'smithy', 'register-github', '--add-teams', feedstock_dir] + owner_info)
                     break
                 except subprocess.CalledProcessError:
                     pass


### PR DESCRIPTION
This is now handled through a web service, which takes care of team updates for all feedstocks. The service picks up any changes pushed to the feedstock and checks to see if any new members were added. If so, it goes through adds them to the correct team. If not, nothing happens. When it comes to a recently added feedstock, this web service will also pick up the changes pushed to the recipe, create the team, and add all members listed in recipe to it. Hence there is no need to maintain this functionality separately in staged-recipes.