### PR TITLE
On Travis CI use Linux for pushes and Mac for PRs

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -10,7 +10,7 @@ git checkout "${TRAVIS_BRANCH}"
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh > ~/miniconda.sh
+curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
 source ~/miniconda/bin/activate root
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 # The language in this case has no bearing - we are going to be making use of conda.
 language: generic
 
-os: osx
-osx_image: xcode6.4
+matrix:
+  include:
+    - if: type NOT pull_request
+      os: linux
+
+matrix:
+  include:
+    - if: type IS pull_request
+      os: osx
+      osx_image: xcode6.4
 
 sudo: false
 


### PR DESCRIPTION
Select which operating system to use for the VM based on whether the build is a PR build or not. For PRs, use macOS as we are presumably trying to build a recipe. For everything else, this should be a feedstock conversion job. So using Linux in this case should be fine. This uses Travis CI's new conditional matrix syntax to select the OS. Hopefully can process conversions a bit faster.

ref: https://docs.travis-ci.com/user/conditional-builds-stages-jobs/