### PR TITLE
Add r-magick to conda-forge

### DIFF
--- a/recipes/r-magick/bld.bat
+++ b/recipes/r-magick/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-magick/bld.bat
+++ b/recipes/r-magick/bld.bat
@@ -1,2 +1,0 @@
-"%R%" CMD INSTALL --build .
-if errorlevel 1 exit 1

--- a/recipes/r-magick/build.sh
+++ b/recipes/r-magick/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-magick/build.sh
+++ b/recipes/r-magick/build.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
-$R CMD INSTALL --build .
+
+export CFLAGS="$(Magick++-config --cflags)"
+export LDFLAGS="$(Magick++-config --libs)"
+
+$R CMD INSTALL --libs .

--- a/recipes/r-magick/meta.yaml
+++ b/recipes/r-magick/meta.yaml
@@ -16,7 +16,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win32]
+  skip: true  # [win]
 
   rpaths:
     - lib/R/lib/
@@ -29,8 +29,6 @@ requirements:
     - r-curl
     - r-knitr
     - r-magrittr
-    - posix                # [win]
-    - {{native}}toolchain  # [win]
     - gcc                  # [not win]
 
   run:
@@ -44,7 +42,6 @@ requirements:
 test:
   commands:
     - $R -e "library('magick')"  # [not win]
-    - "\"%R%\" -e \"library('magick')\""  # [win]
 
 about:
   home: https://github.com/ropensci/magick#readme

--- a/recipes/r-magick/meta.yaml
+++ b/recipes/r-magick/meta.yaml
@@ -46,9 +46,9 @@ test:
     - $R -e "library('magick')"  # [not win]
 
 about:
-  home: https://github.com/ropensci/magick#readme
+  home: https://github.com/ropensci/magick
   license: MIT
-  summary: 'Bindings to ''ImageMagick'': the most comprehensive open-source image processing
+  summary: 'Bindings to ImageMagick: the most comprehensive open-source image processing
     library available. Supports many common formats (png, jpeg, tiff, pdf, etc) and
     manipulations (rotate, scale, crop, trim, flip, blur, etc). All operations are vectorized
     via the Magick++ STL meaning they operate either on a single frame or a series of

--- a/recipes/r-magick/meta.yaml
+++ b/recipes/r-magick/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = '1.6' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-magick
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: magick_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/magick_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/magick/magick_{{ version }}.tar.gz
+  sha256: a1c1bc0554cef8988bbd18011e9e09d4614b53586d595150cce0157b1e7970f6
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rcpp >=0.12.12
+    - r-curl
+    - r-knitr
+    - r-magrittr
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-rcpp >=0.12.12
+    - r-curl
+    - r-knitr
+    - r-magrittr
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('magick')"  # [not win]
+    - "\"%R%\" -e \"library('magick')\""  # [win]
+
+about:
+  home: https://github.com/ropensci/magick#readme
+  license: MIT
+  summary: 'Bindings to ''ImageMagick'': the most comprehensive open-source image processing
+    library available. Supports many common formats (png, jpeg, tiff, pdf, etc) and
+    manipulations (rotate, scale, crop, trim, flip, blur, etc). All operations are vectorized
+    via the Magick++ STL meaning they operate either on a single frame or a series of
+    frames for working with layers, collages, or animation. In RStudio images are automatically
+    previewed when printed to the console, resulting in an interactive editing environment.
+    The latest  version of the package includes a native graphics device for creating  in-memory
+    graphics or drawing onto images using pixel coordinates.'
+
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak

--- a/recipes/r-magick/meta.yaml
+++ b/recipes/r-magick/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - r-curl
     - r-knitr
     - r-magrittr
+    - imagemagick
     - gcc                  # [not win]
 
   run:
@@ -37,6 +38,7 @@ requirements:
     - r-curl
     - r-knitr
     - r-magrittr
+    - imagemagick
     - libgcc  # [not win]
 
 test:


### PR DESCRIPTION
Details on the `magick` package for R at:

+ https://cran.r-project.org/web/packages/magick/index.html
+ https://github.com/ropensci/magick

Pinging @jdblischak who provided advice in https://github.com/conda-forge/r-cowplot-feedstock/pull/4#issuecomment-351222532.