### PR TITLE
Add dask-distance

### DIFF
--- a/recipes/dask-distance/meta.yaml
+++ b/recipes/dask-distance/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "dask-distance" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "e5b972346bcd558a69f57e7d95e4c07cf8f2556fdeb3f24af24d18a920f8205b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - dask
+    - numpy
+
+test:
+  source_files:
+    - tests
+
+  imports:
+    - dask_distance
+
+  requires:
+    - pytest
+    - scipy
+
+  commands:
+    - pytest
+
+about:
+  home: https://github.com/jakirkham/dask-distance
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
+  summary: Distance computations with Dask (akin to scipy.spatial.distance)
+  doc_url: https://dask-distance.readthedocs.io/
+  dev_url: https://github.com/jakirkham/dask-distance
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
A library for computing distances using coordinates in Dask Arrays. Provides an API very similar to that of [`scipy.spatial.distance`]( https://docs.scipy.org/doc/scipy-0.19.1/reference/spatial.distance.html ).