### PR TITLE
Ignore `.swp` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ build_artifacts
 # Compiled Python code
 __pycache__
 *.pyc
+
+# Editor files
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+# macOS folder metadata
 .DS_Store
+
+# User builds
 build_artifacts
+
+# Compiled Python code
 __pycache__
 *.pyc


### PR DESCRIPTION
Refreshes `.gitignore` a bit and adds `.swp` files to the list.

xref: https://github.com/conda-forge/staged-recipes/pull/5743