### PR TITLE
Add r-ggparallel recipe

### DIFF
--- a/recipes/r-ggparallel/bld.bat
+++ b/recipes/r-ggparallel/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-ggparallel/build.sh
+++ b/recipes/r-ggparallel/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/ggparallel
+  mv * $PREFIX/lib/R/library/ggparallel
+fi

--- a/recipes/r-ggparallel/meta.yaml
+++ b/recipes/r-ggparallel/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = '0.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggparallel
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: ggparallel_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/ggparallel_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggparallel/ggparallel_{{ version }}.tar.gz
+  sha256: 8e0b1d78d3f3a65d15455c426394a94af7dcf6b8de0758f5566be2258173aa7f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+  host:
+    - r-base
+    - r-ggplot2 >=2.2.0
+    - r-plyr >=1.8.4
+    - r-reshape2 >=1.4.2
+  run:
+    - r-base
+    - r-ggplot2 >=2.2.0
+    - r-plyr >=1.8.4
+    - r-reshape2 >=1.4.2
+
+test:
+  commands:
+    - $R -e "library('ggparallel')"           # [not win]
+    - "\"%R%\" -e \"library('ggparallel')\""  # [win]
+
+about:
+  home: http://github.com/heike/ggparallel
+  license: MIT
+  summary: Create hammock plots, parallel sets, and common angle plots with 'ggplot2'.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - djcomlab

--- a/recipes/r-ggparallel/meta.yaml
+++ b/recipes/r-ggparallel/meta.yaml
@@ -14,7 +14,6 @@ source:
   sha256: 8e0b1d78d3f3a65d15455c426394a94af7dcf6b8de0758f5566be2258173aa7f
 
 build:
-  merge_build_host: True  # [win]
   number: 0
   skip: true  # [win32]
   rpaths:


### PR DESCRIPTION
Add r-ggparallel recipe. Recipe was generated by `conda_r_skeleton_helper`.

The package is found in https://cran.r-project.org/web/packages/ggparallel/index.html and source https://github.com/heike/ggparallel

Thanks!