### PR TITLE
Add tensorboardX recipe

### DIFF
--- a/recipes/tensorboardx/meta.yaml
+++ b/recipes/tensorboardx/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "tensorboardx" %}
+{% set version = "0.9" %}
+{% set sha256 = "9bb713cbbe6e859ddf26928d1768e269cd914e3443fac85c0be181be5b2b9065" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: v{{ version }}.tar.gz
+  url: https://github.com/lanpa/tensorboard-pytorch/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy
+    - protobuf
+
+test:
+  imports:
+    - tensorboardX
+
+about:
+  home: https://github.com/lanpa/tensorboard-pytorch
+  license: MIT
+  license_family: MIT
+  summary: tensorboard for pytorch
+
+  description: |
+    Write tensorboard events from PyTorch (and Chainer, MXNet, NumPy, ...)
+  doc_url: http://tensorboard-pytorch.readthedocs.io/en/latest/
+  dev_url: https://github.com/lanpa/tensorboard-pytorch
+
+extra:
+  recipe-maintainers:
+    - mdraw

--- a/recipes/tensorboardx/meta.yaml
+++ b/recipes/tensorboardx/meta.yaml
@@ -28,6 +28,15 @@ requirements:
 test:
   imports:
     - tensorboardX
+    - tensorboardX.crc32c
+    - tensorboardX.embedding
+    - tensorboardX.event_file_writer
+    - tensorboardX.graph
+    - tensorboardX.graph_onnx
+    - tensorboardX.record_writer
+    - tensorboardX.summary
+    - tensorboardX.writer
+    - tensorboardX.x2num
 
 about:
   home: https://github.com/lanpa/tensorboard-pytorch


### PR DESCRIPTION
Packages https://github.com/lanpa/tensorboard-pytorch, a library for direct tensorboard logging of NumPy arrays, PyTorch tensors etc. without TensorFlow or TensorBoard requirements.

Notes:
- The repository is still called tensorboard-pytorch, but the project name has been changed
- As far as I see, the log format of tensorboardX is not compatible with recent versions of the official TensorBoard server https://github.com/tensorflow/tensorboard, but only with https://github.com/dmlc/tensorboard, which has a name conflict with Google's Tensorflow (see https://github.com/dmlc/tensorboard/issues/50) and is not packaged on conda-forge. I am not sure how we should deal with this issue. If we decided to also package dmlc/tensorboard, how should we name it?