### PR TITLE
[bioconda cleared] [R2M] Add coreutils to conda-forge

### DIFF
--- a/recipes/coreutils/build.sh
+++ b/recipes/coreutils/build.sh
@@ -1,0 +1,5 @@
+./configure --prefix=$PREFIX
+
+make -j $CPU_COUNT
+make install
+make installcheck

--- a/recipes/coreutils/meta.yaml
+++ b/recipes/coreutils/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "coreutils" %}
+{% set version = "8.29" %}
+{% set sha256 = "92d0fa1c311cacefa89853bdb53c62f4110cdfda3820346b59cbd098f40f955e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://ftp.gnu.org/gnu/{{ name }}/{{ name  }}-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+
+test:
+  commands:
+    - ln --relative --help 
+
+about:
+  home: https://www.gnu.org/software/coreutils
+  license: GPL-2.0
+  license_family: GPL
+  license_file: COPYING
+  summary: 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
+
+  doc_url: https://www.gnu.org/software/coreutils/manual/html_node/index.html
+  dev_url: http://git.savannah.gnu.org/cgit/coreutils.git
+
+extra:
+  recipe-maintainers:
+    - sodre
+    # - msarahan ?

--- a/recipes/coreutils/meta.yaml
+++ b/recipes/coreutils/meta.yaml
@@ -21,6 +21,8 @@ requirements:
 test:
   commands:
     - ln --relative --help 
+    - wc --version
+    - cat --version
 
 about:
   home: https://www.gnu.org/software/coreutils

--- a/recipes/coreutils/meta.yaml
+++ b/recipes/coreutils/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [not linux]
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/coreutils/meta.yaml
+++ b/recipes/coreutils/meta.yaml
@@ -26,7 +26,7 @@ test:
 
 about:
   home: https://www.gnu.org/software/coreutils
-  license: GPL-2.0
+  license: GPL-3.0-or-later
   license_family: GPL
   license_file: COPYING
   summary: 'The GNU Core Utilities are the basic file, shell and text manipulation utilities of the GNU operating system.'
@@ -37,4 +37,4 @@ about:
 extra:
   recipe-maintainers:
     - sodre
-    # - msarahan ?
+    - mbargull


### PR DESCRIPTION
- Coreutils is necessary for systemd, which is needed by systemd-python