### PR TITLE
conda 4.4: config and downgrade in subshell

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -19,18 +19,22 @@ echo ""
 echo "Installing a fresh version of Miniconda."
 curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
+(
+    source ~/miniconda/bin/activate root
+
+    # Configure conda.
+    echo ""
+    echo "Configuring conda."
+    conda config --set show_channel_urls true
+    conda config --set auto_update_conda false
+    conda config --set add_pip_as_python_dependency false
+    conda config --add channels conda-forge
+
+    unset conda
+    conda update -n root --yes --quiet conda conda-env
+)
 source ~/miniconda/bin/activate root
 
-# Configure conda.
-echo ""
-echo "Configuring conda."
-conda config --set show_channel_urls true
-conda config --set auto_update_conda false
-conda config --set add_pip_as_python_dependency false
-conda config --add channels conda-forge
-
-unset conda
-conda update -n root --yes --quiet conda conda-env
 conda install --yes --quiet git=2.12.2
 conda install -n root --yes --quiet jinja2 anaconda-client
 conda install --yes --quiet conda-build=2 conda-smithy


### PR DESCRIPTION
followup to https://github.com/conda-forge/staged-recipes/pull/5241#issuecomment-367361369.

The cleanest solution for now would be to just
```
curl -L https://repo.continuum.io/miniconda/Miniconda2-4.3.31-Linux-x86_64.sh > ~/miniconda.sh
```
. If you don't want that, then you could use the changes from this PR: Activate the 4.4 environment in a subshell so that we don't mix and match 4.4/4.3 and also don't have remnants from the 4.4 activation afterwards.