### PR TITLE
add markdown

### DIFF
--- a/recipes/markdown/meta.yaml
+++ b/recipes/markdown/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "Markdown" %}
+{% set version = "2.6.9" %}
+{% set build = 0 %}
+{% set sha256 = "73af797238b95768b3a9b6fe6270e250e5c09d988b8e5b223fd5efa4e06faf81" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - markdown
+    - markdown.extensions
+  commands:
+    - markdown_py -h
+
+about:
+  home: https://pythonhosted.org/Markdown/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: 'Python implementation of Markdown.'
+  description: |
+    This is a Python implementation of John Gruber’s Markdown. It is almost
+    completely compliant with the reference implementation, though there are a
+    few very minor differences.
+  doc_url: http://pythonhosted.org/Markdown/
+  dev_url: https://github.com/Python-Markdown/markdown
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland


### PR DESCRIPTION
The markdown package is a requirement of tensorflow, currently being pulled in from `defaults`.

`noarch: python` doesn't work because the `markdown_py` script doesn't end up being executable when installed.