### PR TITLE
Add libzip recipe

### DIFF
--- a/recipes/libzip/0001-Unhook-malloc.c-from-build.patch
+++ b/recipes/libzip/0001-Unhook-malloc.c-from-build.patch
@@ -1,0 +1,28 @@
+From be19f6b8931bc6c80072edf27d34c40bf2e34092 Mon Sep 17 00:00:00 2001
+From: Thomas Klausner <tk@giga.or.at>
+Date: Sun, 7 Jan 2018 19:56:36 +0100
+Subject: [PATCH] Unhook malloc.c from build.
+
+Not currently needed, and breaks Windows crosscompilation.
+---
+ regress/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/regress/CMakeLists.txt b/regress/CMakeLists.txt
+index 3a0d4f7..aaded89 100644
+--- a/regress/CMakeLists.txt
++++ b/regress/CMakeLists.txt
+@@ -31,8 +31,8 @@ TARGET_LINK_LIBRARIES(hole zip)
+ ADD_EXECUTABLE(ziptool_regress ziptool_regress.c ${SRC_EXTRA_FILES} source_hole.c)
+ TARGET_LINK_LIBRARIES(ziptool_regress zip)
+ 
+-ADD_LIBRARY(malloc MODULE malloc.c)
+-TARGET_LINK_LIBRARIES(malloc ${CMAKE_DL_LIBS})
++#ADD_LIBRARY(malloc MODULE malloc.c)
++#TARGET_LINK_LIBRARIES(malloc ${CMAKE_DL_LIBS})
+ ADD_LIBRARY(nonrandomopen MODULE nonrandomopen.c)
+ TARGET_LINK_LIBRARIES(nonrandomopen ${CMAKE_DL_LIBS})
+ 
+-- 
+2.16.1
+

--- a/recipes/libzip/0002-disable-nonrandomopentest-from-build.patch
+++ b/recipes/libzip/0002-disable-nonrandomopentest-from-build.patch
@@ -1,0 +1,24 @@
+diff --git a/regress/CMakeLists.txt b/regress/CMakeLists.txt
+index aaded89..ad82fb6 100644
+--- a/regress/CMakeLists.txt
++++ b/regress/CMakeLists.txt
+@@ -9,7 +9,7 @@ SET(TEST_PROGRAMS
+   add_from_filep
+   fopen_unchanged
+   fseek
+-  nonrandomopentest
++  #  nonrandomopentest
+ )
+ 
+ SET(GETOPT_USERS
+@@ -33,8 +33,8 @@ TARGET_LINK_LIBRARIES(ziptool_regress zip)
+ 
+ #ADD_LIBRARY(malloc MODULE malloc.c)
+ #TARGET_LINK_LIBRARIES(malloc ${CMAKE_DL_LIBS})
+-ADD_LIBRARY(nonrandomopen MODULE nonrandomopen.c)
+-TARGET_LINK_LIBRARIES(nonrandomopen ${CMAKE_DL_LIBS})
++# ADD_LIBRARY(nonrandomopen MODULE nonrandomopen.c)
++# TARGET_LINK_LIBRARIES(nonrandomopen ${CMAKE_DL_LIBS})
+ 
+ FOREACH(PROGRAM ${GETOPT_USERS})
+   ADD_EXECUTABLE(${PROGRAM} ${PROGRAM}.c ${SRC_EXTRA_FILES})

--- a/recipes/libzip/0003-Use-cmake-E-tar-to-extract-test-data.patch
+++ b/recipes/libzip/0003-Use-cmake-E-tar-to-extract-test-data.patch
@@ -1,0 +1,36 @@
+From e9244b207c0fc883ff84c1fc46602feb1e2b0347 Mon Sep 17 00:00:00 2001
+From: Thomas Klausner <tk@giga.or.at>
+Date: Wed, 3 Jan 2018 11:41:57 +0100
+Subject: [PATCH] Use 'cmake -E tar' to extract test data.
+
+For easier cross-compilation (Github issue #21).
+---
+ regress/CMakeLists.txt | 12 +++---------
+ 1 file changed, 3 insertions(+), 9 deletions(-)
+
+diff --git a/regress/CMakeLists.txt b/regress/CMakeLists.txt
+index e2ce232..3a0d4f7 100644
+--- a/regress/CMakeLists.txt
++++ b/regress/CMakeLists.txt
+@@ -51,15 +51,9 @@ ADD_CUSTOM_TARGET(cleanup
+ ADD_CUSTOM_TARGET(testinput
+   ALL
+   VERBATIM
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 0 > manyfiles.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 1 > manyfiles-133000.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 2 > manyfiles-65536.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 3 > manyfiles-zip64-modulo.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 4 > manyfiles-zip64.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 5 > manyfiles-fewer.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip cat 6 > manyfiles-more.zip
+-  COMMAND ziptool ${CMAKE_CURRENT_SOURCE_DIR}/bigzero-zip.zip cat 0 > bigzero.zip
+-  DEPENDS ziptool ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip ${CMAKE_CURRENT_SOURCE_DIR}/bigzero-zip.zip
++  COMMAND cmake -E tar x ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip
++  COMMAND cmake -E tar x ${CMAKE_CURRENT_SOURCE_DIR}/bigzero-zip.zip
++  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/manyfiles-zip.zip ${CMAKE_CURRENT_SOURCE_DIR}/bigzero-zip.zip
+ )
+ 
+ SET_PROPERTY(DIRECTORY PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+-- 
+2.16.1
+

--- a/recipes/libzip/bld.bat
+++ b/recipes/libzip/bld.bat
@@ -1,0 +1,13 @@
+@echo on
+mkdir build
+if errorlevel 1 exit /B 1
+cd build
+if errorlevel 1 exit /B 1
+
+cmake -G "NMake Makefiles" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    ..
+if errorlevel 1 exit /B 1
+
+cmake --build . --target INSTALL --config Release
+if errorlevel 1 exit /B 1

--- a/recipes/libzip/build.bat
+++ b/recipes/libzip/build.bat
@@ -1,0 +1,15 @@
+@echo on
+mkdir build
+if errorlevel 1 exit /B 1
+cd build
+if errorlevel 1 exit /B 1
+
+cmake -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ..
+if errorlevel 1 exit /B 1
+
+nmake
+if errorlevel 1 exit /B 1
+nmake test
+if errorlevel 1 exit /B 1
+nmake install
+if errorlevel 1 exit /B 1

--- a/recipes/libzip/build.sh
+++ b/recipes/libzip/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir build && cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX ..
+make
+make test
+make install

--- a/recipes/libzip/meta.yaml
+++ b/recipes/libzip/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "libzip" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "759a89690e155ca52247638b9f97e16e48fbb6077abb7ce2d921dd5b81259940" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://libzip.org/download/libzip-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    # This disables the "malloc" test which also doesn't compile on Windows.
+    # This patch is taken from a commit post 1.4.0 release
+    - 0001-Unhook-malloc.c-from-build.patch  # [win]
+    # This disables a test that the library developers had disabled at one point
+    # https://github.com/nih-at/libzip/commit/57b97e9f069f8f9164ec6877bc00edb00cdb85b3
+    # Disabling for our build for now, pending fix or removal in library
+    - 0002-disable-nonrandomopentest-from-build.patch  # [win]
+    - 0003-Use-cmake-E-tar-to-extract-test-data.patch  # [win]
+
+build:
+  number: 0
+  features:
+    - vc9   # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and py35]
+    - vc14  # [win and py36]
+
+requirements:
+  build:
+    - cmake
+    - zlib
+    - bzip2
+    - python  # [win]
+    - vc 9   # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py35]
+    - vc 14  # [win and py36]
+    # perl is needed to run the package tests
+    - perl
+  run:
+    - zlib
+    - bzip2
+    - vc 9   # [win and py27]
+    - vc 10  # [win and py34]
+    - vc 14  # [win and py35]
+    - vc 14  # [win and py36]
+
+test:
+  commands:
+    - test -f ${PREFIX}/bin/ziptool  # [linux or osx]
+    - test -f ${PREFIX}/lib/libzip.so  # [linux]
+    - test -f ${PREFIX}/lib/libzip.dylib  # [osx]
+    - if not exist %LIBRARY_BIN%\\ziptool.exe exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\zip.lib exit 1  # [win]
+
+about:
+  home: https://libzip.org/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'A C library for reading, creating, and modifying zip archives.'
+  description: |
+      libzip is a C library for reading, creating, and modifying zip archives.
+      Files can be added from data buffers, files, or compressed data copied
+      directly from other zip archives. Changes made without closing the
+      archive can be reverted. The API is documented by man pages.
+  doc_url: https://libzip.org/documentation/
+  dev_url: https://github.com/nih-at/libzip
+
+extra:
+  recipe-maintainers:
+    - ceholden


### PR DESCRIPTION
Add recipe for [libzip](https://libzip.org/), a C library for reading/writing/modifying zip archives. This recipe is being added primarily as a dependency for upgrading to QGIS 3 (see https://github.com/conda-forge/qgis-feedstock/issues/17).