### PR TITLE
Revert "Pin conda to 4.3 in feedstock conversion"

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -31,7 +31,7 @@ bash ~/miniconda.sh -b -p ~/miniconda
     conda config --add channels conda-forge
 
     unset conda
-    conda update -n root --yes --quiet conda=4.3 conda-env
+    conda update -n root --yes --quiet conda conda-env
 )
 source ~/miniconda/bin/activate root
 


### PR DESCRIPTION
Revert https://github.com/conda-forge/staged-recipes/pull/5611

This reverts commit b5bcc6c0b8b21a4ef95c8a84c8e59439787a6864 because of [this build issue]( https://travis-ci.org/conda-forge/staged-recipes/builds/364548000 ).