### PR TITLE
Add send2trash 1.4.2

### DIFF
--- a/recipes/send2trash/LICENSE
+++ b/recipes/send2trash/LICENSE
@@ -1,0 +1,10 @@
+Copyright (c) 2017, Virgil Dupras
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Hardcoded Software Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/send2trash/meta.yaml
+++ b/recipes/send2trash/meta.yaml
@@ -24,8 +24,6 @@ requirements:
     - python
 
 test:
-  requires:
-    - python
   imports:
     - send2trash
   commands:
@@ -36,7 +34,7 @@ about:
   home: https://github.com/hsoft/send2trash
   license: BSD-3-Clause
   license_family: BSD
-  license_file: '{{ RECIPE_DIR }}/LICENSE'
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
   summary: Python library to natively send files to Trash (or Recycle bin) on all platforms.
 
 extra:

--- a/recipes/send2trash/meta.yaml
+++ b/recipes/send2trash/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "Send2Trash" %}
+{% set version = "1.4.2" %}
+{% set sha256 = "725fbce571dffe0b640e2f1788d52c3c544b510f9d8f69b2597c8c2555bc8441" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  requires:
+    - python
+  imports:
+    - send2trash
+  commands:
+    - echo test > test.txt
+    - python -c "from send2trash import *; send2trash('test.txt')"
+
+about:
+  home: https://github.com/hsoft/send2trash
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: '{{ RECIPE_DIR }}/LICENSE'
+  summary: Python library to natively send files to Trash (or Recycle bin) on all platforms.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Adds `send2trash` from PyPI, a future (like tomorrow) dependency of `notebook` (https://github.com/jupyter/notebook/issues/3183).

Includes copied license: will PR to add license in upstream.