### PR TITLE
Add pythran

### DIFF
--- a/recipes/pythran/dprod.py
+++ b/recipes/pythran/dprod.py
@@ -1,0 +1,3 @@
+#pythran export dprod(int list, int list)
+def dprod(l0,l1):
+    return sum(x * y for x, y in zip(l0, l1))

--- a/recipes/pythran/meta.yaml
+++ b/recipes/pythran/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - numpy 1.13.*
     - pytest-runner
   run:
-    - {{ compiler('cxx') }}
     - python
     - gmp 6.*
     - ply
@@ -40,6 +39,8 @@ requirements:
 test:
   files:
     - dprod.py
+  requires:
+    - {{ compiler('cxx') }}
   commands:
     - pythran dprod.py
     - python -c 'import dprod'

--- a/recipes/pythran/meta.yaml
+++ b/recipes/pythran/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "pythran" %}
+{% set version = "0.8.5" %}
+{% set sha256 = "92f67171d03ba3dbed9da639c35aad2fe0982c183f0c4459dcfddd621f69795e" %}
+{% set variant = "openblas" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  skip: true  # [win]
+  features:
+    - blas_{{ variant }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - pip
+    - gmp 6.*
+    - numpy 1.13.*
+    - pytest-runner
+  run:
+    - {{ compiler('cxx') }}
+    - python
+    - gmp 6.*
+    - ply
+    - networkx
+    - numpy 1.13.*
+    - six
+    - gast
+
+test:
+  files:
+    - dprod.py
+  commands:
+    - pythran dprod.py
+    - python -c 'import dprod'
+
+about:
+  home: http://github.com/serge-sans-paille/pythran
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'a claimless python to c++ converter'
+
+  description: |
+    Pythran is an ahead of time compiler for a subset of the Python language,
+    with a focus on scientific computing. It takes a Python module annotated
+    with a few interface description and turns it into a native Python module
+    with the same interface, but (hopefully) faster.
+  doc_url: https://pythran.readthedocs.io/
+  dev_url: https://github.com/serge-sans-paille/pythran
+
+extra:
+  recipe-maintainers:
+    - saraedum
+    - serge-sans-paille


### PR DESCRIPTION
Pythran is an ahead of time compiler for a subset of the Python language, with a focus on scientific computing. It takes a Python module annotated with a few interface description and turns it into a native Python module with the same interface, but (hopefully) faster.

It is meant to efficiently compile scientific programs, and takes advantage of multi-cores and SIMD instruction units.

Fixes https://github.com/serge-sans-paille/pythran/issues/907.