### PR TITLE
Add a recipe for pydata/sparse

### DIFF
--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -20,9 +20,6 @@ requirements:
   build:
     - python
     - pip
-    - numpy >=1.13
-    - scipy >=0.19
-    - numba >=0.37
   run:
     - python
     - numpy >=1.13

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -30,12 +30,6 @@ requirements:
     - numba >=0.37
 
 test:
-  requires:
-    - pytest
-    - pytest-cov
-    - pytest-flake8
-  commands:
-    - py.test
   imports:
     - sparse
 

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -20,12 +20,12 @@ requirements:
   build:
     - python
     - pip
-    - numpy >=1.14
+    - numpy >=1.13
     - scipy >=0.19
     - numba >=0.37
   run:
     - python
-    - numpy >=1.14
+    - numpy >=1.13
     - scipy >=0.19
     - numba >=0.37
 

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sparse" %}
-{% set version = "0.3.0" %}
-{% set sha256 = "bb433d9adf16b0163436e3890bd1d14694d813697cacabd38434830f7901885e" %}
+{% set version = "0.3.1" %}
+{% set sha256 = "d5e427e9cc3ef532889091e1d319ff23dfd18c113cb2e30bd822c37f39d33d54" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - python
     - numpy >=1.13
     - scipy >=0.19
-    - numba >=0.37
 
 test:
   imports:

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -20,6 +20,9 @@ requirements:
   build:
     - python
     - pip
+    - numpy >=1.14
+    - scipy >=0.19
+    - numba >=0.37
   run:
     - python
     - numpy >=1.14

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -46,7 +46,7 @@ about:
   description: |
     sparse implements sparse multidimensional arrays on top of Numpy
     and scipy.sparse. It tries to mimic Numpy's ndarray API.
-  doc_url: https://sparse.pydata.org/en/0.3.0/
+  doc_url: https://sparse.pydata.org/en/{{ version }}/
   dev_url: https://github.com/pydata/sparse
 
 extra:

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "sparse" %}
+{% set version = "0.3.0" %}
+{% set sha256 = "bb433d9adf16b0163436e3890bd1d14694d813697cacabd38434830f7901885e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - numpy >= 1.14
+    - scipy >= 0.19
+    - numba >= 0.37
+
+test:
+  imports:
+    - sparse
+
+about:
+  home: https://github.com/pydata/sparse
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.rst
+  summary: 'Sparse multi-dimensional arrays for the PyData ecosystem'
+
+  description: |
+    sparse implements sparse multidimensional arrays on top of Numpy
+    and scipy.sparse. It tries to mimic Numpy's ndarray API.
+  doc_url: https://sparse.pydata.org/en/0.3.0/
+  dev_url: https://github.com/pydata/sparse
+
+extra:
+  recipe-maintainers:
+    - hameerabbasi
+    - mrocklin

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -22,11 +22,17 @@ requirements:
     - pip
   run:
     - python
-    - numpy >= 1.14
-    - scipy >= 0.19
-    - numba >= 0.37
+    - numpy >=1.14
+    - scipy >=0.19
+    - numba >=0.37
 
 test:
+  requires:
+    - pytest
+    - pytest-cov
+    - pytest-flake8
+  commands:
+    - py.test
   imports:
     - sparse
 

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "sparse" %}
 {% set version = "0.3.1" %}
-{% set sha256 = "d5e427e9cc3ef532889091e1d319ff23dfd18c113cb2e30bd822c37f39d33d54" %}
+{% set sha256 = "e7961a81592e0372a21023fcb29e651787b03ac66e3fd6df81772d3d70dc25a5" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/sparse/meta.yaml
+++ b/recipes/sparse/meta.yaml
@@ -56,3 +56,4 @@ extra:
   recipe-maintainers:
     - hameerabbasi
     - mrocklin
+    - jakevdp


### PR DESCRIPTION
This is to add a recipe for [pydata/sparse](https://github.com/pydata/sparse).

As an aside, can we install the requirements for `py.test` and run it as a command, if possible?

Edit: And how do I specify minimum versions?