### PR TITLE
Fail conversion if not empty

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -121,8 +121,11 @@ if __name__ == '__main__':
     print('Calculating the recipes which need to be turned into feedstocks.')
     with tmp_dir('__feedstocks') as feedstocks_dir:
         feedstock_dirs = []
-        for num, (recipe_dir, name) in enumerate(list_recipes()):
+        recipe_list = list(list_recipes())
+        for num, (recipe_dir, name) in enumerate(recipe_list):
             if num >= 7:
+                if len(recipe_list) > num:
+                    exit_code = 1
                 break
             feedstock_dir = os.path.join(feedstocks_dir, name + '-feedstock')
             print('Making feedstock for {}'.format(name))


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/5408 )

As limiting to 7 recipes seemed to have caused staged-recipes to pass even when there were still more recipes in the queue, this marks conversion as a failure if there are still more recipes there.