### PR TITLE
pyexodus feedstock

### DIFF
--- a/recipes/pyexodus/LICENSE.txt
+++ b/recipes/pyexodus/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 pyexodus developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/recipes/pyexodus/meta.yaml
+++ b/recipes/pyexodus/meta.yaml
@@ -38,7 +38,8 @@ about:
   home: https://salvushub.github.io/pyexodus/
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  # Remove with next pyexodus release.
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE.txt'
   summary: 'Create Exodus files with Python'
 
   description: |

--- a/recipes/pyexodus/meta.yaml
+++ b/recipes/pyexodus/meta.yaml
@@ -1,13 +1,6 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
 {% set name = "pyexodus" %}
 {% set version = "0.1.1" %}
 {% set sha256 = "6ff3be9bbe83af0e0443f5b0a9e23f5fe3f73f117b02c7d5a20fcbd41c91c000" %}
-# sha256 is the prefered checksum -- you can get it for a file with:
-#  `openssl sha256 <file name>`.
-# You may need the openssl package, available on conda-forge
-#  `conda install openssl -c conda-forge``
 
 package:
   name: {{ name|lower }}
@@ -16,36 +9,23 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # If getting the source from GitHub remove the line above
-  # uncomment the line below and modify as needed
-  # url: https://github.com/simplejson/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
-  # noarch: python
+  noarch: python
   number: 0
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
-    # When setuptools is available add the `--single-version-externally-managed --record record.txt` above.
     - setuptools
-    # if your project compiles code (such as a C extension) then add `toolchain` as a build requirement.
   run:
     - python
     - numpy
     - h5netcdf
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   requires:
     - pytest
     - flake8
@@ -56,20 +36,11 @@ test:
 
 about:
   home: https://salvushub.github.io/pyexodus/
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
   license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
   license_family: MIT
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
-  # XXX: conda-build somehow fails if a license file is included.
-  # license_file: LICENSE.txt
+  license_file: LICENSE.txt
   summary: 'Create Exodus files with Python'
 
-  # The remaining entries in this section are optional, but recommended
   description: |
     Pure Python module for reading and writing Exodus mesh files.
   doc_url: https://salvushub.github.io/pyexodus/
@@ -77,6 +48,4 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - krischer

--- a/recipes/pyexodus/meta.yaml
+++ b/recipes/pyexodus/meta.yaml
@@ -1,0 +1,82 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+{% set name = "pyexodus" %}
+{% set version = "0.1.1" %}
+{% set sha256 = "6ff3be9bbe83af0e0443f5b0a9e23f5fe3f73f117b02c7d5a20fcbd41c91c000" %}
+# sha256 is the prefered checksum -- you can get it for a file with:
+#  `openssl sha256 <file name>`.
+# You may need the openssl package, available on conda-forge
+#  `conda install openssl -c conda-forge``
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # If getting the source from GitHub remove the line above
+  # uncomment the line below and modify as needed
+  # url: https://github.com/simplejson/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
+  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
+  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
+  # noarch: python
+  number: 0
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  script: python setup.py install --single-version-externally-managed --record record.txt
+
+requirements:
+  build:
+    - python
+    # When setuptools is available add the `--single-version-externally-managed --record record.txt` above.
+    - setuptools
+    # if your project compiles code (such as a C extension) then add `toolchain` as a build requirement.
+  run:
+    - python
+    - numpy
+    - h5netcdf
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  requires:
+    - pytest
+    - flake8
+  imports:
+    - pyexodus
+  commands:
+    - pytest --pyargs pyexodus
+
+about:
+  home: https://salvushub.github.io/pyexodus/
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
+  license_family: MIT
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
+  # XXX: conda-build somehow fails if a license file is included.
+  # license_file: LICENSE.txt
+  summary: 'Create Exodus files with Python'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    Pure Python module for reading and writing Exodus mesh files.
+  doc_url: https://salvushub.github.io/pyexodus/
+  dev_url: https://github.com/SalvusHub/pyexodus
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - krischer


### PR DESCRIPTION
As the title says. Its a "pure Python" (still requires h5py) library to read and write Exodus mesh files.

https://github.com/SalvusHub/pyexodus