### PR TITLE
R package akima

### DIFF
--- a/recipes/r-akima/LICENSE
+++ b/recipes/r-akima/LICENSE
@@ -28,14 +28,16 @@ All software, both binary and source published by the Association for Computing
 Machinery (hereafter, Software) is copyrighted by the Association (hereafter,
 ACM) and ownership of all right, title and interest in and to the Software
 remains with ACM. By using or copying the Software, User agrees to abide by the
-terms of this Agreement.  Noncommercial Use
+terms of this Agreement.
+
+Noncommercial Use
 
 The ACM grants to you (hereafter, User) a royalty-free, nonexclusive right to
 execute, copy, modify and distribute both the binary and source code solely for
 academic, research and other similar noncommercial uses, subject to the
 following conditions:
 
-    User acknowledges that the Software is still in the development stage and
+1.  User acknowledges that the Software is still in the development stage and
     that it is being supplied "as is," without any support services from
     ACM. Neither ACM nor the author makes any representations or warranties,
     express or implied, including, without limitation, any representations or
@@ -43,36 +45,36 @@ following conditions:
     that the application of the software, will not infringe on any patents or
     other proprietary rights of others.
 
-    ACM shall not be held liable for direct, indirect, incidental or
+2.  ACM shall not be held liable for direct, indirect, incidental or
     consequential damages arising from any claim by User or any third party with
     respect to uses allowed under this Agreement, or from any use of the
     Software.
 
-    User agrees to fully indemnify and hold harmless ACM and/or the author(s) of
+3.  User agrees to fully indemnify and hold harmless ACM and/or the author(s) of
     the original work from and against any and all claims, demands, suits,
     losses, damages, costs and expenses arising out of the User's use of the
     Software, including, without limitation, arising out of the User's
     modification of the Software.
 
-    User may modify the Software and distribute that modified work to third
+4.  User may modify the Software and distribute that modified work to third
     parties provided that: (a) if posted separately, it clearly acknowledges
     that it contains material copyrighted by ACM (b) no charge is associated
     with such copies, (c) User agrees to notify ACM and the Author(s) of the
     distribution, and (d) User clearly notifies secondary users that such
     modified work is not the original Software.
 
-    User agrees that ACM, the authors of the original work and others may enjoy
+5.  User agrees that ACM, the authors of the original work and others may enjoy
     a royalty-free, non-exclusive license to use, copy, modify and redistribute
     these modifications to the Software made by the User and distributed to
     third parties as a derivative work under this agreement.
 
-    This agreement will terminate immediately upon User's breach of, or
+6.  This agreement will terminate immediately upon User's breach of, or
     non-compliance with, any of its terms. User may be held liable for any
     copyright infringement or the infringement of any other proprietary rights
     in the Software that is caused or facilitated by the User's failure to abide
     by the terms of this agreement.
 
-    This agreement will be construed and enforced in accordance with the law of
+7.  This agreement will be construed and enforced in accordance with the law of
     the state of New York applicable to contracts performed entirely within the
     State. The parties irrevocably consent to the exclusive jurisdiction of the
     state or federal courts located in the City of New York for all disputes

--- a/recipes/r-akima/LICENSE
+++ b/recipes/r-akima/LICENSE
@@ -1,0 +1,90 @@
+This package is distributed under the ACM license at
+http://www.acm.org/publications/policies/software-copyright-notice
+
+In detail:
+
+1. Fortran code (src/*.f): 
+
+Copyrighted and Licensed by ACM, 
+see http://www.acm.org/publications/policies/software-copyright-notice
+
+
+2. R interface (src/init.c src/akima.h R/*.R man/*.Rd data/*): 
+
+The R interface code has been developed as work based on the 
+ACM licensed code, hence it is also ACM licensed, copyright 
+is by A. Gebhardt <albrecht.gebhardt@uni-klu.ac.at>. 
+
+In order to fulfill the ACM copyright and license noted above, 
+it is stated here that this work contains modified ACM material, 
+and to fulfill this, the modified work including the R interface 
+is available free to secondary users, and no charge is associated 
+with such copies.
+
+
+ACM Software License Agreement
+
+All software, both binary and source published by the Association for Computing
+Machinery (hereafter, Software) is copyrighted by the Association (hereafter,
+ACM) and ownership of all right, title and interest in and to the Software
+remains with ACM. By using or copying the Software, User agrees to abide by the
+terms of this Agreement.  Noncommercial Use
+
+The ACM grants to you (hereafter, User) a royalty-free, nonexclusive right to
+execute, copy, modify and distribute both the binary and source code solely for
+academic, research and other similar noncommercial uses, subject to the
+following conditions:
+
+    User acknowledges that the Software is still in the development stage and
+    that it is being supplied "as is," without any support services from
+    ACM. Neither ACM nor the author makes any representations or warranties,
+    express or implied, including, without limitation, any representations or
+    warranties of the merchantability or fitness for any particular purpose, or
+    that the application of the software, will not infringe on any patents or
+    other proprietary rights of others.
+
+    ACM shall not be held liable for direct, indirect, incidental or
+    consequential damages arising from any claim by User or any third party with
+    respect to uses allowed under this Agreement, or from any use of the
+    Software.
+
+    User agrees to fully indemnify and hold harmless ACM and/or the author(s) of
+    the original work from and against any and all claims, demands, suits,
+    losses, damages, costs and expenses arising out of the User's use of the
+    Software, including, without limitation, arising out of the User's
+    modification of the Software.
+
+    User may modify the Software and distribute that modified work to third
+    parties provided that: (a) if posted separately, it clearly acknowledges
+    that it contains material copyrighted by ACM (b) no charge is associated
+    with such copies, (c) User agrees to notify ACM and the Author(s) of the
+    distribution, and (d) User clearly notifies secondary users that such
+    modified work is not the original Software.
+
+    User agrees that ACM, the authors of the original work and others may enjoy
+    a royalty-free, non-exclusive license to use, copy, modify and redistribute
+    these modifications to the Software made by the User and distributed to
+    third parties as a derivative work under this agreement.
+
+    This agreement will terminate immediately upon User's breach of, or
+    non-compliance with, any of its terms. User may be held liable for any
+    copyright infringement or the infringement of any other proprietary rights
+    in the Software that is caused or facilitated by the User's failure to abide
+    by the terms of this agreement.
+
+    This agreement will be construed and enforced in accordance with the law of
+    the state of New York applicable to contracts performed entirely within the
+    State. The parties irrevocably consent to the exclusive jurisdiction of the
+    state or federal courts located in the City of New York for all disputes
+    concerning this agreement.
+
+Commercial Use
+
+Any User wishing to make a commercial use of the Software must contact ACM at
+permissions@acm.org to arrange an appropriate license. Commercial use includes
+(1) integrating or incorporating all or part of the source code into a product
+for sale or license by, or on behalf of, User to third parties, or (2)
+distribution of the binary or source code to third parties for use with a
+commercial product sold or licensed by, or on behalf of, User.
+
+Revised 6/98

--- a/recipes/r-akima/bld.bat
+++ b/recipes/r-akima/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-akima/build.sh
+++ b/recipes/r-akima/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-akima/meta.yaml
+++ b/recipes/r-akima/meta.yaml
@@ -50,6 +50,7 @@ about:
     for regular grids was also added for comparison with the bicubic interpolator on
     regular grids.'
   license_family: OTHER
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
 
 extra:
   recipe-maintainers:

--- a/recipes/r-akima/meta.yaml
+++ b/recipes/r-akima/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = '0.6-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-akima
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: akima_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/akima_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/akima/akima_{{ version }}.tar.gz
+  sha256: 61da3e556553eea6d1f8db7c92218254441da31e365bdef82dfe5da188cc97ce
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+requirements:
+  build:
+    - r-base
+    - r-sp
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-sp
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('akima')"  # [not win]
+    - "\"%R%\" -e \"library('akima')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=akima
+  license: ACM (Restricts use)
+  summary: 'Several cubic spline interpolation methods of H. Akima for irregular and regular
+    gridded data are available through this package, both for the bivariate case (irregular
+    data: ACM 761, regular data: ACM 760) and univariate case (ACM 433 and ACM 697).
+    Linear interpolation of irregular gridded data is also covered by reusing D. J.
+    Renkas triangulation code which is part of Akimas Fortran code. A bilinear interpolator
+    for regular grids was also added for comparison with the bicubic interpolator on
+    regular grids.'
+  license_family: OTHER
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak


### PR DESCRIPTION
CRAN R package [akima](https://cran.r-project.org/package=akima). Recipe created with conda-build 2.1.17 and [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).

The license is non-standard. I manually combined the license text provided by the package authors and the full ACM license text into a new file LICENSE.