### PR TITLE
[R2M] Package jaydebeapi

### DIFF
--- a/recipes/jaydebeapi/meta.yaml
+++ b/recipes/jaydebeapi/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipes/jaydebeapi/meta.yaml
+++ b/recipes/jaydebeapi/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "JayDeBeApi" %}
+{% set version = "1.1.1" %}
+{% set sha256 = "ba2dfa92c55e39476cea5a4b1a1750d94c8b3d166ed3c7f99601f19f744f2828" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - jpype1
+
+test:
+  imports:
+    - jaydebeapi
+
+about:
+  home: https://github.com/baztian/jaydebeapi
+  license: LGPL-3.0
+  license_family: GPL
+  license_file: COPYING
+  summary: 'A Python DB-APIv2.0 compliant library for JDBC Drivers'
+
+  description: |
+    The JayDeBeApi module allows you to connect from Python code to
+    databases using Java JDBC. It provides a Python DB-API v2.0 to that
+    database.
+
+    It works on ordinary Python (cPython) using the JPype Java
+    integration or on Jython to make use of the Java JDBC driver.
+
+    In contrast to zxJDBC from the Jython project JayDeBeApi let's you
+    access a database with Jython AND Python with only minor code
+    modifications. JayDeBeApi's future goal is to provide a unique and
+    fast interface to different types of JDBC-Drivers through a flexible
+    plug-in mechanism.
+  dev_url: https://github.com/baztian/jaydebeapi
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
The [JayDeBeApi](https://pypi.org/project/JayDeBeApi/) module allows you to connect from Python code to databases using Java JDBC. It provides a Python DB-API v2.0 to that database.

It will be used as part of the airflow meta-package `airflow-with-jdbc`