### PR TITLE
Fold Travis build trigger into create_feedstocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,7 @@ script:
         echo "Creating feedstocks from the recipe(s).";
         git config --global user.name "Travis-CI on github.com/conda-forge/staged-recipes";
         git config --global user.email "conda-forge@googlegroups.com";
-        source ./.travis_scripts/create_feedstocks || {
-            python .travis_scripts/trigger_travis_build.py "conda-forge/staged-recipes"; exit 1;
-        };
+        source ./.travis_scripts/create_feedstocks;
       else
         echo "Building all recipes.";
         source ./.travis_scripts/build_all;

--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -45,4 +45,7 @@ mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 set -x
 
-python .travis_scripts/create_feedstocks.py
+python .travis_scripts/create_feedstocks.py || {
+    python .travis_scripts/trigger_travis_build.py "conda-forge/staged-recipes";
+    exit 1;
+};


### PR DESCRIPTION
Related to issue ( https://github.com/conda-forge/staged-recipes/issues/5655 ).

In case Travis CI is somehow capturing the failed exit status and blocking our retriggering of the `master` build conversion job, fold this call into the `create_feedstocks` script. This should ensure the request for a new build is sent to Travis CI.