### PR TITLE
Add gwpy

### DIFF
--- a/recipes/gwpy/meta.yaml
+++ b/recipes/gwpy/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "gwpy" %}
+{% set version = "0.11.0" %}
+{% set sha256 = "47a17967508f006cee9c1c4a62cceff4d6d9870096cad9eedf9f1a4af788ba17" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - six>=1.5
+    - python-dateutil
+    - numpy>=1.7.1
+    - scipy>=0.12.1
+    - matplotlib>=1.2.0
+    - astropy>=1.1.1
+    - h5py>=1.3
+    - ligo-segments>=1.0.0
+    - tqdm>=4.10.0
+    - lal  # [not win]
+    - ligotimegps  # [win]
+
+test:
+  requires:
+    - pytest>=3.1
+    - freezegun
+    - sqlparse
+    - beautifulsoup4
+    - mock  # [py2k]
+  commands:
+    - python -m pytest --pyargs {{ name }}
+
+about:
+  home: https://gwpy.github.io
+  license: GPLv3
+  license_family: GPL
+  license_file: LICENSE
+  summary: A python package for gravitational-wave astrophysics
+  description: |
+    GWpy is a collaboration-driven Python package providing tools for
+    studying data from ground-based gravitational-wave detectors.
+
+    GWpy provides a user-friendly, intuitive interface to the common
+    time-domain and frequency-domain data produced by the LIGO and Virgo
+    observatories and their analyses, with easy-to-follow tutorials at each
+    step.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds [gwpy](//pypi.org/project/gwpy), a Python package for gravitational-wave astrophysics.