### PR TITLE
let's test if this is still needed

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -17,7 +17,7 @@ export PYTHONUNBUFFERED=1
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-curl -L https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh > ~/miniconda.sh
+curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
 (
     source ~/miniconda/bin/activate root


### PR DESCRIPTION
The reason for using `miniconda2` here is undocumented.
Let's update it and check if this is still needed. If it is we need to fix it for Python 3 compatibility.