### PR TITLE
Add python-bidi

### DIFF
--- a/recipes/python-bidi/meta.yaml
+++ b/recipes/python-bidi/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "python-bidi" %}
+{% set version = "0.4.0" %}
+{% set sha256 = "1a1b3dbee4a0b307c91a465ba4caa8baaaa178151acd20de50ba24f9385f7e13" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  entry_points:
+    - pybidi = bidi:main
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - six
+    - pip
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - bidi
+  commands:
+    - pybidi --help
+
+about:
+  home: https://github.com/MeirKriheli/python-bidi
+  license: GNU Library or Lesser General Public License (LGPL)
+  license_family: LGPL
+  license_file: ''
+  summary: Pure python implementation of the BiDi layout algorithm
+  description: Bi-directional (BiDi) layout implementation in pure python
+  doc_url: http://python-bidi.readthedocs.io/en/latest/
+  dev_url: https://github.com/MeirKriheli/python-bidi
+
+extra:
+  recipe-maintainers: kastman

--- a/recipes/python-bidi/meta.yaml
+++ b/recipes/python-bidi/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: https://github.com/MeirKriheli/python-bidi
-  license: GNU Library or Lesser General Public License (LGPL)
+  license: LGPL
   license_family: LGPL
   license_file: ''
   summary: Pure python implementation of the BiDi layout algorithm
@@ -44,4 +44,5 @@ about:
   dev_url: https://github.com/MeirKriheli/python-bidi
 
 extra:
-  recipe-maintainers: kastman
+  recipe-maintainers:
+    - kastman

--- a/recipes/python-bidi/meta.yaml
+++ b/recipes/python-bidi/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   host:
     - python
     - setuptools
-    - six
     - pip
   run:
     - python
@@ -35,9 +34,9 @@ test:
 
 about:
   home: https://github.com/MeirKriheli/python-bidi
-  license: LGPL
+  license: LGPLv3
   license_family: LGPL
-  license_file: ''
+  license_file: 'COPYING.LESSER'
   summary: Pure python implementation of the BiDi layout algorithm
   description: Bi-directional (BiDi) layout implementation in pure python
   doc_url: http://python-bidi.readthedocs.io/en/latest/


### PR DESCRIPTION
For some reason this isn't correctly re-locating the console_script entry point, so the test is failing with `bad interpreter`. Will look more after the full CI is run here.