### PR TITLE
Adding msrest and msrestazure

### DIFF
--- a/recipes/adal/meta.yaml
+++ b/recipes/adal/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "adal" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "120821f72ca9d59a7c7197fc14d0e27448ff8d331fae230f92d713b9b5c721f7" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - pyjwt >=1.0.0
+    - requests >=2.0.0
+    - python-dateutil >=2.1.0
+    - cryptography >=1.1.0
+
+test:
+  imports:
+    - adal
+
+about:
+  home: https://github.com/AzureAD/azure-activedirectory-library-for-python
+  license: MIT
+  license_family: MIT
+  summary: | 
+  The ADAL for Python library makes it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources.

--- a/recipes/adal/meta.yaml
+++ b/recipes/adal/meta.yaml
@@ -13,13 +13,12 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - pip
   run:
     - python
     - pyjwt >=1.0.0

--- a/recipes/adal/meta.yaml
+++ b/recipes/adal/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - pyjwt >=1.0.0

--- a/recipes/adal/meta.yaml
+++ b/recipes/adal/meta.yaml
@@ -35,3 +35,8 @@ about:
   license: MIT
   license_family: MIT
   summary: The ADAL for Python library makes it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources.
+  
+extra:
+  recipe-maintainers:
+    - ivoflipse
+    - Korijn

--- a/recipes/adal/meta.yaml
+++ b/recipes/adal/meta.yaml
@@ -34,5 +34,4 @@ about:
   home: https://github.com/AzureAD/azure-activedirectory-library-for-python
   license: MIT
   license_family: MIT
-  summary: | 
-  The ADAL for Python library makes it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources.
+  summary: The ADAL for Python library makes it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources.

--- a/recipes/adal/meta.yaml
+++ b/recipes/adal/meta.yaml
@@ -13,12 +13,14 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - pyjwt >=1.0.0
@@ -34,7 +36,9 @@ about:
   home: https://github.com/AzureAD/azure-activedirectory-library-for-python
   license: MIT
   license_family: MIT
-  summary: The ADAL for Python library makes it easy for python application to authenticate to Azure Active Directory (AAD) in order to access AAD protected web resources.
+  summary: |
+    The ADAL for Python library makes it easy for python application to authenticate 
+    to Azure Active Directory (AAD) in order to access AAD protected web resources.
   
 extra:
   recipe-maintainers:

--- a/recipes/msrest/meta.yaml
+++ b/recipes/msrest/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "msrest" %}
+{% set version = "0.4.26" %}
+{% set sha256 = "388294f55127102b770f6fd633b6971af56c0f3b20fdce151be1ae22ac0b9e8b" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - requests >=2.14
+    - requests-oauthlib >=0.5.0
+    - isodate >=0.6.0
+    - certifi >=2017.4.17
+test:
+  imports:
+    - msrest
+    - msrest.authentication
+    - msrest.exceptions
+    - msrest.pipeline
+
+about:
+  home: https://github.com/Azure/msrest-for-python
+  license: MIT
+  license_family: MIT
+  summary: AutoRest swagger generator Python client runtime.
+  
+extra:
+  recipe-maintainers:
+    - ivoflipse
+    - Korijn

--- a/recipes/msrest/meta.yaml
+++ b/recipes/msrest/meta.yaml
@@ -13,13 +13,12 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - pip
   run:
     - python
     - requests >=2.14

--- a/recipes/msrest/meta.yaml
+++ b/recipes/msrest/meta.yaml
@@ -13,12 +13,14 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - requests >=2.14

--- a/recipes/msrest/meta.yaml
+++ b/recipes/msrest/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - requests >=2.14

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "msrestazure" %}
+{% set version = "0.4.26" %}
+{% set sha256 = "229713ee9603596d9ac9ad8f4f1cc09897395316405f612e4b58bf9cfa8146cb" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - msrest >=0.4.25
+    - keyring >=5.6
+    - adal ~=0.5.0
+test:
+  imports:
+    - msrestazure
+    - msrestazure.azure_active_directory
+    - msrestazure.azure_exceptions
+    - msrestazure.azure_operation
+
+about:
+  home: https://github.com/Azure/msrestazure-for-python
+  license: MIT
+  license_family: MIT
+  summary: The runtime library "msrestazure" for AutoRest generated Python clients
+  
+extra:
+  recipe-maintainers:
+    - ivoflipse
+    - Korijn

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -13,12 +13,14 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - msrest >=0.4.25

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
   build:

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "msrestazure" %}
-{% set version = "0.4.26" %}
+{% set version = "0.4.22" %}
 {% set sha256 = "229713ee9603596d9ac9ad8f4f1cc09897395316405f612e4b58bf9cfa8146cb" %}
 
 package:

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - msrest >=0.4.25
     - keyring >=5.6
-    - adal ~=0.5.0
+    - adal >=0.5.0
 test:
   imports:
     - msrestazure

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -13,13 +13,12 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - python
     - setuptools
-    - pip
   run:
     - python
     - msrest >=0.4.25

--- a/recipes/msrestazure/meta.yaml
+++ b/recipes/msrestazure/meta.yaml
@@ -19,6 +19,7 @@ requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - msrest >=0.4.25


### PR DESCRIPTION
In order to fix the recipes for azure-mgmt-* we need msrestazure, which in turn needs mrest. See https://github.com/conda-forge/azure-mgmt-storage-feedstock/pull/5