### PR TITLE
Added recipe for r-multipanelfigure

### DIFF
--- a/recipes/r-multipanelfigure/bld.bat
+++ b/recipes/r-multipanelfigure/bld.bat
@@ -1,0 +1,8 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1
+
+@rem Add more build steps here, if they are necessary.
+
+@rem See
+@rem http://docs.continuum.io/conda/build.html
+@rem for a list of environment variables that are set during the build process.

--- a/recipes/r-multipanelfigure/bld.bat
+++ b/recipes/r-multipanelfigure/bld.bat
@@ -1,8 +1,0 @@
-"%R%" CMD INSTALL --build .
-if errorlevel 1 exit 1
-
-@rem Add more build steps here, if they are necessary.
-
-@rem See
-@rem http://docs.continuum.io/conda/build.html
-@rem for a list of environment variables that are set during the build process.

--- a/recipes/r-multipanelfigure/build.sh
+++ b/recipes/r-multipanelfigure/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# R refuses to build packages that mark themselves as Priority: Recommended
+mv DESCRIPTION DESCRIPTION.old
+grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+
+$R CMD INSTALL --build .
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/r-multipanelfigure/meta.yaml
+++ b/recipes/r-multipanelfigure/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = '0.10.6' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-multipanelfigure
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: multipanelfigure_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/multipanelfigure_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/multipanelfigure/multipanelfigure_{{ version }}.tar.gz
+  sha256: 037a447bbcdce331fb0a2fa69f4857e505ef1136b9bfea831b6a79bbac72a3ec
+
+build:
+  skip: True  # [win or osx]
+  number: 0
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_7
+    - r-assertive.files >=0.0_2
+    - r-assertive.numbers >=0.0_2
+    - r-assertive.properties >=0.0_4
+    - r-assertive.types >=0.0_3
+    - r-catools >=1.17.1
+    - r-ggplot2 >=2.2.1
+    - r-gridgraphics >=0.2
+    - r-gtable >=0.2.0
+    - r-jpeg >=0.1_8
+    - r-magrittr >=1.5
+    - r-png >=0.1_7
+    - r-rsvg >=1.1
+    - r-tiff >=0.1_5
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_7
+    - r-assertive.files >=0.0_2
+    - r-assertive.numbers >=0.0_2
+    - r-assertive.properties >=0.0_4
+    - r-assertive.types >=0.0_3
+    - r-catools >=1.17.1
+    - r-ggplot2 >=2.2.1
+    - r-gridgraphics >=0.2
+    - r-gtable >=0.2.0
+    - r-jpeg >=0.1_8
+    - r-magrittr >=1.5
+    - r-png >=0.1_7
+    - r-rsvg >=1.1
+    - r-tiff >=0.1_5
+
+test:
+  commands:
+    - $R -e "library('multipanelfigure')"  # [not win]
+    - "\"%R%\" -e \"library('multipanelfigure')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=multipanelfigure
+  license: GPL (>= 3)
+  summary: Tools to create a layout for figures made of multiple panels, and to fill the panels
+    with base, 'lattice', 'ggplot2' and 'ComplexHeatmap' plots, grobs, and PNG, JPEG,
+    SVG and TIFF images.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - jenzopr

--- a/recipes/r-multipanelfigure/meta.yaml
+++ b/recipes/r-multipanelfigure/meta.yaml
@@ -69,6 +69,8 @@ about:
     with base, 'lattice', 'ggplot2' and 'ComplexHeatmap' plots, grobs, and PNG, JPEG,
     SVG and TIFF images.
   license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Hi all,

at least for Linux, all dependencies of r-multipanelfigure are available from conda-forge. 
The biggest problem was r-rsvg, which is currently not available for win/osx. However, I will continue to try to make it work on both missing platforms.

Multipanelfigure provides functions to create a layout for figures made of multiple panels, and to fill the panels with base, lattice and ggplot2 plots, grobs, and PNG, JPEG, and TIFF images. Panels are flexible in size and (rectangular) shape and their borders and labels can be adjusted. It does a great job for creating scripted (and therefore reproducible) figures for publications.

Best,
Jens  