### PR TITLE
Add fswatch

### DIFF
--- a/recipes/fswatch/build.sh
+++ b/recipes/fswatch/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./configure --prefix="$PREFIX"
+make
+make check
+make install

--- a/recipes/fswatch/meta.yaml
+++ b/recipes/fswatch/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "fswatch" %}
+{% set version = "1.11.2" %}
+{% set sha256 = "b7dadb84848ce666aac0311f9b4c739fbfee6a90c6097807a1f45ad4367294c2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/emcrisostomo/fswatch/releases/download/{{ version }}/fswatch-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - toolchain
+    - libtool    # [unix]
+
+test:
+  commands:
+    - fswatch --help
+    - test -d "${PREFIX}/include/libfswatch"              # [unix]
+    - test -f "${PREFIX}/lib/libfswatch${SHLIB_EXT}"      # [unix]
+    - conda inspect linkages -p "${PREFIX}" "{{ name }}"  # [unix]
+    - conda inspect objects -p "${PREFIX}" "{{ name }}"   # [osx]
+
+about:
+  home: https://github.com/emcrisostomo/fswatch
+  license: GPL-3.0
+  license_family: GPL
+  license_file: COPYING
+  summary: |
+    "A cross-platform file change monitor with multiple backends: Apple OS X
+     File System Events, *BSD kqueue, Solaris/Illumos File Events Notification,
+     Linux inotify, Microsoft Windows and a stat()-based backend."
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Provides a recipe to build [`fswatch`]( https://github.com/emcrisostomo/fswatch ) for macOS and Linux. Should be possible to build for Windows as well; however, the directions are based off of Cygwin. So not going to tackle that for now.