### PR TITLE
[skip lint] Don't add teams in staged-recipes

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
                     # Capture the output, as it may contain the GH_TOKEN.
                     out = subprocess.check_output(['git', 'push', 'upstream_with_token', 'HEAD:master'], cwd=feedstock_dir,
                                                   stderr=subprocess.STDOUT)
-                    subprocess.check_call(['conda', 'smithy', 'register-github', '--add-teams', feedstock_dir] + owner_info)
+                    subprocess.check_call(['conda', 'smithy', 'register-github', feedstock_dir] + owner_info)
                     break
                 except subprocess.CalledProcessError:
                     pass


### PR DESCRIPTION
This is so that the updating of teams happen in conda-forge-webservices only.
cc @jakirkham