### PR TITLE
add recipe for ipypivot

### DIFF
--- a/recipes/ipypivot/meta.yaml
+++ b/recipes/ipypivot/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.2.4b0" %}
+{% set sha256 = "f6073cbb044ab1a1a3576df155de5a48153e83f73faeed48d5ad3e7e21ce2680" %}
+
+package:
+  name: ipypivot
+  version: {{ version }}
+
+source:
+  fn: ipypivot-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/i/ipypivot/ipypivot-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - jupyter
+    run:
+        - python
+        - ipywidgets >=7.0.0,<8.0
+        - traitlets >=4.3.0,<5.0
+        - traittypes >=0.0.6
+        - numpy >=1.10.4
+        - pandas
+
+test:
+    imports:
+        - ipypivot
+
+about:
+  home: https://github.com/PierreMarion23/ipypivot
+  license: MIT
+  license_family: MIT
+  summary: 'A jupyter widget (or ipywidget) wrapping the very convenient pivotTable.js library'
+
+  description: |
+    This is a jupyter widget (or ipywidget) wrapping the very convenient pivotTable.js library.
+    It enables to display and embed a pivotTable in a Jupyter notebook in a few Python lines.
+  dev_url: https://github.com/PierreMarion23/ipypivot
+
+extra:
+  recipe-maintainers:
+    - PierreMarion23
+    - ocoudray
+    - oscar6echo

--- a/recipes/ipypivot/post-link.bat
+++ b/recipes/ipypivot/post-link.bat
@@ -1,0 +1,3 @@
+@echo off
+
+"%PREFIX%\Scripts\jupyter-nbextension.exe" enable ipypivot --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipes/ipypivot/post-link.sh
+++ b/recipes/ipypivot/post-link.sh
@@ -1,0 +1,1 @@
+"${PREFIX}/bin/jupyter-nbextension" enable ipypivot --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1

--- a/recipes/ipypivot/pre-unlink.bat
+++ b/recipes/ipypivot/pre-unlink.bat
@@ -1,0 +1,3 @@
+@echo off
+
+"%PREFIX%\Scripts\jupyter-nbextension.exe" disable ipypivot --py --sys-prefix >> "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipes/ipypivot/pre-unlink.sh
+++ b/recipes/ipypivot/pre-unlink.sh
@@ -1,0 +1,1 @@
+"${PREFIX}/bin/jupyter-nbextension" disable ipypivot --py --sys-prefix >> "${PREFIX}/.messages.txt" 2>&1


### PR DESCRIPTION
This package is a rename for the `ipywidget-pivot-table` package.
Thus, after the PR is merged, could you delete the `ipywidget-pivot-table` package? Many thanks!