### PR TITLE
Recipe for os-service-types

### DIFF
--- a/recipes/os-service-types/meta.yaml
+++ b/recipes/os-service-types/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "os-service-types" %}
+{% set version = "1.2.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "b08fb4ec1249d313afea2728fa4db916b1907806364126fe46de482671203111" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.{{ file_ext }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  {{ hash_type }}: {{ hash_value }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+    - pbr !=2.1.0,>=2.0.0
+
+  run:
+    - python
+    - pbr !=2.1.0,>=2.0.0
+
+about:
+  home: https://docs.openstack.org/os-service-types/latest/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Summary of the package
+  description: Python library for consuming OpenStack sevice-types-authority data.
+  doc_url: https://docs.openstack.org/os-service-types/latest/
+  dev_url: https://git.openstack.org/cgit/openstack/os-service-types
+
+extra:
+  recipe-maintainers: pmlandwehr

--- a/recipes/os-service-types/meta.yaml
+++ b/recipes/os-service-types/meta.yaml
@@ -27,6 +27,11 @@ requirements:
   run:
     - python
     - pbr !=2.1.0,>=2.0.0
+    
+  test:
+    imports:
+      - os_service_types
+      
 
 about:
   home: https://docs.openstack.org/os-service-types/latest/
@@ -39,4 +44,5 @@ about:
   dev_url: https://git.openstack.org/cgit/openstack/os-service-types
 
 extra:
-  recipe-maintainers: pmlandwehr
+  recipe-maintainers:
+    - pmlandwehr

--- a/recipes/os-service-types/meta.yaml
+++ b/recipes/os-service-types/meta.yaml
@@ -27,11 +27,10 @@ requirements:
   run:
     - python
     - pbr !=2.1.0,>=2.0.0
-    
-  test:
-    imports:
-      - os_service_types
-      
+
+test:
+  imports:
+    - os_service_types
 
 about:
   home: https://docs.openstack.org/os-service-types/latest/


### PR DESCRIPTION
`os-service-types` is a new dependency for `openstacksdk` (see [this pull](https://github.com/conda-forge/openstacksdk-feedstock/pull/6)), which various other Open Stack packages depend on.