### PR TITLE
2nd attempt:  Has fn and url tags

### DIFF
--- a/recipes/ncexplorer/meta.yaml
+++ b/recipes/ncexplorer/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "ncexplorer" %}
-{% set version = "0.7.2" %}
-{% set sha256 = "396665b81e52958a7cb508e91e84d3b0bd56c64fdbb0c6597929dbfb14ed2385"
+{% set version = "0.7.3" %}
+{% set sha256 = "396665b81e52958a7cb508e91e84d3b0bd56c64fdbb0c6597929dbfb14ed2385" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/ncexplorer/meta.yaml
+++ b/recipes/ncexplorer/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "ncexplorer" %}
+{% set version = "0.7.1" %}
+{% set sha256 = "4161e8cdef9d96f6ecc2dc17dd9d65d2c87619c76f7d8953e3fdbf4aed72b87d" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - ncexplorer
+
+about:
+  home: https://github.com/godfrey4000/ncexplorer
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+

--- a/recipes/ncexplorer/meta.yaml
+++ b/recipes/ncexplorer/meta.yaml
@@ -32,4 +32,8 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
+  summary: 'Analysis and visualization of NetCDF climate data.'
 
+extra:
+  recipe-maintainers:
+    - godfrey4000

--- a/recipes/ncexplorer/meta.yaml
+++ b/recipes/ncexplorer/meta.yaml
@@ -1,14 +1,14 @@
 {% set name = "ncexplorer" %}
-{% set version = "0.7.1" %}
-{% set sha256 = "4161e8cdef9d96f6ecc2dc17dd9d65d2c87619c76f7d8953e3fdbf4aed72b87d" %}
+{% set version = "0.7.2" %}
+{% set sha256 = "396665b81e52958a7cb508e91e84d3b0bd56c64fdbb0c6597929dbfb14ed2385"
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  fn: 0.7.2.tar.gz
+  url: https://github.com/godfrey4000/ncexplorer/archive/0.7.2.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
Updated the meta.yaml fn and url tags to point to the source tarball on github/godfrey4000.