### PR TITLE
added r-zeallot recipe

### DIFF
--- a/recipes/r-zeallot/LICENSE.txt
+++ b/recipes/r-zeallot/LICENSE.txt
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/recipes/r-zeallot/bld.bat
+++ b/recipes/r-zeallot/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-zeallot/build.sh
+++ b/recipes/r-zeallot/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/zeallot
+  mv * $PREFIX/lib/R/library/zeallot
+fi

--- a/recipes/r-zeallot/meta.yaml
+++ b/recipes/r-zeallot/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-zeallot
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: zeallot_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/zeallot_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/zeallot/zeallot_{{ version }}.tar.gz
+  sha256: 439f1213c97c8ddef9a1e1499bdf81c2940859f78b76bc86ba476cebd88ba1e9
+
+build:
+  number: 0
+  skip: true  # [win32]
+
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+
+  host:
+    - r-base
+
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('zeallot')"           # [not win]
+    - "\"%R%\" -e \"library('zeallot')\""  # [win]
+
+about:
+  home: https://github.com/nteetor/zeallot
+  license: MIT
+  summary: Provides a %<-% operator to perform multiple, unpacking, and destructuring assignment
+    in R. The  operator unpacks the right-hand side of an assignment into multiple values
+    and assigns these values to  variables on the left-hand side of the assignment.
+  license_family: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - zamorarr 


### PR DESCRIPTION
[zeallot](https://cran.r-project.org/web/packages/zeallot/index.html) recipe generated by [conda r skeleton helper](https://github.com/bgruening/conda_r_skeleton_helper)

This is a dependency for `r-keras`, which I plan to submit next. 