### PR TITLE
readd diffoscope

### DIFF
--- a/recipes/diffoscope/build.sh
+++ b/recipes/diffoscope/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export PYTHONHASHSEED=0
+
+python setup.py install --single-version-externally-managed --record record.txt

--- a/recipes/diffoscope/meta.yaml
+++ b/recipes/diffoscope/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "diffoscope" %}
+{% set version = "91" %}
+{% set sha256 = "17fe87134a501ebbb3eab3a83fac74f424fb3409689880e83f32e892c13c9093" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 1
+  skip: true  # [win or py2k]
+  entry_points:
+    - diffoscope = diffoscope.main:main
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - python-libarchive-c
+    - python-magic
+    - setuptools
+
+test:
+  imports:
+    - diffoscope
+  commands:
+    - diffoscope --help
+    - diffoscope --list-tools
+    - diffoscope --version
+
+about:
+  home: https://diffoscope.org
+  license: GPL-3.0
+  summary: in-depth comparison of files, archives, and directories
+  license_family: GPL
+  license_file: COPYING
+  dev_url: https://anonscm.debian.org/cgit/reproducible/diffoscope.git
+  description: >
+    diffoscope will try to get to the bottom of what makes files or
+    directories different. It will recursively unpack archives of many kinds
+    and transform various binary formats into more human readable form to
+    compare them. It can compare two tarballs, ISO images, or PDF just as
+    easily.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Had some [key issues](https://github.com/conda-forge/diffoscope-feedstock/issues/5), and found at the the bottom of the issue stack that it was because the CircleCI key is bad... figured this would rekick that!