### PR TITLE
Add ligo-common

### DIFF
--- a/recipes/ligo-common/meta.yaml
+++ b/recipes/ligo-common/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - pip
   run:
     - python
+    - setuptools
 
 test:
   imports:

--- a/recipes/ligo-common/meta.yaml
+++ b/recipes/ligo-common/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "1.0.3" %}
+
+package:
+  name: ligo-common
+  version: {{version}}
+
+source:
+  fn: ligo-common-{{version}}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/ligo-common-{{version}}.tar.gz
+  md5: 142c2e287cc09bd0192c916a0be6e492
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - ligo
+
+about:
+  home: https://git.ligo.org/lscsoft/ligo-common
+  license: GPLv3
+  license_file: LICENSE
+  summary: Base package for `ligo` python namespace
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/ligo-common/meta.yaml
+++ b/recipes/ligo-common/meta.yaml
@@ -2,12 +2,13 @@
 
 package:
   name: ligo-common
-  version: {{version}}
+  version: {{ version }}
 
 source:
-  fn: ligo-common-{{version}}.tar.gz
-  url: http://software.ligo.org/lscsoft/source/ligo-common-{{version}}.tar.gz
+  fn: ligo-common-{{ version }}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/ligo-common-{{ version }}.tar.gz
   md5: 142c2e287cc09bd0192c916a0be6e492
+  sha256: a3e00d79bf3b0474b429f50fb60079da015453afa09658f90efcab8ae158a835
 
 build:
   number: 0


### PR DESCRIPTION
`ligo-common` is the base package for the python `ligo` namespace used in GW astronomy.