### PR TITLE
Initial draft of ocaml recipe

### DIFF
--- a/recipes/ocaml/build.sh
+++ b/recipes/ocaml/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 ./configure -prefix $PREFIX
 make world.opt
-umask 022
 make tests
 make install

--- a/recipes/ocaml/build.sh
+++ b/recipes/ocaml/build.sh
@@ -3,4 +3,5 @@ export LC_ALL=C
 ./configure -prefix $PREFIX
 make world.opt
 umask 022
+make tests
 make install

--- a/recipes/ocaml/build.sh
+++ b/recipes/ocaml/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export LC_ALL=C
+./configure -prefix $PREFIX
+make world.opt
+umask 022
+make install

--- a/recipes/ocaml/build.sh
+++ b/recipes/ocaml/build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export LC_ALL=C
 ./configure -prefix $PREFIX
 make world.opt
 umask 022

--- a/recipes/ocaml/meta.yaml
+++ b/recipes/ocaml/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/ocaml/meta.yaml
+++ b/recipes/ocaml/meta.yaml
@@ -2,14 +2,16 @@
 {% set version = "4.06.0" %}
 {% set sha256 = "c17578e243c4b889fe53a104d8927eb8749c7be2e6b622db8b3c7b386723bf50" %}
 
+{% set version_major   = version.split(".")[0] %}
+{% set version_minor   = version.split(".")[1] %}
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  # TODO: Can we extract the major.minor part of the version reliably?
-  url: http://caml.inria.fr/pub/distrib/{{ name }}-4.06/{{ name }}-{{ version }}.tar.gz
+  url: http://caml.inria.fr/pub/distrib/{{ name }}-{{ version_major }}.{{ version_minor }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
@@ -54,6 +56,4 @@ about:
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - peterjc

--- a/recipes/ocaml/meta.yaml
+++ b/recipes/ocaml/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "ocaml" %}
+{% set version = "4.06.0" %}
+{% set sha256 = "c17578e243c4b889fe53a104d8927eb8749c7be2e6b622db8b3c7b386723bf50" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  # TODO: Can we extract the major.minor part of the version reliably?
+  url: http://caml.inria.fr/pub/distrib/{{ name }}-4.06/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - toolchain
+
+test:
+  commands:
+    - ocaml -version
+
+about:
+  home: https://ocaml.org/
+  license: LGPL-2.1
+  license_family: LGPL
+  license_file: LICENSE
+  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    OCaml is an implementation of the ML language, based on the Caml Light
+    dialect extended with a complete class-based object system and a powerful
+    module system in the style of Standard ML.
+    
+    OCaml comprises two compilers. One generates bytecode which is then
+    interpreted by a C program. This compiler runs quickly, generates compact
+    code with moderate memory requirements, and is portable to essentially any
+    32 or 64 bit Unix platform. Performance of generated programs is quite good
+    for a bytecoded implementation.  This compiler can be used either as a
+    standalone, batch-oriented compiler that produces standalone programs, or as
+    an interactive, toplevel-based system.
+    
+    The other compiler generates high-performance native code for a number of
+    processors. Compilation takes longer and generates bigger code, but the
+    generated programs deliver excellent performance, while retaining the
+    moderate memory requirements of the bytecode compiler.
+  doc_url: https://ocaml.org/docs/
+  dev_url: https://github.com/ocaml/ocaml
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - peterjc


### PR DESCRIPTION
This is in order to package hevea, see #5532.

Hevea is written in Objective Caml. Therefore it seems we may first need to package Objective Caml (ocaml) and/or OPAM, the OCaml package manager, in order to package hevea for conda. I currently have no interest in this or other ocaml packages except as a means to an end - simple installation of hevea.