### PR TITLE
Backports.ssl match hostname

### DIFF
--- a/recipes/backports.ssl_match_hostname/meta.yaml
+++ b/recipes/backports.ssl_match_hostname/meta.yaml
@@ -32,7 +32,7 @@ about:
   home: https://bitbucket.org/brandon/backports.ssl_match_hostname/src/default/
   license: Python v2.0
   license_family: PSF
-  license_file: LICENSE.txt
+  license_file: backports/ssl_match_hostname/LICENSE.txt
   summary: 'The match_hostname() function from the Python 3.2 ssl Standard Library package.'
 
 extra:

--- a/recipes/backports.ssl_match_hostname/meta.yaml
+++ b/recipes/backports.ssl_match_hostname/meta.yaml
@@ -11,18 +11,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: echo "this is a metapackage"
+  skip: True  # [py>=35]
 
 requirements:
-  host:
-    - python
-    - pip
   run:
-    - python
-    - backports
-    - ipaddress
+    - ssl_match_hostname ={{ version }}
 
 test:
   imports:

--- a/recipes/backports.ssl_match_hostname/meta.yaml
+++ b/recipes/backports.ssl_match_hostname/meta.yaml
@@ -31,7 +31,7 @@ test:
 about:
   home: https://bitbucket.org/brandon/backports.ssl_match_hostname/src/default/
   license: Python v2.0
-  license_family: PSL
+  license_family: PSF
   license_file: LICENSE.txt
   summary: 'The match_hostname() function from the Python 3.2 ssl Standard Library package.'
 

--- a/recipes/backports.ssl_match_hostname/meta.yaml
+++ b/recipes/backports.ssl_match_hostname/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "backports.ssl_match_hostname" %}
+{% set version = "3.5.0.1" %}
+{% set sha256 = "502ad98707319f4a51fa2ca1c677bd659008d27ded9f6380c79e8932e38dcdf2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - backports
+    - ipaddress
+
+test:
+  imports:
+    - backports.ssl_match_hostname
+
+about:
+  home: https://bitbucket.org/brandon/backports.ssl_match_hostname/src/default/
+  license: Python v2.0
+  license_family: PSL
+  license_file: LICENSE.txt
+  summary: 'The match_hostname() function from the Python 3.2 ssl Standard Library package.'
+
+extra:
+  recipe-maintainers:
+    - scopatz


### PR DESCRIPTION
needed to address https://github.com/conda-forge/websocket-client-feedstock/issues/10

noarch: python