### PR TITLE
Pin conda to 4.3 in feedstock conversion

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -31,7 +31,7 @@ bash ~/miniconda.sh -b -p ~/miniconda
     conda config --add channels conda-forge
 
     unset conda
-    conda update -n root --yes --quiet conda conda-env
+    conda update -n root --yes --quiet conda=4.3 conda-env
 )
 source ~/miniconda/bin/activate root
 


### PR DESCRIPTION
The current version of `conda-smithy`, 2.4.5, is not compatible with `conda` 4.4+. So pin to `conda` 4.3 in the `staged-recipes` conversion script.

cc @conda-forge/core