### PR TITLE
add google-api-core

### DIFF
--- a/recipes/google-api-core-feedstock/meta.yaml
+++ b/recipes/google-api-core-feedstock/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "google-api-core" %}
+{% set version = "0.1.1" %}
+{% set sha256 = "7deffb08c6afa4b6e60fa28d805cfe0909a506930d038bae8422da86a9667e64" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 1
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - googleapis-common-protos >=1.5.3,<2.0dev
+    - protobuf >=3.0.0
+    - google-auth >=0.4.0,<2.0.0dev
+    - requests >=2.18.0,<3.0.0dev
+    - setuptools >=34.0.0
+    - six >=1.10.0
+    # Backport of concurrent.futures for Python < 3.2.
+    - futures >=3.0.0  # [py2k]
+
+test:
+  imports:
+    - google.api_core.exceptions
+
+about:
+  home: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/core
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Core Library for Google Client Libraries'
+  description: This library is not meant to stand-alone. Instead it defines
+    common helpers used by all Google API clients.
+  doc_url: https://googlecloudplatform.github.io/google-cloud-python/latest/core/
+  dev_url: https://github.com/GoogleCloudPlatform/google-cloud-python/tree/master/api_core
+
+extra:
+  recipe-maintainers:
+    - parthea
+    - tswast


### PR DESCRIPTION
Depends on update to googleapis-common-protos to 1.5.3 in https://github.com/conda-forge/googleapis-common-protos-feedstock/pull/1.