### PR TITLE
pytest-django-haystack

### DIFF
--- a/recipes/pytest-django-haystack/LICENSE
+++ b/recipes/pytest-django-haystack/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Andy Freeland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/pytest-django-haystack/meta.yaml
+++ b/recipes/pytest-django-haystack/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "pytest-django-haystack" %}
+{% set version = "0.3.0" %}
+{% set sha256 = "43547d5d8a816d1b460835a2b384a8ddac985c06ff79ab3f9216107460174f80" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - pytest
+    - django
+    - pytest-django
+
+test:
+  imports:
+    - pytest_django_haystack
+
+about:
+  home: https://github.com/rouge8/pytest-django-haystack
+  license: MIT
+  license_family: MIT
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: 'django-haystack plugin for py.test'
+
+extra:
+  recipe-maintainers:
+    - scopatz


### PR DESCRIPTION
New `noarch: python` recipe