### PR TITLE
Add Macholib and altgraph

### DIFF
--- a/recipes/altgraph/meta.yaml
+++ b/recipes/altgraph/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "altgraph" %}
+{% set version = "0.14" %}
+{% set sha256 = "481bac8feb1716bb8e485e652ed94002cc11304abccb2911f8f4574fc9dc207b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - setuptools
+
+test:
+  imports:
+    - altgraph
+
+about:
+  home: https://bitbucket.org/ronaldoussoren/altgraph
+  license: MIT
+  license_family: MIT
+  # the licence file is missing in this package
+  # license_file: LICENSE.txt
+  summary: 'altgraph is a fork of graphlib'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+      altgraph is a fork of graphlib: a graph (network)
+      package for constructing graphs, BFS and DFS traversals,
+      topological sort, shortest paths, etc. with graphviz output.
+
+  doc_url: https://altgraph.readthedocs.io/en/latest/
+  dev_url: https://bitbucket.org/ronaldoussoren/altgraph
+
+extra:
+  recipe-maintainers:
+    - rth

--- a/recipes/altgraph/meta.yaml
+++ b/recipes/altgraph/meta.yaml
@@ -32,16 +32,12 @@ about:
   home: https://bitbucket.org/ronaldoussoren/altgraph
   license: MIT
   license_family: MIT
-  # the licence file is missing in this package
-  # license_file: LICENSE.txt
+  license_file: doc/license.rst
   summary: 'altgraph is a fork of graphlib'
-
-  # The remaining entries in this section are optional, but recommended
   description: |
       altgraph is a fork of graphlib: a graph (network)
       package for constructing graphs, BFS and DFS traversals,
       topological sort, shortest paths, etc. with graphviz output.
-
   doc_url: https://altgraph.readthedocs.io/en/latest/
   dev_url: https://bitbucket.org/ronaldoussoren/altgraph
 

--- a/recipes/macholib/meta.yaml
+++ b/recipes/macholib/meta.yaml
@@ -33,10 +33,8 @@ about:
   license: MIT
   license_family: MIT
   # the licence file is missing in this package
-  # license_file: LICENSE.txt
+  # https://bitbucket.org/ronaldoussoren/macholib/issues/22/license-file
   summary: 'Mach-O header analysis and editing'
-
-  # The remaining entries in this section are optional, but recommended
   description: |
       macholib can be used to analyze and edit Mach-O headers,
       the executable format used by Mac OS X.

--- a/recipes/macholib/meta.yaml
+++ b/recipes/macholib/meta.yaml
@@ -27,6 +27,8 @@ requirements:
 test:
   imports:
     - macholib
+  commands:
+    - python -m macholib find /tmp/
 
 about:
   home: http://bitbucket.org/ronaldoussoren/macholib

--- a/recipes/macholib/meta.yaml
+++ b/recipes/macholib/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "macholib" %}
+{% set version = "1.8" %}
+{% set sha256 = "323c9c8b85768244554b3c040808ed6393c783aa6eb1122e04dc8905f442e559" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - altgraph >=0.13
+
+test:
+  imports:
+    - macholib
+
+about:
+  home: http://bitbucket.org/ronaldoussoren/macholib
+  license: MIT
+  license_family: MIT
+  # the licence file is missing in this package
+  # license_file: LICENSE.txt
+  summary: 'Mach-O header analysis and editing'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+      macholib can be used to analyze and edit Mach-O headers,
+      the executable format used by Mac OS X.
+  doc_url: https://macholib.readthedocs.io/en/latest/
+  dev_url: http://bitbucket.org/ronaldoussoren/macholib
+
+extra:
+  recipe-maintainers:
+    - rth


### PR DESCRIPTION
This adds a recepe for the [Macholib](https://pypi.python.org/pypi/macholib/) package (fixes https://github.com/conda-forge/staged-recipes/issues/4144) and also its dependency package [altgraph](https://pypi.python.org/pypi/altgraph/). 

Macholib is now a dependency of the latest PyInstaller version (https://github.com/conda-forge/pyinstaller-feedstock/pull/12)

cc @jakirkham @ronaldoussoren

~~Neither~~ Macholib package includes a license file, so that field is left empty. Using the bitbucket repo for the home page as specified in setup.cfg

**Edit:** added setuptools to run requirements of altograph as it was importing `pkg_resources`.