### PR TITLE
Add pyct

### DIFF
--- a/recipes/pyct/meta.yaml
+++ b/recipes/pyct/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "pyct" %}
+{% set version = "0.4.3" %}
+{% set sha256 = "2e74b0bf43d7428a76d0dc6ecb8b8949f090f25e286bc44682de05a74ff89eab" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python >=2.7
+    - pyyaml
+    - requests
+
+test:
+  imports:
+    - pyct
+    - pyct.cmd
+
+about:
+  home: 'http://github.com/pyviz/pyct',
+  license: BSD 3-Clause
+  license_file: LICENSE
+  summary: python package common tasks for users (e.g. copy examples, fetch data, ...)
+
+extra:
+  recipe-maintainers:
+    - ceball

--- a/recipes/pyct/meta.yaml
+++ b/recipes/pyct/meta.yaml
@@ -30,7 +30,7 @@ test:
     - pyct.cmd
 
 about:
-  home: 'http://github.com/pyviz/pyct',
+  home: http://github.com/pyviz/pyct
   license: BSD 3-Clause
   license_file: LICENSE
   summary: python package common tasks for users (e.g. copy examples, fetch data, ...)


### PR DESCRIPTION
A recipe for pyct, which is required for datashader 0.6.6 (and other pyviz projects in the future).