### PR TITLE
Add libgta

### DIFF
--- a/recipes/libgta/build.sh
+++ b/recipes/libgta/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+export CFLAGS="$CFLAGS -I$PREFIX/include"
+export CPPFLAGS="$CPPFLAGS -I$PREFIX/include"
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
+
+mkdir build
+cd build
+cmake \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=TRUE \
+    -DCMAKE_BUILD_TYPE=Release \
+    ../libgta
+make -j $CPU_COUNT
+make install

--- a/recipes/libgta/meta.yaml
+++ b/recipes/libgta/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "libgta" %}
+{% set version = "1.0.8" %}
+{% set sha256 = "1738415eb69541c77acd5fa823fe0bb46b53b689746b4ee23a96b709d27e8325" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: gta-{{ name }}-{{ version }}.tar.gz
+  url: http://git.savannah.nongnu.org/cgit/gta.git/snapshot/gta-{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - doxygen
+    - bzip2
+    - xz
+    - zlib
+  run:
+    - bzip2
+    - xz
+    - zlib
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libgta.a"
+    - test -f "${PREFIX}/lib/libgta.so"
+    - test -f "${PREFIX}/include/gta/gta_version.h"
+    - test -f "${PREFIX}/include/gta/gta.h"
+    - test -f "${PREFIX}/include/gta/gta.hpp"
+
+about:
+  home: http://gta.nongnu.org/libgta.html
+  license: LGPL
+  license_file: libgta/COPYING
+  summary: 'Libgta is a portable library that implements the GTA file format.'
+
+  description: |
+    The library works with three basic entities: GTA headers, GTA tag lists,
+    and the array data.
+
+    A GTA header stores all the information about the array data: array
+    dimensions, array element components, and tag lists. There is one
+    global tag list for the whole array, one tag list for each dimension, and
+    one tag list for each element component.
+
+    The array data can be read and written in one of three ways:
+    * completely in memory (for arrays that are not too big),
+    * stream-based (for streamable tasks),
+    * or block-based (for random access to the array data).
+
+    The library provides interfaces for C and C++
+  doc_url: http://gta.nongnu.org/doc/reference/index.html
+  dev_url: http://git.savannah.gnu.org/cgit/gta.git
+
+extra:
+  recipe-maintainers:
+    - microe


### PR DESCRIPTION
[libgta](http://gta.nongnu.org/libgta.html) supports generic tagged arrays, ([GTA](http://gta.nongnu.org/)). This package is a dependency for [OpenSceneGraph](http://www.openscenegraph.org/).