### PR TITLE
Add recipe for skein

### DIFF
--- a/recipes/skein/meta.yaml
+++ b/recipes/skein/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "skein" %}
+{% set version = "0.0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/py2.py3/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}-py2.py3-none-any.whl
+  sha256: ec52ffb78e72489156221682bd6c7a13133a5e3664bc6b1d1883399190b2fd4d
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed {{ name }}-{{ version }}-py2.py3-none-any.whl
+  entry_points:
+    - skein = skein.cli:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - cryptography
+    - grpcio >=1.11.0
+    - protobuf >=3.5.0
+    - pyyaml
+
+test:
+  imports:
+    - skein
+    - skein.proto
+  commands:
+    - skein --help
+
+about:
+  home: https://jcrist.github.io/skein/
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: A simple tool for deploying applications on Apache YARN
+  doc_url: https://jcrist.github.io/skein/
+  dev_url: https://github.com/jcrist/skein
+
+extra:
+  recipe-maintainers:
+    - jcrist


### PR DESCRIPTION
This diverges a bit from the normal conda-forge recipe template, as the grpcio-tools/grpcio packages needed for building aren't on conda-forge (and `grpcio-tools` isn't on anaconda.org). Since the package is a universal wheel and the java source is already built on pypi, opted to just build from the pypi wheel, similar to the [tensorflow feedstock](https://github.com/conda-forge/tensorflow-feedstock/blob/master/recipe/meta.yaml). If there is a better/more preferred way please let me know.