### PR TITLE
Readd ase

### DIFF
--- a/recipes/ase/meta.yaml
+++ b/recipes/ase/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "ase" %}
+{% set version = "3.16.0" %}
+{% set sha256 = "a999b7d95c0160092218b4d30380b14fa7993a5149183b80b0dda75f3470eea6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  #script: python setup.py install --single-version-externally-managed --record record.txt
+  script: python -m pip install --no-deps --ignore-installed . 
+  entry_points:
+    - ase=ase.cli.main:main
+    - ase-db=ase.cli.main:old
+    - ase-gui=ase.cli.main:old
+    - ase-run=ase.cli.main:old
+    - ase-info=ase.cli.main:old
+    - ase-build=ase.cli.main:old
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - flask
+    - matplotlib
+    - numpy 
+    - scipy
+
+test:
+  imports:
+    - ase
+  commands:
+    - export DISPLAY=""   # [not win]
+    - ase test -v
+
+
+about:
+  home: https://gitlab.com/ase/ase
+  license: LGPL-2.1+
+  license_file: LICENSE
+  summary: 'ASE is a python package providing an open source Atomic Simulation Environment in the Python language.'
+
+  description: |
+    ASE is a set of tools and Python modules for setting up, 
+    manipulating, running, visualizing and analyzing atomistic simulations.
+    Python 2.6-3.6 
+  doc_url: http://wiki.fysik.dtu.dk/ase
+  dev_url: https://gitlab.com/ase/ase
+
+extra:
+  recipe-maintainers:
+    - jochym
+    - CJ-Wright

--- a/recipes/ase/ngl_fix.patch
+++ b/recipes/ase/ngl_fix.patch
@@ -1,0 +1,11 @@
+--- ase/visualize/nglview.py	2017-12-17 17:22:19.871994011 +0100
++++ ase/visualize/nglview.py	2017-12-17 17:40:12.669979238 +0100
+@@ -33,7 +33,9 @@
+                                args=['%dpx' % (xsize,), '%dpx' % (ysize,)])
+         self.view.add_unitcell()
+         self.view.add_spacefill()
++        self.view.remove_ball_and_stick()
+         self.view.camera = 'orthographic'
++        self.view.parameters = { "clipDist": 0 }
+         self.view.update_spacefill(radiusType='covalent', scale=0.7)
+         self.view.center()


### PR DESCRIPTION
Closes https://github.com/conda-forge/ase-feedstock/issues/19

Readding `ase` to fix CI settings. In particular the `Skip branches without appveyor.yml` setting on AppVeyor.

xref: https://github.com/appveyor/ci/issues/1198#issuecomment-377392072

cc @conda-forge/ase