### PR TITLE
Added recipe for pyinstrument_cext

### DIFF
--- a/recipes/pyinstrument_cext/LICENSE
+++ b/recipes/pyinstrument_cext/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Joe Rickerby
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/pyinstrument_cext/meta.yaml
+++ b/recipes/pyinstrument_cext/meta.yaml
@@ -33,6 +33,7 @@ test:
 
 about:
   home: https://github.com/joerick/pyinstrument_cext
+  # No local license - see https://github.com/joerick/pyinstrument_cext/pull/1
   license_file: {{ RECIPE_DIR }}/LICENSE
   license: BSD 3-Clause
   license_family: BSD

--- a/recipes/pyinstrument_cext/meta.yaml
+++ b/recipes/pyinstrument_cext/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pyinstrument_cext" %}
+{% set version = "0.1.2" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "e5dce5836086ebcd5a5e5848f3329896ae36ffc583d7ad30d821b157b2fa56be" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+
+  run:
+    - python
+
+test:
+  imports:
+    - pyinstrument_cext
+
+about:
+  home: https://github.com/joerick/pyinstrument_cext
+  license_file: {{ RECIPE_DIR }}/LICENSE
+  license: BSD 3-Clause
+  license_family: BSD
+  summary: 'A CPython extension supporting pyinstrument'
+  dev_url: https://github.com/joerick/pyinstrument_cext
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr


### PR DESCRIPTION
[`pyinstrument_cext`](https://github.com/joerick/pyinstrument_cext) is a collection of CPython extensions used by the latest version of [`pyinstrument`](https://github.com/joerick/pyinstrument); we need this package to update the `pyinstrument` feedstock.