### PR TITLE
Adjust staged-recipes CI retrigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,10 @@ script:
 after_failure:
   # Trigger a build only if this is not a pull request and is on the `master` branch.
   # Also ensure that no recipes were converted (otherwise we already triggered a build by pushing).
-  - (
-        [ "${TRAVIS_REPO_SLUG}" == "conda-forge/staged-recipes" ] &&
-        [ "${TRAVIS_PULL_REQUEST}" == "false" ] &&
-        [ "${TRAVIS_BRANCH}" == "master" ]
-    ) && \
-    ( git remote remove upstream_with_token || python .CI/trigger_travis_build.py "conda-forge/staged-recipes" )
+  - if   [ "${TRAVIS_REPO_SLUG}" == "conda-forge/staged-recipes" ] &&
+         [ "${TRAVIS_PULL_REQUEST}" == "false" ] &&
+         [ "${TRAVIS_BRANCH}" == "master" ];
+    then
+        python .CI/trigger_travis_build.py "conda-forge/staged-recipes";
+    fi
 


### PR DESCRIPTION
Try adjusting the `after_failure` section of `.travis.yml` to have a little cleaner syntax. Namely use an actual `if` and avoid messing with the repo's remote (as this extra check is unnecessary). Hopefully will ensure the trigger goes through without issues.