### PR TITLE
Add aggdraw recipe

### DIFF
--- a/recipes/aggdraw/meta.yaml
+++ b/recipes/aggdraw/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - pip
     - setuptools
     - freetype
   run:

--- a/recipes/aggdraw/meta.yaml
+++ b/recipes/aggdraw/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "aggdraw" %}
+{% set version = "1.3.3" %}
+{% set sha256 = "ed531c790ef2fdac45d9526ec0737b96ed506dc0abb95abdbc07aeacb8e9061c" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - setuptools
+    - freetype
+  run:
+    - python
+    - pillow
+
+test:
+  imports:
+    - aggdraw
+  commands:
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME   # [osx]
+
+about:
+  home: https://github.com/pytroll/aggdraw
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: High quality drawing interface for PIL.
+  description: 'The aggdraw module implements the basic WCK 2D Drawing Interface on
+    top of the AGG library. This library provides high-quality drawing,
+    with anti-aliasing and alpha compositing, while being fully compatible
+    with the WCK renderer.'
+  doc_url: ''
+  dev_url: https://github.com/pytroll/aggdraw
+
+extra:
+  recipe-maintainers:
+    - djhoese
+    - mraspaud
+    - adybbroe
+    - pnuu


### PR DESCRIPTION
Add aggdraw package recipe. The freetype dependency is technically optional, but with conda all the hard work is already done.