### PR TITLE
Readd pystache

### DIFF
--- a/recipes/pystache/meta.yaml
+++ b/recipes/pystache/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "pystache" %}
+{% set version = "0.5.4" %}
+{% set build = 1 %}
+{% set md5 = "485885e67a0f6411d5252e69b20a35ca" %}
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+source:
+    fn: {{ name }}-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    md5: {{ md5 }}
+
+build:
+    number: {{ build }}
+    script: python setup.py install --single-version-externally-managed --record record.txt
+    noarch: python
+    entry_points:
+        - pystache = pystache.commands.render:main
+        - pystache-test = pystache.commands.test:main
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - python
+
+test:
+    imports:
+        - pystache
+        - pystache.commands
+        - pystache.tests
+        - pystache.tests.data
+        - pystache.tests.data.locator
+        - pystache.tests.examples
+
+    commands:
+        - pystache --help
+        - pystache-test
+
+about:
+    home: http://github.com/defunkt/pystache
+    license: MIT
+    license_file: LICENSE
+    summary: 'Mustache for Python'
+
+extra:
+    recipe-maintainers:
+        - kwilcox


### PR DESCRIPTION
Needed as the SSH key used to checkout pystache on CircleCI has expired. Readding it through staged-recipes should fix that by adding a new SSH key.

cc @conda-forge/pystache