### PR TITLE
MRG: vispy 0.5.0

### DIFF
--- a/recipes/vispy/ctypes_fontconfig.diff
+++ b/recipes/vispy/ctypes_fontconfig.diff
@@ -1,0 +1,27 @@
+diff --git a/vispy/ext/fontconfig.py b/vispy/ext/fontconfig.py
+index ff24662..29cdea5 100644
+--- a/vispy/ext/fontconfig.py
++++ b/vispy/ext/fontconfig.py
+@@ -1,5 +1,7 @@
+ # -*- coding: utf-8 -*-
+ 
++import os
++import sys
+ import warnings
+ from ctypes import (util, cdll, c_void_p, c_char_p, c_double, c_int, c_bool,
+                     Union, Structure, byref, POINTER)
+@@ -7,7 +9,13 @@ from ..util.wrappers import run_subprocess
+ 
+ # Some code adapted from Pyglet
+ 
+-fc = util.find_library('fontconfig')
++from sys import platform as _platform
++
++if _platform == "linux" or _platform == "linux2":
++   fc = os.path.join(sys.prefix, 'lib', 'libfontconfig.so')
++elif _platform == "darwin" or _platform == "win32":
++   fc = util.find_library('fontconfig')
++
+ if fc is None:
+     raise ImportError('fontconfig not found')
+ fontconfig = cdll.LoadLibrary(fc)

--- a/recipes/vispy/meta.yaml
+++ b/recipes/vispy/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.5.0" %}
+
+package:
+  name: vispy
+  version: {{ version }}
+
+source:
+  fn: vispy-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/v/vispy/vispy-{{ version }}.tar.gz
+  sha256: fa24f925ec5998d3d68cc96bae0fe438082b78a4e198ba928dfa5b35b283c19e
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - vispy
+  requires:
+    - pyqt 4.*
+  commands:
+    - python -c "import vispy; print(vispy.sys_info()); vispy.test()"
+
+about:
+  home: http://vispy.org/
+  license: BSD 3-Clause
+  summary: 'VisPy is a high-performance interactive 2D/3D data visualization library.'
+
+extra:
+  recipe-maintainers:
+    - davidh-ssec
+    - kmuehlbauer

--- a/recipes/vispy/meta.yaml
+++ b/recipes/vispy/meta.yaml
@@ -18,10 +18,12 @@ requirements:
     - python
     - setuptools
     - numpy
+    - fontconfig  # [unix]
 
   run:
     - python
     - numpy
+    - fontconfig  # [unix]
 
 test:
   imports:

--- a/recipes/vispy/meta.yaml
+++ b/recipes/vispy/meta.yaml
@@ -30,10 +30,11 @@ requirements:
 test:
   imports:
     - vispy
-  requires:
-    - pyqt 4.*
-  commands:
-    - python -c "import vispy; print(vispy.sys_info()); vispy.test()"
+  # todo: check headless testing
+  #requires:
+  #  - pyqt 4.*
+  #commands:
+  #  - python -c "import vispy; print(vispy.sys_info()); vispy.test()"
 
 about:
   home: http://vispy.org/

--- a/recipes/vispy/meta.yaml
+++ b/recipes/vispy/meta.yaml
@@ -8,6 +8,8 @@ source:
   fn: vispy-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/v/vispy/vispy-{{ version }}.tar.gz
   sha256: fa24f925ec5998d3d68cc96bae0fe438082b78a4e198ba928dfa5b35b283c19e
+  patches:
+    - ctypes_fontconfig.diff
 
 build:
   number: 0

--- a/recipes/vispy/meta.yaml
+++ b/recipes/vispy/meta.yaml
@@ -14,17 +14,22 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: true  # [osx]
 
 requirements:
   build:
     - python
     - setuptools
-    - numpy
+    - numpy 1.8.*  # [not (win and (py35 or py36))]
+    - numpy 1.9.*  # [win and py35]
+    - numpy 1.11.*  # [win and py36]
     - fontconfig  # [unix]
 
   run:
     - python
-    - numpy
+    - numpy >=1.8  # [not (win and (py35 or py36))]
+    - numpy >=1.9  # [win and py35]
+    - numpy >=1.11  # [win and py36]
     - fontconfig  # [unix]
 
 test:


### PR DESCRIPTION
Adding vispy 0.5.0

VisPy needs backends for running and using opengl accelerated graphics, but the user should decide which backend he want to use. 

Testing is done with pyqt version4 .