### PR TITLE
Reuse Github token in `repo_exists`

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -11,7 +11,6 @@ Such as:
 from __future__ import print_function
 
 from conda_build.metadata import MetaData
-from conda_smithy.github import gh_token
 from contextlib import contextmanager
 from datetime import datetime
 from github import Github, GithubException
@@ -52,9 +51,7 @@ def tmp_dir(*args, **kwargs):
         shutil.rmtree(temp_dir)
 
 
-def repo_exists(organization, name):
-    token = gh_token()
-    gh = Github(token)
+def repo_exists(gh, organization, name):
     # Use the organization provided.
     org = gh.get_organization(organization)
     try:
@@ -146,7 +143,7 @@ if __name__ == '__main__':
                                   cwd=feedstock_dir)
 
             # Sometimes we already have the feedstock created. We need to deal with that case.
-            if repo_exists('conda-forge', name + '-feedstock'):
+            if repo_exists(gh, 'conda-forge', name + '-feedstock'):
                 subprocess.check_call(['git', 'fetch', 'upstream_with_token'], cwd=feedstock_dir)
                 subprocess.check_call(['git', 'branch', '-m', 'master', 'old'], cwd=feedstock_dir)
                 try:


### PR DESCRIPTION
As we have already gone through the trouble of constructing a `Github` object, just pass it into `repo_exists` for reuse. This already what we do in a few other functions. So we might as well do the same here.