### PR TITLE
Add pyosreplace

### DIFF
--- a/recipes/pyosreplace/meta.yaml
+++ b/recipes/pyosreplace/meta.yaml
@@ -41,4 +41,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - alimanfoo
     - jakirkham

--- a/recipes/pyosreplace/meta.yaml
+++ b/recipes/pyosreplace/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pyosreplace" %}
+{% set version = "0.1" %}
+{% set sha256 = "3b4a587525cf2d98deae834a5263163250b370d463da4d78721dda13f254ad41" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.zip
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not win]
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - osreplace
+  source_files:
+    - tests.py
+  commands:
+    - python tests.py
+
+about:
+  home: https://bitbucket.org/tiran/pyosreplace
+  license: PSF 2
+  license_file: LICENSE
+  summary: "os.replace() backport for Python 2.x"
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/issues/5972

Adds a recipe for `pyosreplace`, a backport of the Python 3 `os.replace` command for Windows.