### PR TITLE
Temporarily disable trace of shell commands

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -42,7 +42,9 @@ conda install --yes --quiet conda-build=2 conda-smithy
 conda info
 conda config --get
 
+set +x
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
+set -x
 
 python .travis_scripts/create_feedstocks.py


### PR DESCRIPTION
Follow up to PR ( https://github.com/conda-forge/staged-recipes/pull/5238 )

Travis CI does a good job of hiding this anyways. Still we should be careful not to have this accidentally echoing in the log.

cc @isuruf