### PR TITLE
WIP, RFC: Add macosx_sdk

### DIFF
--- a/recipes/macosx_sdk/meta.yaml
+++ b/recipes/macosx_sdk/meta.yaml
@@ -1,0 +1,21 @@
+{% set version = "10.9" %}
+
+
+package:
+  name: "macosx_sdk"
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true  # [not osx]
+  script:
+    - mkdir -p "${PREFIX}/Xcode/Platforms/MacOSX.platform/Developer/SDKs/"
+    - mv "$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{ version }}.sdk" "${PREFIX}/Xcode/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{ version }}.sdk"
+
+test:
+  imports:
+    - test -d "${PREFIX}/Xcode/Platforms/MacOSX.platform/Developer/SDKs/MacOSX{{ version }}.sdk"
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
This is a rough proposal at this stage. However it is something we could act on should we decide to.

Creates a package for the MacOS SDK currently used on Travis CI. This should make it easier to port to other systems (e.g. CircleCI or users machines) where it might not otherwise be available. Also should ensure we have a way to get at this SDK whenever Travis CI decides to move on.

We could look at using the package we extract from Travis CI to bootstrap the package once the feedstock has built once. IOW including the SDK binary in the feedstock and using that to create the conda package.

Versioning scheme can be discussed. Right now have left the version out of the name as this is a build time dependency only. So there shouldn't be a need to install multiple copies at runtime unlike what we do with VS.

Picked a somewhat arbitrary location to store these relative to the prefix. Shouldn't overlap with anything else and matches relatively closely to what is already done with these SDKs currently.

There are many system level libraries linked to the SDK bundle. So it takes a while to fix the linkages of all of them with `install_name_tool`. Should be faster with `conda-build` 3.

Unclear about the licensing. So will need some help from others to look into this. However this problem is really no different from what we need to do if we looked at any other alternative like this (e.g. [phracker's MacOSX SDK collection]( https://github.com/phracker/MacOSX-SDKs )).

cc @conda-forge/core