### PR TITLE
added r-paco; conda-build passing

### DIFF
--- a/recipes/r-paco/bld.bat
+++ b/recipes/r-paco/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-paco/build.sh
+++ b/recipes/r-paco/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/paco
+  mv * $PREFIX/lib/R/library/paco
+fi

--- a/recipes/r-paco/meta.yaml
+++ b/recipes/r-paco/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = '0.3.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paco
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: paco_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/paco_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paco/paco_{{ version }}.tar.gz
+  sha256: cc40096d0803fa07e7b7c7e4808dbfbac8cab5e29e529f203c0d608a9d48c661
+
+build:
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+  host:
+    - r-base
+    - r-plyr
+    - r-vegan >=2.2_0
+  run:
+    - r-base
+    - r-plyr
+    - r-vegan >=2.2_0
+
+test:
+  commands:
+    - $R -e "library('paco')"           # [not win]
+    - "\"%R%\" -e \"library('paco')\""  # [win]
+
+about:
+  home: http://www.uv.es/cophylpaco/
+  license: MIT
+  summary: Procrustes analyses to infer co-phylogenetic matching between pairs of (ultrametric)
+    phylogenetic trees.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - nick-youngblut


### PR DESCRIPTION
This is my first contribution. `conda-build r-paco` is passing on my mac (OSX v10.11.6). 