### PR TITLE
Doit

### DIFF
--- a/recipes/doit/meta.yaml
+++ b/recipes/doit/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "doit" %}
+{% set version = "0.30.3" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "2988c8450fb3fb281877eb9a16860e1a8873c6ee0bb75ef0d78bb03a18d59ab9" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  entry_points:
+    - doit = doit.__main__:main
+  script: python setup.py install  --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - cloudpickle  # All platforms
+    - macfsevents  # MacOS only
+    - pyinotify  # Linux only
+
+test:
+  imports:
+    - doit
+  commands:
+    - doit --help
+
+about:
+  home: http://pydoit.org
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: doit - Automation Tool
+  description: "
+    `doit` is a task management & automation tool.
+
+    `doit` comes from the idea of bringing the power of build-tools to execute
+    any kind of **task**
+
+    `doit` is a modern open-source build-tool written in python designed to be
+    simple to use and flexible to deal with complex work-flows.
+
+    It is specially suitable for building and managing custom work-flows where
+    there is no out-of-the-box solution available. 
+    
+    `doit` has been successfully used on: systems test/integration automation,
+    scientific computational pipelines, content generation, configuration
+    management, etc."
+  doc_url: 'http://pydoit.org/contents.html'
+  dev_url: 'https://github.com/pydoit/doit'
+
+extra:
+  recipe-maintainers:
+    - pbronez

--- a/recipes/doit/meta.yaml
+++ b/recipes/doit/meta.yaml
@@ -24,9 +24,9 @@ requirements:
     - setuptools
   run:
     - python
-    - cloudpickle  # All platforms
-    - macfsevents  # MacOS only
-    - pyinotify  # Linux only
+    - cloudpickle
+    - macfsevents  # [osx]
+    - pyinotify  # [linux]
 
 test:
   imports:

--- a/recipes/doit/meta.yaml
+++ b/recipes/doit/meta.yaml
@@ -20,10 +20,10 @@ build:
 
 requirements:
   build:
-    - python
+    - python >=3
     - setuptools
   run:
-    - python
+    - python >=3
     - cloudpickle
     - macfsevents  # [osx]
     - pyinotify  # [linux]

--- a/recipes/doit/meta.yaml
+++ b/recipes/doit/meta.yaml
@@ -14,16 +14,17 @@ source:
 
 build:
   number: 0
+  skip: True  # [py2k]
   entry_points:
     - doit = doit.__main__:main
   script: python setup.py install  --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
-    - python >=3
+    - python
     - setuptools
   run:
-    - python >=3
+    - python
     - cloudpickle
     - macfsevents  # [osx]
     - pyinotify  # [linux]


### PR DESCRIPTION
Conda recipe for DoIt ([Homepage](http://pydoit.org/index.html), [PyPi](https://pypi.python.org/pypi/doit), [Github](https://github.com/pydoit/doit)), a "task management & automation tool."

Builds successfully on my Macbook with:

```bash
conda build \
--channel https://conda.anaconda.org/conda-forge/noarch \
--channel https://conda.anaconda.org/conda-forge/osx-64 \
--override-channels \
recipes/doit/meta.yaml
```

Note: on OSX, `doit` has a runtime dependency on [MacFSEvents](https://pypi.python.org/pypi/MacFSEvents), which is not currently available on conda-forge. I've submitted a separate [pull request for that](https://github.com/conda-forge/staged-recipes/pull/4219).