### PR TITLE
add recipe for qtwebkit

### DIFF
--- a/recipes/qtwebkit/build.sh
+++ b/recipes/qtwebkit/build.sh
@@ -1,4 +1,39 @@
+#!/bin/bash
+
+set -e # Abort on error.
+
+export PING_SLEEP=30s
+export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export BUILD_OUTPUT=$WORKDIR/build.out
+
+touch $BUILD_OUTPUT
+
+dump_output() {
+   echo Tailing the last 500 lines of output:
+   tail -500 $BUILD_OUTPUT
+}
+error_handler() {
+  echo ERROR: An error was encountered with the build.
+  dump_output
+  exit 1
+}
+
+# If an error occurs, run our error handler to output a tail of the build.
+trap 'error_handler' ERR
+
+# Set up a repeating loop to send some output to Travis.
+bash -c "while true; do echo \$(date) - building ...; sleep $PING_SLEEP; done" &
+PING_LOOP_PID=$!
 
 qmake
-make -j$CPU_COUNT
-make install
+make -j $CPU_COUNT >> $BUILD_OUTPUT 2>&1
+make install >> $BUILD_OUTPUT 2>&1
+
+## END BUILD
+
+# The build finished without returning an error so dump a tail of the output.
+dump_output
+
+# Nicely terminate the ping output loop.
+kill $PING_LOOP_PID
+

--- a/recipes/qtwebkit/build.sh
+++ b/recipes/qtwebkit/build.sh
@@ -1,0 +1,4 @@
+
+qmake
+make -j$CPU_COUNT
+make install

--- a/recipes/qtwebkit/meta.yaml
+++ b/recipes/qtwebkit/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "qtwebkit" %}
+{% set version = "5.6.2" %}
+{% set md5 = "5196f47b75e2d6cc9663c89cf9902ef0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-opensource-src-{{ version }}.tar.xz
+  url: http://download.qt.io/community_releases/5.6/{{ version }}/{{ name }}-opensource-src-{{ version }}.tar.xz
+  md5: {{ md5 }}
+
+build:
+  number: 0
+  skip: True  # [not osx]
+
+requirements:
+  build:
+    - toolchain
+    - qt 5.6.*
+  run:
+    - qt 5.6.*
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libQt5WebKit.dylib  # [osx]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://wiki.qt.io/Qt_WebKit
+  license: GPL-3.0
+  license_file: LICENSE.GPLv3
+  summary: 'WebKit is one of the major engine to render webpages and execute JavaScript code'
+  description: |
+    Qt WebKit is the port of WebKit on top of Qt. QtWebKit relies on the public APIs of Qt 
+    and can theoretically be used on any platform supported by Qt 
+    (theoretically because WebKit also requires a recent/good compiler).
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - ceholden
+    - ocefpaf


### PR DESCRIPTION
Since `qt` does not have [WebKit support on OSX](https://github.com/conda-forge/qt-feedstock/issues/52#issuecomment-324898728), this recipe adds it for this platform. Linux and Windows `qt` builds already do have WebKit.

My motivation for doing this is for [`qgis` 3](https://github.com/conda-forge/qgis-feedstock/issues/17) but I suspect there will be other packages that require it. This recipe could be extended to other platforms when WebEngine is adopted instead of WebKit in all the `qt` builds.

@ceholden @ocefpaf are you happy to be maintainers?