### PR TITLE
Add dis3

### DIFF
--- a/recipes/dis3/meta.yaml
+++ b/recipes/dis3/meta.yaml
@@ -12,9 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
-  skip: True  # [py>=30]
+  skip: True  # [py3k]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -32,10 +31,10 @@ about:
   home: https://pypi.python.org/pypi/dis3
   license: MIT
   license_family: MIT
+  # the LICENCE file is mentioned in the README but not included in the .tar.gz
+  # distributed on PyPi. Since this package is not maintained anymore, we
+  # cannot fix this, unfortunately.
   summary: 'Python 2.7 backport of the "dis" module from Python 3.5+'
-
-  description: |
-      `dis3` is a Python 2.7 backport of the `dis` module from Python 3.5.
 
 extra:
   recipe-maintainers:

--- a/recipes/dis3/meta.yaml
+++ b/recipes/dis3/meta.yaml
@@ -29,11 +29,13 @@ test:
 
 about:
   home: https://pypi.python.org/pypi/dis3
+  # The home page specified at PyPi (https://github.com/tomxtobin/python-dis3) no longer exists,
+  # however it appears that a new repository with the full git history is accessible at,
+  # https://github.com/xoviat/python-dis3
   license: MIT
   license_family: MIT
   # the LICENCE file is mentioned in the README but not included in the .tar.gz
-  # distributed on PyPi. Since this package is not maintained anymore, we
-  # cannot fix this, unfortunately.
+  # distributed on PyPi.
   summary: 'Python 2.7 backport of the "dis" module from Python 3.5+'
 
 extra:

--- a/recipes/dis3/meta.yaml
+++ b/recipes/dis3/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "dis3" %}
+{% set version = "0.1.1" %}
+{% set sha256 = "ee9f71e1a0c01a3ba742a36be91147948db99da3ee29094dccb48857c54608ef" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  skip: True  # [py>=30]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - dis3
+
+about:
+  home: https://pypi.python.org/pypi/dis3
+  license: MIT
+  license_family: MIT
+  summary: 'Python 2.7 backport of the "dis" module from Python 3.5+'
+
+  description: |
+      `dis3` is a Python 2.7 backport of the `dis` module from Python 3.5.
+
+extra:
+  recipe-maintainers:
+    - rth


### PR DESCRIPTION
Adding dis3 (https://pypi.python.org/pypi/dis3). 

> Python 2.7 backport of the "dis" module from Python 3.5+

This is module is also a dependency of the latest version of pyinstaller cf https://github.com/conda-forge/pyinstaller-feedstock/pull/12

I'm not sure, is it possible to build a noarch package that's python 2.7 only?

**Edit** The LICENCE file was mentionned in the README but it's actually not included in the .tar.gz on PyPi

cc @jakirkham 