### PR TITLE
Add gsd package

### DIFF
--- a/recipes/gsd/meta.yaml
+++ b/recipes/gsd/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "gsd" %}
+{% set version = "1.3.0" %}
+{% set sha256 = "800b8c4727a74b8656d203a53b9796da1ff4dd01d31a32b243130f0458f873b1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://bitbucket.org/glotzer/{{ name }}/get/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy 1.11.*
+    - cython
+    - toolchain
+
+  run:
+    - python
+    - numpy >=1.11
+
+test:
+  imports:
+    - gsd
+    - gsd.fl
+    - gsd.pygsd
+    - gsd.hoomd
+
+about:
+  home: https://bitbucket.org/glotzer/gsd
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'General simulation data'
+
+  description: |
+   GSD (General Simulation Data) is a file format specification
+   and a library to read and write it. The package also contains a python module
+   that reads and writes hoomd schema gsd files with an easy to use syntax.
+   doc_url: https://signac.readthedocs.io dev_url:
+   https://bitbucket.org/glotzer/signac
+
+  doc_url: https://gsd.readthedocs.io
+  dev_url: https://bitbucket.org/glotzer/gsd
+
+extra:
+  recipe-maintainers:
+    - joaander


### PR DESCRIPTION
GSD is a python package that reads and writes GSD files produced by HOOMD-blue. Packaging GSD on conda-forge will enable it for use in other packages, such as mdanalysis.