### PR TITLE
add google-cloud-datastore recipe

### DIFF
--- a/google-cloud-datastore/meta.yaml
+++ b/google-cloud-datastore/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "google-cloud-datastore" %}
+{% set version = "1.3.0" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "7b75111bf332ab177e55b860bd2c1b954645c6bb435b1a1a8580bd3f6ea5b346" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - google-cloud-core >=0.27.0,<0.28dev
+    - google-gax >=0.15.7,<0.16dev
+    - gapic-google-cloud-datastore-v1 >=0.15.0,<0.16dev
+  run:
+    - python
+    - google-cloud-core >=0.27.0,<0.28dev
+    - google-gax >=0.15.7,<0.16dev
+    - gapic-google-cloud-datastore-v1 >=0.15.0,<0.16dev
+
+test:
+  imports:
+    - google
+    - google.cloud
+    - google.cloud.datastore
+
+about:
+  home: https://github.com/GoogleCloudPlatform/google-cloud-python
+  license: Apache 2.0
+  license_family: APACHE
+  license_file: ''
+  summary: Python Client for Google Cloud Datastore
+  description: "Python Client for Google Cloud Datastore\n========================================\n\n    Python idiomatic client for `Google Cloud Datastore`_\n\n.. _Google Cloud Datastore: https://cloud.google.com/datastore/docs\n\
+    \n|pypi| |versions|\n\n-  `Documentation`_\n\n.. _Documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/datastore/client.html\n\nQuick Start\n-----------\n\n.. code-block::\
+    \ console\n\n    $ pip install --upgrade google-cloud-datastore\n\nAuthentication\n--------------\n\nWith ``google-cloud-python`` we try to make authentication as painless as\npossible. Check out the\
+    \ `Authentication section`_ in our documentation to\nlearn more. You may also find the `authentication document`_ shared by all\nthe ``google-cloud-*`` libraries to be helpful.\n\n.. _Authentication\
+    \ section: https://google-cloud-python.readthedocs.io/en/latest/core/auth.html\n.. _authentication document: https://github.com/GoogleCloudPlatform/gcloud-common/tree/master/authentication\n\nUsing\
+    \ the API\n-------------\n\nGoogle `Cloud Datastore`_ (`Datastore API docs`_) is a fully managed,\nschemaless database for storing non-relational data. Cloud Datastore\nautomatically scales with your\
+    \ users and supports ACID transactions, high\navailability of reads and writes, strong consistency for reads and ancestor\nqueries, and eventual consistency for all other queries.\n\n.. _Cloud Datastore:\
+    \ https://cloud.google.com/datastore/docs\n.. _Datastore API docs: https://cloud.google.com/datastore/docs/\n\nSee the ``google-cloud-python`` API `datastore documentation`_ to learn how to\ninteract\
+    \ with the Cloud Datastore using this Client Library.\n\n.. _datastore documentation: https://googlecloudplatform.github.io/google-cloud-python/latest/datastore/client.html\n\nSee the `official Google\
+    \ Cloud Datastore documentation`_ for more details on\nhow to activate Cloud Datastore for your project.\n\n.. _official Google Cloud Datastore documentation: https://cloud.google.com/datastore/docs/activate\n\
+    \n.. code:: python\n\n    from google.cloud import datastore\n    # Create, populate and persist an entity\n    entity = datastore.Entity(key=datastore.Key('EntityKind'))\n    entity.update({\n    \
+    \    'foo': u'bar',\n        'baz': 1337,\n        'qux': False,\n    })\n    # Then query for entities\n    query = datastore.Query(kind='EntityKind')\n    for result in query.fetch():\n        print(result)\n\
+    \n.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-datastore.svg\n   :target: https://pypi.org/project/google-cloud-datastore/\n.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-datastore.svg\n\
+    \   :target: https://pypi.org/project/google-cloud-datastore/\n\n\n"
+  doc_url: ''
+  dev_url: ''
+
+extra:
+  recipe-maintainers:
+    - eklitzke


### PR DESCRIPTION
This adds a recipe for `google-cloud-datastore`; a bunch of the other related google-cloud libs (e.g. google-cloud-storage) are already on conda-forge, but this one is missing.

This is the first recipe I'm submitting, let me know if I did something wrong.