### PR TITLE
add py2cytoscape

### DIFF
--- a/recipes/py2cytoscape/meta.yaml
+++ b/recipes/py2cytoscape/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "py2cytoscape" %}
+{% set version = "0.7.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bb5be0ceb967b1e2bdb37efdc43d284f1a79c3a832fb74d644ce543f9f22d9cf
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  noarch: python
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - networkx
+    - pandas
+    - pydot
+    - pydotplus
+    - pyparsing
+    - python
+    - python-igraph
+    - requests
+
+test:
+  requires:
+    - ipython
+    - jinja2
+    - scipy
+  imports:
+    - py2cytoscape
+    - py2cytoscape.cyrest
+    - py2cytoscape.data.network_client
+    - py2cytoscape.data.table
+    - py2cytoscape.util
+    - py2cytoscape.util.cytoscapejs
+    - py2cytoscape.util.util_dataframe
+    - py2cytoscape.util.util_graphlab
+    - py2cytoscape.util.util_igraph
+    - py2cytoscape.util.util_networkx
+    - py2cytoscape.util.util_numpy
+
+about:
+  home: https://github.com/cytoscape/py2cytoscape
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Python utilities for Cytoscape and Cytoscape.js
+  doc_url: https://py2cytoscape.readthedocs.io
+  dev_url: https://github.com/cytoscape/py2cytoscape
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/py2cytoscape/meta.yaml
+++ b/recipes/py2cytoscape/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
+  skip: true  # [py2k]
 
 requirements:
   build:

--- a/recipes/py2cytoscape/meta.yaml
+++ b/recipes/py2cytoscape/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
-  noarch: python
 
 requirements:
   build:
@@ -25,7 +24,7 @@ requirements:
     - pydotplus
     - pyparsing
     - python
-    - python-igraph
+    - python-igraph  # [unix]
     - requests
 
 test:
@@ -42,7 +41,7 @@ test:
     - py2cytoscape.util.cytoscapejs
     - py2cytoscape.util.util_dataframe
     - py2cytoscape.util.util_graphlab
-    - py2cytoscape.util.util_igraph
+    - py2cytoscape.util.util_igraph  # [unix]
     - py2cytoscape.util.util_networkx
     - py2cytoscape.util.util_numpy
 

--- a/recipes/py2cytoscape/meta.yaml
+++ b/recipes/py2cytoscape/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
-  skip: true  # [py2k]
+  skip: true  # [py2k or win]
 
 requirements:
   build:
@@ -25,7 +25,7 @@ requirements:
     - pydotplus
     - pyparsing
     - python
-    - python-igraph  # [unix]
+    - python-igraph
     - requests
 
 test:
@@ -42,7 +42,7 @@ test:
     - py2cytoscape.util.cytoscapejs
     - py2cytoscape.util.util_dataframe
     - py2cytoscape.util.util_graphlab
-    - py2cytoscape.util.util_igraph  # [unix]
+    - py2cytoscape.util.util_igraph
     - py2cytoscape.util.util_networkx
     - py2cytoscape.util.util_numpy
 


### PR DESCRIPTION
Adds [py2cytoscape](https://github.com/cytoscape/py2cytoscape).

Tests aren't packaged, and would mostly not work since we'd need Big Java Cytoscape for many of them.