### PR TITLE
Clhep

### DIFF
--- a/recipes/clhep/build.sh
+++ b/recipes/clhep/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ "$(uname)" == "Darwin" ]; then
+
+    export CC=clang
+    export CXX=clang++
+
+else
+    
+    export CC=${PREFIX}/bin/gcc
+    export CXX=${PREFIX}/bin/g++
+
+fi
+
+export LDFLAGS="-Wl,-rpath,${PREFIX}/lib"
+
+mkdir build
+cd build
+
+cmake ../CLHEP/ -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,${PREFIX}/lib" -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_C_COMPILER=${CC} -DCMAKE_CXX_COMPILER=${CXX}
+
+make -j ${CPU_COUNT}
+make test
+make install
+

--- a/recipes/clhep/build.sh
+++ b/recipes/clhep/build.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ]; then
-
-    export CC=clang
-    export CXX=clang++
-
-else
-    
-    export CC=${PREFIX}/bin/gcc
-    export CXX=${PREFIX}/bin/g++
-
-fi
-
-export LDFLAGS="-Wl,-rpath,${PREFIX}/lib"
-
 mkdir build
 cd build
 

--- a/recipes/clhep/meta.yaml
+++ b/recipes/clhep/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     
 test:
   commands:
-    - test -f ${PREFIX}/lib/libCLHEP.so [linux]
-    - test -f ${PREFIX}/lib/libCLHEP.dylib [osx]
+    - test -f ${PREFIX}/lib/libCLHEP.so  # [linux]
+    - test -f ${PREFIX}/lib/libCLHEP.dylib  # [osx]
     - test -d ${PREFIX}/include/CLHEP
     - conda inspect linkages -p $PREFIX clhep  # [not win]
     - conda inspect objects -p $PREFIX clhep  # [osx]
@@ -44,5 +44,6 @@ about:
   dev_url: https://gitlab.cern.ch/CLHEP/CLHEP
 
 extra:
-  maintainers:
-   - giacomov
+  
+  recipe-maintainers:    
+      - giacomov

--- a/recipes/clhep/meta.yaml
+++ b/recipes/clhep/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "clhep" %}
+{% set version = "2.1.4.2" %}
+{% set sha256 = "c9f6e9ceebea068eca59c86595ab010774752c8fe4f67161c75b9412afd97bb2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://proj-clhep.web.cern.ch/proj-clhep/DISTRIBUTION/tarFiles/{{ name }}-{{ version }}.tgz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+  
+requirements:
+
+  build:
+    - toolchain
+    - gcc  # [linux]
+    - cmake
+  
+  run:
+    - libgcc  # [linux]
+    
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libCLHEP.so [linux]
+    - test -f ${PREFIX}/lib/libCLHEP.dylib [osx]
+    - test -d ${PREFIX}/include/CLHEP
+    - conda inspect linkages -p $PREFIX clhep  # [not win]
+    - conda inspect objects -p $PREFIX clhep  # [osx]
+
+about:
+  home: http://proj-clhep.web.cern.ch/proj-clhep/
+  license: GPL
+  license_family: GPL
+  license_file: CLHEP/COPYING
+  summary: 'A Class Library for High Energy Physics'
+  description: It is intended to be a set of HEP-specific foundation and utility classes such as random generators, physics vectors, geometry and linear algebra.
+  doc_url: http://proj-clhep.web.cern.ch/proj-clhep/
+  dev_url: http://proj-clhep.web.cern.ch/proj-clhep/
+
+extra:
+  maintainers:
+   - giacomov

--- a/recipes/clhep/meta.yaml
+++ b/recipes/clhep/meta.yaml
@@ -16,14 +16,9 @@ build:
   skip: true  # [win]
   
 requirements:
-
   build:
     - toolchain
-    - gcc  # [linux]
     - cmake
-  
-  run:
-    - libgcc  # [linux]
     
 test:
   commands:
@@ -44,6 +39,5 @@ about:
   dev_url: https://gitlab.cern.ch/CLHEP/CLHEP
 
 extra:
-  
   recipe-maintainers:    
       - giacomov

--- a/recipes/clhep/meta.yaml
+++ b/recipes/clhep/meta.yaml
@@ -40,8 +40,8 @@ about:
   license_file: CLHEP/COPYING
   summary: 'A Class Library for High Energy Physics'
   description: It is intended to be a set of HEP-specific foundation and utility classes such as random generators, physics vectors, geometry and linear algebra.
-  doc_url: http://proj-clhep.web.cern.ch/proj-clhep/
-  dev_url: http://proj-clhep.web.cern.ch/proj-clhep/
+  doc_url: http://proj-clhep.web.cern.ch/proj-clhep/index.html#docu
+  dev_url: https://gitlab.cern.ch/CLHEP/CLHEP
 
 extra:
   maintainers:


### PR DESCRIPTION
The CLHEP project was proposed by Leif Lönnblad at CHEP 92. It is intended to be a set of HEP-specific foundation and utility classes such as random generators, physics vectors, geometry and linear algebra:

http://proj-clhep.web.cern.ch/proj-clhep/