### PR TITLE
Always skip CI after conversion

### DIFF
--- a/.CI/create_feedstocks.py
+++ b/.CI/create_feedstocks.py
@@ -234,7 +234,7 @@ if __name__ == '__main__':
         msg = ('Removed recipe{s} ({}) after converting into feedstock{s}.'
                ''.format(', '.join(removed_recipes),
                          s=('s' if len(removed_recipes) > 1 else '')))
-        msg += ' [ci skip]' if exit_code == 0 else ' [skip appveyor]'
+        msg += ' [ci skip]'
         if is_merged_pr:
             # Capture the output, as it may contain the GH_TOKEN.
             out = subprocess.check_output(['git', 'remote', 'add', 'upstream_with_token',


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/4188 )

Even if only some recipes are converted to feedstocks, make sure to skip CI via commit message. The reason being we already retrigger conversion using Travis CI's API if conversion fails. This happens regardless whether no recipes were converted or only some where converted. Thus there is no need to trigger Travis CI by pushing a commit as well. Hence we skip CI completely.