### PR TITLE
Recipe for doctest-ignore-unicode

### DIFF
--- a/recipes/doctest-ignore-unicode/meta.yaml
+++ b/recipes/doctest-ignore-unicode/meta.yaml
@@ -40,4 +40,5 @@ about:
   dev_url: 'https://github.com/gnublade/doctest-ignore-unicode'
 
 extra:
-  recipe-maintainers: 'pbronez'
+  recipe-maintainers:
+    - 'pbronez'

--- a/recipes/doctest-ignore-unicode/meta.yaml
+++ b/recipes/doctest-ignore-unicode/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "doctest-ignore-unicode" %}
+{% set version = "0.1.2" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "fc90b2d0846477285c6b67fc4cb4d6f39fcf76d8752f4df0a241486f31512ad5" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - nose
+  run:
+    - python
+    - setuptools
+    - nose
+
+about:
+  home: http://github.com/gnublade/doctest-ignore-unicode
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: ''  # Source does not provide a license file
+  summary: Add flag to ignore unicode literal prefixes in doctests
+  description: "Overview\n========\n\ndoctest-ignore-unicode is a plugin (currently only for `Nose`_) that adds\na flag to ignore unicode literal prefixes in doctests.\n\n.. _Nose: http://somethingaboutorange.com/mrl/projects/nose\n\
+    \nThe implmentation is inspired by\nhttps://github.com/nltk/nltk/blob/2and3/nltk/test/doctest_nose_plugin.py\n\nUsage\n=====\n\n    >>> def hello_world():\n    ...     return 'Hello World'\n    >>>\
+    \ hello_world()  # doctest: +IGNORE_UNICODE\n    u'Hello World'\n\nFAQ\n===\n\nWhy?\n----\n\nIf you need to ask you probably don't need it.  (Hint: supporting python 2 & 3\nin the same codebase)."
+  doc_url: 'https://github.com/gnublade/doctest-ignore-unicode/blob/master/README.rst'
+  dev_url: 'https://github.com/gnublade/doctest-ignore-unicode'
+
+extra:
+  recipe-maintainers: 'pbronez'

--- a/recipes/doctest-ignore-unicode/meta.yaml
+++ b/recipes/doctest-ignore-unicode/meta.yaml
@@ -22,10 +22,16 @@ requirements:
     - python
     - setuptools
     - nose
+  test:
+    - python
+    - nose
   run:
     - python
-    - setuptools
     - nose
+
+test:
+  imports:
+    - nose_plugin
 
 about:
   home: http://github.com/gnublade/doctest-ignore-unicode


### PR DESCRIPTION
[`doctest-ignore-unicode`](https://github.com/gnublade/doctest-ignore-unicode) is a Nose plugin that simplifies testing code bases that support Python 2 and Python 3. It is a test dependency for [`rdflib`](https://github.com/RDFLib/rdflib), which I'm trying to package for conda-forge as well.

This is my first submission to conda-forge. I followed the [instructions](https://conda-forge.org/docs/recipe.html#avoid-dependencies-outside-of-conda-forge). The upstream package does not have tests or a License file, so these are omitted from the recipe. I've clarified the Apache licensing created by `conda skeleton` from PyPi.

The recipe builds successfully on my `osx-64` machine using:
```
conda build \
--channel https://conda.anaconda.org/conda-forge/noarch \
--channel https://conda.anaconda.org/conda-forge/osx-64 \
--override-channels \
recipes/doctest-ignore-unicode/meta.yaml
```