### PR TITLE
Add betse.

### DIFF
--- a/recipes/betse/meta.yaml
+++ b/recipes/betse/meta.yaml
@@ -29,11 +29,11 @@ requirements:
     - networkx >=2.0
     - numpy >=1.8.2
     - pillow >=2.3.0
+    - pydot >=1.0.28
+    - pyyaml >=3.10
     - scipy >=0.12.0
     - setuptools >=3.3
     - six >=1.5.2
-    - pydot >=1.0.28
-    - pyyaml >=3.10
     - ffmpeg
     - pyside2
   run:
@@ -44,11 +44,11 @@ requirements:
     - networkx >=2.0
     - numpy >=1.8.2
     - pillow >=2.3.0
+    - pydot >=1.0.28
+    - pyyaml >=3.10
     - scipy >=0.12.0
     - setuptools >=3.3
     - six >=1.5.2
-    - pydot >=1.0.28
-    - pyyaml >=3.10
     - ffmpeg
     - pyside2
 

--- a/recipes/betse/meta.yaml
+++ b/recipes/betse/meta.yaml
@@ -16,12 +16,11 @@ build:
   entry_points:
     - betse = betse.__main__:main
   script: python -m pip install --no-deps --ignore-installed .
-  skip: True  # [py<34]
+  noarch: python
 
 requirements:
   build:
     - pip
-  host:
     - python >=3.4
     - dill >=0.2.3
     - graphviz >=2.38.0

--- a/recipes/betse/meta.yaml
+++ b/recipes/betse/meta.yaml
@@ -22,21 +22,10 @@ requirements:
   build:
     - pip
     - python >=3.4
-    - dill >=0.2.3
-    - graphviz >=2.38.0
-    - matplotlib >=1.5.0
-    - networkx >=2.0
-    - numpy >=1.8.2
-    - pillow >=2.3.0
-    - pydot >=1.0.28
-    - pyyaml >=3.10
-    - scipy >=0.12.0
     - setuptools >=3.3
-    - six >=1.5.2
-    - ffmpeg
-    - pyside2
   run:
     - python >=3.4
+    - setuptools >=3.3
     - dill >=0.2.3
     - graphviz >=2.38.0
     - matplotlib >=1.5.0
@@ -46,7 +35,6 @@ requirements:
     - pydot >=1.0.28
     - pyyaml >=3.10
     - scipy >=0.12.0
-    - setuptools >=3.3
     - six >=1.5.2
     - ffmpeg
     - pyside2

--- a/recipes/betse/meta.yaml
+++ b/recipes/betse/meta.yaml
@@ -1,0 +1,85 @@
+{% set name = "betse" %}
+{% set version = "0.7.0" %}
+{% set sha256 = "845896f4c30b3970d5bd9501e0ca754eef5af0d742de76103f66c8c8c58e4eca" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  entry_points:
+    - betse = betse.__main__:main
+  script: python -m pip install --no-deps --ignore-installed .
+  skip: True  # [py<34]
+
+requirements:
+  build:
+    - pip
+  host:
+    - python >=3.4
+    - dill >=0.2.3
+    - graphviz >=2.38.0
+    - matplotlib >=1.5.0
+    - networkx >=2.0
+    - numpy >=1.8.2
+    - pillow >=2.3.0
+    - scipy >=0.12.0
+    - setuptools >=3.3
+    - six >=1.5.2
+    - pydot >=1.0.28
+    - pyyaml >=3.10
+    - ffmpeg
+    - pyside2
+  run:
+    - python >=3.4
+    - dill >=0.2.3
+    - graphviz >=2.38.0
+    - matplotlib >=1.5.0
+    - networkx >=2.0
+    - numpy >=1.8.2
+    - pillow >=2.3.0
+    - scipy >=0.12.0
+    - setuptools >=3.3
+    - six >=1.5.2
+    - pydot >=1.0.28
+    - pyyaml >=3.10
+    - ffmpeg
+    - pyside2
+
+test:
+  imports:
+    - betse
+    - betse.cli
+    - betse.lib
+    - betse.util
+  commands:
+    - betse --matplotlib-backend=agg
+    - betse --matplotlib-backend=agg --help
+    - betse --matplotlib-backend=agg --version
+    - betse --matplotlib-backend=agg info
+
+about:
+  home: https://gitlab.com/betse/betse
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: BETSE, the BioElectric Tissue Simulation Engine
+  description: |
+    BETSE (BioElectric Tissue Simulation Engine) is an open-source cross-platform finite
+    volume simulator for 2D computational multiphysics problems in the life sciences -
+    including electrodiffusion, electro-osmosis, galvanotaxis, voltage-gated ion channels,
+    gene regulatory networks, and biochemical reaction networks (e.g., metabolism). BETSE is
+    portably implemented in pure Python 3, continuously stress-tested with GitLab-CI *
+    Appveyor + py.test, and permissively distributed under the BSD 2-clause license.
+  doc_url: https://www.dropbox.com/s/n8qfms2oks9cvv2/BETSE04_Documentation_Dec1st2016.pdf?dl=0
+  dev_url: https://gitlab.com/betse/betse
+
+extra:
+  recipe-maintainers:
+    - leycec


### PR DESCRIPTION
Greetings, tireless conda-forgers. This pull requests adds a simple recipe for [BETSE](https://gitlab.com/betse/betse), the pure-Python 3.x multiphysics biology simulator [my wife](https://www.researchgate.net/profile/Alexis_Pietak) and I actively maintain. A few ignorable caveats that no one probably cares about:

* Although pure-Python, I didn't mark this recipe as `noarch`. We require Python >= 3.4 for that sweet `Enum` action, which appears to contradict [brutal and unforgiving `noarch` constraints](https://conda-forge.org/docs/meta.html#building-noarch-packages). I'm surprised *any* packages satisfy those constraints, actually. We'd love to reduce your CI burden, but... I don't think we can. *Cue sad face.*
* Although we provide an extensive py.nose-based test suite of functional and unit tests, I decided *not* to exercise any of them in the `test:` section. I suspect you have better things to do with scarce CI resources than run expensive multiphysics simulations all day. Instead, I defaulted to just testing the importability of top-level subpackages and the executability of our entry point script. *Cue happy face.*
* I didn't know whether to shove build dependencies into the `requirements/build:` or `requirements/host:` lists. Since `conda skeleton pip` silently chose the latter *and* [official conda documentation](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#host) also suggests the latter (e.g., "You should also include the base interpreter **[** in `host:`**]** for packages that need one. In other words, a Python package would list `python` here..."), I accepted this choice. That said, I have no idea what I'm doing. Hopefully, it's sufficient as is. *Cue confused face.*
* I didn't know how to avoid duplicating build dependencies between the `requirements/host:` and `requirements/run:` keys. Although the `build/run-exports:` key *appeared* to be of relevance, I found the [official conda documentation](https://conda.io/docs/user-guide/tasks/build-packages/define-metadata.html#export-runtime-requirements) on that key to be unreadable. I briefly contemplated littering the top of the `meta.yaml` file with Jinja2 templating (e.g., `{% set python_req = "python >=3.4" %}`), but quickly realized that I was lazy. So, I just duplicated everything. *Cue lazy face.*
* I didn't know how to actually test whether my recipe does anything it claims to or not. I suspect that locally installing `conda-smithy` would help in some obscure manner, but... I failed to grep a working example. I'm probably just supposed to submit a pull request and let CI yell at me if it's broken. That's cool. I can do that.

That's about it. Thanks for the excellent community infrastructure, conda-forge. I can hardly fathom how much continued blood, sweat, and tears must go into this project. (But I bet it's *alot.*)