### PR TITLE
DOC Remove deprecated numpy x.x README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ Additionally, when pushing commits for a recipe that excludes Windows, put `[ski
 on Windows from even starting.
 
 
-### 4. **What does `numpy x.x` mean?**
-
-If you have a package which links against numpy you need to build and run against the same version of numpy.
-Putting `numpy x.x` in the build and run requirements ensure that a separate package will be built for each
-version of numpy that conda-forge builds against.
-
 ### 5. **What does the `build: 0` entry mean?**
 
 The build number is used when the source code for the package has not changed but you need to make a new

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo is a holding area for recipes destined for a conda-forge feedstock rep
 ## Getting started
 
 1. Fork this repository.
-2. Make a new folder in `recipes` for your package. Look at the example recipe and our [FAQ](https://github.com/conda-forge/staged-recipes#faq) for help.
+2. Make a new folder in `recipes` for your package. Look at the example recipe, our [documentation](https://conda-forge.org/docs/recipe.html) and the [FAQ](https://github.com/conda-forge/staged-recipes#faq)  for help.
 3. Open a pull request. Building of your package will be tested on Windows, Mac and Linux.
 4. When your pull request is merged a new repository, called a feedstock, will be created in the github conda-forge organization, and build/upload of your package will automatically be triggered. Once complete, the package is available on conda-forge.
 
@@ -56,7 +56,7 @@ Additionally, when pushing commits for a recipe that excludes Windows, put `[ski
 on Windows from even starting.
 
 
-### 5. **What does the `build: 0` entry mean?**
+### 4. **What does the `build: 0` entry mean?**
 
 The build number is used when the source code for the package has not changed but you need to make a new
 build. For example, if one of the dependencies of the package was not properly specified the first time
@@ -65,25 +65,25 @@ number.
 
 When the package version changes you should reset the build number to `0`.
 
-### 6. **Do I have to import all of my unit tests into the recipe's `test` field?**
+### 5. **Do I have to import all of my unit tests into the recipe's `test` field?**
 
 No, you do not.
 
-### 7. **Do all of my package's dependencies have to be in conda(-forge) already?**
+### 6. **Do all of my package's dependencies have to be in conda(-forge) already?**
 
 Short answer: yes. Long answer: In principle, as long as your dependencies are in at least one of
 your user's conda channels they will be able to install your package. In practice, that is difficult
 to manage, and we strive to get all dependencies built in conda-forge.
 
-### 8. **When or why do I need to use `python setup.py install --single-version-externally-managed --record record.txt`?**
+### 7. **When or why do I need to use `python setup.py install --single-version-externally-managed --record record.txt`?**
 
 These options should be added to setup.py if your project uses setuptools. The goal is to prevent `setuptools` from creating an `egg-info` directory because they do not interact well with conda.
 
-### 9. **Do I need `bld.bat` and/or `build.sh`?**
+### 8. **Do I need `bld.bat` and/or `build.sh`?**
 
 In many cases, no. Python packages almost never need it. If the build can be done with one line you can put it in the `script` line of the `build` section.
 
-### 10. What does being a conda-forge feedstock maintainer entail?
+### 9. What does being a conda-forge feedstock maintainer entail?
 
 The maintainers "job" is to:
 
@@ -91,11 +91,11 @@ The maintainers "job" is to:
 - keep the package updated by bumping the version whenever there is a new release;
 - answer eventual question about the package on the feedstock issue tracker.
 
-### 11. Why are there recipes already in the `recipes` directory? Should I do something about it?
+### 10. Why are there recipes already in the `recipes` directory? Should I do something about it?
 
 When a PR of recipe(s) is ready to go, it is merged into `master`. This will trigger a CI build specially designed to convert the recipe(s). However, for any number of reasons the recipe(s) may not be converted right away. In the interim, the recipe(s) will remain in `master` until they can be converted. There is no action required on the part of recipe contributors to resolve this. Also it should have no impact on any other PRs being proposed. If these recipe(s) pending conversion do cause issues for your submission, please ping `conda-forge/core` for help.
 
-### 12. **Some checks failed, but it wasn't my recipe! How do I trigger a rebuild?**
+### 11. **Some checks failed, but it wasn't my recipe! How do I trigger a rebuild?**
 
 Sometimes, some of the CI tools' builds fail due to no error within your recipe. If that happens, you can trigger a rebuild by re-creating the last commit and force pushing it to your branch:
 


### PR DESCRIPTION
`numpy  x.x` is now deprecated and will raise a deprecation warning by the linter, with a link to [the docs](https://conda-forge.org/docs/meta.html#building-against-numpy). This removes this section as discussed in https://github.com/conda-forge/pykrige-feedstock/pull/1#issuecomment-335007092.

cc @ocefpaf 

The only issue is that this makes the FAQ item numbering non-contigous. I could re-index all the subsequent items but it would mean that any existing relative URL links will break (e.g.
https://github.com/conda-forge/staged-recipes#5-what-does-the-build-0-entry-mean
)
not sure which one is a less bad option...