### PR TITLE
giza, a drop-in replacement for pgplot.

### DIFF
--- a/recipes/giza/build.sh
+++ b/recipes/giza/build.sh
@@ -15,13 +15,11 @@ make check
 ctests="
 arrow
 band
-box
 colour-index
 error-bars
 format-number
 line-cap
 line-style
-openclose
 points
 qtext
 rectangle

--- a/recipes/giza/build.sh
+++ b/recipes/giza/build.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+set -e
+set -o pipefail
+
+configure_args=(
+    --prefix=$PREFIX
+)
+
+./configure "${configure_args[@]}" || { cat config.log ; exit 1 ; }
+make # note: parallel build doesn't work reliably due to lack of rule defining creation of `giza.mod`
+
+make check
+
+ctests="
+arrow
+band
+box
+colour-index
+error-bars
+format-number
+line-cap
+line-style
+openclose
+points
+qtext
+rectangle
+set-line-width
+vector
+window
+"
+
+for t in $ctests ; do
+    echo /png |test/C/test-$t
+done
+
+./test/C/test-change-page <<EOF
+/png
+/pdf
+/svg
+EOF
+./test/C/test-environment <<EOF
+/png
+/png
+/png
+/png
+/png
+/png
+EOF
+./test/C/test-pdf
+./test/C/test-png
+./test/C/test-svg
+./test/F90/test-2D
+./test/F90/test-fortran
+# other fortran tests require X
+
+make install
+
+cd $PREFIX
+find . '(' -name '*.la' -o -name '*.a' ')' -delete
+rm -rf share/doc/giza

--- a/recipes/giza/disable-macos-tests.patch
+++ b/recipes/giza/disable-macos-tests.patch
@@ -1,0 +1,19 @@
+diff --git a/test/C/Makefile.in b/test/C/Makefile.in
+index 7041dd5..0a40ad9 100644
+--- a/test/C/Makefile.in
++++ b/test/C/Makefile.in
+@@ -102,12 +102,11 @@ CONFIG_HEADER = $(top_builddir)/config.h
+ CONFIG_CLEAN_FILES =
+ CONFIG_CLEAN_VPATH_FILES =
+ am__EXEEXT_1 = test-arrow$(EXEEXT) test-band$(EXEEXT) \
+-	test-box$(EXEEXT) test-cairo-xw$(EXEEXT) \
+ 	test-change-page$(EXEEXT) test-circle$(EXEEXT) \
+ 	test-colour-index$(EXEEXT) test-environment$(EXEEXT) \
+ 	test-error-bars$(EXEEXT) test-format-number$(EXEEXT) \
+-	test-giza-xw$(EXEEXT) test-line-cap$(EXEEXT) \
+-	test-line-style$(EXEEXT) test-openclose$(EXEEXT) \
++	test-line-cap$(EXEEXT) \
++	test-line-style$(EXEEXT) \
+ 	test-pdf$(EXEEXT) test-png$(EXEEXT) test-points$(EXEEXT) \
+ 	test-qtext$(EXEEXT) test-rectangle$(EXEEXT) \
+ 	test-set-line-width$(EXEEXT) test-svg$(EXEEXT) \

--- a/recipes/giza/fix-tests.patch
+++ b/recipes/giza/fix-tests.patch
@@ -1,0 +1,287 @@
+diff --git a/test/C/test-arrow.c b/test/C/test-arrow.c
+index 83eb984..16b7e8c 100644
+--- a/test/C/test-arrow.c
++++ b/test/C/test-arrow.c
+@@ -84,4 +84,5 @@ main ()
+   giza_arrow (0.625, 0.625, 0.650, 0.650);
+ 
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-band.c b/test/C/test-band.c
+index 7b2bcc5..0e91524 100644
+--- a/test/C/test-band.c
++++ b/test/C/test-band.c
+@@ -42,4 +42,5 @@ main ()
+   printf ("x = %f, y = %f, ch =%c\n", x, y, ch);
+ 
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-box.c b/test/C/test-box.c
+index 4344122..3353abe 100644
+--- a/test/C/test-box.c
++++ b/test/C/test-box.c
+@@ -67,5 +67,6 @@ main ()
+   giza_set_window (0., 1., 10.2, 11.);
+   giza_box ("BCTN", 0., 0, "BCTNL", 0., 0);
+ 
+- giza_close_device ();
++  giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-change-page.c b/test/C/test-change-page.c
+index d9f15b9..c4296a2 100644
+--- a/test/C/test-change-page.c
++++ b/test/C/test-change-page.c
+@@ -47,4 +47,5 @@ main ()
+   giza_change_page ();
+   giza_box ("BCTN", 0., 0, "BCTN", 0., 0);
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-circle.c b/test/C/test-circle.c
+index df0a5d7..fecae75 100644
+--- a/test/C/test-circle.c
++++ b/test/C/test-circle.c
+@@ -39,6 +39,7 @@ main ()
+   aux(0.3, 0.2, 0.1, 2, 3);
+ 
+   giza_close_device ();
++  return 0;
+ }
+ 
+ void
+diff --git a/test/C/test-colour-index.c b/test/C/test-colour-index.c
+index e144c01..5aef708 100644
+--- a/test/C/test-colour-index.c
++++ b/test/C/test-colour-index.c
+@@ -47,5 +47,5 @@ main ()
+     }
+ 
+   giza_close_device ();
+-
++  return 0;
+ }
+diff --git a/test/C/test-contour.c b/test/C/test-contour.c
+index 9a3ffec..545a4cf 100644
+--- a/test/C/test-contour.c
++++ b/test/C/test-contour.c
+@@ -82,5 +82,5 @@ main ()
+   giza_contour (dimx, dimy, data, 0, dimx - 1, 0, dimy - 1, ncont, cont, affine);
+   giza_box ("BCNT", 0., 0, "BCNT", 0., 0);
+   giza_close_device ();
+-
++  return 0;
+ }
+diff --git a/test/C/test-environment.c b/test/C/test-environment.c
+index 61b9afa..7863fb3 100644
+--- a/test/C/test-environment.c
++++ b/test/C/test-environment.c
+@@ -62,4 +62,5 @@ main ()
+   giza_set_environment (0., 10., 0., 40., 1, 0);
+ 
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-error-bars-2.c b/test/C/test-error-bars-2.c
+index c5795b1..5f1d378 100644
+--- a/test/C/test-error-bars-2.c
++++ b/test/C/test-error-bars-2.c
+@@ -46,4 +46,5 @@ int main (void)
+ 	giza_error_bars (dir, N, x, y, err, 2);
+      }
+    giza_close_device ();
++   return 0;
+ }
+diff --git a/test/C/test-error-bars.c b/test/C/test-error-bars.c
+index c002089..58450a1 100644
+--- a/test/C/test-error-bars.c
++++ b/test/C/test-error-bars.c
+@@ -71,4 +71,5 @@ main ()
+   giza_points (2, xpts, ypts, 178);
+ 
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-format-number.c b/test/C/test-format-number.c
+index 4378455..204bd27 100644
+--- a/test/C/test-format-number.c
++++ b/test/C/test-format-number.c
+@@ -149,5 +149,5 @@ main ()
+   giza_format_number(x, 3, string);
+   printf("%e: %s \n",x,string);
+ */
+-
++  return 0;
+ }
+diff --git a/test/C/test-line-style.c b/test/C/test-line-style.c
+index 6b65e1f..6fcf3f1 100644
+--- a/test/C/test-line-style.c
++++ b/test/C/test-line-style.c
+@@ -46,4 +46,5 @@ main ()
+     }
+ 
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-openclose.c b/test/C/test-openclose.c
+index f4eb183..b7125eb 100644
+--- a/test/C/test-openclose.c
++++ b/test/C/test-openclose.c
+@@ -33,5 +33,5 @@ int main ()
+   ierr = giza_open_device("/xw","test");
+   giza_stop_prompting();
+   giza_close_device();
+-
++  return 0;
+ }
+diff --git a/test/C/test-pdf.c b/test/C/test-pdf.c
+index 64e35d6..e7ca573 100644
+--- a/test/C/test-pdf.c
++++ b/test/C/test-pdf.c
+@@ -26,8 +26,8 @@
+ static double sinx(double *x);
+ 
+ int main() {
+- int ierr, i;
+- ierr = giza_open_device("/pdf","test");
++ int devid, i;
++ devid = giza_open_device("/pdf","test");
+  for (i=1;i<=10;i++) {
+      giza_set_environment(0.,1.,-1.,1.,0,0);
+      giza_label("x","y","title");
+@@ -35,7 +35,7 @@ int main() {
+  }
+  giza_close_device();
+ 
+- return ierr;
++ return 0;
+ }
+ 
+ double sinx(double *x) {
+diff --git a/test/C/test-png.c b/test/C/test-png.c
+index 92c5f8c..059cacf 100644
+--- a/test/C/test-png.c
++++ b/test/C/test-png.c
+@@ -26,8 +26,8 @@
+ static double sinx(double *x);
+ 
+ int main() {
+- int ierr, i;
+- ierr = giza_open_device("/png","test");
++ int devid, i;
++ devid = giza_open_device("/png","test");
+  for (i=1;i<=10;i++) {
+      giza_set_environment(0.,1.,-1.,1.,0,0);
+      giza_label("x","y","title");
+@@ -35,7 +35,7 @@ int main() {
+  }
+  giza_close_device();
+ 
+- return ierr;
++ return 0;
+ }
+ 
+ double sinx(double *x) {
+diff --git a/test/C/test-points.c b/test/C/test-points.c
+index 91ce8d8..fa41845 100644
+--- a/test/C/test-points.c
++++ b/test/C/test-points.c
+@@ -54,6 +54,7 @@ main ()
+   giza_change_page ();
+ 
+   giza_close_device ();
++  return 0;
+ }
+ 
+ void
+diff --git a/test/C/test-qtext.c b/test/C/test-qtext.c
+index a74adb6..f3f2fbc 100644
+--- a/test/C/test-qtext.c
++++ b/test/C/test-qtext.c
+@@ -147,5 +147,6 @@ main ()
+   printf ("Y[0] = %f, Y[1] = %f, Y[2] = %f, Y[3] = %f\n", ybox[0], ybox[1], ybox[2], ybox[3]);
+ 
+   giza_close_device ();
++  return 0;
+ }
+  
+diff --git a/test/C/test-rectangle.c b/test/C/test-rectangle.c
+index dc20bbe..431fd2b 100644
+--- a/test/C/test-rectangle.c
++++ b/test/C/test-rectangle.c
+@@ -39,6 +39,7 @@ main ()
+   aux(0.3, 0.5, 0.1, 0.3, 2, 3);
+ 
+   giza_close_device ();
++  return 0;
+ }
+ 
+ void
+diff --git a/test/C/test-render.c b/test/C/test-render.c
+index 0ab547f..9836cc9 100644
+--- a/test/C/test-render.c
++++ b/test/C/test-render.c
+@@ -128,4 +128,5 @@ main ()
+   giza_render (100, 100, data, 0, 99, 0, 99, 0, 100, affine);
+ 
+   giza_close_device ();
++  return 0;
+ }
+diff --git a/test/C/test-set-line-width.c b/test/C/test-set-line-width.c
+index 8a4e78b..87f595f 100644
+--- a/test/C/test-set-line-width.c
++++ b/test/C/test-set-line-width.c
+@@ -95,6 +95,7 @@ main ()
+ 
+   giza_close_device ();
+   */
++  return 0;
+ }
+ 
+ void
+diff --git a/test/C/test-svg.c b/test/C/test-svg.c
+index 75f17e2..a13023e 100644
+--- a/test/C/test-svg.c
++++ b/test/C/test-svg.c
+@@ -26,8 +26,8 @@
+ static double sinx(double *x);
+ 
+ int main() {
+- int ierr, i;
+- ierr = giza_open_device("/svg","test");
++ int devid, i;
++ devid = giza_open_device("/svg","test");
+  for (i=1;i<=10;i++) {
+      giza_set_environment(0.,1.,-1.,1.,0,0);
+      giza_label("x","y","title");
+@@ -35,7 +35,7 @@ int main() {
+  }
+  giza_close_device();
+ 
+- return ierr;
++ return 0;
+ }
+ 
+ double sinx(double *x) {
+diff --git a/test/C/test-vector.c b/test/C/test-vector.c
+index 0b459df..c4eab08 100644
+--- a/test/C/test-vector.c
++++ b/test/C/test-vector.c
+@@ -55,4 +55,5 @@ main ()
+   giza_vector_float (n, m, hori, vert, 0, 1, 0, 1, scale, 0, affine, 1000.);
+ 
+   giza_close_device ();
++  return 0;
+ } 
+diff --git a/test/C/test-window.c b/test/C/test-window.c
+index 5b35a7f..35e362d 100644
+--- a/test/C/test-window.c
++++ b/test/C/test-window.c
+@@ -40,4 +40,5 @@ main ()
+   giza_change_page ();
+ 
+   giza_close_device ();
++  return 0;
+ }

--- a/recipes/giza/meta.yaml
+++ b/recipes/giza/meta.yaml
@@ -13,6 +13,7 @@ source:
   sha256: {{ sha256 }}
   patches:
     - fix-tests.patch
+    - disable-macos-tests.patch  # [osx]
 
 build:
   number: 0

--- a/recipes/giza/meta.yaml
+++ b/recipes/giza/meta.yaml
@@ -1,0 +1,49 @@
+# TODO: this package should be marked as conflicting with pgplot.
+
+{% set name = 'giza' %}
+{% set version = '0.9.4' %}
+{% set sha256 = "1615bd177a708be6d1c87b404eeedd13447de17d344f817b5a1a0e4565addf41" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pilotfiber.dl.sourceforge.net/project/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - fix-tests.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - pthread-stubs
+    - toolchain
+    - cairo 1.14.*
+    - xorg-libx11 1.6.*
+  run:
+    - cairo 1.14.*
+    - xorg-libx11 1.6.*
+
+test:
+  # note: most tests are run in build.sh
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - test -e $PREFIX/lib/libgiza$SHLIB_EXT
+    - test -e $PREFIX/lib/libpgplot$SHLIB_EXT
+    - test -e $PREFIX/lib/libcpgplot$SHLIB_EXT
+
+about:
+  home: http://giza.sourceforge.net/
+  license: GPLv2
+  license_file: COPYING
+  summary: A drop-in replacement for PGPLOT using C and Cairo.
+
+extra:
+  recipe-maintainers:
+    - pkgw

--- a/recipes/giza/meta.yaml
+++ b/recipes/giza/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - gcc  # [osx]
     - pkg-config
     - pthread-stubs
     - toolchain
@@ -27,6 +28,7 @@ requirements:
     - xorg-libx11 1.6.*
   run:
     - cairo 1.14.*
+    - libgfortran  # [unix]
     - xorg-libx11 1.6.*
 
 test:

--- a/recipes/giza/yum_requirements.txt
+++ b/recipes/giza/yum_requirements.txt
@@ -1,0 +1,1 @@
+devtoolset-2-gcc-gfortran


### PR DESCRIPTION
This package should in fact be marked as conflicting with pgplot, when that becomes possible.