### PR TITLE
Add tslearn

### DIFF
--- a/recipes/tslearn/LICENSE
+++ b/recipes/tslearn/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2017, Romain Tavenard
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/tslearn/meta.yaml
+++ b/recipes/tslearn/meta.yaml
@@ -29,16 +29,9 @@ requirements:
     - scikit-learn
 
 test:
-  requires:
-    - pytest
   imports:
     - tslearn
     - tslearn.metrics
-  commands:
-    - pytest --doctest-modules
-             --ignore tslearn/docs/
-             --ignore tslearn/shapelets.py
-             -k 'not SVC and not SVR' tslearn
 
 about:
   home: http://tslearn.readthedocs.io/

--- a/recipes/tslearn/meta.yaml
+++ b/recipes/tslearn/meta.yaml
@@ -29,9 +29,16 @@ requirements:
     - scikit-learn
 
 test:
+  requires:
+    - pytest
   imports:
     - tslearn
     - tslearn.metrics
+  commands:
+    - pytest --doctest-modules \
+             --ignore tslearn/docs/ \
+             --ignore tslearn/shapelets.py \
+             -k 'not SVC and not SVR' tslearn
 
 about:
   home: http://tslearn.readthedocs.io/

--- a/recipes/tslearn/meta.yaml
+++ b/recipes/tslearn/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "tslearn" %}
+{% set version = "0.1.10.8" %}
+{% set sha256 = "7b1e22f93c107884fb104d5d25d37eb8772a341aeab91b3a22ce6d860ef4cde8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - toolchain
+    - cython
+    - numpy 1.11.*
+  run:
+    - python
+    - numpy >=1.11
+    - scipy
+    - scikit-learn
+
+
+test:
+  imports:
+    - tslearn
+    - tslearn.metrics
+
+about:
+    home: http://tslearn.readthedocs.io/
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: 'A machine learning toolkit dedicated to time-series data '
+  description: |
+      tslearn is a Python package that provides machine learning tools
+      for the analysis of time series. This package builds on
+      scikit-learn, numpy and scipy libraries.
+  doc_url: http://tslearn.readthedocs.io/
+  dev_url: https://github.com/rtavenar/tslearn
+
+extra:
+  recipe-maintainers:
+    - rth

--- a/recipes/tslearn/meta.yaml
+++ b/recipes/tslearn/meta.yaml
@@ -28,18 +28,17 @@ requirements:
     - scipy
     - scikit-learn
 
-
 test:
   imports:
     - tslearn
     - tslearn.metrics
 
 about:
-    home: http://tslearn.readthedocs.io/
+  home: http://tslearn.readthedocs.io/
   license: BSD-2-Clause
   license_family: BSD
   license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
-  summary: 'A machine learning toolkit dedicated to time-series data '
+  summary: 'A machine learning toolkit dedicated to time-series data'
   description: |
       tslearn is a Python package that provides machine learning tools
       for the analysis of time series. This package builds on

--- a/recipes/tslearn/meta.yaml
+++ b/recipes/tslearn/meta.yaml
@@ -35,9 +35,9 @@ test:
     - tslearn
     - tslearn.metrics
   commands:
-    - pytest --doctest-modules \
-             --ignore tslearn/docs/ \
-             --ignore tslearn/shapelets.py \
+    - pytest --doctest-modules
+             --ignore tslearn/docs/
+             --ignore tslearn/shapelets.py
              -k 'not SVC and not SVR' tslearn
 
 about:


### PR DESCRIPTION
This adds [tslearn](https://github.com/rtavenar/tslearn) -- a machine learning toolkit dedicated to time-series data 

keras is an optional dependency (needed for just one module). I decided not to add it by default, as it will pull tensorflow on Unix which is a pretty heavy dependency and only a fraction of users of this package need the corresponding functionality.