### PR TITLE
add robotframework-sshlibrary

### DIFF
--- a/recipes/robotframework-sshlibrary/meta.yaml
+++ b/recipes/robotframework-sshlibrary/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "robotframework-sshlibrary" %}
+{% set version = "3.0.0" %}
+{% set sha256 = "2a266bdcc2854fec8b40baf968e02b996e069964ae4b1ae84501c2f396a02276" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - robotframework >=3.0
+    - paramiko >=1.15.0
+
+test:
+  imports:
+    - SSHLibrary
+
+about:
+  home: https://github.com/robotframework/SSHLibrary
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: Robot Framework test library for SSH and SFTP
+  description: |
+    SSHLibrary is operating system independent and supports Python 2.7 as well
+    as Python 3.4 or newer. In addition to the normal Python interpreter, it
+    also works with Jython 2.7.
+
+    The library has the following main usages:
+
+    - Executing commands on the remote machine, either with blocking or
+      non-blocking behavior.
+    - Writing and reading in an interactive shell.
+    - Transferring files and directories over SFTP.
+    - Ensuring that files and directories exist on the remote machine.
+  doc_url: http://robotframework.org/SSHLibrary/SSHLibrary.html
+  dev_url: https://github.com/robotframework/SSHLibrary
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Adds the [:robot:framework-ssh:books:](https://github.com/robotframework/SSHLibrary), which just added python3 compatibility and `sudo` support.