### PR TITLE
Add ligotimegps

### DIFF
--- a/recipes/ligotimegps/meta.yaml
+++ b/recipes/ligotimegps/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "ligotimegps" %}
+{% set version = "1.2.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b3a53a7ec5728e8510f8a1a48e833c6ab9dbf7ee3b15aeef03790917de6241f7
+
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - setuptools
+    - pip
+  run:
+    - python
+    - six
+
+test:
+  requires:
+    - pytest
+  commands:
+    - pytest --pyargs {{ name }}
+
+about:
+  home: https://pypi.org/project/{{ name }}/
+  license: GPLv3
+  license_file: LICENSE
+  summary: A pure-python version of lal.LIGOTimeGPS
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/ligotimegps/meta.yaml
+++ b/recipes/ligotimegps/meta.yaml
@@ -34,6 +34,7 @@ about:
   home: https://pypi.org/project/{{ name }}/
   license: GPLv3
   license_file: LICENSE
+  license_family: GPL
   summary: A pure-python version of lal.LIGOTimeGPS
 
 extra:

--- a/recipes/ligotimegps/meta.yaml
+++ b/recipes/ligotimegps/meta.yaml
@@ -17,7 +17,8 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
+    - python
     - setuptools
     - pip
   run:


### PR DESCRIPTION
[`ligotimegps`](https://pypi.org/project/ligotimegps/) provides a pure-python version of `lal.LIGOTimeGPS`, a class that walks and talks like a float, but preserves nanosecond precision for GPS times by using two integers for underlying storage.