### PR TITLE
Add su-exec

### DIFF
--- a/recipes/su-exec/build.sh
+++ b/recipes/su-exec/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+make
+mv "${SRC_DIR}/su-exec" "${PREFIX}/bin/su-exec"

--- a/recipes/su-exec/meta.yaml
+++ b/recipes/su-exec/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "0.2" %}
+{% set sha256 = "ec4acbd8cde6ceeb2be67eda1f46c709758af6db35cacbcde41baac349855e25" %}
+
+package:
+  name: su-exec
+  version: {{ version }}
+
+source:
+  fn: su-exec-{{ version }}.tar.gz
+  url: https://github.com/ncopa/su-exec/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not linux]
+
+test:
+  commands:
+    - which su-exec
+    - su-exec --help
+
+about:
+  home: https://github.com/ncopa/su-exec
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Switch user and group id and exec
+
+  description: |
+    This is a simple tool that will simply execute a program with different
+    privileges. The program will not run as a child, like su and sudo, so we
+    work around TTY and signal issues.
+
+  dev_url: https://github.com/ncopa/su-exec
+  doc_url: https://github.com/ncopa/su-exec
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/4749

Adds a package for [`su-exec`]( https://github.com/ncopa/su-exec ). A utility for switching users and running a command on Linux (e.g. in Docker containers). Similar to `gosu`, but much lighter weight and with a permissive license.