### PR TITLE
added r-castor recipe

### DIFF
--- a/recipes/r-castor/bld.bat
+++ b/recipes/r-castor/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-castor/build.sh
+++ b/recipes/r-castor/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-castor/meta.yaml
+++ b/recipes/r-castor/meta.yaml
@@ -51,7 +51,8 @@ about:
     mean trait depth (trait conservatism), ancestral state reconstruction and hidden
     character prediction of discrete characters. Simulating and fitting models of trait
     evolution, and generating random trees using birth-death models. Dating trees, comparing
-    two trees, and reading/writing trees to a file. Citation
+    two trees, and reading/writing trees to a file. Citation - Louca, Stilianos and Doebeli,
+    Michael (2017) <doi:10.1093/bioinformatics/btx701>.
   license_family: GPL3
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
   license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]

--- a/recipes/r-castor/meta.yaml
+++ b/recipes/r-castor/meta.yaml
@@ -58,4 +58,9 @@ about:
 
 extra:
   recipe-maintainers:
-    - gavinmdouglas 
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - gavinmdouglas

--- a/recipes/r-castor/meta.yaml
+++ b/recipes/r-castor/meta.yaml
@@ -1,0 +1,61 @@
+{% set version = '1.3.3' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-castor
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: castor_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/castor_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/castor/castor_{{ version }}.tar.gz
+  sha256: 68e78c5738ab8d418abd52d9bd01ca33a4ff516b2b59c2491c0c89578420ed58
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-rcpp >=0.12.10
+    - r-naturalsort
+    - posix                # [win]
+    - {{native}}toolchain  # [win]
+    - gcc                  # [not win]
+
+  run:
+    - r-base
+    - r-rcpp >=0.12.10
+    - r-naturalsort
+    - libgcc  # [not win]
+
+test:
+  commands:
+    - $R -e "library('castor')"  # [not win]
+    - "\"%R%\" -e \"library('castor')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=castor
+  license: GPL (>= 2)
+  summary: Efficient tree manipulations for large phylogenies, including pruning, rerooting,
+    calculation of most-recent common ancestors, calculating distances from the tree
+    root and calculating pairwise distances. Calculation of phylogenetic signal and
+    mean trait depth (trait conservatism), ancestral state reconstruction and hidden
+    character prediction of discrete characters. Simulating and fitting models of trait
+    evolution, and generating random trees using birth-death models. Dating trees, comparing
+    two trees, and reading/writing trees to a file. Citation
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - gavinmdouglas 


### PR DESCRIPTION
Recipe for [castor R package](https://cran.r-project.org/web/packages/castor/index.html) built based on instructions from https://github.com/bgruening/conda_r_skeleton_helper.

This recipe was built with the ```bash run.sh``` command.

Please note that I am not the developer of castor.