### PR TITLE
Adding r-assertive.* packages for developers

### DIFF
--- a/recipes/r-assertive.base/bld.bat
+++ b/recipes/r-assertive.base/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.base/build.sh
+++ b/recipes/r-assertive.base/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.base/meta.yaml
+++ b/recipes/r-assertive.base/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = '0.0-7' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.base
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.base_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.base_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.base/assertive.base_{{ version }}.tar.gz
+  sha256: f02d4eca849f512500abb266a2a751d1fa2cf064f7142e5161a77c20b7f643f7
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('assertive.base')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.base')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.base
+  license: GPL (>= 3)
+  summary: A minimal set of predicates and assertions used by the assertive package.  This is
+    mainly for use by other package developers who want to include run-time testing
+    features in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.code/bld.bat
+++ b/recipes/r-assertive.code/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.code/build.sh
+++ b/recipes/r-assertive.code/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.code/meta.yaml
+++ b/recipes/r-assertive.code/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = '0.0-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.code
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.code_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.code_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.code/assertive.code_{{ version }}.tar.gz
+  sha256: dc5b55bbcadb52f4751dec3bd78ce380c29777059ddf4d45f9d37e4913cb2d37
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.properties
+    - r-assertive.types
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.properties
+    - r-assertive.types
+
+test:
+  commands:
+    - $R -e "library('assertive.code')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.code')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.code
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of code. This is mainly
+    for use by other package developers who want to include run-time testing features
+    in their own packages. End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.data.uk/bld.bat
+++ b/recipes/r-assertive.data.uk/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.data.uk/build.sh
+++ b/recipes/r-assertive.data.uk/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.data.uk/meta.yaml
+++ b/recipes/r-assertive.data.uk/meta.yaml
@@ -1,0 +1,58 @@
+{% set version = '0.0-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.data.uk
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.data.uk_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.data.uk_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.data.uk/assertive.data.uk_{{ version }}.tar.gz
+  sha256: 0e36a9b9bbc2af81e4b9f1c8025aaad6961c836430566675f2ff9341ddbe507c
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.strings
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.strings
+
+test:
+  commands:
+    - $R -e "library('assertive.data.uk')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.data.uk')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.data.uk
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of UK-specific complex
+    data types.  This is mainly for use by other package developers who want to include
+    run-time testing features in their own packages.  End-users will usually want to
+    use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.data.us/bld.bat
+++ b/recipes/r-assertive.data.us/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.data.us/build.sh
+++ b/recipes/r-assertive.data.us/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.data.us/meta.yaml
+++ b/recipes/r-assertive.data.us/meta.yaml
@@ -1,0 +1,58 @@
+{% set version = '0.0-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.data.us
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.data.us_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.data.us_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.data.us/assertive.data.us_{{ version }}.tar.gz
+  sha256: 73a599e33e353fd1c8e2c27a2d64b1f3c5ebf5662bfabb8854bdaecfd474dc59
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.strings
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.strings
+
+test:
+  commands:
+    - $R -e "library('assertive.data.us')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.data.us')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.data.us
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of US-specific complex
+    data types.  This is mainly for use by other package developers who want to include
+    run-time testing features in their own packages.  End-users will usually want to
+    use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.data/bld.bat
+++ b/recipes/r-assertive.data/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.data/build.sh
+++ b/recipes/r-assertive.data/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.data/meta.yaml
+++ b/recipes/r-assertive.data/meta.yaml
@@ -1,0 +1,58 @@
+{% set version = '0.0-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.data
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.data_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.data_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.data/assertive.data_{{ version }}.tar.gz
+  sha256: 63883fbae1e3579b8824eb269650a769e8e917ac7992881a572935735c3e5c5e
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.strings
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.strings
+
+test:
+  commands:
+    - $R -e "library('assertive.data')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.data')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.data
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of (country independent)
+    complex data types.  This is mainly for use by other package developers who want
+    to include run-time testing features in their own packages.  End-users will usually
+    want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.datetimes/bld.bat
+++ b/recipes/r-assertive.datetimes/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.datetimes/build.sh
+++ b/recipes/r-assertive.datetimes/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.datetimes/meta.yaml
+++ b/recipes/r-assertive.datetimes/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '0.0-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.datetimes
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.datetimes_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.datetimes_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.datetimes/assertive.datetimes_{{ version }}.tar.gz
+  sha256: e8d4b1af89cc8b544f32092a7e8c0ee067526baf1c41af261bf98e8bba434901
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.types
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.types
+
+test:
+  commands:
+    - $R -e "library('assertive.datetimes')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.datetimes')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.datetimes
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of dates and times.  This
+    is mainly for use by other package developers who want to include run-time testing
+    features in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak

--- a/recipes/r-assertive.files/bld.bat
+++ b/recipes/r-assertive.files/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.files/build.sh
+++ b/recipes/r-assertive.files/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.files/meta.yaml
+++ b/recipes/r-assertive.files/meta.yaml
@@ -1,0 +1,57 @@
+{% set version = '0.0-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.files
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.files_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.files_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.files/assertive.files_{{ version }}.tar.gz
+  sha256: be6adda6f18a0427449249e44c2deff4444a123244b16fe82c92f15d24faee0a
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.numbers
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.numbers
+
+test:
+  commands:
+    - $R -e "library('assertive.files')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.files')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.files
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of files and connections.  This
+    is mainly for use by other package developers who want to include run-time testing
+    features in their own packages. End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.matrices/bld.bat
+++ b/recipes/r-assertive.matrices/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.matrices/build.sh
+++ b/recipes/r-assertive.matrices/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.matrices/meta.yaml
+++ b/recipes/r-assertive.matrices/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.0-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.matrices
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.matrices_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.matrices_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.matrices/assertive.matrices_{{ version }}.tar.gz
+  sha256: 2e7a1f6f86c8a35ba499b42b6ed2f5b8c7d43b8a6a2b0b7a61f9a00c0c8a60ee
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+
+test:
+  commands:
+    - $R -e "library('assertive.matrices')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.matrices')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.matrices
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of matrices.  This
+    is mainly for use by other package developers who want to include run-time testing
+    features in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.models/bld.bat
+++ b/recipes/r-assertive.models/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.models/build.sh
+++ b/recipes/r-assertive.models/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.models/meta.yaml
+++ b/recipes/r-assertive.models/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.0-1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.models
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.models_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.models_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.models/assertive.models_{{ version }}.tar.gz
+  sha256: 9225c44b6197d55c316c3be5adefcbbeb6a38672ab90b2abb4a734ba95d67ede
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+
+test:
+  commands:
+    - $R -e "library('assertive.models')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.models')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.models
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of models.  This is
+    mainly for use by other package developers who want to include run-time testing
+    features in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.numbers/bld.bat
+++ b/recipes/r-assertive.numbers/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.numbers/build.sh
+++ b/recipes/r-assertive.numbers/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.numbers/meta.yaml
+++ b/recipes/r-assertive.numbers/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.0-2' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.numbers
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.numbers_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.numbers_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.numbers/assertive.numbers_{{ version }}.tar.gz
+  sha256: bae18c0b9e5b960a20636e127eb738ecd8a266e5fc29d8bc5ca712498cd68349
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+
+test:
+  commands:
+    - $R -e "library('assertive.numbers')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.numbers')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.numbers
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of numbers.  This is
+    mainly for use by other package developers who want to include run-time testing
+    features in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.properties/bld.bat
+++ b/recipes/r-assertive.properties/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.properties/build.sh
+++ b/recipes/r-assertive.properties/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.properties/meta.yaml
+++ b/recipes/r-assertive.properties/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.0-4' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.properties
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.properties_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.properties_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.properties/assertive.properties_{{ version }}.tar.gz
+  sha256: 5c0663fecb4b7c30f2e1d65da8644534fcfe97fb3d8b51f74c1327cd14291a6b
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_7
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_7
+
+test:
+  commands:
+    - $R -e "library('assertive.properties')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.properties')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.properties
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of variables, such
+    as length, names and attributes.  This is mainly for use by other package developers
+    who want to include run-time testing features in their own packages.  End-users
+    will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak

--- a/recipes/r-assertive.reflection/bld.bat
+++ b/recipes/r-assertive.reflection/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.reflection/build.sh
+++ b/recipes/r-assertive.reflection/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.reflection/meta.yaml
+++ b/recipes/r-assertive.reflection/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = '0.0-4' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.reflection
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.reflection_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.reflection_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.reflection/assertive.reflection_{{ version }}.tar.gz
+  sha256: 123672e1a99fc79e7e9e91566ee21bba1fb45fd13e353e41c52e3300ecd2f5a7
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_7
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_7
+
+test:
+  commands:
+    - $R -e "library('assertive.reflection')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.reflection')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.reflection
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the state and capabilities of R, the
+    operating system it is running on, and the IDE being used.  This is mainly for use
+    by other package developers who want to include run-time testing features in their
+    own packages. End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.sets/bld.bat
+++ b/recipes/r-assertive.sets/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.sets/build.sh
+++ b/recipes/r-assertive.sets/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.sets/meta.yaml
+++ b/recipes/r-assertive.sets/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.0-3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.sets
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.sets_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.sets_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.sets/assertive.sets_{{ version }}.tar.gz
+  sha256: 876975a16ed911ea1ad12da284111c6eada6abfc0118585033abc0edb5801bb3
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_7
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_7
+
+test:
+  commands:
+    - $R -e "library('assertive.sets')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.sets')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.sets
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of sets.  This is mainly
+    for use by other package developers who want to include run-time testing features
+    in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.strings/bld.bat
+++ b/recipes/r-assertive.strings/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.strings/build.sh
+++ b/recipes/r-assertive.strings/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.strings/meta.yaml
+++ b/recipes/r-assertive.strings/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = '0.0-3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.strings
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.strings_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.strings_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.strings/assertive.strings_{{ version }}.tar.gz
+  sha256: d541d608a01640347d661cc9a67af8202904142031a20caa270f1c83d0ccd258
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.types
+    - r-stringi
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_2
+    - r-assertive.types
+    - r-stringi
+
+test:
+  commands:
+    - $R -e "library('assertive.strings')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.strings')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.strings
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the properties of strings.  This is
+    mainly for use by other package developers who want to include run-time testing
+    features in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive.types/bld.bat
+++ b/recipes/r-assertive.types/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive.types/build.sh
+++ b/recipes/r-assertive.types/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive.types/meta.yaml
+++ b/recipes/r-assertive.types/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = '0.0-3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive.types
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive.types_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive.types_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive.types/assertive.types_{{ version }}.tar.gz
+  sha256: ab6db2eb926e7bc885f2043fab679330aa336d07755375282d89bf9f9d0cb87f
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_7
+    - r-assertive.properties
+    - r-codetools
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_7
+    - r-assertive.properties
+    - r-codetools
+
+test:
+  commands:
+    - $R -e "library('assertive.types')"  # [not win]
+    - "\"%R%\" -e \"library('assertive.types')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive.types
+  license: GPL (>= 3)
+  summary: A set of predicates and assertions for checking the types of variables.  This is mainly
+    for use by other package developers who want to include run-time testing features
+    in their own packages.  End-users will usually want to use assertive directly.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-assertive/bld.bat
+++ b/recipes/r-assertive/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive/build.sh
+++ b/recipes/r-assertive/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive/meta.yaml
+++ b/recipes/r-assertive/meta.yaml
@@ -1,0 +1,84 @@
+{% set version = '0.3-5' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive/assertive_{{ version }}.tar.gz
+  sha256: 23ff6c8893e9c0b5b6bf4009a10de42a4a3a86eec2c48e7b73ae2cd6295c8b2e
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_4
+    - r-assertive.code
+    - r-assertive.data
+    - r-assertive.data.uk
+    - r-assertive.data.us
+    - r-assertive.datetimes
+    - r-assertive.files
+    - r-assertive.matrices
+    - r-assertive.models
+    - r-assertive.numbers
+    - r-assertive.properties >=0.0_2
+    - r-assertive.reflection >=0.0_2
+    - r-assertive.sets >=0.0_2
+    - r-assertive.strings
+    - r-assertive.types >=0.0_2
+    - r-knitr
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_4
+    - r-assertive.code
+    - r-assertive.data
+    - r-assertive.data.uk
+    - r-assertive.data.us
+    - r-assertive.datetimes
+    - r-assertive.files
+    - r-assertive.matrices
+    - r-assertive.models
+    - r-assertive.numbers
+    - r-assertive.properties >=0.0_2
+    - r-assertive.reflection >=0.0_2
+    - r-assertive.sets >=0.0_2
+    - r-assertive.strings
+    - r-assertive.types >=0.0_2
+    - r-knitr
+
+test:
+  commands:
+    - $R -e "library('assertive')"  # [not win]
+    - "\"%R%\" -e \"library('assertive')\""  # [win]
+
+about:
+  home: https://bitbucket.org/richierocks/assertive
+  license: GPL (>= 3)
+  summary: Lots of predicates (is_* functions) to check the state of your variables, and assertions
+    (assert_* functions) to throw errors if they aren't in the right form.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr


### PR DESCRIPTION
Hi all,
this PR adds the `r-assertive` package and all of its assertive* dependencies:
- r-assertive.base
- r-assertive.code
- r-assertive.data
- r-assertive.data.uk
- r-assertive.data.us
- r-assertive.datetimes
- r-assertive.files
- r-assertive.matrices
- r-assertive.models
- r-assertive.numbers
- r-assertive.properties
- r-assertive.reflection
- r-assertive.sets
- r-assertive.strings
- r-assertive.types

They contain lots of predicates (is_* functions) to check the state of variables, and assertions (assert_* functions) to throw errors if they aren't in the right form.

Best,
Jens