### PR TITLE
add back event-model after ci key error [ci skip]

### DIFF
--- a/recipes/event-model/meta.yaml
+++ b/recipes/event-model/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "1.4.0" %}
+
+package:
+    name: event-model
+    version: {{ version }}
+
+source:
+    url: https://github.com/NSLS-II/event-model/archive/v{{ version }}.tar.gz
+    fn: event-model-v{{version}}.tar.gz
+    sha256: 9339e23854acb760b80fad35219c5770e52ff9d40b9253dec6ded4fb887dd5fd
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - python
+        - enum34  # [py2k]
+        - setuptools
+
+test:
+    imports:
+        - event_model
+
+about:
+    home: https://github.com/NSLS-II/event-model
+    license: BSD 3-Clause
+    summary: data model for event-based data collection and analysis
+
+extra:
+    recipe-maintainers:
+        - ericdill
+        - licode
+        - tacaswell
+        - CJ-Wright


### PR DESCRIPTION
https://circleci.com/gh/conda-forge/event-model-feedstock/10?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link