### PR TITLE
Add robotframework-seleniumlibrary

### DIFF
--- a/recipes/robotframework-seleniumlibrary/meta.yaml
+++ b/recipes/robotframework-seleniumlibrary/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "robotframework-seleniumlibrary" %}
+{% set version = "3.1.1" %}
+{% set sha256 = "d29213ff38a22352cf983f36c581be76428d899e5e390890acafe13ac278824c" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - selenium >=2.53.6
+    - robotframework >=2.8.7
+
+test:
+  imports:
+    - SeleniumLibrary
+
+about:
+  home: https://github.com/robotframework/SeleniumLibrary
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: Web testing library for Robot Framework
+  doc_url: http://robotframework.org/SeleniumLibrary/SeleniumLibrary.html
+  dev_url: https://github.com/robotframework/SeleniumLibrary
+  description: |
+    SeleniumLibrary is a web testing library for Robot Framework that utilizes
+    the Selenium tool internally. The project is hosted on GitHub and downloads
+    can be found from PyPI.
+
+    SeleniumLibrary works with Selenium 2.53.6 or newer, including Selenium 3.
+    It supports Python 2.7 as well as Python 3.3 or newer. In addition to the
+    normal Python interpreter, it works also with PyPy and Jython.
+    Unfortunately Selenium is not currently supported by IronPython and thus
+    this library does not work with IronPython either.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Adds `robotframework-seleniumlibrary` 3.1.1 from pypi

Looking forward to getting a (chrome|gecko)driver added as well.

@windelbouwmanbosch @windelbouwman any interest in being added as a co-maintainer?