### PR TITLE
Add dask-drmaa

### DIFF
--- a/recipes/dask-drmaa/meta.yaml
+++ b/recipes/dask-drmaa/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "dask-drmaa" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "c98041835727539fd541a2a08963831c6b1f3371784df145ab48298d5de19aff" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - dask-drmaa = dask_drmaa.cli.dask_drmaa:go
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - dask-core
+    - distributed
+    - drmaa
+    - click
+
+about:
+  home: https://github.com/dask/dask-drmaa
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
+  summary: Dask on DRMAA
+
+  dev_url: https://github.com/dask/dask-drmaa
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - mrocklin

--- a/recipes/dask-drmaa/run_test.py
+++ b/recipes/dask-drmaa/run_test.py
@@ -1,0 +1,9 @@
+try:
+    import dask_drmaa
+except RuntimeError as e:
+    assert str(e) == "Could not find drmaa library.  Please specify its full path using the environment variable DRMAA_LIBRARY_PATH"
+
+try:
+    import dask_drmaa.cli
+except RuntimeError as e:
+    assert str(e) == "Could not find drmaa library.  Please specify its full path using the environment variable DRMAA_LIBRARY_PATH"


### PR DESCRIPTION
Submits `dask-drmaa` for inclusion. Makes it easy to start a `distributed` cluster for use with `dask` by leveraging DRMAA.