### PR TITLE
Package cgroupspy

### DIFF
--- a/recipes/cgroupspy/meta.yaml
+++ b/recipes/cgroupspy/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipes/cgroupspy/meta.yaml
+++ b/recipes/cgroupspy/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "cgroupspy" %}
+{% set version = "0.1.6" %}
+{% set sha256 = "fb4aac7938499cff53c260112fb0759a54fb5f8bad89d9be0326c70a7619821a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - cgroupspy
+    - cgroupspy.contenttypes
+    - cgroupspy.controllers
+    - cgroupspy.interfaces
+    - cgroupspy.nodes
+    - cgroupspy.trees
+    - cgroupspy.utils
+
+about:
+  home: https://github.com/cloudsigma/cgroupspy
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python library for managing cgroups'
+
+  description: |
+    Python library for managing cgroups
+
+    The library provides a pythonic way to manage and represent cgroups.
+    It provides interfaces that convert python objects to cgroups
+    compatible strings and vise versa.
+  dev_url: https://github.com/cloudsigma/cgroupspy
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
[cgroupspy](https://pypi.org/project/cgroupspy/#description)  is a Python library for managing cgroups

The library provides a pythonic way to manage and represent cgroups. It provides interfaces that convert
python objects to cgroups compatible strings and vise versa.

It will be used as part of the airflow metapackage `airflow-with-cgroups`