### PR TITLE
readd tpot after ci ssh fail [ci skip]

### DIFF
--- a/recipes/tpot/meta.yaml
+++ b/recipes/tpot/meta.yaml
@@ -1,0 +1,84 @@
+{% set name = "TPOT" %}
+{% set version = "0.9.1" %}
+{% set sha256 = "293ee765a1258822c835b50e8eae5cf72462549c771c5e421a9883c571a09a13" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record record.txt
+  entry_points:
+    - tpot=tpot:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - deap >=1.0
+    - numpy >=1.12.1
+    - pandas >=0.20.2
+    - python
+    - scikit-learn >=0.18.1
+    - scipy >=0.19.0
+    - stopit >=1.1.1
+    - tqdm >=4.11.2
+    - update_checker >=0.16
+
+test:
+  imports:
+    - tpot
+    - tpot.base
+    - tpot.builtins
+    - tpot.config
+    - tpot.decorators
+    - tpot.driver
+    - tpot.export_utils
+    - tpot.gp_deap
+    - tpot.gp_types
+    - tpot.metrics
+    - tpot.operator_utils
+    - tpot.tpot
+  commands:
+    - tpot --help
+    - tpot --version
+
+about:
+  home: https://rhiever.github.io/tpot/
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'A Python tool that automatically creates and optimizes Machine Learning pipelines using genetic programming.'
+  dev_url: https://github.com/rhiever/tpot
+  description: |
+    Consider TPOT your Data Science Assistant. TPOT is a Python Automated
+    Machine Learning tool that optimizes machine learning pipelines using
+    genetic programming.
+
+    TPOT will automate the most tedious part of machine learning by
+    intelligently exploring thousands of possible pipelines to find the best
+    one for your data.
+
+    Once TPOT is finished searching (or you get tired of waiting), it provides
+    you with the Python code for the best pipeline it found so you can tinker
+    with the pipeline from there.
+
+    TPOT is built on top of scikit-learn, so all of the code it generates
+    should look familiar... if you're familiar with scikit-learn, anyway.
+
+    TPOT is still under active development and we encourage you to check back
+    on this repository regularly for updates.
+
+extra:
+  recipe-maintainers:
+    - proinsias
+    - bollwyvl


### PR DESCRIPTION
After https://github.com/conda-forge/tpot-feedstock/pull/2 (which went to `noarch: python`), re-adding, as per gitter feedback: https://gitter.im/conda-forge/conda-forge.github.io?at=5a4e83b5ce68c3bc747c11a9