### PR TITLE
Add librsvg

### DIFF
--- a/recipes/librsvg/build.sh
+++ b/recipes/librsvg/build.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+configure_args=(
+    --prefix=$PREFIX
+    --disable-Bsymbolic
+)
+
+rm -f $PREFIX/lib/*.la # deps have busted files
+./configure "${configure_args[@]}" || { cat config.log ; exit 1 ; }
+make -j$NJOBS
+make install
+
+cd $PREFIX
+find . '(' -name '*.la' -o -name '*.a' ')' -delete
+rm -rf share/gtk-doc

--- a/recipes/librsvg/build.sh
+++ b/recipes/librsvg/build.sh
@@ -7,7 +7,7 @@ configure_args=(
 
 rm -f $PREFIX/lib/*.la # deps have busted files
 ./configure "${configure_args[@]}" || { cat config.log ; exit 1 ; }
-make -j$NJOBS
+make -j$CPU_COUNT
 make install
 
 cd $PREFIX

--- a/recipes/librsvg/meta.yaml
+++ b/recipes/librsvg/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = '2.40.19' %}
+{% set version_major = version.split('.', 1)[0] %}
+{% set version_majmin = version.rsplit('.', 1)[0] %}
+{% set sha256 = "612b4d8b8609036f5d899be3fe70d9866b5f6ac5c971154c1c0ef7242216c1f7" %}
+
+package:
+  name: librsvg
+  version: {{ version }}
+
+source:
+  fn: librsvg-{{ version }}.tar.xz
+  url: http://ftp.gnome.org/pub/gnome/sources/librsvg/{{ version_majmin }}/librsvg-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - pkg-config
+    - glib 2.55.*
+    - libxml2 2.9.*
+    - cairo 1.14.*
+    - gdk-pixbuf 2.36.*
+    - libcroco 0.6.*
+    - pango 1.40.*
+  run:
+    - glib 2.55.*
+    - libxml2 2.9.*
+    - cairo 1.14.*
+    - gdk-pixbuf 2.36.*
+    - libcroco 0.6.*
+    - pango 1.40.*
+
+test:
+  commands:
+    - test -f $PREFIX/lib/librsvg-{{ version_major }}$SHLIB_EXT
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - rsvg-convert --version
+
+about:
+  home: https://wiki.gnome.org/Projects/LibRsvg
+  license: GPLv2
+  license_file: COPYING
+  summary: librsvg is a library to render SVG files using cairo.
+
+extra:
+  recipe-maintainers:
+    - jenzopr
+    - pkgw


### PR DESCRIPTION
Based on work by @jenzopr. Tested on Linux; we'll see what macOS needs.

Closes #3991.