### PR TITLE
[r4r] Add kubernetes-federation to conda-forge.

### DIFF
--- a/recipes/kubernetes-federation/build.sh
+++ b/recipes/kubernetes-federation/build.sh
@@ -18,22 +18,10 @@ build_linux()
     popd
 }
 
-build_osx()
-{
-    make kubefed
-
-    make test WHAT=./federation/pkg/kubefed
-
-    mv _output/bin/kubefed $PREFIX/bin
-}
-
 make_goroot_read_only
 
 case $(uname -s) in
     "Linux")
         build_linux
-        ;;
-    "Darwin")
-        build_osx
         ;;
 esac

--- a/recipes/kubernetes-federation/build.sh
+++ b/recipes/kubernetes-federation/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+make_goroot_read_only()
+{
+    find $PREFIX/go -type d -exec chmod 555 {} \;
+}
+
+build_linux()
+{
+    make fcp kubefed
+
+    make test
+
+    mv _output/bin/{fcp,kubefed} $PREFIX/bin
+
+    pushd $PREFIX/bin
+    ./fcp --make-symlinks
+    popd
+}
+
+build_osx()
+{
+    make kubefed
+
+    make test WHAT=./federation/pkg/kubefed
+
+    mv _output/bin/kubefed $PREFIX/bin
+}
+
+make_goroot_read_only
+
+case $(uname -s) in
+    "Linux")
+        build_linux
+        ;;
+    "Darwin")
+        build_osx
+        ;;
+esac

--- a/recipes/kubernetes-federation/meta.yaml
+++ b/recipes/kubernetes-federation/meta.yaml
@@ -15,7 +15,7 @@ source:
   sha256: {{ sha256 }}  # [not win]
 
 build:
-  skip: True  # [win]
+  skip: True  # [not linux]
   number: "{{ version_suffix }}-0"
 
 requirements:

--- a/recipes/kubernetes-federation/meta.yaml
+++ b/recipes/kubernetes-federation/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "kubernetes-federation" %}
+{% set version = "1.9.0" %}
+{% set version_suffix = "alpha.3" %}
+
+{% set sha256 = "9cbc8fb14318a5ebd9bf4c4a7f8a1a5e7508445c9488e59c58482c3c2607f6bb" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/kubernetes/federation/archive/v{{ version }}-{{version_suffix}}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz  # [not win]
+  sha256: {{ sha256 }}  # [not win]
+
+build:
+  skip: True  # [win]
+  number: "{{ version_suffix }}-0"
+
+requirements:
+  build:
+    - go 1.9.*  # [not win]
+    - rsync  # [not win]
+    - make  # [not win]
+    - toolchain  # [not win]
+
+test:
+  commands:
+    - fcp --help  # [linux]
+    - federation-apiserver --help  # [linux]
+    - federation-controller-manager --help  # [linux]
+    - kubefed help
+
+about:
+  home: https://www.kubernetes.io
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE  # [not win]
+  summary: Production-Grade Container Orchestration / Federation
+  doc_url: https://docs.kubernetes.io/docs/home/
+  dev_url: https://github.com/kubernetes/federation
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
- Beginning with kubernetes 1.9.x, the kubefed and federation controllers are 
    bundled separately from the main package