### PR TITLE
Re-add `aipy`.

### DIFF
--- a/recipes/aipy/meta.yaml
+++ b/recipes/aipy/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "aipy" %}
+{% set version = "2.1.9" %}
+{% set sha256 = "fbc20526dac47ec7be8ae5d47ef0c40fcc7349d72ad8b0a48bd21d2c7858fe25" %}
+
+package:
+  name: {{ name }}
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 1
+  script: python setup.py install --single-version-externally-managed --record=files.txt
+  skip: true  # [win or py3k]
+
+requirements:
+  build:
+    - toolchain
+    - astropy >=2.0
+    - ephem
+    - numpy 1.11.*
+    - python <3
+    - setuptools
+
+  run:
+    - astropy >=2.0
+    - ephem
+    - numpy >=1.11
+    - python <3
+
+test:
+  imports:
+    - aipy
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PRFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://github.com/HERA-Team/aipy
+  license: GPL v2+
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'Astronomical interferometry in Python'
+
+extra:
+  recipe-maintainers:
+    - pkgw


### PR DESCRIPTION
CircleCI builds on the aipy feedstock are not running automatically because "the repo has no followers". I'm not quite sure what this means but it sounds like something about the feedstock setup went wrong. Resubmitting to see if that fixes things.