### PR TITLE
Added recipe for python-ldap

### DIFF
--- a/recipes/python-ldap/meta.yaml
+++ b/recipes/python-ldap/meta.yaml
@@ -38,7 +38,7 @@ test:
 about:
   home: https://www.python-ldap.org/
   license_file: LICENSE
-  license: Python Software Foundation License
+  license: PSF
   summary: 'Python modules for implementing LDAP clients'
   license_family: PSF
   doc_url: https://www.python-ldap.org/en/latest/
@@ -47,4 +47,3 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
-

--- a/recipes/python-ldap/meta.yaml
+++ b/recipes/python-ldap/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "python-ldap" %}
+{% set version = "2.5.2" %}
+{% set bundle = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash = "b8c134dfedaef0e6ff4a4b94277708dcadb758b448905a83b8946df077356ed2" %}
+{% set build = 0 %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ bundle }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ bundle }}
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: {{ build }}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - toolchain
+
+  run:
+    - python
+
+test:
+  imports:
+    - ldap
+    - ldap.controls
+    - ldap.extop
+    - ldap.schema
+    - slapdtest
+
+about:
+  home: https://www.python-ldap.org/
+  license_file: LICENSE
+  license: Python Software Foundation License
+  summary: 'Python modules for implementing LDAP clients'
+  license_family: PSF
+  doc_url: https://www.python-ldap.org/en/latest/
+  dev_url: https://github.com/python-ldap/python-ldap
+
+extra:
+  recipe-maintainers:
+    - pmlandwehr
+


### PR DESCRIPTION
[`python-ldap`](https://www.python-ldap.org/en/latest/) is a module for providing LDAP access in python; It's a replacement for the now-deprecated [`pyldap`](https://github.com/pyldap/pyldap/). (Note that the two projects were merged starting at the 3.0.0 version. This is for the 2.5.2 release since that's the most recent version on pypi.)