### PR TITLE
Use `conda`'s quiet option when installing

### DIFF
--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -40,7 +40,7 @@ conda clean --lock
 # Ensure that `noarch` exists otherwise `conda` won't think this channel is valid.
 conda index /home/conda/staged-recipes/build_artifacts/noarch
 
-conda install --yes conda-forge-ci-setup=1.* conda-forge-pinning networkx
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/5869 )

As we now use an interactive TTY, the `--quiet` option is needed to suppress progress bars and such that generally get rendered poorly on CIs. Hence we add the `--quiet` option here to address this cosmetic issue.