### PR TITLE
Root 5

### DIFF
--- a/recipes/root5/build.sh
+++ b/recipes/root5/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+cd build
+
+if [ "$(uname)" == "Darwin" ]; then
+
+    cmake .. -Dall=ON -Dkrb5=OFF -Dcocoa=ON -Dgnuinstall=ON -Drpath=ON -Dsoversion=ON -DBUILD_SHARED_LIBS=ON\
+             -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_SYSCONFDIR=${PREFIX}/etc/root \
+             -Dopengl=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+             -DCMAKE_FIND_ROOT_PATH=${PREFIX} -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,${PREFIX}/lib:${PREFIX}/lib/root" \
+             -DCMAKE_CXX_FLAGS="${CXXFLAGS} -Wl,-rpath,${PREFIX}/lib:${PREFIX}/lib/root" \
+             -DCMAKE_C_FLAGS="${CFLAGS} -Wl,-rpath,${PREFIX}/lib:${PREFIX}/lib/root"
+
+else
+    
+    CC=${PREFIX}/bin/gcc
+    CXX=${PREFIX}/bin/g++
+    
+    cmake .. -Dall=ON -Dkrb5=OFF -Dgnuinstall=ON -Drpath=ON -Dsoversion=ON \
+             -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_SYSCONFDIR=${PREFIX}/etc/root -DCMAKE_FIND_ROOT_PATH=${PREFIX} \
+             -Dopengl=OFF -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX} \
+             -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath-link,${PREFIX}/lib:${PREFIX}/lib/root" \
+             -DCMAKE_CXX_FLAGS="-Wl,-rpath-link,${PREFIX}/lib:${PREFIX}/lib/root"
+
+fi
+
+# For some reason, CMAKE does not put "-I${PREFIX}/include" in the command line
+# when compiling, with of course disastrous results...
+ln -s $PREFIX/include/* include/
+
+cmake --build . --target install -- -j ${CPU_COUNT}
+
+# Install pyROOT in the site-packages so there is no need for
+# setting PYTHONPATH
+cp ${PREFIX}/lib/root/libPyROOT.* ${PREFIX}/lib/python2.7/site-packages/
+cp ${PREFIX}/lib/root/ROOT.py ${PREFIX}/lib/python2.7/site-packages/

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -68,7 +68,7 @@ about:
   license: LGPL
   summary: 'A modular scientific software framework. It provides all the functionalities needed to deal with big data processing, statistical analysis, visualisation and storage. It is mainly written in C++ but integrated with other languages such as Python and R.'
   license_family: GPL
-  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  license_file: '{{ environ["SRC_DIR"] }}/LICENSE'
 
 extra:
   recipe-maintainers:

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -68,6 +68,7 @@ about:
   license: LGPL
   summary: 'A modular scientific software framework. It provides all the functionalities needed to deal with big data processing, statistical analysis, visualisation and storage. It is mainly written in C++ but integrated with other languages such as Python and R.'
   license_family: GPL
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
 
 extra:
   recipe-maintainers:

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -19,7 +19,7 @@ requirements:
  
  build:
      - toolchain
-     - gcc # [linux]
+     - gcc  # [linux]
      - python x.x
      - gsl
      - fftw
@@ -51,8 +51,8 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/root/libCore.so [linux]
-    - test -f ${PREFIX}/lib/root/libCore.so [osx]
+    - test -f ${PREFIX}/lib/root/libCore.so  # [linux]
+    - test -f ${PREFIX}/lib/root/libCore.so  # [osx]
     - test -f ${PREFIX}/include/root/TROOT.h
     - conda inspect linkages -p $PREFIX root5  # [not win]
     - conda inspect objects -p $PREFIX root5  # [osx]

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
    number: 0
    skip: true  # [win]
+   skip: true  # [py3k]
 
 requirements:
  

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -1,0 +1,57 @@
+package:
+   name: root5
+   version: "5.34.36"
+
+source:
+  url: https://root.cern.ch/download/root_v5.34.36.source.tar.gz
+  
+build:
+  number: 0
+
+requirements:
+ 
+ build:
+     - toolchain
+     - gcc # [linux]
+     - python x.x
+     - gsl
+     - fftw
+     - cmake
+     - cfitsio
+     - xorg-libxft  # [linux]
+     - xorg-libxpm  # [linux]
+     - xorg-libsm  # [linux]
+     - jpeg
+     - libpng
+     - zlib
+     - libxml2
+     - mesalib
+    
+ run:
+     - python x.x
+     - gsl
+     - fftw
+     - cfitsio
+     - xorg-libxft  # [linux]
+     - xorg-libxpm  # [linux]
+     - xorg-libsm  # [linux]
+     - jpeg
+     - libpng
+     - zlib
+     - libgcc  # [linux]
+     - libxml2
+     - mesalib
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/root/libCore.so [linux]
+    - test -f ${PREFIX}/lib/root/libCore.so [osx]
+    - test -f ${PREFIX}/include/root/TROOT.h
+    - conda inspect linkages -p $PREFIX root5  # [not win]
+    - conda inspect objects -p $PREFIX root5  # [osx]
+    - root -b -q ${PREFIX}/share/doc/root/tutorials/roofit/rf101_basics.C
+    - root -b -q ${PREFIX}/share/doc/root/tutorials/fft/FFT.C
+    - root -b -q ${PREFIX}/share/doc/root/tutorials/physics/PhaseSpace.C
+    - cd ${PREFIX}/share/doc/root/tutorials/pyroot && python fillrandom.py && python fit1.py
+    - cd ${PREFIX}/share/doc/root/tutorials/fitsio && root -b -q FITS_tutorial1.C
+    - 

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -54,13 +54,13 @@ test:
     - test -f ${PREFIX}/lib/root/libCore.so  # [linux]
     - test -f ${PREFIX}/lib/root/libCore.so  # [osx]
     - test -f ${PREFIX}/include/root/TROOT.h
-    - conda inspect linkages -p $PREFIX root5  # [not win]
-    - conda inspect objects -p $PREFIX root5  # [osx]
-    - root -b -q ${PREFIX}/share/doc/root/tutorials/roofit/rf101_basics.C
-    - root -b -q ${PREFIX}/share/doc/root/tutorials/fft/FFT.C
-    - root -b -q ${PREFIX}/share/doc/root/tutorials/physics/PhaseSpace.C
-    - cd ${PREFIX}/share/doc/root/tutorials/pyroot && python fillrandom.py && python fit1.py
-    - cd ${PREFIX}/share/doc/root/tutorials/fitsio && root -b -q FITS_tutorial1.C
+    #- conda inspect linkages -p $PREFIX root5  # [not win]
+    #- conda inspect objects -p $PREFIX root5  # [osx]
+    - root -b -q ${PREFIX}/share/doc/root/tutorials/roofit/rf101_basics.C >& /dev/null
+    - root -b -q ${PREFIX}/share/doc/root/tutorials/fft/FFT.C >& /dev/null
+    - root -b -q ${PREFIX}/share/doc/root/tutorials/physics/PhaseSpace.C >& /dev/null
+    - cd ${PREFIX}/share/doc/root/tutorials/pyroot && python fillrandom.py && python fit1.py >& /dev/null
+    - cd ${PREFIX}/share/doc/root/tutorials/fitsio && root -b -q FITS_tutorial1.C >& /dev/null
 
 about:
   home: https://root.cern.ch/

--- a/recipes/root5/meta.yaml
+++ b/recipes/root5/meta.yaml
@@ -1,12 +1,19 @@
+{% set name = "root5" %}
+{% set version = "5.34.36" %}
+{% set sha256 = "fc868e5f4905544c3f392cc9e895ef5571a08e48682e7fe173bd44c0ba0c7dcd" %}
+
 package:
-   name: root5
-   version: "5.34.36"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: https://root.cern.ch/download/root_v5.34.36.source.tar.gz
-  
+  fn: root_v{{version}}.source.tar.gz
+  url: https://root.cern.ch/download/root_v{{version}}.source.tar.gz
+  sha256: {{ sha256 }}
+
 build:
-  number: 0
+   number: 0
+   skip: true  # [win]
 
 requirements:
  
@@ -54,4 +61,13 @@ test:
     - root -b -q ${PREFIX}/share/doc/root/tutorials/physics/PhaseSpace.C
     - cd ${PREFIX}/share/doc/root/tutorials/pyroot && python fillrandom.py && python fit1.py
     - cd ${PREFIX}/share/doc/root/tutorials/fitsio && root -b -q FITS_tutorial1.C
-    - 
+
+about:
+  home: https://root.cern.ch/
+  license: LGPL
+  summary: 'A modular scientific software framework. It provides all the functionalities needed to deal with big data processing, statistical analysis, visualisation and storage. It is mainly written in C++ but integrated with other languages such as Python and R.'
+  license_family: GPL
+
+extra:
+  recipe-maintainers:
+    - giacomov


### PR DESCRIPTION
The 5.* version of the CERN ROOT package:

https://root.cern.ch/

used by many people in particle physics and astrophysics (especially the high-energy community).