### PR TITLE
[R4R] Add git-secret to conda-forge

### DIFF
--- a/recipes/git-secret/bld.bat
+++ b/recipes/git-secret/bld.bat
@@ -1,0 +1,8 @@
+copy %RECIPE_DIR%\build.sh build.sh
+
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
+bash build.sh
+if errorlevel 1 exit 1
+exit 0

--- a/recipes/git-secret/build.sh
+++ b/recipes/git-secret/build.sh
@@ -1,6 +1,5 @@
 if [[ $OS == "Windows" ]]; then
-  export
-  PREFIX=$LIBRARY_PREFIX make git-secret install
+  make git-secret install PREFIX=$LIBRARY_PREFIX
 else
   make git-secret install
 fi

--- a/recipes/git-secret/build.sh
+++ b/recipes/git-secret/build.sh
@@ -1,4 +1,5 @@
 if [[ $OS == "Windows" ]]; then
+  export
   PREFIX=$LIBRARY_PREFIX make git-secret install
 else
   make git-secret install

--- a/recipes/git-secret/build.sh
+++ b/recipes/git-secret/build.sh
@@ -1,1 +1,5 @@
-make git-secret install
+if [[ $OS == "Windows" ]]; then
+  PREFIX=$LIBRARY_PREFIX make git-secret install
+else
+  make git-secret install
+fi

--- a/recipes/git-secret/build.sh
+++ b/recipes/git-secret/build.sh
@@ -1,6 +1,6 @@
-if [[ $OS == "Windows" ]]; then
-  export PREFIX=$LIBRARY_PREFIX
-  make -e git-secret install
+set -x
+if [ ! -z ${LIBRARY_PREFIX+x} ]; then
+  PREFIX=$LIBRARY_PREFIX/usr make git-secret install
 else
   make git-secret install
 fi

--- a/recipes/git-secret/build.sh
+++ b/recipes/git-secret/build.sh
@@ -1,0 +1,1 @@
+make git-secret install

--- a/recipes/git-secret/build.sh
+++ b/recipes/git-secret/build.sh
@@ -1,5 +1,6 @@
 if [[ $OS == "Windows" ]]; then
-  make git-secret install PREFIX=$LIBRARY_PREFIX
+  export PREFIX=$LIBRARY_PREFIX
+  make -e git-secret install
 else
   make git-secret install
 fi

--- a/recipes/git-secret/meta.yaml
+++ b/recipes/git-secret/meta.yaml
@@ -24,7 +24,8 @@ requirements:
 
 test:
   commands :
-    - test $(git secret --version) = {{ version }}
+    - test $(git secret --version) = {{ version }}  # [not win]
+    - where git-secret
 
 about:
   home: https://git-secret.io

--- a/recipes/git-secret/meta.yaml
+++ b/recipes/git-secret/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "git-secret" %}
+{% set version = "0.2.2" %}
+{% set sha256 = "a4672c2d5eca7b5c3b27388060609307b851edc7f7b653e1d21e3e0b328f43f4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/sobolevn/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - make
+  run:
+    - git
+
+test:
+  commands :
+    - test $(git secret --version) = {{ version }}
+
+about:
+  home: https://git-secret.io
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: 'git-secret stores your private data inside a git repo'
+
+  description: |
+    git-secret is a bash tool to store your private data inside a git repo. 
+    It encrypts tracked files using gpg with the public keys of all the users 
+    that you trust. So everyone of them can decrypt these files using only 
+    their personal secret key.
+  doc_url: https://git-secret.io
+  dev_url: https://github.com/sobolevn/git-secret
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/git-secret/meta.yaml
+++ b/recipes/git-secret/meta.yaml
@@ -18,14 +18,14 @@ requirements:
   build:
     - make
     - posix  # [win]
+    - toolchain
   run:
     - git
     - m2-gnupg  # [win]
 
 test:
   commands :
-    - test $(git secret --version) = {{ version }}  # [not win]
-    - git secret --version  # [win]
+    - bash -c 'test $(git secret --version) = {{ version }}'
 
 about:
   home: https://git-secret.io

--- a/recipes/git-secret/meta.yaml
+++ b/recipes/git-secret/meta.yaml
@@ -13,13 +13,14 @@ source:
 
 build:
   number: 0
-  skip: True  # [win]
 
 requirements:
   build:
     - make
+    - posix  # [win]
   run:
     - git
+    - m2-gnupg  # [win]
 
 test:
   commands :

--- a/recipes/git-secret/meta.yaml
+++ b/recipes/git-secret/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 test:
   commands :
     - test $(git secret --version) = {{ version }}  # [not win]
-    - where git-secret
+    - git secret --version  # [win]
 
 about:
   home: https://git-secret.io


### PR DESCRIPTION
From the [website](https://git-secret.io)
> `git-secret` is a bash tool to store your private data inside a git repo. How’s that? Basically, it just encrypts, using `gpg`, the tracked files with the public keys of all the users that you trust. So everyone of them can decrypt these files using only their personal secret key. Why deal with all this private-public keys stuff? Well, to make it easier for everyone to manage access rights. There are no passwords that change. When someone is out - just delete their public key, re-encrypt the files, and they won’t be able to decrypt secrets anymore.