### PR TITLE
[skip appveyor] Add llvm-meta

### DIFF
--- a/recipes/llvm-meta/meta.yaml
+++ b/recipes/llvm-meta/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: llvm-meta
+  version: 5.0.0
+
+build:
+  noarch: generic
+  number: 0
+
+test:
+  commands:
+    - echo 'Meta package for tracking llvm version'
+
+about:
+  home: http://github.com/conda-forge/llvm-meta-feedstock
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: 'Meta package for tracking llvm version'
+
+extra:
+  recipe-maintainers:
+    - isuruf


### PR DESCRIPTION
This is a poor man's version of run_constrained for the llvm packages since it's going to take some time for conda 4.4 to be widely available.

cc @jakirkham 