### PR TITLE
Add cadquery

### DIFF
--- a/recipes/cadquery/meta.yaml
+++ b/recipes/cadquery/meta.yaml
@@ -21,7 +21,7 @@ build:
   script: cd dist && python -m pip install --no-deps --ignore-installed .
 
 requirements:
-  build:
+  host:
     - python >=3.6,<3.7
     - pip
   run:

--- a/recipes/cadquery/meta.yaml
+++ b/recipes/cadquery/meta.yaml
@@ -9,6 +9,8 @@ source:
   - folder: dist
     url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: 9988adad97357a699128967bd379d9b8d63c8947e06c3584e6371df699363abc
+    patches:
+      - osx_freecad_path.patch  # [osx]
   - folder: src
     url: https://github.com/dcowden/cadquery/archive/v{{ version }}.tar.gz
     sha256: cda199182eda0e757f5021d08453090234585f35c6f628336197c6d85883027d
@@ -20,10 +22,10 @@ build:
 
 requirements:
   build:
-    - python >=3.6
+    - python >=3.6,<3.7
     - pip
   run:
-    - python >=3.6
+    - python >=3.6,<3.7
     - pyparsing
 
 test:
@@ -45,9 +47,11 @@ about:
   license_family: Apache
   license_file: src/LICENSE
   summary: |
-    CadQuery is an intuitive, easy-to-use python library for building
-    parametric 3D CAD models
+    CadQuery is a parametric scripting language for creating and traversing 
+    CAD models
   description: |
+    CadQuery is an intuitive, easy-to-use python library for building
+    parametric 3D CAD models. It has several goals:
     - Build models with scripts that are as close as possible to how you’d
       describe the object to a human, using a standard, already established
       programming language

--- a/recipes/cadquery/meta.yaml
+++ b/recipes/cadquery/meta.yaml
@@ -10,7 +10,7 @@ source:
     url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
     sha256: 9988adad97357a699128967bd379d9b8d63c8947e06c3584e6371df699363abc
     patches:
-      - osx_freecad_path.patch  # [osx]
+      - osx_freecad_path.patch
   - folder: src
     url: https://github.com/dcowden/cadquery/archive/v{{ version }}.tar.gz
     sha256: cda199182eda0e757f5021d08453090234585f35c6f628336197c6d85883027d
@@ -47,7 +47,7 @@ about:
   license_family: Apache
   license_file: src/LICENSE
   summary: |
-    CadQuery is a parametric scripting language for creating and traversing 
+    CadQuery is a parametric scripting language for creating and traversing
     CAD models
   description: |
     CadQuery is an intuitive, easy-to-use python library for building

--- a/recipes/cadquery/meta.yaml
+++ b/recipes/cadquery/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "cadquery" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - folder: dist
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 9988adad97357a699128967bd379d9b8d63c8947e06c3584e6371df699363abc
+  - folder: src
+    url: https://github.com/dcowden/cadquery/archive/v{{ version }}.tar.gz
+    sha256: cda199182eda0e757f5021d08453090234585f35c6f628336197c6d85883027d
+
+build:
+  number: 0
+  noarch: python
+  script: cd dist && python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - pyparsing
+
+test:
+  source_files:
+    - src/tests
+    - src/runtests.py
+  requires:
+    - freecad
+    - mock
+  imports:
+    - cadquery
+  commands:
+    - cd src
+    - python runtests.py
+
+about:
+  home: https://github.com/dcowden/cadquery
+  license: Apache-2.0
+  license_family: Apache
+  license_file: src/LICENSE
+  summary: |
+    CadQuery is an intuitive, easy-to-use python library for building
+    parametric 3D CAD models
+  description: |
+    - Build models with scripts that are as close as possible to how you’d
+      describe the object to a human, using a standard, already established
+      programming language
+    - Create parametric models that can be very easily customized by end users
+    - Output high quality CAD formats like STEP and AMF in addition to
+      traditional STL
+    - Provide a non-proprietary, plain text model format that can be edited and
+      executed with only a web browser
+  doc_url: http://dcowden.github.io/cadquery/
+  dev_url: https://github.com/dcowden/cadquery
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/cadquery/osx_freecad_path.patch
+++ b/recipes/cadquery/osx_freecad_path.patch
@@ -1,0 +1,11 @@
+--- a/cadquery/freecad_impl/__init__.py
++++ b/cadquery/freecad_impl/__init__.py
+@@ -63,7 +63,7 @@ def _fc_path():
+
+     # Try to guess if using Anaconda
+     if 'env' in sys.prefix:
+-        if sys.platform.startswith('linux'):
++        if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
+             _PATH = os.path.join(sys.prefix,'lib')
+             # return PATH if FreeCAD.[so,pyd] is present
+             if len(glob.glob(os.path.join(_PATH,'FreeCAD.so'))) > 0:


### PR DESCRIPTION
Thanks to @looooo, we now have [cross-platform `freecad`](https://anaconda.org/conda-forge/freecad/files), so we can have [`cadquery`](https://github.com/dcowden/cadquery)! :tada:

While conda packages for a [`freecad`-less `cadquery` 2.0 are desired](https://github.com/dcowden/cadquery/issues/275), this is a bit of an early :birthday: :gift: .

I have tested this on both linux and a(n increasingly unstable) win10 VM. The OSX package does concern me, as it's clocking in at 7x the size of the others, so it's possible this one will have to mellow for a while... but who knows! :slot_machine:

I've taken the liberty of bringing in both the pypi sdist and the gh tarball for tests, just so we start to get an idea of the robustness of the full system. Oh and the license: [PR here](https://github.com/dcowden/cadquery/pull/282). The long pole in the installs is the env setup time, so it seems like 188 tests for 10s is a good trade rather than just importing.

While `cadquery` itself is pure python, at present (and perhaps for the foreseeable future) our `freecad` is `py36` only... not sure if `noarch: python` and `python >= 3.6` is the right way to indicate this, but appears to be used elsewhere. I'm guessing from the conda-forge perspective, having a "works with at least one tree of conda-forge packages" is better than "works with more possible graphs of conda-forge packages, and a one particular huge dependency from conda-forge or... somewhere". On the above 2.0 roadmap, they suggest 3.5+ is the way forward, so this doesn't seem like a huge burden.

Hooray!