### PR TITLE
Add R package getPass.

### DIFF
--- a/recipes/r-getpass/LICENSE
+++ b/recipes/r-getpass/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2016, Drew Schmidt and Wei-Chen Chen
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/recipes/r-getpass/bld.bat
+++ b/recipes/r-getpass/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-getpass/build.sh
+++ b/recipes/r-getpass/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-getpass/meta.yaml
+++ b/recipes/r-getpass/meta.yaml
@@ -1,0 +1,57 @@
+{% set version = '0.2-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-getpass
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: getPass_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/getPass_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/getPass/getPass_{{ version }}.tar.gz
+  sha256: 8cfdc7e8cabeae5dd325015d735b139d9828bd54ea8e7c2dcb636a00a153cd0f
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rstudioapi >=0.5
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-rstudioapi >=0.5
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('getPass')"  # [not win]
+    - "\"%R%\" -e \"library('getPass')\""  # [win]
+
+about:
+  home: https
+  license: BSD 2-clause
+  summary: A micro-package for reading "passwords", i.e.  reading user input with masking, so
+    that the input is not displayed as it  is typed.  Currently we have support for
+    'RStudio', the command line (every OS), and any platform where 'tcltk' is present.
+  license_family: BSD
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak


### PR DESCRIPTION
CRAN R package [getPass](https://cran.r-project.org/package=getPass). Recipe created with conda-build 2.1.18 and [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper). I manually packaged the BSD 2-clause license.