### PR TITLE
add fribidi (new pango dep)

### DIFF
--- a/recipes/fribidi/build.sh
+++ b/recipes/fribidi/build.sh
@@ -1,0 +1,8 @@
+meson builddir -Ddocs=false --prefix=$PREFIX -Ddefault_library=shared
+cd builddir
+ninja
+ninja install
+# stuff gets installed into lib64 when we only use lib for conda
+mkdir -p $PREFIX/lib
+mv $PREFIX/lib64/* $PREFIX/lib
+rm -rf $PREFIX/lib64

--- a/recipes/fribidi/meta.yaml
+++ b/recipes/fribidi/meta.yaml
@@ -1,0 +1,50 @@
+{% set version="1.0.2" %}
+{% set sha256="bd6d1b530c4f6066f42461200ed6a31f2db8db208570ea4ccaab2b935e88832b" %}
+
+package:
+  name: fribidi
+  version:  {{ version }}
+
+source:
+  git_url: https://github.com/fribidi/fribidi
+  # 1.0.2 tag
+  git_tag: f2c9d50722cb60d0cdec3b1bafba9029770e86b4
+  # bug in 1.0.2 tarball - missing files.  See https://github.com/fribidi/fribidi/issues/76
+  # url: https://github.com/fribidi/fribidi/releases/download/v{{ version }}/fribidi-{{ version }}.tar.bz2
+  # sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage('fribidi') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - meson
+    - ninja
+
+test:
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+    - fribidi -h
+
+about:
+  home: https://github.com/fribidi/fribidi
+  license: LGPL-2.1
+  license_file: COPYING
+  summary: The Free Implementation of the Unicode Bidirectional Algorithm.
+  description: |
+    One of the missing links stopping the penetration of free software in Middle
+    East is the lack of support for the Arabic and Hebrew alphabets. In order to
+    have proper Arabic and Hebrew support, the bidi algorithm needs to be
+    implemented. It is our hope that this library will stimulate more free
+    software in the Middle Eastern countries.
+  doc_url: https://github.com/fribidi/fribidi
+  dev_url: https://github.com/fribidi/fribidi
+
+extra:
+  package-maintainers:
+    - msarahan


### PR DESCRIPTION
This is done with the new conda-build 3 style compilers, so it might need to sit a while until CB3 is in full use at CF.