### PR TITLE
Add recipe for Perl DBI 1.641

### DIFF
--- a/recipes/perl-dbi/bld.bat
+++ b/recipes/perl-dbi/bld.bat
@@ -1,0 +1,29 @@
+:: If it has Build.PL use that, otherwise use Makefile.PL
+IF exist Build.PL (
+    perl Build.PL
+    IF %ERRORLEVEL% NEQ 0 exit 1
+    Build
+    IF %ERRORLEVEL% NEQ 0 exit 1
+    Build test
+    :: Make sure this goes in site
+    Build install --installdirs site
+    IF %ERRORLEVEL% NEQ 0 exit 1
+) ELSE IF exist Makefile.PL (
+    :: Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    IF %ERRORLEVEL% NEQ 0 exit 1
+    make
+    IF %ERRORLEVEL% NEQ 0 exit 1
+    make test
+    IF %ERRORLEVEL% NEQ 0 exit 1
+    make install
+) ELSE (
+    ECHO 'Unable to find Build.PL or Makefile.PL. You need to modify bld.bat.'
+    exit 1
+)
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/recipes/perl-dbi/build.sh
+++ b/recipes/perl-dbi/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# If it has Build.PL use that, otherwise use Makefile.PL
+if [ -f Build.PL ]; then
+    perl Build.PL
+    perl ./Build
+    perl ./Build test
+    # Make sure this goes in site
+    perl ./Build install --installdirs site
+elif [ -f Makefile.PL ]; then
+    # Make sure this goes in site
+    perl Makefile.PL INSTALLDIRS=site
+    make
+    make test
+    make install
+else
+    echo 'Unable to find Build.PL or Makefile.PL. You need to modify build.sh.'
+    exit 1
+fi
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/recipes/perl-dbi/meta.yaml
+++ b/recipes/perl-dbi/meta.yaml
@@ -1,0 +1,31 @@
+{% set name = "perl-dbi" %}
+{% set version = "1.641" %}
+{% set sha256 = "5509e532cdd0e3d91eda550578deaac29e2f008a12b64576e8c261bb92e8c2c1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: DBI-1.641.tar.gz
+  url: https://cpan.metacpan.org/authors/id/T/TI/TIMB/DBI-1.641.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - perl
+
+  run:
+    - perl
+
+test:
+  imports:
+    - DBI
+
+about:
+  home: http://dbi.perl.org/
+  license: Artistic-1.0
+  summary: 'Database independent interface for Perl'


### PR DESCRIPTION
NOTE: this passes .circleci/run_docker_build.sh for perl 5.22.0 and 5.22.2, but for 5.26.0 with a `x86_64-conda_cos6-linux-gnu-gcc: No such file or directory` message. Submitting a PR so another set of eyes can take a look.