### PR TITLE
Recipe for gax-python (google-gax), grpcio 

### DIFF
--- a/recipes/gax-python/meta.yaml
+++ b/recipes/gax-python/meta.yaml
@@ -1,0 +1,59 @@
+{% set condaforge_name = "gax-python" %}
+{% set name = "google-gax"}
+{% set version = "0.15.16" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "518e8d5eb90774af2041080d242f4bcec4c6e653226c693901eaf82eda8a395c" %}
+{% set build = 0}
+
+package:
+  name: {{ condaforge_name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ file_ext }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  {{ hash_type }}: {{ hash_value }}
+
+build:
+  noarch: python
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+    - dill >=0.2.5,<0.3dev
+    - future >=0.16.0,<0.17dev
+    - googleapis-common-protos >=1.5.2,<2.0dev
+    - grpcio >=1.0.2,<2.0dev
+    - google-auth >=1.0.0,<2.0dev
+    - ply ==3.8
+    - protobuf >=3.0.0,<4.0dev
+    - requests >=2.13.0,<3.0dev
+
+test:
+  imports:
+    - google
+    - google.gapic
+    - google.gapic.longrunning
+    - google.gax
+    - google.gax.utils
+
+about:
+  home: https://github.com/googleapis/gax-python
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Google API Extensions for Python
+  description: API Extensions for Python (gax-python) is a set of modules which aids the development of APIs for clients and servers based on gRPC and Google API conventions.  Application code will rarely need to use most of the classes within this library directly, but code generated automatically from the API definition files in Google APIs can use services such as page streaming and request bundling to provide a more convenient and idiomatic API surface to callers.
+  doc_url: https://gax-python.readthedocs.org
+  dev_url: https://github.com/googleapis/gax-python
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/gax-python/meta.yaml
+++ b/recipes/gax-python/meta.yaml
@@ -1,5 +1,5 @@
 {% set condaforge_name = "gax-python" %}
-{% set name = "google-gax"}
+{% set name = "google-gax" %}
 {% set version = "0.15.16" %}
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}

--- a/recipes/gax-python/meta.yaml
+++ b/recipes/gax-python/meta.yaml
@@ -4,7 +4,7 @@
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}
 {% set hash_value = "518e8d5eb90774af2041080d242f4bcec4c6e653226c693901eaf82eda8a395c" %}
-{% set build = 0}
+{% set build = 0 %}
 
 package:
   name: {{ condaforge_name|lower }}

--- a/recipes/grpcio/LICENSE
+++ b/recipes/grpcio/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   build:
     - python
     - setuptools
-    - coverage>=4.0
+    - coverage >=4.0
     - cython >=0.23
     - enum34 >=1.0.4
     - futures >=2.2.0

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "grpcio" %}
-{% set version = "1.7.0" %}
+{% set version = "1.8.4" %}
 {% set file_ext = "tar.gz" %}
 {% set hash_type = "sha256" %}
-{% set hash_value = "6662af1f07cf7a3d171a7f56afc2cfeff262a5f2c52d15ae5ea581d0c367aea8" %}
+{% set hash_value = "88d87aab9c7889b3ab29dd74aac1a5493ed78b9bf5afba1c069c9dd5531f951d" %}
 {% set build = 0 %}
 
 package:
@@ -22,13 +22,19 @@ requirements:
   build:
     - python
     - setuptools
-    - cython
+    - coverage>=4.0
+    - cython >=0.23
+    - enum34 >=1.0.4
+    - futures >=2.2.0
+    - protobuf >=3.5.0.post1
+    - six >=1.10
+    - wheel >=0.29
     - toolchain
 
   run:
     - python
     - six >=1.5.2
-    - protobuf >=3.3.0
+    - protobuf >=3.5.0.post1
     - futures >=2.2.0  # [py27]
     - enum34 >=1.0.4  # [py27]
 

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "grpcio" %}
+{% set version = "1.7.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "6662af1f07cf7a3d171a7f56afc2cfeff262a5f2c52d15ae5ea581d0c367aea8" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ file_ext }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  {{ hash_type }}: {{ hash_value }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+
+  run:
+    - python
+    - six >=1.5.2
+    - protobuf >=3.3.0
+    - futures >=2.2.0
+    - enum34 >=1.0.4
+
+test:
+  imports:
+    - grpc
+    - grpc._cython
+    - grpc._cython._cygrpc
+    - grpc.beta
+    - grpc.framework
+    - grpc.framework.common
+    - grpc.framework.foundation
+    - grpc.framework.interfaces
+    - grpc.framework.interfaces.base
+    - grpc.framework.interfaces.face
+
+about:
+  home: https://grpc.io
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: HTTP/2-based RPC framework
+  description: The C based gRPC (C++, Node.js, Python, Ruby, Objective-C, PHP, C#)
+  doc_url: https://grpc.io
+  dev_url: https://github.com/grpc/grpc
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - six >=1.5.2
-    - protobuf >=3.5.0.post1
+    - protobuf >=3.3.0
     - futures >=2.2.0  # [py27]
     - enum34 >=1.0.4  # [py27]
 

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -49,7 +49,7 @@ about:
   home: https://grpc.io
   license: Apache 2.0
   license_family: Apache
-  license_file: LICENSE
+  license_file: {{ RECIPE_DIR }}/LICENSE
   summary: HTTP/2-based RPC framework
   description: The C based gRPC (C++, Node.js, Python, Ruby, Objective-C, PHP, C#)
   doc_url: https://grpc.io

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -22,14 +22,15 @@ requirements:
   build:
     - python
     - setuptools
+    - cython
     - toolchain
 
   run:
     - python
     - six >=1.5.2
-    - protobuf >=3.3.0
-    - futures >=2.2.0
-    - enum34 >=1.0.4
+    - protobuf >=3.5.0.post1
+    - futures >=2.2.0  # [py27]
+    - enum34 >=1.0.4  # [py27]
 
 test:
   imports:


### PR DESCRIPTION
This recipe is for for the [python version](https://github.com/googleapis/gax-python) of `google-gax`.  I've opted to call it `gax-python` even though it's `google-gax` in PyPi b/c gax has been implemented in [a variety of languages](https://github.com/googleapis?utf8=%E2%9C%93&q=gax&type=&language=). (This naming scheme is entirely negotiable.) I've also added a recipe for [`grpcio`](https://grpc.io/) as well b/c it's a dependency. Getting it built seems much more intense.