### PR TITLE
[wip] Add fakechroot to conda-forge

### DIFF
--- a/recipes/fakechroot/build.sh
+++ b/recipes/fakechroot/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+./autogen.sh
+./configure --prefix $PREFIX
+
+make -j $CPU_COUNT
+set +e
+make check
+cat test/test-suite.log
+set -e
+
+make install
+

--- a/recipes/fakechroot/build.sh
+++ b/recipes/fakechroot/build.sh
@@ -6,5 +6,4 @@ set -e -o pipefail
 ./configure --prefix $PREFIX
 
 make -j $CPU_COUNT
-
 make install

--- a/recipes/fakechroot/meta.yaml
+++ b/recipes/fakechroot/meta.yaml
@@ -20,8 +20,6 @@ requirements:
     - toolchain
     - libtool >=2.0
     - automake >=1.10
-  run:
-    - fakeroot
 
 test:
   commands:

--- a/recipes/fakechroot/meta.yaml
+++ b/recipes/fakechroot/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "fakechroot" %}
+{% set version = "2.19" %}
+{% set sha256 = "39ffbbbe3a823be7450928b8e3b99ae4cb339c47213b2f1d8ff903e0246f2e15" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/dex4er/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - toolchain
+    - libtool >=2.0
+    - automake >=1.10
+  run:
+    - fakeroot
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX {{ name }}  # [not win]
+    - fakechroot -v
+
+about:
+  home: http://github.com/dex4er/fakechroot
+  license: LGPL-2.1
+  license_family: LGPL
+  license_file: LICENSE
+  summary: 'fakechroot runs a command in an environment without requiring root privileges'
+
+  description: |
+    fakechroot runs a command in an environment were is additional possibility 
+    to use chroot(8) command without root privileges. This is useful for 
+    allowing users to create own chrooted environment with possibility to 
+    install another packages without need for root privileges.
+  dev_url: http://github.com/dex4er/fakechroot
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/fakeroot-ng/build.sh
+++ b/recipes/fakeroot-ng/build.sh
@@ -2,9 +2,7 @@
 
 set -e -o pipefail
 
-./autogen.sh
-./configure --prefix $PREFIX
+./configure --prefix=$PREFIX --with-mem-dir=/dev/shm
 
 make -j $CPU_COUNT
-
 make install

--- a/recipes/fakeroot-ng/meta.yaml
+++ b/recipes/fakeroot-ng/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "fakeroot-ng" %}
+{% set version = "0.18" %}
+{% set sha256 = "189eacda630752980d40e34b2c01ce23d839daab3d691a4706bb9eac79f7e144" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  # arhived versions url: https://sourceforge.net/projects/fakerootng/files/{{ name }}/{{ version }}/{{ name }}-{{ version }}.tar.gz/download
+  url: https://sourceforge.net/projects/fakerootng/files/{{ name }}/{{ name }}-{{ version }}.tar.gz/download
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - toolchain
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX {{ name }}  # [not win]
+    - whoami | grep -v -c 'root' >/dev/null
+    - fakeroot-ng bash -c 'whoami' | grep -c 'root' >/dev/null
+
+about:
+  home: https://fakeroot-ng.lingnu.com
+  license: LGPL-2.1
+  license_family: LGPL
+  license_file: COPYING
+  summary: 'Fakeroot-ng is a clean re-implementation of fakeroot'
+
+  description: |
+    Fakeroot-ng is a clean re-implementation of fakeroot. The core idea is 
+    to run a program, but wrap all system calls that program performs so 
+    that it thinks it is running as root, while it is, in practice, running 
+    as an unprivileged user. When the program is trying to perform a privileged 
+    operation (such as modifying a file's owner or creating a block device), 
+    this operation is emulated, so that an unprivileged operation is actually 
+    carried out, but the result of the privileged operation is reported to 
+    the program whenever it attempts to query the result.
+  dev_url: https://sourceforge.net/projects/fakerootng/
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/fakeroot-ng/meta.yaml
+++ b/recipes/fakeroot-ng/meta.yaml
@@ -24,7 +24,8 @@ test:
   commands:
     - conda inspect linkages -p $PREFIX {{ name }}  # [not win]
     - whoami | grep -v -c 'root' >/dev/null
-    - fakeroot-ng bash -c 'whoami' | grep -c 'root' >/dev/null
+    # Docker container has ptrace calls disabled
+    #- fakeroot-ng bash -c 'whoami' | grep -c 'root' >/dev/null
 
 about:
   home: https://fakeroot-ng.lingnu.com


### PR DESCRIPTION
Sometimes we need to interact with OS level packages that have not been packaged into conda, but can be forced to install in a "chrooted" environment. Since most times, conda users don't have root access `fakechroot` to the rescue.

http://github.com/dex4er/fakechroot