### PR TITLE
Bumped r-kohonen version to 3.0.4

### DIFF
--- a/recipes/r-kohonen/meta.yaml
+++ b/recipes/r-kohonen/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '3.0.4' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-kohonen
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: kohonen_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/kohonen_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/kohonen/kohonen_{{ version }}.tar.gz
+  sha256: e8689d5a9c90c2e9047d273f47524efec89678e2a8d53b1d5b08a14b5b95e2b5
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-mass
+    - r-rcpp >=0.12.7
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-mass
+    - r-rcpp >=0.12.7
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('kohonen')"  # [not win]
+    - "\"%R%\" -e \"library('kohonen')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=kohonen
+  license: GPL (>= 2)
+  summary: Functions to train self-organising maps (SOMs). Also interrogation of the maps and
+    prediction using trained maps are supported. The name of the package refers to Teuvo
+    Kohonen, the inventor of the SOM.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening


### PR DESCRIPTION
Hi all,

The Kohonen package in R has a new upstream version. I bumped the version here.

Best,
Jens