### PR TITLE
Create dummy noarch index for conda on Linux

### DIFF
--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -37,6 +37,9 @@ export CONDA_NPY='19'
 # A lock sometimes occurs with incomplete builds. The lock file is stored in build_artifacts.
 conda clean --lock
 
+# Ensure that `noarch` exists otherwise `conda` won't think this channel is valid.
+conda index /home/conda/staged-recipes/build_artifacts/noarch
+
 conda install --yes conda-forge-ci-setup=1.* conda-forge-pinning networkx
 source run_conda_forge_build_setup
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/5869 ).

The `noarch` index doesn't seem to be generated by `conda-build` in this case as we are using a non-standard API. However not having `noarch` seems to cause `conda` to fail in this case. To fix this issue, go ahead and create a dummy `noarch` index so this appears to be a valid channel. This seems to satisfy `conda` and allows the build to proceed.