### PR TITLE
New ReproZip packages

### DIFF
--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "reprounzip-qt" %}
 {% set version = "1.0.11" %}
+{% set postversion = "-1" %}
 {% set sha256 = "6738edae930aa8e447ec1c6e1fb0341bbe84ca94ed7e54e14c2abbb3b21af563" %}
 
 package:
@@ -8,7 +9,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-1.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ postversion }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - setuptools
   run:
     - python
+    - setuptools
     - pyqt <5
 
 test:

--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "reprounzip-qt" %}
+{% set version = "1.0.11" %}
+{% set sha256 = "5cb71f598753150249674208ca47316fe660bdb3feafeaab039874af104f64c4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pyqt <5
+
+test:
+  imports:
+    - reprounzip_qt.main
+
+  commands:
+    - reprounzip-qt --help
+
+about:
+  home: http://github.com/ViDA-NYU/reprozip
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Graphical user interface for reprounzip, using Qt'
+  description: |
+    ReproZip is a tool aimed at simplifying the process of creating reproducible
+    experiments from command-line executions, a frequently-used common
+    denominator in computational science. It tracks operating system calls and
+    creates a package that contains all the binaries, files and dependencies
+    required to run a given command on the author's computational environment
+    (packing step). A reviewer can then extract the experiment in his
+    environment to reproduce the results (unpacking step).
+  doc_url: https://docs.reprozip.org/
+  dev_url: https://github.com/ViDA-NYU/reprozip
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "reprounzip-qt" %}
 {% set version = "1.0.11" %}
-{% set sha256 = "5cb71f598753150249674208ca47316fe660bdb3feafeaab039874af104f64c4" %}
+{% set sha256 = "6738edae930aa8e447ec1c6e1fb0341bbe84ca94ed7e54e14c2abbb3b21af563" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-1.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - setuptools
     - pyyaml
     - pyqt <5
+    - reprounzip
 
 test:
   imports:

--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: true  # [not py27]
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
 

--- a/recipes/reprounzip-qt/meta.yaml
+++ b/recipes/reprounzip-qt/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   run:
     - python
     - setuptools
+    - pyyaml
     - pyqt <5
 
 test:

--- a/recipes/reprozip-jupyter/meta.yaml
+++ b/recipes/reprozip-jupyter/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "reprozip-jupyter" %}
+{% set version = "0.2" %}
+{% set sha256 = "852bd6bb9bb7a8d1131eed29c194bc566da747ce4bd35c88419d4d76f1765e52" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - rpaths >=0.8
+    - reprounzip >=1.0
+    - notebook
+    - jupyter_client
+    - nbformat
+    - nbconvert
+
+test:
+  imports:
+    - reprozip_jupyter.main
+
+  commands:
+    - reprozip-jupyter --help
+
+about:
+  home: http://github.com/ViDA-NYU/reprozip
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Jupyter Notebook tracing/reproduction using ReproZip'
+  description: |
+    ReproZip is a tool aimed at simplifying the process of creating reproducible
+    experiments from command-line executions, a frequently-used common
+    denominator in computational science. It tracks operating system calls and
+    creates a package that contains all the binaries, files and dependencies
+    required to run a given command on the author's computational environment
+    (packing step). A reviewer can then extract the experiment in his
+    environment to reproduce the results (unpacking step).
+  doc_url: https://docs.reprozip.org/
+  dev_url: https://github.com/ViDA-NYU/reprozip
+
+extra:
+  recipe-maintainers:
+    - remram44

--- a/recipes/reprozip-jupyter/meta.yaml
+++ b/recipes/reprozip-jupyter/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "reprozip-jupyter" %}
 {% set version = "0.2" %}
-{% set sha256 = "852bd6bb9bb7a8d1131eed29c194bc566da747ce4bd35c88419d4d76f1765e52" %}
+{% set sha256 = "1425976a0b9d559f7f7eb107ae7185807e610585cd0939ec974ac4ad5e830075" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-1.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipes/reprozip-jupyter/meta.yaml
+++ b/recipes/reprozip-jupyter/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools
   run:
     - python
+    - setuptools
     - rpaths >=0.8
     - reprounzip >=1.0
     - notebook

--- a/recipes/reprozip-jupyter/meta.yaml
+++ b/recipes/reprozip-jupyter/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "reprozip-jupyter" %}
 {% set version = "0.2" %}
+{% set postversion = "-1" %}
 {% set sha256 = "1425976a0b9d559f7f7eb107ae7185807e610585cd0939ec974ac4ad5e830075" %}
 
 package:
@@ -8,7 +9,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-1.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ postversion }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Hello again!

Because building Conda packages is a pain I thought I'd leverage your awesome initiative once more.

I might be overdoing this but ReproZip is split in a variety of plugins and tools. Some new packages have appeared since #2193 got merged.

This PR adds reprounzip-qt (GUI for reprounzip, separate from the tool because PyQt is a big dependency) and reprozip-jupyter (Jupyter extension for ReproZIp, separate because it depends on Jupyter stuff).

We'll see if I can get this passing on my ~first~ fifth try.