### PR TITLE
Adjust headers used to trigger webpage build

### DIFF
--- a/.CI/trigger_conda-forge.github.io.py
+++ b/.CI/trigger_conda-forge.github.io.py
@@ -15,7 +15,9 @@ def rebuild_travis(repo_slug):
     headers = conda_smithy.ci_register.travis_headers()
 
     # If we don't specify the API version, we get a 404.
-    headers.update({'Travis-API-Version': '3'})
+    # Also fix the accepted content type.
+    headers["Accept"] = "application/json"
+    headers["Travis-API-Version"] = "3"
 
     # Trigger a build on `master`.
     encoded_slug = six.moves.urllib.parse.quote(repo_slug, safe='')


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/4107 ).

Was using a different accepted value type. This matches the API more closely. Hopefully ensures this triggers the webpage build ok.