### PR TITLE
add PyVISA

### DIFF
--- a/recipes/pyvisa/meta.yaml
+++ b/recipes/pyvisa/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "PyVISA" %}
+{% set version = "1.9.0" %}
+{% set sha256 = "38e4a2800122b06441346d8469317f8117ee0d8ce700d12bf5bef337e6c152b5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - enum34  # [py<3]
+
+test:
+  imports:
+    - visa
+
+about:
+  home: https://github.com/pyvisa/pyvisa
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A Python package with bindings to the VISA library'
+  description: |
+    A Python package with bindings to the "Virtual Instrument Software
+    Architecture" VISA library, in order to control measurement devices and test
+     equipment via GPIB, RS232, or USB.
+  doc_url: https://pyvisa.readthedocs.io/
+  dev_url: https://github.com/pyvisa/pyvisa
+
+extra:
+  recipe-maintainers:
+    - carlodri


### PR DESCRIPTION
A Python package for support of the "Virtual Instrument Software Architecture" (VISA), in order to control measurement devices and test equipment via GPIB, RS232, Ethernet or USB.