### PR TITLE
add GNU parallel

### DIFF
--- a/recipes/parallel/build.sh
+++ b/recipes/parallel/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX
+make
+make install

--- a/recipes/parallel/meta.yaml
+++ b/recipes/parallel/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "20180122" %}
+{% set sha256 = "5c8346dc28a8cecf22a310da795e7b81f0d0d43c05ba6cb112325dd9e0c373f2" %}
+
+package:
+  name: parallel
+  version: {{ version }}
+
+source:
+  url: http://ftpmirror.gnu.org/parallel/parallel-{{ version }}.tar.bz2
+  fn: parallel-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+  run:
+    - perl
+  
+test:
+  commands:
+    - parallel --version
+
+about:
+  home: http://www.gnu.org/software/parallel/
+  license: GPL-3
+  license_family: GPL
+  summary: GNU parallel is a shell tool for executing jobs in parallel using one or more computers.
+
+extra:
+  recipe-maintainers:
+    - rvalieris


### PR DESCRIPTION
GNU parallel is a shell tool for executing jobs in parallel using one or more computers.

recipe migrated from the bioconda channel.
xref: https://github.com/bioconda/bioconda-recipes/pull/7334