### PR TITLE
Add ADIOS Python Bindings

### DIFF
--- a/recipes/adios-python/build.sh
+++ b/recipes/adios-python/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "$(uname)" == "Darwin" ]; then
+#    export CXX="${CXX} -stdlib=libc++"
+#    export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
+
+    # remove -lrt
+    sed -i '.bak' 's/ -lrt//g' $SRC_DIR/wrappers/numpy/Makefile
+fi
+
+# Python3 fixes
+if [[ "${PY_VER}" =~ 3 ]]
+then
+  find $SRC_DIR/utils -name "*.py" -exec 2to3 -w -n {} \;
+fi
+
+# numpy bindings
+cd wrappers/numpy
+make python
+python setup.py install

--- a/recipes/adios-python/build.sh
+++ b/recipes/adios-python/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 if [ "$(uname)" == "Darwin" ]; then
-#    export CXX="${CXX} -stdlib=libc++"
-#    export LDFLAGS="${LDFLAGS} -Wl,-rpath,$PREFIX/lib"
-
     # remove -lrt
     sed -i '.bak' 's/ -lrt//g' $SRC_DIR/wrappers/numpy/Makefile
 fi
@@ -17,4 +14,4 @@ fi
 # numpy bindings
 cd wrappers/numpy
 make python
-python setup.py install
+$PYTHON setup.py install

--- a/recipes/adios-python/meta.yaml
+++ b/recipes/adios-python/meta.yaml
@@ -16,7 +16,12 @@ build:
   skip: True  # [win]
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
+    # pinned ADIOS c library version is important:
+    # only works with exactly same release.
     - adios {{ version }}
     - python
     - setuptools

--- a/recipes/adios-python/meta.yaml
+++ b/recipes/adios-python/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "adios-python" %}
+{% set version = "1.13.1" %}
+{% set sha256 = "684096cd7e5a7f6b8859601d4daeb1dfaa416dfc2d9d529158a62df6c5bcd7a0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://users.nccs.gov/%7Epnorbert/adios-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  host:
+    - adios {{ version }}
+    - python
+    - setuptools
+    - cython
+    - numpy
+  run:
+    - adios {{ version }}
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  requires:
+    - numpy
+  imports:
+    - adios
+  commands:
+    - python -c "import adios; print(adios.__version__)"
+
+about:
+  home: https://www.olcf.ornl.gov/center-projects/adios/
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: COPYING
+  summary: 'Python bindings for the Adaptable IO System (ADIOS) for flexible and fast scientific data processing.'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    These are the python bindings for Adaptable IO System (ADIOS).
+    ADIOS provides a simple, flexible way
+    for scientists to describe the data in their code that may need
+    to be written, read, or processed outside of the running
+    simulation. By providing an external to the code XML file
+    describing the various elements, their types, and how you wish
+    to process them this run, the routines in the host code (either
+    Fortran or C) can transparently change how they process the
+    data.
+  doc_url: https://users.nccs.gov/~pnorbert/ADIOS-UsersManual-{{ version }}.pdf
+  dev_url: https://github.com/ornladios/ADIOS
+
+extra:
+  recipe-maintainers:
+    - ax3l


### PR DESCRIPTION
Follow-up to #5932, addion the numpy python bindings of ADIOS.

I could alternatively also put Python as a `host` dependency of the C library and always build both in the [`adios` recipe](https://github.com/conda-forge/adios-feedstock). We should be able to spare a python build matrix for the c library by separating the two.