### PR TITLE
initial conda recipe for python-fastimport

### DIFF
--- a/recipes/fastimport/meta.yaml
+++ b/recipes/fastimport/meta.yaml
@@ -38,7 +38,7 @@ about:
   description: |
     This package provides a parser for and generator of the Git fastimport format.
   doc_url: https://www.kernel.org/pub/software/scm/git/docs/git-fast-import.html
-  dev_url: htps://github.com/jelmer/python-fastimport
+  dev_url: https://github.com/jelmer/python-fastimport
 
 extra:
   recipe-maintainers:

--- a/recipes/fastimport/meta.yaml
+++ b/recipes/fastimport/meta.yaml
@@ -29,7 +29,7 @@ test:
     - fastimport.processors
 
 about:
-  home: htps://github.com/jelmer/python-fastimport
+  home: https://github.com/jelmer/python-fastimport
   license: GPL-2.0
   license_family: GPL
   license_file: COPYING

--- a/recipes/fastimport/meta.yaml
+++ b/recipes/fastimport/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "fastimport" %}
+{% set version = "0.9.6" %}
+{% set sha256 = "83d0ae7b14f58c90cf56d0bf190d339abbd8bf1be702492c3d15d74c6cd412ab" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install 
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - fastimport
+    - fastimport.tests
+    - fastimport.processors
+
+about:
+  home: htps://github.com/jelmer/python-fastimport
+  license: GPL-2.0
+  license_family: GPL
+  license_file: COPYING
+  summary: 'VCS fastimport/fastexport parser'
+
+  description: |
+    This package provides a parser for and generator of the Git fastimport format.
+  doc_url: https://www.kernel.org/pub/software/scm/git/docs/git-fast-import.html
+  dev_url: htps://github.com/jelmer/python-fastimport
+
+extra:
+  recipe-maintainers:
+    - mikofski


### PR DESCRIPTION
fastimport is an optional requirement for dulwich that implements a parser/generator for the git-fastimport format