### PR TITLE
rxcpp recipe

### DIFF
--- a/recipes/rxcpp/install-to-include.patch
+++ b/recipes/rxcpp/install-to-include.patch
@@ -1,0 +1,20 @@
+From 5b7b2a5519f712a7831053865a4ae6082dac4ed5 Mon Sep 17 00:00:00 2001
+From: Peter Majchrak <petoknm@gmail.com>
+Date: Sat, 22 Jul 2017 19:37:05 +0200
+Subject: [PATCH] Add 'include' to the install path of the headers
+
+---
+ projects/CMake/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/projects/CMake/CMakeLists.txt b/projects/CMake/CMakeLists.txt
+index 6130d0591..7230ca782 100644
+--- a/projects/CMake/CMakeLists.txt
++++ b/projects/CMake/CMakeLists.txt
+@@ -133,5 +133,5 @@ SET_TARGET_PROPERTIES(RxCpp PROPERTIES LINKER_LANGUAGE CXX)
+ 
+ set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY TRUE CACHE BOOL "Don't require all projects to be built in order to install" FORCE)
+ 
+-install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION rxcpp
++install(DIRECTORY ${RXCPP_DIR}/Rx/v2/src/rxcpp/ DESTINATION include/rxcpp
+         FILES_MATCHING PATTERN "*.hpp")

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -23,7 +23,7 @@ build:
     - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -B. ../CMake
     # build a simple example to make sure everything works
     -  make println && examples/println/println     # [unix]
-    - nmake println && examples\\println\\println   # [win]
+    - nmake rxcpp::examples::println && examples\\println\\println   # [win]
     # install the source files (since it's header-only)
     - make install
 

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -21,13 +21,11 @@ build:
     - cd projects
     - mkdir build
     - cd build
-    - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX          ../CMake  # [unix]
-    - cmake -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ../CMake  # [win]
+    - cmake -G"Unix Makefiles"  -DCMAKE_INSTALL_PREFIX=$PREFIX          ../CMake  # [unix]
+    - cmake -G"NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ../CMake  # [win]
     # Run a quick build test that things are sensible.
-    # Can't convince nmake to only build one thing, though, so build everything
-    # there.
-    - make rxcpp_test_group_by && test/rxcpp_test_group_by  # [unix]
-    - nmake && tests\\rxcpp_test_group_by                   # [win]
+    - make rxcpp_test_group_by  && test/rxcpp_test_group_by    # [unix]
+    - nmake rxcpp_test_group_by && tests\\rxcpp_test_group_by  # [win]
     # Install header files (won't install tests/examples):
     - make install
 

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "rxcpp" %}
+{% set version = "4.0.0" %}
+{% set sha256 = "50e7395ab1bc2a0000df126c6920a36dd3c4ee04a71496b2f4c10adf50d65178" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/Reactive-Extensions/RxCpp/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script:
+    - cd projects
+    - mkdir build
+    - cd build
+    - cmake -B. ../CMake
+    # build a simple example to make sure everything works
+    -  make println && examples/println/println     # [unix]
+    - nmake println && examples\\println\\println   # [win]
+    # install the source files (since it's header-only)
+    - make install
+
+requirements:
+  build:
+    - cmake
+    - toolchain
+  # NOTE: rxcpp is header-only, so don't need to do the python dance on Windows
+
+test:
+  commands:
+    - test -f $PREFIX/include/rxcpp/rx-util.hpp              # [unix]
+    - if not exist %LIBRARY_INC%\\rxcpp\\rx-util.hpp exit 1  # [win]
+
+about:
+  home: https://github.com/Reactive-Extensions/RxCpp
+  license: Apache-2.0
+  license_family: Apache
+  license_file: license.md
+  summary: 'Reactive Extensions for C++'
+  description: |
+    The Reactive Extensions for C++ (RxCpp) is a library of algorithms for
+    values-distributed-in-time. 
+  doc_url: http://reactive-extensions.github.io/RxCpp/
+  dev_url: https://github.com/Reactive-Extensions/RxCpp
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -21,13 +21,20 @@ build:
     - cd projects
     - mkdir build
     - cd build
+
     - cmake -G"Unix Makefiles"  -DCMAKE_INSTALL_PREFIX=$PREFIX          ../CMake  # [unix]
     - cmake -G"NMake Makefiles" -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ../CMake  # [win]
+    - if errorlevel 1 exit 1  # [win]
+
     # Run a quick build test that things are sensible.
     - make rxcpp_test_group_by  && test/rxcpp_test_group_by    # [unix]
     - nmake rxcpp_test_group_by && tests\\rxcpp_test_group_by  # [win]
+    - if errorlevel 1 exit 1  # [win]
+
     # Install header files (won't install tests/examples):
-    - make install
+    - make install   # [unix]
+    - nmake install  # [win]
+    - if errorlevel 1 exit 1  # [win]
 
 requirements:
   build:

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -17,14 +17,17 @@ source:
 build:
   number: 0
   script:
+    - set -ex  # conda-build 2 doesn't do this automatically  # [unix]
     - cd projects
     - mkdir build
     - cd build
     - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX          ../CMake  # [unix]
     - cmake -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ../CMake  # [win]
     # Run a quick build test that things are sensible.
-    - make rxcpp_test_group_by && test/rxcpp_test_group_by      # [unix]
-    - nmake rxcpp_test_group_by && tests\/rxcpp_test_group_by   # [win]
+    # Can't convince nmake to only build one thing, though, so build everything
+    # there.
+    - make rxcpp_test_group_by && test/rxcpp_test_group_by  # [unix]
+    - nmake && tests\\rxcpp_test_group_by                   # [win]
     # Install header files (won't install tests/examples):
     - make install
 

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -20,11 +20,12 @@ build:
     - cd projects
     - mkdir build
     - cd build
-    - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -B. ../CMake
-    # build a simple example to make sure everything works
-    -  make println && examples/println/println     # [unix]
-    - nmake rxcpp::examples::println && examples\\println\\println   # [win]
-    # install the source files (since it's header-only)
+    - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX          ../CMake  # [unix]
+    - cmake -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ../CMake  # [win]
+    # Run a quick build test that things are sensible.
+    - make rxcpp_test_group_by && test/rxcpp_test_group_by      # [unix]
+    - nmake rxcpp_test_group_by && tests\/rxcpp_test_group_by   # [win]
+    # Install header files (won't install tests/examples):
     - make install
 
 requirements:

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -14,6 +14,10 @@ source:
     - install-to-include.patch  # Patch is already in upstream:
     # https://github.com/Reactive-Extensions/RxCpp/commit/5b7b2a5
 
+# WARNING: this source doesn't include the Catch submodule, which is used for
+#          the test commands. It's not used for the examples, and we can just
+#          ignore it there.
+
 build:
   number: 0
   script:
@@ -27,8 +31,8 @@ build:
     - if errorlevel 1 exit 1  # [win]
 
     # Run a quick build test that things are sensible.
-    - make rxcpp_test_group_by  && test/rxcpp_test_group_by    # [unix]
-    - nmake rxcpp_test_group_by && tests\\rxcpp_test_group_by  # [win]
+    - make  println && examples/println/println    # [unix]
+    - nmake println && examples\\println\\println  # [win]
     - if errorlevel 1 exit 1  # [win]
 
     # Install header files (won't install tests/examples):

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -39,12 +39,23 @@ build:
     - make install   # [unix]
     - nmake install  # [win]
     - if errorlevel 1 exit 1  # [win]
+  skip: true  # [win and py27]
 
 requirements:
   build:
     - cmake
     - toolchain
-  # NOTE: rxcpp is header-only, so don't need to do the python dance on Windows
+    - python  # [win]
+    - vc 9    # [win and py27]
+    - vc 10   # [win and py34]
+    - vc 14   # [win and py>=35]
+  run:
+    - vc 9   # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py>=35]
+  # NOTE: rxcpp is header-only, but we still need the vc version dance because
+  #       the build system doesn't work on vc9. Not sure if the actual library
+  #       works or not.
 
 test:
   commands:

--- a/recipes/rxcpp/meta.yaml
+++ b/recipes/rxcpp/meta.yaml
@@ -10,6 +10,9 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/Reactive-Extensions/RxCpp/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - install-to-include.patch  # Patch is already in upstream:
+    # https://github.com/Reactive-Extensions/RxCpp/commit/5b7b2a5
 
 build:
   number: 0
@@ -17,7 +20,7 @@ build:
     - cd projects
     - mkdir build
     - cd build
-    - cmake -B. ../CMake
+    - cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -B. ../CMake
     # build a simple example to make sure everything works
     -  make println && examples/println/println     # [unix]
     - nmake println && examples\\println\\println   # [win]


### PR DESCRIPTION
https://github.com/Reactive-Extensions/RxCpp/. Header-only, but like eigen is still probably useful to make not-noarch so we can run a quick check and so on.