### PR TITLE
add tableone for python

### DIFF
--- a/recipes/tableone/meta.yaml
+++ b/recipes/tableone/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "tableone" %}
+{% set version = "0.4.8" %}
+{% set sha256 = "63c6d55a7bc0010ced0a6b1e88f295ce41fd93d9f8a473e14cf1c760c93a27b1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+
+  run:
+    - python
+    - pandas
+    - numpy
+    - scipy
+
+test:
+  imports:
+    - tableone
+
+about:
+  home: http://github.com/tompollard/tableone
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Create Table 1 for research papers in Python'
+  description: |
+    tableone is a package for creating Table 1 for research papers
+    in Python.
+  doc_url: http://tableone.readthedocs.io/
+  dev_url: https://github.com/tompollard/tableone
+
+extra:
+  recipe-maintainers:
+    - tompollard
+    - alistairewj


### PR DESCRIPTION
Adds recipe for tableone, a Python package for creating Table 1 summary statistics for scientific research papers. See: https://github.com/tompollard/tableone