### PR TITLE
Mount directories in `conda` user's home

### DIFF
--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -12,7 +12,7 @@ channels:
  - defaults
 
 conda-build:
- root-dir: /staged-recipes/build_artifacts
+ root-dir: /home/conda/staged-recipes/build_artifacts
 
 always_yes: true
 show_channel_urls: true
@@ -31,18 +31,18 @@ if hash docker-machine 2> /dev/null && docker-machine active > /dev/null; then
 fi
 
 cat << EOF | docker run -i \
-                        -v ${REPO_ROOT}:/staged-recipes \
+                        -v ${REPO_ROOT}:/home/conda/staged-recipes \
                         -a stdin -a stdout -a stderr \
                         -e HOST_USER_ID=${HOST_USER_ID} \
                         $IMAGE_NAME \
                         bash -ex || exit $?
 
 # Copy the host recipes folder so we don't ever muck with it
-cp -r /staged-recipes/recipes ~/conda-recipes
+cp -r /home/conda/staged-recipes/recipes ~/conda-recipes
 
 # Find the recipes from master in this PR and remove them.
 echo "Finding recipes merged in master and removing them from the build."
-pushd /staged-recipes/recipes > /dev/null
+pushd /home/conda/staged-recipes/recipes > /dev/null
 git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf ~/conda-recipes/{} && echo Removing recipe: {}"
 popd > /dev/null
 


### PR DESCRIPTION
Pulls over PR ( https://github.com/conda-forge/conda-smithy/pull/635 ).

Makes sure to mount all directories in the `conda` user's home directory. Previously they were mounted at `/`, which meant they required `root` to modify the directories or their contents. Relocating them to the `conda` user's home directory should avoid these issues as the `conda` user has permissions on those locations.
  