### PR TITLE
add fusepy

### DIFF
--- a/recipes/fusepy/meta.yaml
+++ b/recipes/fusepy/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "2.0.4" %}
+
+package:
+  name: fusepy
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/f/fusepy/fusepy-{{ version }}.tar.gz
+  sha256: 10f5c7f5414241bffecdc333c4d3a725f1d6605cae6b4eaf86a838ff49cdaf6c
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - fuse
+
+about:
+  home: http://github.com/terencehonles/fusepy
+  license: ISC
+  # Waiting on https://github.com/fusepy/fusepy/pull/74
+  # license_file: ''
+  summary: Simple ctypes bindings for FUSE
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/fusepy/yum_requirements.txt
+++ b/recipes/fusepy/yum_requirements.txt
@@ -1,0 +1,1 @@
+fuse-libs


### PR DESCRIPTION
@rsignell-usgs ideally we should package `libfuse` too to avoid relying on the system lib here.