### PR TITLE
Vendor conda-forge-build-setup config

### DIFF
--- a/.CI/create_feedstocks
+++ b/.CI/create_feedstocks
@@ -7,6 +7,12 @@ set -e
 # recipes from. Currently this is `master`.
 git checkout "${TRAVIS_BRANCH}"
 
+# 2 core available on Travis CI Linux workers: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+# CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149
+export CPU_COUNT=2
+
+export PYTHONUNBUFFERED=1
+
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
@@ -18,11 +24,16 @@ source ~/miniconda/bin/activate root
 echo ""
 echo "Configuring conda."
 conda config --set show_channel_urls true
+conda config --set auto_update_conda false
+conda config --set add_pip_as_python_dependency false
 conda config --add channels conda-forge
+conda update -n root --yes --quiet conda conda-env
 conda install --yes --quiet git=2.12.2
-conda install --yes --quiet conda-smithy
-conda install --yes --quiet conda-forge-build-setup
-source run_conda_forge_build_setup
+conda install -n root --yes --quiet jinja2 anaconda-client
+conda install --yes --quiet conda-build=2 conda-smithy
+
+conda info
+conda config --get
 
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token


### PR DESCRIPTION
Preparation for the merge of PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/84 ). Includes the `conda-forge-build-setup` steps for Linux explicitly in `create_feedstocks`. In particular pins `conda-build` to 2 until `conda-smithy` can be updated.

cc @conda-forge/core