### PR TITLE
Add awslogs-sd to conda-forge

### DIFF
--- a/recipes/awslogs-sd/meta.yaml
+++ b/recipes/awslogs-sd/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - systemd-python
 
 test:
-  import:
+  imports:
     - awslogs_sd
   commands:
     - awslogs-sd --help

--- a/recipes/awslogs-sd/meta.yaml
+++ b/recipes/awslogs-sd/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "awslogs-sd" %}
+{% set version = "0.5" %}
+{% set sha256 = "6d37e2396abb76fefef563ed9528c702becff6dd2428123ea439c003af54cdf2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - awslogs-sd: awslogs_sd.awslogs_sd:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python >=3
+    - awscli-cwlogs
+    - boto3
+    - gevent
+    - pyyaml
+    - requests
+    - retrying
+    - systemd-python
+
+test:
+  import:
+    - awslogs_sd
+  commands:
+    - awslogs-sd --help
+
+about:
+  home: https://github.com/mbachry/awslogs-sd
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'Forward systemd journal logs to cloudwatch'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    Forward systemd journal logs to CloudWatch.
+    A log forwarder daemon similar to Amazon's awslogs agent, but using 
+    per systemd unit journal output instead of text log files.
+  dev_url: https://github.com/mbachry/awslogs-sd
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
awslogs-sd is a log forwarder daemon similar to Amazon’s awslogs agent, but using per systemd unit journal output instead of text log files.

Two dependencies are missing from conda-forge:
  - [x] awscli-cwlogs
  - [ ] systemd-python

