### PR TITLE
Add monkeytype (and retype and pytest-smartcov) 

### DIFF
--- a/recipes/monkeytype/LICENSE
+++ b/recipes/monkeytype/LICENSE
@@ -1,0 +1,30 @@
+BSD License
+
+For MonkeyType software
+
+Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -42,6 +42,7 @@ test:
     - git checkout v{{ PKG_VERSION }}
     - rm -rf monkeytype  # [not win]
     - rd /s /q monkeytype  # [win]
+    - del pytest.ini  # [win]
     # FIXME: not sure about this one
     - python -m pytest -k "not test_includes_otherwise"
 

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py2k]
+  skip: true  # [not py36]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -66,3 +66,4 @@ about:
 extra:
   recipe-maintainers:
     - bollwyvl
+    - nehaljwani

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -44,7 +44,10 @@ test:
     - rd /s /q monkeytype  # [win]
     - del pytest.ini  # [win]
     # FIXME: not sure about this one
-    - python -m pytest -k "not test_includes_otherwise"
+    - python -m pytest -k "not test_includes_otherwise"  # [not win]
+    - python -m pytest -k "not test_includes_otherwise and not test_generate_stub and not test_no_traces and not test_display_sample_count_from_cli and not test_retype_failure"  # [win]
+
+
 
 about:
   home: https://github.com/Instagram/MonkeyType

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -13,7 +13,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [not py36]
+  skip: true  # [py2k]
+  skip: true  # [py34]
+  skip: true  # [py35]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -16,6 +16,8 @@ build:
   skip: true  # [py2k]
   skip: true  # [py34]
   skip: true  # [py35]
+  entry_points:
+    - monkeytype=monkeytype.cli:entry_point_main
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -36,6 +38,7 @@ test:
   imports:
     - monkeytype
   commands:
+    - monkeytype --help
     # TODO: make upstream PR for redistributing tests
     - git clone https://github.com/Instagram/MonkeyType
     - cd MonkeyType

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -13,9 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py2k]
-  skip: true  # [py34]
-  skip: true  # [py35]
+  skip: true  # [py<36]
   entry_points:
     - monkeytype=monkeytype.cli:entry_point_main
   script: python -m pip install --no-deps --ignore-installed .

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -34,6 +34,7 @@ test:
   imports:
     - monkeytype
   commands:
+    # TODO: make upstream PR for redistributing tests
     - git clone https://github.com/Instagram/MonkeyType
     - cd MonkeyType
     - git checkout v{{ PKG_VERSION }}

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -40,7 +40,9 @@ test:
     - git clone https://github.com/Instagram/MonkeyType
     - cd MonkeyType
     - git checkout v{{ PKG_VERSION }}
-    - rm -rf monkeytype
+    - rm -rf monkeytype  # [not win]
+    - rd /s /q monkeytype  # [win]
+    # FIXME: not sure about this one
     - python -m pytest -k "not test_includes_otherwise"
 
 about:

--- a/recipes/monkeytype/meta.yaml
+++ b/recipes/monkeytype/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "MonkeyType" %}
+{% set version = "18.1.11" %}
+{% set sha256 = "a856c4cf7bce054b0a7384b45b415339bf9b5932bf800a2c8f4bf6dbe29ee740" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [py2k]
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - pip
+    - python
+    - setuptools
+  run:
+    - python
+    - retype
+
+test:
+  requires:
+    - cython
+    - django
+    - git
+    - pytest-smartcov
+  imports:
+    - monkeytype
+  commands:
+    - git clone https://github.com/Instagram/MonkeyType
+    - cd MonkeyType
+    - git checkout v{{ PKG_VERSION }}
+    - rm -rf monkeytype
+    - python -m pytest -k "not test_includes_otherwise"
+
+about:
+  home: https://github.com/Instagram/MonkeyType
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: Generating type annotations from sampled production types
+
+  description: |
+    MonkeyType collects runtime types of function arguments and return values,
+    and can automatically generate stub files or even add draft type
+    annotations directly to your Python code based on the types collected at
+    runtime.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/pytest-smartcov/meta.yaml
+++ b/recipes/pytest-smartcov/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pytest-smartcov" %}
+{% set version = "0.3" %}
+{% set sha256 = "db99c7a1a9717f5386303a528ee6bcbe8cbcb43ce08e239cfc32bd68bb1281a1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - pip
+    - python
+    - setuptools
+  run:
+    - coverage
+    - pytest
+    - python
+
+test:
+  imports:
+    - smartcov
+
+about:
+  home: https://github.com/carljm/pytest-smartcov
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Smart coverage measurement for py.test.
+
+  description: |
+    Smart coverage measurement and reporting for py.test test suites.
+
+    Test suites are usually structured parallel to (or integrated with) the
+    structure of the code they test. If you ask py.test to run a certain subset
+    of your tests, you shouldn't have to also tell coverage which subset of
+    your code it should measure coverage on for that run. With pytest-smartcov,
+    you don't have to.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/pytest-smartcov/meta.yaml
+++ b/recipes/pytest-smartcov/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/pytest-smartcov/meta.yaml
+++ b/recipes/pytest-smartcov/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - setuptools
   run:
-    - coverage >= 3.6
+    - coverage >=3.6
     - pytest
     - python
 

--- a/recipes/pytest-smartcov/meta.yaml
+++ b/recipes/pytest-smartcov/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - setuptools
   run:
-    - coverage
+    - coverage >= 3.6
     - pytest
     - python
 

--- a/recipes/pytest-smartcov/meta.yaml
+++ b/recipes/pytest-smartcov/meta.yaml
@@ -49,3 +49,4 @@ about:
 extra:
   recipe-maintainers:
     - bollwyvl
+    - nehaljwani

--- a/recipes/retype/LICENSE
+++ b/recipes/retype/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Łukasz Langa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/retype/meta.yaml
+++ b/recipes/retype/meta.yaml
@@ -16,6 +16,8 @@ build:
   skip: true  # [py2k]
   skip: true  # [py34]
   skip: true  # [py35]
+  entry_points:
+    - retype=retype:main
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -34,6 +36,7 @@ test:
   imports:
     - retype
   commands:
+    - retype --help
     - cd tests
     - python test_retype.py
 

--- a/recipes/retype/meta.yaml
+++ b/recipes/retype/meta.yaml
@@ -13,9 +13,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py2k]
-  skip: true  # [py34]
-  skip: true  # [py35]
+  skip: true  # [py<36]
   entry_points:
     - retype=retype:main
   script: python -m pip install --no-deps --ignore-installed .

--- a/recipes/retype/meta.yaml
+++ b/recipes/retype/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "retype" %}
+{% set version = "17.12.0" %}
+{% set sha256 = "b64b767befbe6f5fd918603ab7d6bbff07fc4c431bae2f471e195677a0c9b327" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [py2k]
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - pip
+    - python
+    - setuptools
+  run:
+    - click
+    - python
+    - typed-ast
+
+test:
+  source_files:
+    - tests
+  imports:
+    - retype
+  commands:
+    - cd tests
+    - python test_retype.py
+
+about:
+  home: https://github.com/ambv/retype
+  license: MIT
+  license_family: MIT
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: Re-apply type annotations from .pyi stubs to your codebase.
+
+  description: |
+    When you run retype, it goes through all files you passed as SRC, finds the
+    corresponding .pyi files in the types/ directory, and re-applies typing
+    annotations from .pyi to the sources, using the Python 3 function and
+    variable annotation syntax. The resulting combined sources are saved in
+    typed-src/.
+
+    You can also pass directories as sources, in which case retype will look
+    for .py files in them recursively.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/retype/meta.yaml
+++ b/recipes/retype/meta.yaml
@@ -39,6 +39,7 @@ about:
   home: https://github.com/ambv/retype
   license: MIT
   license_family: MIT
+  # FIXME: The upstream PR might land some time >17.12.0
   license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
   summary: Re-apply type annotations from .pyi stubs to your codebase.
 

--- a/recipes/retype/meta.yaml
+++ b/recipes/retype/meta.yaml
@@ -59,3 +59,4 @@ about:
 extra:
   recipe-maintainers:
     - bollwyvl
+    - nehaljwani

--- a/recipes/retype/meta.yaml
+++ b/recipes/retype/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: 0
   skip: true  # [py2k]
+  skip: true  # [py34]
+  skip: true  # [py35]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
Some more tools for observing and working with typed python.

- https://github.com/Instagram/MonkeyType
- https://github.com/ambv/retype
- also some testing stuff: https://github.com/carljm/pytest-smartcov

@nehaljwani, as the `mypy-feedstock` maintainer would you be interested in being added as a maintainer on any of these? Any feedback on dependency revision specs?