### PR TITLE
Initial draft of hevea recipe

### DIFF
--- a/recipes/hevea/build.sh
+++ b/recipes/hevea/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+make
+make install

--- a/recipes/hevea/meta.yaml
+++ b/recipes/hevea/meta.yaml
@@ -57,6 +57,4 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - peterjc

--- a/recipes/hevea/meta.yaml
+++ b/recipes/hevea/meta.yaml
@@ -20,6 +20,7 @@ build:
 requirements:
   build:
     - ocaml
+    - ocamlbuild
     - toolchain
   run:
     - ocaml

--- a/recipes/hevea/meta.yaml
+++ b/recipes/hevea/meta.yaml
@@ -25,9 +25,10 @@ requirements:
     - ocaml
 
 test:
-  - hevea -version
-  - hacha -version
-  # imagen is a shell script with no nice API, not checking here
+  commands:
+    - hevea -version
+    - hacha -version
+    # imagen is a shell script with no nice API, not checking here
 
 about:
   home: http://hevea.inria.fr/

--- a/recipes/hevea/meta.yaml
+++ b/recipes/hevea/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "hevea" %}
+{% set version = "2.31" %}
+{% set sha256 = "fbd7ad20aff45e557f5835f99a53d29a1753657cf2c004f26de83345b1b5b997" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://hevea.inria.fr/distri/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  skip: True [win]
+  # The Makefile will obey $PREFIX for setting $LIBDIR (for style files)
+  # and $BINDIR (for binaries hevea, hacha, imagen)
+
+requirements:
+  build:
+    - ocaml
+    - toolchain
+  run:
+    - ocaml
+
+test:
+  hevea -version
+  hacha -version
+  # imagen is a shell script with no nice API, not checking here
+
+about:
+  home: http://hevea.inria.fr/
+  license: QPL-1.0
+  license_file: LICENSE.txt
+  summary: 'HEVEA is a quite complete and fast LATEX to HTML translator'
+  description: |
+    HEVEA is a LaTeX to HTML translator.  The input language is a fairly
+    complete subset of LaTeX2e (old LaTeX style is also accepted) and the
+    output language is HTML that is (hopefully) correct with respect to
+    version 5.
+
+    Exotic symbols are translated into the so-called HTML 'entities',
+    in other words into references to UNICODE chararacters.
+
+    HEVEA understands LaTeX macro definitions. Simple user style
+    files are understood with little or no modifications.
+    Furthermore, HEVEA customization is done by writing LaTeX code.
+    
+    HEVEA is written in OCaml, as many lexers. It is quite fast
+    and flexible. Using HEVEA it is possible to translate large documents
+    such as manuals, books, etc. very quickly. All documents are
+    translated as one single HTML file. Then, the output file can be cut
+    into smaller files, using the companion program HACHA.
+  doc_url: http://hevea.inria.fr/doc/index.html
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - peterjc

--- a/recipes/hevea/meta.yaml
+++ b/recipes/hevea/meta.yaml
@@ -12,7 +12,8 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  skip: True [win]
+  number: 0
+  skip: True  # [win]
   # The Makefile will obey $PREFIX for setting $LIBDIR (for style files)
   # and $BINDIR (for binaries hevea, hacha, imagen)
 
@@ -24,8 +25,8 @@ requirements:
     - ocaml
 
 test:
-  hevea -version
-  hacha -version
+  - hevea -version
+  - hacha -version
   # imagen is a shell script with no nice API, not checking here
 
 about:

--- a/recipes/hevea/meta.yaml
+++ b/recipes/hevea/meta.yaml
@@ -33,7 +33,7 @@ test:
 about:
   home: http://hevea.inria.fr/
   license: QPL-1.0
-  license_file: LICENSE.txt
+  license_file: LICENSE
   summary: 'HEVEA is a quite complete and fast LATEX to HTML translator'
   description: |
     HEVEA is a LaTeX to HTML translator.  The input language is a fairly


### PR DESCRIPTION
I would like to have hevea on conda, http://hevea.inria.fr/

Essentially this is a tool which can turn LaTeX documents into HTML.

Hevea is written in Objective Caml. Therefore it seems we may first need to package Objective Caml (ocaml) and/or OPAM, the OCaml package manager, in order to package hevea for conda. I currently have no interest in this or other ocaml packages except as a means to an end - simple installation of hevea.

The old ocmal website has source and pre-compiled Linux binaries (Debian packages, Fedora packages & Gentoo packages), http://caml.inria.fr/ocaml/release.en.html

> The most recent version of OCaml is 4.06.0. It was released on 2017-11-03.
> http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.gz
> http://caml.inria.fr/pub/distrib/ocaml-4.06/ocaml-4.06.0.tar.xz

The new website recommends using OPAM, the OCaml package manager, or your local system package manager - which is perhaps where conda would sit?

https://ocaml.org/docs/install.html

The source releases include instructions. This also listed v4.06.0 as the latest, and the downloads refer to the old site URLs as listed above.

--

Do we need to package ``ocaml`` first? Can we recycle a pre-compiled binary package?

I presume it does not make sense to package ``OPAM`` instead (the OCaml package manager)?