### PR TITLE
Add menuinst

### DIFF
--- a/recipes/menuinst/meta.yaml
+++ b/recipes/menuinst/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "1.4.8" %}
+{% set sha256 = "053994cea32d71acf2846efc6dbd97b2fe5a4e98fa105ac36098d0a6d9c4ad9e" %}
+
+package:
+  name: menuinst
+  version: {{ version }}
+
+source:
+  fn: menuinst-{{ version }}.tar.gz
+  url: https://github.com/ContinuumIO/menuinst/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not win]
+  script:
+    - python setup.py install
+    - copy "%SRC_DIR%\\cwp.py" "%PREFIX%\\"
+  entry_points:
+    - menuinst = menuinst.main:main
+  skip_compile_pyc:
+    - cwp.py
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+    - pywin32
+
+test:
+  imports:
+    - menuinst
+
+  commands:
+    - menuinst --help
+
+about:
+  home: https://github.com/ContinuumIO/menuinst
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: "cross platform install of menu items"
+
+  dev_url: https://github.com/ContinuumIO/menuinst
+  doc_url: https://github.com/ContinuumIO/menuinst/wiki
+
+extra:
+  recipe-maintainers:
+    - goanpeca
+    - jakirkham


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/1934

Provides a package for `menuinst` on Windows. While it can be built on other platforms theoretically, it is not done in `defaults`. Also there are some words of caution in the README about other platforms (snippet below). So the recipe has been restricted to Windows.


> Menuinst is currently only supported on Windows. Legacy code exists for Linux and OS X - use at your own risk. It may mess up your menus.