### PR TITLE
Restart Travis CI on staged-recipes after failure

### DIFF
--- a/.CI/trigger_staged-recipes.py
+++ b/.CI/trigger_staged-recipes.py
@@ -1,0 +1,33 @@
+"""
+Trigger the staged-recipes Travis job to restart.
+"""
+
+
+import os
+
+import requests
+import six
+
+import conda_smithy.ci_register
+
+
+def rebuild_travis(repo_slug):
+    headers = conda_smithy.ci_register.travis_headers()
+
+    # If we don't specify the API version, we get a 404.
+    headers.update({'Travis-API-Version': '3'})
+
+    # Trigger a build on `master`.
+    encoded_slug = six.moves.urllib.parse.quote(repo_slug, safe='')
+    url = 'https://api.travis-ci.org/repo/{}/requests'.format(encoded_slug)
+    response = requests.post(
+        url,
+        json={"request": {"branch": "master"}},
+        headers=headers
+    )
+    if response.status_code != 201:
+        response.raise_for_status()
+
+
+if __name__ == '__main__':
+    rebuild_travis('conda-forge/staged-recipes')

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,13 @@ script:
         source ./.CI/build_all;
       fi
 
+after_failure:
+  # Trigger a build only if this is not a pull request and is on the `master` branch.
+  # Also ensure that no recipes were converted (otherwise we already triggered a build by pushing).
+  - (
+        [ "${TRAVIS_REPO_SLUG}" == "conda-forge/staged-recipes" ] &&
+        [ "${TRAVIS_PULL_REQUEST}" == "false" ] &&
+        [ "${TRAVIS_BRANCH}" == "master" ]
+    ) && \
+    ( git remote remove upstream_with_token || echo .CI/trigger_staged-recipes.py )
+


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/2619

If Travis CI completely fails to convert recipes, trigger a rebuild of staged-recipes through the API. There is a pretty low rate limit when it comes to rebuilding things with Travis CI through the API. Still this should help out when someone is unable to intervene manually. Also may be handy for keeping old failed logs around should debugging be necessary.

This borrows heavily from the former [`.CI/trigger_travis_conda-forge.github.io.py`]( https://github.com/conda-forge/staged-recipes/blob/24fca413071590dfce3926e4a0cd64dbd7262140/.CI/trigger_travis_conda-forge.github.io.py ) script, which triggered builds on the webpage repo. However it is vastly simplified thanks to improvements in `conda-smithy`.

cc @conda-forge/core