### PR TITLE
Add R package RcppGSL.

### DIFF
--- a/recipes/r-rcppgsl/bld.bat
+++ b/recipes/r-rcppgsl/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-rcppgsl/build.sh
+++ b/recipes/r-rcppgsl/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copied from r-gsl recipe:
+# https://github.com/conda-forge/r-gsl-feedstock/blob/master/recipe/build.sh
+
+export CFLAGS="$(gsl-config --cflags)"
+export LDFLAGS="$(gsl-config --libs)"
+
+# For whatever reason, it can't link to gsl correctly without this on OS X.
+export DYLD_FALLBACK_LIBRARY_PATH=$PREFIX/lib
+
+$R CMD INSTALL --build .

--- a/recipes/r-rcppgsl/meta.yaml
+++ b/recipes/r-rcppgsl/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = '0.3.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rcppgsl
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: RcppGSL_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/RcppGSL_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/RcppGSL/RcppGSL_{{ version }}.tar.gz
+  sha256: 39ef207779361c9c2a84f06667136743750608ee8b34cbffbca067e317a30646
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rcpp
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+    - {{native}}gsl
+
+  run:
+    - r-base
+    - r-rcpp
+    - libgcc  # [not win]
+    - {{native}}gsl
+
+test:
+  commands:
+    - $R -e "library('RcppGSL')"  # [not win]
+    - "\"%R%\" -e \"library('RcppGSL')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=RcppGSL
+  license: GPL (>= 2)
+  summary: '''Rcpp'' integration for ''GNU GSL'' vectors and matrices The ''GNU Scientific Library''
+    (or ''GSL'') is a collection of numerical routines for scientific computing. It
+    is particularly useful for C and C++ programs as it provides a standard C interface
+    to a wide range of mathematical routines. There are over 1000 functions in total
+    with an extensive test suite. The ''RcppGSL'' package provides an easy-to-use interface
+    between ''GSL'' data structures and R using concepts from ''Rcpp'' which is itself
+    a package that eases the interfaces between R and C++. This package also serves
+    as a prime example of how to build a package that uses ''Rcpp'' to connect to another
+    third-party library. The ''autoconf'' script, ''inline'' plugin and example package
+    can all be used as a stanza to  write a similar package against another library.'
+
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak


### PR DESCRIPTION
CRAN R package [RcppGSL](https://cran.r-project.org/package=RcppGSL). Recipe created with conda-build 2.1.18 and [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).

I copied the extra build steps from the recipe for [r-gsl](https://github.com/conda-forge/r-gsl-feedstock/blob/master/recipe/build.sh).