### PR TITLE
Add a recipe for secretstorage

### DIFF
--- a/recipes/secretstorage/meta.yaml
+++ b/recipes/secretstorage/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "secretstorage" %}
+{% set version = "3.0.1" %}
+{% set sha256 = "819087ca89c0d6c5711692f41fb26f786af9dcc5bb89d567722a66edfbb2a689" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not linux]
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - cryptography
+    - jeepney
+
+test:
+  imports:
+    - secretstorage
+
+about:
+  home: https://github.com/mitya57/secretstorage
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python bindings to Freedesktop.org Secret Service API'
+  description: |
+    This module provides a way for securely storing passwords and
+    other secrets. It uses D-Bus Secret Service API that is
+    supported by GNOME Keyring (since version 2.30) and
+    KSecretsService.
+  doc_url: https://secretstorage.readthedocs.io/en/latest/
+  dev_url: https://github.com/mitya57/secretstorage
+
+extra:
+  recipe-maintainers:
+    - ccordoba12

--- a/recipes/secretstorage/meta.yaml
+++ b/recipes/secretstorage/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "secretstorage" %}
+{% set name = "SecretStorage" %}
 {% set version = "3.0.1" %}
 {% set sha256 = "819087ca89c0d6c5711692f41fb26f786af9dcc5bb89d567722a66edfbb2a689" %}
 
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:


### PR DESCRIPTION
This is needed to make the `keyring` package work on Linux.