### PR TITLE
Package (Python) lz4

### DIFF
--- a/recipes/lz4/meta.yaml
+++ b/recipes/lz4/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "lz4" %}
+{% set version = "1.1.0" %}
+{% set sha256 = "9ede632d668995d6148942022c025c0f7ea0d97c275c099f9ad156e02cc1711e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - toolchain
+    - python
+    - pip
+    - pytest-runner
+    - setuptools_scm
+    - pkgconfig
+    - lz4-c 1.8.1
+  run:
+    - python
+    - lz4-c 1.8.1
+
+test:
+  imports:
+    - lz4
+
+about:
+  home: https://github.com/python-lz4/python-lz4
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: "LZ4 Bindings for Python"
+
+  doc_url: http://python-lz4.readthedocs.io/en/stable/
+  dev_url: https://github.com/python-lz4/python-lz4
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Adds a package for the Python `lz4` library. Uses `lz4-c` to provide the C library implementation used.

ref: https://pypi.org/project/lz4