### PR TITLE
Drop # recipes check when reaching limit

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -121,11 +121,9 @@ if __name__ == '__main__':
     print('Calculating the recipes which need to be turned into feedstocks.')
     with tmp_dir('__feedstocks') as feedstocks_dir:
         feedstock_dirs = []
-        recipe_list = list(list_recipes())
-        for num, (recipe_dir, name) in enumerate(recipe_list):
+        for num, (recipe_dir, name) in enumerate(list_recipes()):
             if num >= 7:
-                if len(recipe_list) > num:
-                    exit_code = 1
+                exit_code = 1
                 break
             feedstock_dir = os.path.join(feedstocks_dir, name + '-feedstock')
             print('Making feedstock for {}'.format(name))


### PR DESCRIPTION
There is no need to check if we have more recipes than are conversion threshold as we have already met it if we are here. So this drops the `if` check and reverts what was done to add it and just always uses a non-zero exit code.

ref: https://github.com/conda-forge/staged-recipes/pull/5416#pullrequestreview-104274224

cc @isuruf