### PR TITLE
Add py-earth (continued)

### DIFF
--- a/recipes/pyearth/meta.yaml
+++ b/recipes/pyearth/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "pyearth" %}
+{% set name_pypi = "sklearn-contrib-py-earth" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "3d0f1efa5f5508610500deec0fe1084716acce1d0fc4fc81d48c52791ce7ba0c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name_pypi }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name_pypi[0] }}/{{ name_pypi }}/{{ name_pypi }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - toolchain 
+    # Notes:
+    # 1. Cython is not used in build as
+    #     a) .c files are included
+    #     b) with the current setup.py cythonizing requires an additional
+    #        parameter
+    # 2. pyearth cimports BLAS from scipy
+    #    These combinations of pinned numpy/scipy versions
+    #    are known to work, see related discussion in
+    #    conda-forge/staged-recipes#4808 and conda-forge/implicit-feedstock#4
+    - numpy 1.11.*
+    - scipy 0.18.*
+
+  run:
+    - python
+    - numpy >=1.11
+    - scipy >=0.18
+    - scikit-learn >=0.16
+
+test:
+  imports:
+    - pyearth
+
+about:
+  home: https://github.com/scikit-learn-contrib/py-earth
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: |
+            A Python implementation of Jerome Friedman's
+            Multivariate Adaptive Regression Splines
+
+  description: |
+            A Python implementation of Jerome Friedman's 
+            Multivariate Adaptive Regression Splines algorithm,
+            in the style of scikit-learn. 
+     
+  doc_url: http://contrib.scikit-learn.org/py-earth/
+  dev_url: https://github.com/scikit-learn-contrib/py-earth
+
+extra:
+  recipe-maintainers:
+    - mehdidc
+    - rth

--- a/recipes/pyearth/meta.yaml
+++ b/recipes/pyearth/meta.yaml
@@ -32,9 +32,11 @@ requirements:
     #    conda-forge/staged-recipes#4808 and conda-forge/implicit-feedstock#4
     - numpy 1.11.*
     - scipy 0.18.*
+    - six
 
   run:
     - python
+    - six
     - numpy >=1.11
     - scipy >=0.18
     - scikit-learn >=0.16

--- a/recipes/sklearn-contrib-py-earth/meta.yaml
+++ b/recipes/sklearn-contrib-py-earth/meta.yaml
@@ -1,5 +1,4 @@
-{% set name = "pyearth" %}
-{% set name_pypi = "sklearn-contrib-py-earth" %}
+{% set name = "sklearn-contrib-py-earth" %}
 {% set version = "0.1.0" %}
 {% set sha256 = "3d0f1efa5f5508610500deec0fe1084716acce1d0fc4fc81d48c52791ce7ba0c" %}
 
@@ -8,8 +7,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name_pypi }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name_pypi[0] }}/{{ name_pypi }}/{{ name_pypi }}-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
This adds the [py-earth](https://github.com/scikit-learn-contrib/py-earth) setup

Continued from https://github.com/conda-forge/staged-recipes/pull/1119 (that PR is now outdated both in the code and in the review comments regarding building with numpy).

Whether this feedstock should be called `py-earth` (as the github repo), `pyearth` (as the imported package) or something else (e.g. PyPi package name) is an open question (related to https://github.com/scikit-learn-contrib/scikit-learn-contrib/issues/27). cc @mehdidc @jcrudy