### PR TITLE
Drop webpage CI trigger

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -28,4 +28,3 @@ mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 
 python .CI/create_feedstocks.py
-python .CI/trigger_travis_build.py "conda-forge/conda-forge.github.io"


### PR DESCRIPTION
This is no longer needed as the feedstock listing is now generated and stored in the feedstocks repo using a webservice. This will be accurately updated using the feedstocks repo's content any time there is a push to staged-recipes. In practice, this means that listing will be updated any time staged-recipes clears out some or all recipes during feedstock conversion as they will already have been added to the feedstocks repo as part of conversion. By switching to the webservice, this will cutdown rate limiting problems that the old strategy webpage based strategy was bound to encounter. Also this will be more reliable during partial conversions.

xref: https://github.com/conda-forge/conda-forge-webservices/pull/142
xref: https://github.com/conda-forge/conda-forge.github.io/pull/466
xref: https://github.com/conda-forge/staged-recipes/pull/4107