### PR TITLE
Add PythonQwt recipe

### DIFF
--- a/recipes/pythonqwt/meta.yaml
+++ b/recipes/pythonqwt/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "PythonQwt" %}
+{% set version = "0.5.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/PierreRaybaut/PythonQwt/archive/v{{ version }}.tar.gz
+  sha256: ca3b4e34f51ade4681b99d73b5a9134498fee84a832e36cfd8f400b9acc07723
+  patches:
+    - removed_entry_points.patch
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  noarch: python
+
+requirements:
+  build:
+    - setuptools
+    - python
+    - pyqt
+    - numpy
+    - pip
+  run:
+    - python
+    - pyqt
+    - numpy
+
+test:
+  imports:
+    - qwt
+    - qwt.tests
+    - qwt.plot
+    - qwt.qt
+
+about:
+  home: http://pierreraybaut.github.io/PythonQwt/
+  license: LGPL
+  license_family: LGPL
+  license_file: LICENSE
+  summary: 'PythonQwt: Qt plotting widgets for Python'
+  description: |
+    The PythonQwt project was initiated to solve -at least temporarily- the
+    obsolescence issue of PyQwt (the Python-Qwt C++ bindings library) which is
+    no longer maintained. The idea was to translate the original Qwt C++ code
+    to Python and then to optimize some parts of the code by writing new
+    modules based on NumPy and other libraries.
+  doc_url: https://pythonhosted.org/PythonQwt/
+  dev_url: https://github.com/PierreRaybaut/PythonQwt
+
+extra:
+  recipe-maintainers:
+    - marcelotrevisani

--- a/recipes/pythonqwt/removed_entry_points.patch
+++ b/recipes/pythonqwt/removed_entry_points.patch
@@ -1,0 +1,12 @@
+--- setup.py	2016-01-17 14:01:36.000000000 +0100
++++ setup.py	2018-05-03 19:38:13.436323207 +0200
+@@ -120,9 +120,6 @@
+                         'Doc':  ["Sphinx>=1.1"],
+                         'Tests':  ["guidata>=1.7.0"],
+                         },
+-      entry_points={'gui_scripts':
+-                    ['PythonQwt-tests-py%d = qwt.tests:run [Tests]'\
+-                     % sys.version_info.major,]},
+       author = "Pierre Raybaut",
+       author_email = 'pierre.raybaut@gmail.com',
+       url = 'https://github.com/PierreRaybaut/%s' % LIBNAME,


### PR DESCRIPTION
Add PythonQwt (It's not the same as PyQwt)

http://pierreraybaut.github.io/PythonQwt/
https://github.com/PierreRaybaut/PythonQwt

"The PythonQwt project was initiated to solve -at least temporarily- the obsolescence issue of PyQwt (the Python-Qwt C++ bindings library) which is no longer maintained. The idea was to translate the original Qwt C++ code to Python and then to optimize some parts of the code by writing new modules based on NumPy and other libraries."