### PR TITLE
Add message to webpage repo trigger

### DIFF
--- a/.CI/trigger_conda-forge.github.io.py
+++ b/.CI/trigger_conda-forge.github.io.py
@@ -24,7 +24,12 @@ def rebuild_travis(repo_slug):
     url = 'https://api.travis-ci.org/repo/{}/requests'.format(encoded_slug)
     response = requests.post(
         url,
-        json={"request": {"branch": "master"}},
+        json={
+            "request": {
+                "branch": "master",
+                "message": "Triggering build from staged-recipes",
+            }
+        },
         headers=headers
     )
     if response.status_code != 201:


### PR DESCRIPTION
Should fix triggering builds on the webpage repo even when the most recent commit message skip the CI build. Also should make it easier to identify builds started by this trigger.