### PR TITLE
Add recipe for libcxxwrap-julia

### DIFF
--- a/recipes/libcxxwrap-julia/bld.bat
+++ b/recipes/libcxxwrap-julia/bld.bat
@@ -1,0 +1,8 @@
+cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/libcxxwrap-julia/build.sh
+++ b/recipes/libcxxwrap-julia/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_INSTALL_LIBDIR=lib $SRC_DIR
+make install

--- a/recipes/libcxxwrap-julia/meta.yaml
+++ b/recipes/libcxxwrap-julia/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "libcxxwrap-julia" %}
+{% set version = "0.2.2" %}
+{% set sha256 = "62cb4216efb3dc39736630ec747fb35e8685e6cd888b65d6e431905ba45918c6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/JuliaInterop/libcxxwrap-julia/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  # Julia has not been packaged for conda on OS X or Windows
+  skip: true  # [not linux]
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('cxx') }}
+    - julia >=0.6,<0.7
+  run:
+    - julia >=0.6,<0.7
+
+test:
+  commands:
+    - test -d ${PREFIX}/include/jlcxx  # [unix]
+    - test -f ${PREFIX}/include/jlcxx/jlcxx.hpp  # [unix]
+    - test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfig.cmake  # [unix]
+    - test -f ${PREFIX}/lib/cmake/JlCxx/JlCxxConfigVersion.cmake  # [unix]
+
+    - if exist %LIBRARY_PREFIX%\include\JlCxx\jlcxx.hpp (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfig.cmake (exit 0) else (exit 1)  # [win]
+    - if exist %LIBRARY_PREFIX%\lib\cmake\JlCxx\JlCxxConfigVersion.cmake (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://github.com/JuliaInterop/CxxWrap.jl
+  license: MIT
+  license_family: MIT
+  # LICENSE file missing from source.
+  # cf https://github.com/JuliaInterop/libcxxwrap-julia/issues/2
+  # license_file: LICENSE
+  summary: 'Seamless operability between C++11 and Julia'
+  description: 'Lightweight library that exposes C++ types in Julia and vice versa'
+  doc_url: https://github.com/JuliaInterop/libcxxwrap-julia
+  dev_url: https://github.com/JuliaInterop/libcxxwrap-julia
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay
+    - JohanMabille
+    - barche


### PR DESCRIPTION
CxxWrap was split into 

 - `libcxxwrap-julia` the pure C++ library, which can be installed in the general prefix as a native package.
 - `CxxWrap.jl` for the Julia part, seeking `libcxxwrap-julia` in the right place depending on the value of an environment variable at build time.

This PR adds a recipe for `libcxxwrap-julia`.