### PR TITLE
Adding pseudonetcdf recipe

### DIFF
--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -54,7 +54,7 @@ about:
   home: http://github.com/barronh/pseudonetcdf
   license: GPL-3.0
   license_family: GPL
-  license_file: LICENSE.md
+  license_file: LICENSE
   summary: 'PseudoNetCDF like NetCDF except for many scientific format backends'
   doc_url: http://pseudonetcdf.readthedocs.io/
   dev_url: http://github.com/barronh/pseudonetcdf

--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -2,8 +2,8 @@
 
 # Jinja variables help maintain the recipe as you'll update the version only here.
 {% set name = "pseudonetcdf" %}
-{% set version = "v3.0.0-alpha" %}
-{% set sha256 = "f5e222cc4e6e5d07ffe78a5fe6f33b8f1bba431be67c0a5c6706420a55b545f8" %}
+{% set version = "v3.0.0" %}
+{% set sha256 = "eb1ee1fa8f16f4a976d0851084b1a353a47f8ece41ab0519c95358dd53d27942" %}
 # sha256 is the prefered checksum -- you can get it for a file with:
 #  `openssl sha256 <file name>`.
 # You may need the openssl package, available on conda-forge
@@ -39,7 +39,6 @@ requirements:
     - pandas
     - netcdf4
     - scipy
-    - h5netcdf
     - pyyaml
     - matplotlib
 

--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -1,0 +1,66 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+{% set name = "pseudonetcdf" %}
+{% set version = "v3.0.0-alpha" %}
+{% set sha256 = "f5e222cc4e6e5d07ffe78a5fe6f33b8f1bba431be67c0a5c6706420a55b545f8" %}
+# sha256 is the prefered checksum -- you can get it for a file with:
+#  `openssl sha256 <file name>`.
+# You may need the openssl package, available on conda-forge
+#  `conda install openssl -c conda-forge``
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/barronh/pseudonetcdf/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
+  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
+  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
+  # noarch: python
+  number: 0
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python
+    - numpy
+    - pandas
+    - netcdf4
+    - scipy
+    - h5netcdf
+    - pyyaml
+    - matplotlib
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - PseudoNetCDF
+    - PseudoNetCDF.test
+
+about:
+  home: http://github.com/barronh/pseudonetcdf
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE.md
+  summary: 'PseudoNetCDF like NetCDF except for many scientific format backends'
+  doc_url: http://pseudonetcdf.readthedocs.io/
+  dev_url: https://github.com/barronh/pseudonetcdf
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - barronh

--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -1,13 +1,6 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
 {% set name = "pseudonetcdf" %}
 {% set version = "3.0.0" %}
 {% set sha256 = "eb1ee1fa8f16f4a976d0851084b1a353a47f8ece41ab0519c95358dd53d27942" %}
-# sha256 is the prefered checksum -- you can get it for a file with:
-#  `openssl sha256 <file name>`.
-# You may need the openssl package, available on conda-forge
-#  `conda install openssl -c conda-forge``
 
 package:
   name: {{ name|lower }}
@@ -19,14 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
-  # noarch: python
+  noarch: python
   number: 0
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -44,8 +31,6 @@ requirements:
     - matplotlib
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - PseudoNetCDF
     - PseudoNetCDF.test
@@ -61,6 +46,4 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - barronh

--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -15,7 +15,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/barronh/pseudonetcdf/archive/v{{ version }}.tar.gz
+  url: http://github.com/barronh/pseudonetcdf/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -56,7 +56,7 @@ about:
   license_file: LICENSE.md
   summary: 'PseudoNetCDF like NetCDF except for many scientific format backends'
   doc_url: http://pseudonetcdf.readthedocs.io/
-  dev_url: https://github.com/barronh/pseudonetcdf
+  dev_url: http://github.com/barronh/pseudonetcdf
 
 extra:
   recipe-maintainers:

--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -2,7 +2,7 @@
 
 # Jinja variables help maintain the recipe as you'll update the version only here.
 {% set name = "pseudonetcdf" %}
-{% set version = "v3.0.0" %}
+{% set version = "3.0.0" %}
 {% set sha256 = "eb1ee1fa8f16f4a976d0851084b1a353a47f8ece41ab0519c95358dd53d27942" %}
 # sha256 is the prefered checksum -- you can get it for a file with:
 #  `openssl sha256 <file name>`.

--- a/recipes/pseudonetcdf/meta.yaml
+++ b/recipes/pseudonetcdf/meta.yaml
@@ -33,6 +33,7 @@ requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
     - numpy


### PR DESCRIPTION
Adding a conda-recipe for PseudoNetCDF. PseudoNetCDF is a pure python package that provides access to many scientific data formats through a NetCDF common data model.