### PR TITLE
Add r-assertive.

### DIFF
--- a/recipes/r-assertive/bld.bat
+++ b/recipes/r-assertive/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+if errorlevel 1 exit 1

--- a/recipes/r-assertive/build.sh
+++ b/recipes/r-assertive/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$R CMD INSTALL --build .

--- a/recipes/r-assertive/meta.yaml
+++ b/recipes/r-assertive/meta.yaml
@@ -1,0 +1,85 @@
+{% set version = '0.3-5' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-assertive
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: assertive_{{ version }}.tar.gz
+  url:
+    - https://cran.r-project.org/src/contrib/assertive_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/assertive/assertive_{{ version }}.tar.gz
+  sha256: 23ff6c8893e9c0b5b6bf4009a10de42a4a3a86eec2c48e7b73ae2cd6295c8b2e
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - r-base
+    - r-assertive.base >=0.0_4
+    - r-assertive.code
+    - r-assertive.data
+    - r-assertive.data.uk
+    - r-assertive.data.us
+    - r-assertive.datetimes
+    - r-assertive.files
+    - r-assertive.matrices
+    - r-assertive.models
+    - r-assertive.numbers
+    - r-assertive.properties >=0.0_2
+    - r-assertive.reflection >=0.0_2
+    - r-assertive.sets >=0.0_2
+    - r-assertive.strings
+    - r-assertive.types >=0.0_2
+    - r-knitr
+
+  run:
+    - r-base
+    - r-assertive.base >=0.0_4
+    - r-assertive.code
+    - r-assertive.data
+    - r-assertive.data.uk
+    - r-assertive.data.us
+    - r-assertive.datetimes
+    - r-assertive.files
+    - r-assertive.matrices
+    - r-assertive.models
+    - r-assertive.numbers
+    - r-assertive.properties >=0.0_2
+    - r-assertive.reflection >=0.0_2
+    - r-assertive.sets >=0.0_2
+    - r-assertive.strings
+    - r-assertive.types >=0.0_2
+    - r-knitr
+
+test:
+  commands:
+    - $R -e "library('assertive')"  # [not win]
+    - "\"%R%\" -e \"library('assertive')\""  # [win]
+
+about:
+  home: https
+  license: GPL (>= 3)
+  summary: Lots of predicates (is_* functions) to check the state of your variables, and assertions
+    (assert_* functions) to throw errors if they aren't in the right form.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - roryk


### PR DESCRIPTION
This is the virtual package that includes all of the assertive.* packages. There are some R packages import this instead of the specific assertive.* package they want. This is made from the CRAN helper script.