### PR TITLE
add xdg package

### DIFF
--- a/recipes/xdg/meta.yaml
+++ b/recipes/xdg/meta.yaml
@@ -30,7 +30,7 @@ test:
 about:
   home: https://github.com/srstevenson/xdg
   license: ISC
-  license_file: LICENSE
+  license_file: LICENCE
   summary: 'Variables defined by the XDG Base Directory Specification'
 
   description: |

--- a/recipes/xdg/meta.yaml
+++ b/recipes/xdg/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "xdg" %}
+{% set version = "1.0.5" %}
+{% set sha256 = "d495c8c620a6a34b6111f3254d6fab5f06c1a7ce532e8f34e029209a19e6ce65" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - xdg
+
+about:
+  home: https://github.com/srstevenson/xdg
+  license: ISC
+  license_file: LICENSE
+  summary: 'Variables defined by the XDG Base Directory Specification'
+
+  description: |
+      xdg is a tiny Python module which provides the variables defined by the XDG Base Directory Specification, to save you from 
+      duplicating the same snippet of logic in every Python utility you write that deals with user cache, configuration, or data files. 
+      It has no external dependencies and supports Python 2 and 3.
+
+extra:
+  recipe-maintainers:
+    - kain88-de

--- a/recipes/xdg/meta.yaml
+++ b/recipes/xdg/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: True # [win]
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/xdg/meta.yaml
+++ b/recipes/xdg/meta.yaml
@@ -12,9 +12,9 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
+  skip: True # [win]
 
 requirements:
   build:


### PR DESCRIPTION
xdg is a tiny Python module which provides the variables defined by the XDG Base Directory Specification, to save you from duplicating the same snippet of logic in every Python utility you write that deals with user cache, configuration, or data files. It has no external dependencies and supports Python 2 and 3.