### PR TITLE
add tensorflow-hub

### DIFF
--- a/recipes/tensorflow-hub/meta.yaml
+++ b/recipes/tensorflow-hub/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: tensorflow-hub
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/py2.py3/t/tensorflow_hub/tensorflow_hub-{{ version }}-py2.py3-none-any.whl
+  sha256: ea03fae411c9db759a966e9311a1eae8c19dd360b9ab8bb03923f846912280dd
+
+build:
+  number: 0
+  noarch: python
+  # install using pip from the whl files on PyPI
+  # b/c this uses bazel to build.
+  script: python -m pip install --no-deps --ignore-installed tensorflow_hub-{{ version }}-py2.py3-none-any.whl
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - tensorflow
+
+test:
+  imports:
+    # Skip the import test on Linux as wheel file require a more recent
+    # version of GLIBC++ than the VM used to build and test package.
+    - tensorflow_hub  # [not linux]
+
+about:
+  home: https://www.tensorflow.org/hub/
+  license: Apache-2.0
+  license_file: tensorflow_hub-{{ version }}.dist-info/LICENSE.txt
+  summary: A library for transfer learning by reusing parts of TensorFlow models.
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
@rsignell-usgs I decided to re-package the wheel here b/c there is no source distribution on PyPI and the GitHub instructions seems to use `bazel`.

However, I have a suspect that this package is actually a pure python package and it would be possible to package from source without `bazel`. I'll investigate this later once I get some free time.