### PR TITLE
add parameterized 0.6.1

### DIFF
--- a/recipes/parameterized/meta.yaml
+++ b/recipes/parameterized/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "parameterized" %}
+{% set version = "0.6.1" %}
+{% set sha256 = "caf58e717097735de0d7e15386a46ffa5ce25bb6a13a43716a8854a8d34841e2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - parameterized
+
+about:
+  home: https://github.com/wolever/parameterized
+  license: BSD 2-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Parameterized testing with any Python test framework'
+  description: |
+    Parameterized testing in Python sucks.
+    parameterized fixes that. For everything. Parameterized testing for nose,
+    parameterized testing for py.test, parameterized testing for unittest.
+  dev_url: https://github.com/wolever/parameterized
+
+extra:
+  recipe-maintainers:
+    - chohner


### PR DESCRIPTION
This adds the renamed `parameterized` package, since `nose-parameterized` is deprecated (see https://pypi.python.org/pypi/parameterized)