### PR TITLE
Initial recipe for kastore.

### DIFF
--- a/recipes/kastore/meta.yaml
+++ b/recipes/kastore/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "kastore" %}
+{% set version = "0.1.0" %}
+{% set sha256 = "f74e9b8f41f4ad0680fb1e669ef2a8e92d18f3066853e7542518e98eeb022626" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - kastore=kastore.__main__:main
+  # We need C99 and the Windows compilers before py35 won't work.
+  skip: True  # [win and py<35]
+
+# Following the guidance here for building against numpy:
+# https://conda-forge.org/docs/meta.html#building-against-numpy
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - setuptools
+    - python
+    - pip
+    - numpy
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - six
+    - humanize
+
+test:
+  imports:
+    - kastore
+
+  commands:
+    - kastore --help
+
+about:
+  home: http://github.com/kastore/kastore
+  license: MIT
+  license_family: MIT
+  # FIXME Not including this for now because it's not in the tarball. Fix 
+  # for version 0.2.0 https://github.com/tskit-dev/kastore/issues/43
+  # license_file: LICENSE
+  summary: Write-once-read-many key-array store
+  description: Simple key-value store for arrays of numerical data.
+  doc_url: 'http://kastore.readthedocs.io/en/stable'
+  dev_url: 'https://github.com/tskit-dev/kastore'
+
+extra:
+  recipe-maintainers:
+    - jeromekelleher


### PR DESCRIPTION
A small package for storing numerical arrays of data in a read-only store. Uses a C extension and the numpy C api.