### PR TITLE
Add pyviz_comms

### DIFF
--- a/recipes/pyviz_comms/meta.yaml
+++ b/recipes/pyviz_comms/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "1.5.0" %}
+
+package:
+  name: pyviz_comms
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-0.1.0.tar.gz
+  sha256: 8d10e2d91ef117bbf718addc0fa80ec7073cf9fd9f9cfc327916bdb33b9a9262
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+  
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - pyviz_comms
+
+about:
+  home: www.pyviz.org
+  summary: Bidirectional communication for PyViz
+  license: BSD 3-Clause
+
+extra:
+  recipe-maintainers:
+    - jlstevens
+    - philippjfr

--- a/recipes/pyviz_comms/meta.yaml
+++ b/recipes/pyviz_comms/meta.yaml
@@ -29,6 +29,7 @@ about:
   home: www.pyviz.org
   summary: Bidirectional communication for PyViz
   license: BSD 3-Clause
+  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:

--- a/recipes/pyviz_comms/meta.yaml
+++ b/recipes/pyviz_comms/meta.yaml
@@ -29,7 +29,6 @@ about:
   home: www.pyviz.org
   summary: Bidirectional communication for PyViz
   license: BSD 3-Clause
-  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:

--- a/recipes/pyviz_comms/meta.yaml
+++ b/recipes/pyviz_comms/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = "1.5.0" %}
+{% set version = "0.1.0" %}
 
 package:
   name: pyviz_comms
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-0.1.0.tar.gz
+  url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-{{ version }}.tar.gz
   sha256: 8d10e2d91ef117bbf718addc0fa80ec7073cf9fd9f9cfc327916bdb33b9a9262
 
 build:

--- a/recipes/pyviz_comms/meta.yaml
+++ b/recipes/pyviz_comms/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: pyviz_comms
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyviz_comms/pyviz_comms-{{ version }}.tar.gz
-  sha256: 8d10e2d91ef117bbf718addc0fa80ec7073cf9fd9f9cfc327916bdb33b9a9262
+  sha256: ab0f6dcaf9fdb4593ebea43d03078da29a97a3864f3f0a573dfcb18989380389
 
 build:
   number: 0
@@ -17,9 +17,11 @@ build:
 requirements:
   build:
     - python
+    - param
     - pip
   run:
     - python
+    - param
 
 test:
   imports:
@@ -29,6 +31,7 @@ about:
   home: www.pyviz.org
   summary: Bidirectional communication for PyViz
   license: BSD 3-Clause
+  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds a recipe for [pyviz_comms](https://github.com/pyviz/pyviz_comms), a project used to support a number of [pyviz](http://pyviz.org/) tools including [holoviews](http://holoviews.org/) and [parambokeh](https://github.com/ioam/parambokeh).