### PR TITLE
Retrigger `staged-recipes` build from `script`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,19 +35,11 @@ script:
         echo "Creating feedstocks from the recipe(s).";
         git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
         git config --global user.email "conda-forge@googlegroups.com";
-        source ./.CI/create_feedstocks;
+        source ./.CI/create_feedstocks || {
+            python .CI/trigger_travis_build.py "conda-forge/staged-recipes"; exit 1;
+        };
       else
         echo "Building all recipes.";
         source ./.CI/build_all;
       fi
-
-after_failure:
-  # Trigger a build only if this is not a pull request and is on the `master` branch.
-  # Also ensure that no recipes were converted (otherwise we already triggered a build by pushing).
-  - if   [ "${TRAVIS_REPO_SLUG}" == "conda-forge/staged-recipes" ] &&
-         [ "${TRAVIS_PULL_REQUEST}" == "false" ] &&
-         [ "${TRAVIS_BRANCH}" == "master" ];
-    then
-        python .CI/trigger_travis_build.py "conda-forge/staged-recipes";
-    fi
 


### PR DESCRIPTION
Seems that for some reason the `after_failure` section is not being run when `script` errors out. To workaround this issue, try calling the script to retrigger Travis CI in `script` after feedstock conversion fails. Ensure that the build is still broken when this script is called. Hopefully this way we can be sure that Travis CI is actually triggered when feedstock creation fails.
