### PR TITLE
Add embree3

### DIFF
--- a/recipes/embree3/bld.bat
+++ b/recipes/embree3/bld.bat
@@ -1,0 +1,33 @@
+setlocal EnableDelayedExpansion
+
+:: Make build directory
+mkdir build
+cd build
+
+:: Specify location of TBB
+set "TBB_ROOT=%LIBRARY_PREFIX%"
+
+:: Configure
+cmake ../ ^
+      -G "NMake Makefiles" ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_LIBDIR=lib ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DEMBREE_TUTORIALS=OFF ^
+      -DEMBREE_MAX_ISA="AVX2" ^
+      -DEMBREE_ISPC_SUPPORT=OFF
+if errorlevel 1 exit 1
+
+:: Compile
+nmake
+if errorlevel 1 exit 1
+
+:: embree lacks unit tests
+
+nmake install
+if errorlevel 1 exit 1
+
+:: remove tutorial models (which embree installed even when EMBREE_TUTORIALS=off)
+:: this is easier than patching embree's cmake
+rd /s /q %LIBRARY_PREFIX%/bin/models
+if errorlevel 1 exit 1

--- a/recipes/embree3/build.sh
+++ b/recipes/embree3/build.sh
@@ -1,8 +1,11 @@
+# Make build directory
 mkdir build
 cd build
 
+# Specify location of TBB
 export TBB_ROOT=${PREFIX}
 
+# Configure
 cmake ../ \
       -DCMAKE_INSTALL_PREFIX=${PREFIX} \
       -DCMAKE_INSTALL_LIBDIR=lib \
@@ -11,6 +14,7 @@ cmake ../ \
       -DEMBREE_MAX_ISA="AVX2" \
       -DEMBREE_ISPC_SUPPORT=OFF
 
+# Compile
 make -j ${CPU_COUNT}
 
 # embree lacks unit tests

--- a/recipes/embree3/build.sh
+++ b/recipes/embree3/build.sh
@@ -1,0 +1,18 @@
+mkdir build
+cd build
+
+export TBB_ROOT=${PREFIX}
+
+cmake ../ \
+      -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DEMBREE_TUTORIALS=OFF \
+      -DEMBREE_MAX_ISA="AVX2" \
+      -DEMBREE_ISPC_SUPPORT=OFF
+
+make -j ${CPU_COUNT}
+
+# embree lacks unit tests
+
+make install

--- a/recipes/embree3/build.sh
+++ b/recipes/embree3/build.sh
@@ -16,3 +16,7 @@ make -j ${CPU_COUNT}
 # embree lacks unit tests
 
 make install
+
+# remove tutorial models (which embree installed even when EMBREE_TUTORIALS=off)
+# this is easier than patching embree's cmake
+rm -rf ${PREFIX}/bin/models

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -31,6 +31,8 @@ test:
   commands:
     - test -f "${PREFIX}/lib/libembree3.so"  # [linux]
     - test -f "${PREFIX}/lib/libembree3.dylib"  # [osx]
+    - exist "%LIBRARY_PREFIX%/lib/embree.lib"  # [win]
+    - exist "%LIBRARY_PREFIX%/lib/embree.dll"  # [win]
 
 about:
   home: https://embree.github.io/

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   # upstream supports visual studio 13+
-  skip: true  # [vc<13]]
+  skip: true  # [win and vc<13]]
 
 requirements:
   build:

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -13,8 +13,8 @@ source:
 
 build:
   number: 0
-  # upstream supports windows, but I am not attempting to build that package yet
-  skip: true  # [win]
+  # upstream supports visual studio 13+
+  skip: true  # [vc<13]]
 
 requirements:
   build:

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -29,7 +29,7 @@ requirements:
 
 test:
   commands:
-    - test -f "${PREFIX}/lib/libembree3.${SHLIB_EXT}"  # [not win]
+    - test -f "${PREFIX}/lib/libembree3${SHLIB_EXT}"  # [not win]
 
 about:
   home: https://embree.github.io/

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -29,8 +29,7 @@ requirements:
 
 test:
   commands:
-    - test -f "${PREFIX}/lib/libembree3.so"  # [linux]
-    - test -f "${PREFIX}/lib/libembree3.dylib"  # [osx]
+    - test -f "${PREFIX}/lib/libembree3.${SHLIB_EXT}"  # [not win]
 
 about:
   home: https://embree.github.io/

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "embree3" %}
+{% set version = "3.2.0" %}
+{% set sha256 = "9f4fe73dc2b1fc5ff26840d65d87dcba9b5faef70fccb8c231d85437e0a5bf34" %}
+
+package:
+  name: {{ name }}
+  version: "{{ version }}"
+
+source:
+  fn: {{ version }}.tar.gz
+  url: https://github.com/embree/embree/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  # upstream supports windows, but I am not attempting to build that package yet
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+
+  host:
+    - tbb
+
+  run:
+    - tbb
+
+test:
+  commands:
+    - test -f "${PREFIX}/lib/libembree3.so"  # [linux]
+    - test -f "${PREFIX}/lib/libembree3.dylib"  # [osx]
+
+about:
+  home: https://embree.github.io/
+  license: Apache 2.0
+  license_file: LICENSE.txt
+  summary: High Performance Ray Tracing Kernels
+
+extra:
+  recipe-maintainers:
+    - joaander

--- a/recipes/embree3/meta.yaml
+++ b/recipes/embree3/meta.yaml
@@ -31,8 +31,6 @@ test:
   commands:
     - test -f "${PREFIX}/lib/libembree3.so"  # [linux]
     - test -f "${PREFIX}/lib/libembree3.dylib"  # [osx]
-    - exist "%LIBRARY_PREFIX%/lib/embree.lib"  # [win]
-    - exist "%LIBRARY_PREFIX%/lib/embree.dll"  # [win]
 
 about:
   home: https://embree.github.io/


### PR DESCRIPTION
[Fresnel](https://github.com/conda-forge/fresnel-feedstock), a library I develop and conda-forge package that I maintain, will switch from embree v2 to embree v3 in its next release. Thus, I submit this embree3 package for inclusion in conda-forge.

The embree3 API is **not backwards compatible** with embree2. Upstream developers have taken steps to ensure that the two versions may be installed side by side. Specifically, headers are in include/embree2/ and include/embree3, and the new library is named libembree3. I have structured this recipe so that there should be no file collisions with the existing conda-forge [embree v2 conda-forge package](https://github.com/conda-forge/embree-feedstock). Specifically, I remove the tutorial binaries and example model files which are not needed for applications that link to embree anyways.