### PR TITLE
add pivy

### DIFF
--- a/recipes/pivy/bld.bat
+++ b/recipes/pivy/bld.bat
@@ -1,2 +1,4 @@
+SET GENERATOR=Ninja
+
 %PYTHON% setup.py clean
 %PYTHON% setup.py install

--- a/recipes/pivy/bld.bat
+++ b/recipes/pivy/bld.bat
@@ -1,4 +1,8 @@
-SET GENERATOR=Visual Studio 14 2015 Win64
+if [ "$ARCH" == "64" ]; then  
+	SET GENERATOR=Visual Studio 14 2015 Win64
+else
+	SET GENERATOR=Visual Studio 14 2015 Win32
+fi
 
 %PYTHON% setup.py clean
 %PYTHON% setup.py install

--- a/recipes/pivy/bld.bat
+++ b/recipes/pivy/bld.bat
@@ -1,0 +1,4 @@
+SET GENERATOR=Visual Studio 14 2015 Win64
+
+%PYTHON% setup.py clean
+%PYTHON% setup.py install

--- a/recipes/pivy/bld.bat
+++ b/recipes/pivy/bld.bat
@@ -1,8 +1,2 @@
-if [ "$ARCH" == "64" ]; then  
-	SET GENERATOR=Visual Studio 14 2015 Win64
-else
-	SET GENERATOR=Visual Studio 14 2015 Win32
-fi
-
 %PYTHON% setup.py clean
 %PYTHON% setup.py install

--- a/recipes/pivy/build.sh
+++ b/recipes/pivy/build.sh
@@ -1,0 +1,2 @@
+$PYTHON setup.py clean
+$PYTHON setup.py install

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -30,6 +30,7 @@ requirements:
         - coin3d
         - qt 5.6.*
         - pyside2
+        - libglu  # [linux]
         # - soqt
 
 test:

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -28,6 +28,8 @@ requirements:
         - libgcc  # [unix]
         - python
         - coin3d
+        - qt 5.6.*
+        - pyside2
         # - soqt
 
 test:

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -17,6 +17,7 @@ requirements:
         - nomkl  # [unix]
         - vc 14  # [win]
         - gcc  # [unix]
+        - msinttypes  # [win]
         - cmake
         - python
         - swig  3.0.8

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
     fn: pivy.tar.gz
     url: https://github.com/FreeCAD/pivy/archive/master.tar.gz
-    sha256: 8059aa5811d4a15c874983abed8a02e3956804326e9a65e5a9773d34ebbf8a9b
+    sha256: c53f549eb348ba1d1800e8e44b3be5c63a2992036c5292430b727179a20fd635
 
 
 build:
@@ -41,7 +41,7 @@ test:
 
 about:
     home: https://github.com/FreeCAD/pivy
-    license: ISC License
+    license: BSD
     license_family: BSD
     license_file: LICENSE
     summary: python bindings to coin3d.

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pivy" %}
-{% set version = "0.6.4-beta1" %}
-{% set sha256 = "ef335defece8d57c33534a7b04e9e484f2dae07a63f454d4f7703d682ae542f9" %}
+{% set version = "0.6.4b1" %}
+{% set sha256 = "98743d0daa3b7aaaf33bb055035cf5141679a5ec6f237c4a8ee3c40d594f3510" %}
 
 package:
     name: {{ name }}

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -1,8 +1,6 @@
-
 {% set name = "pivy" %}
-{% set version = "0.6.3" %}
-{% set commit = "6502b59ef12f193d5c36e48f07a3451ef7432a75" %}
-{% set sha256 = "d71e2275fa2b3d2659d0403e5b183c3433ebfa524d356696d682ac048a483058" %}
+{% set version = "0.6.4-beta1" %}
+{% set sha256 = "ef335defece8d57c33534a7b04e9e484f2dae07a63f454d4f7703d682ae542f9" %}
 
 package:
     name: {{ name }}
@@ -10,7 +8,7 @@ package:
 
 source:
     fn: {{ name }}.tar.gz
-    url: https://github.com/FreeCAD/pivy/archive/{{ commit }}.tar.gz
+    url: https://github.com/FreeCAD/pivy/archive/{{ version }}.tar.gz
     sha256: {{ sha256 }}
 
 
@@ -53,7 +51,7 @@ test:
 
 about:
     home: https://github.com/FreeCAD/pivy
-    license: BSD
+    license: ISC
     license_family: BSD
     license_file: LICENSE
     summary: python bindings to coin3d.

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -4,8 +4,8 @@ package:
 
 source:
     fn: pivy.tar.gz
-    url: https://github.com/FreeCAD/pivy/archive/master.zip
-    sha256: 4be58af5b5a72c987412a314a96db2dc8d3581c2a2cd019e158a548f16c7fa5b
+    url: https://github.com/FreeCAD/pivy/archive/master.tar.gz
+    sha256: 8059aa5811d4a15c874983abed8a02e3956804326e9a65e5a9773d34ebbf8a9b
 
 
 build:
@@ -36,13 +36,13 @@ test:
         # - pivy.gui.soqt
 
 about:
-    home: https://github.com/looooo/pivy
+    home: https://github.com/FreeCAD/pivy
     license: ISC License
     license_family: BSD
     license_file: LICENSE
     summary: python bindings to coin3d.
-    doc_url: https://github.com/looooo/pivy
-    dev_url: https://github.com/looooo/pivy
+    doc_url: https://github.com/FreeCAD/pivy
+    dev_url: https://github.com/FreeCAD/pivy
 
 extra:
     recipe-maintainers:

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
     fn: pivy.tar.gz
     url: https://github.com/FreeCAD/pivy/archive/6502b59ef12f193d5c36e48f07a3451ef7432a75.tar.gz
-    sha256: b091e3e545d87dfc29ea7de8031c35c62440586a73ed124e51eae8e3e965fe24
+    sha256: d71e2275fa2b3d2659d0403e5b183c3433ebfa524d356696d682ac048a483058
 
 
 build:

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -1,11 +1,17 @@
+
+{% set name = "pivy" %}
+{% set version = "0.6.3" %}
+{% set commit = "6502b59ef12f193d5c36e48f07a3451ef7432a75" %}
+{% set sha256 = "d71e2275fa2b3d2659d0403e5b183c3433ebfa524d356696d682ac048a483058" %}
+
 package:
-    name: pivy
-    version: 0.6.3
+    name: {{ name }}
+    version: {{ version }}
 
 source:
-    fn: pivy.tar.gz
-    url: https://github.com/FreeCAD/pivy/archive/6502b59ef12f193d5c36e48f07a3451ef7432a75.tar.gz
-    sha256: d71e2275fa2b3d2659d0403e5b183c3433ebfa524d356696d682ac048a483058
+    fn: {{ name }}.tar.gz
+    url: https://github.com/FreeCAD/pivy/archive/{{ commit }}.tar.gz
+    sha256: {{ sha256 }}
 
 
 build:

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -1,0 +1,49 @@
+package:
+    name: pivy
+    version: 0.6.3
+
+source:
+    fn: pivy.tar.gz
+    url: https://github.com/FreeCAD/pivy/archive/master.zip
+    sha256: 4be58af5b5a72c987412a314a96db2dc8d3581c2a2cd019e158a548f16c7fa5b
+
+
+build:
+    number: 0
+
+requirements:
+    build:
+        - toolchain
+        - nomkl  # [unix]
+        - vc 14  # [win]
+        - gcc  # [unix]
+        - cmake
+        - python
+        - swig  3.0.8
+        - coin3d
+        - colorama
+        # - soqt
+    run:
+        - vc 14  # [win]
+        - libgcc  # [unix]
+        - python
+        - coin3d
+        # - soqt
+
+test:
+    imports:
+        - pivy.coin
+        # - pivy.gui.soqt
+
+about:
+    home: https://github.com/looooo/pivy
+    license: ISC License
+    license_family: BSD
+    license_file: LICENSE
+    summary: python bindings to coin3d.
+    doc_url: https://github.com/looooo/pivy
+    dev_url: https://github.com/looooo/pivy
+
+extra:
+    recipe-maintainers:
+        - looooo

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -52,7 +52,6 @@ test:
 about:
     home: https://github.com/FreeCAD/pivy
     license: ISC
-    license_family: BSD
     license_file: LICENSE
     summary: python bindings to coin3d.
     doc_url: https://github.com/FreeCAD/pivy

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -10,6 +10,10 @@ source:
 
 build:
     number: 0
+    skip: true  # [(win and not py36)]
+
+    features:
+        - vc14  # [(win and py36)]
 
 requirements:
     build:

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -5,7 +5,7 @@ package:
 source:
     fn: pivy.tar.gz
     url: https://github.com/FreeCAD/pivy/archive/master.tar.gz
-    sha256: c53f549eb348ba1d1800e8e44b3be5c63a2992036c5292430b727179a20fd635
+    sha256: b091e3e545d87dfc29ea7de8031c35c62440586a73ed124e51eae8e3e965fe24
 
 
 build:
@@ -23,6 +23,7 @@ requirements:
         - swig  3.0.8
         - coin3d
         - colorama
+        - qt 5.6*
         # - soqt
     run:
         - vc 14  # [win]

--- a/recipes/pivy/meta.yaml
+++ b/recipes/pivy/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
     fn: pivy.tar.gz
-    url: https://github.com/FreeCAD/pivy/archive/master.tar.gz
+    url: https://github.com/FreeCAD/pivy/archive/6502b59ef12f193d5c36e48f07a3451ef7432a75.tar.gz
     sha256: b091e3e545d87dfc29ea7de8031c35c62440586a73ed124e51eae8e3e965fe24
 
 
@@ -23,6 +23,7 @@ requirements:
         - swig  3.0.8
         - coin3d
         - colorama
+        - ninja
         - qt 5.6*
         # - soqt
     run:

--- a/recipes/pivy/yum_requirements.yaml
+++ b/recipes/pivy/yum_requirements.yaml
@@ -1,0 +1,4 @@
+libXt-devel
+libXmu-devel
+libXi-devel
+mesa-libGLU-devel

--- a/recipes/pivy/yum_requirements.yaml
+++ b/recipes/pivy/yum_requirements.yaml
@@ -1,4 +1,0 @@
-libXt-devel
-libXmu-devel
-libXi-devel
-mesa-libGLU-devel


### PR DESCRIPTION
optionally depends on soqt...

this version uses a fork of the origin project: https://bitbucket.org/Coin3D/pivy
but has somehow divorced to support python3 and qt5. 