### PR TITLE
Add cloudyr r-aws.s3 and its cloudyr dependencies

### DIFF
--- a/recipes/r-aws.ec2metadata/bld.bat
+++ b/recipes/r-aws.ec2metadata/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-aws.ec2metadata/build.sh
+++ b/recipes/r-aws.ec2metadata/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  mv DESCRIPTION DESCRIPTION.old
+  grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/aws.ec2metadata
+  mv * $PREFIX/lib/R/library/aws.ec2metadata
+fi

--- a/recipes/r-aws.ec2metadata/meta.yaml
+++ b/recipes/r-aws.ec2metadata/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '0.1.4' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-aws.ec2metadata
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: aws.ec2metadata_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/aws.ec2metadata_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/aws.ec2metadata/aws.ec2metadata_{{ version }}.tar.gz
+  sha256: 5cab4cedb64b924479f55ca3812dff6b952b85af6107016736ce5061b17d8122
+
+build:
+  merge_build_host: True  # [win]
+  # If this is a new build for the same version, increment the build number.
+  number: 0
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+
+  host:
+    - r-base
+    - r-curl
+    - r-jsonlite
+
+  run:
+    - r-base
+    - r-curl
+    - r-jsonlite
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('aws.ec2metadata')"           # [not win]
+    - "\"%R%\" -e \"library('aws.ec2metadata')\""  # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: https://github.com/cloudyr/aws.ec2metadata
+  license: GPL (>= 2)
+  summary: Retrieve Amazon EC2 instance metadata from within the running instance.
+  license_family: GPL3
+
+# The original CRAN metadata for this package was:
+
+# Package: aws.ec2metadata
+# Type: Package
+# Title: Get EC2 Instance Metadata
+# Version: 0.1.4
+# Date: 2018-04-02
+# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com"))
+# Description: Retrieve Amazon EC2 instance metadata from within the running instance.
+# License: GPL (>= 2)
+# URL: https://github.com/cloudyr/aws.ec2metadata
+# BugReports: https://github.com/cloudyr/aws.ec2metadata/issues
+# Imports: curl, jsonlite
+# RoxygenNote: 6.0.1
+# NeedsCompilation: no
+# Packaged: 2018-04-02 21:28:34 UTC; THOMAS
+# Author: Thomas J. Leeper [aut, cre]
+# Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2018-04-03 07:45:54 UTC
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/r-aws.ec2metadata/meta.yaml
+++ b/recipes/r-aws.ec2metadata/meta.yaml
@@ -16,10 +16,8 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  # If this is a new build for the same version, increment the build number.
   number: 0
 
-  # This is required to make R link correctly on Linux.
   rpaths:
     - lib/R/lib/
     - lib/
@@ -39,43 +37,22 @@ requirements:
 
 test:
   commands:
-    # You can put additional test commands to be run here.
     - $R -e "library('aws.ec2metadata')"           # [not win]
     - "\"%R%\" -e \"library('aws.ec2metadata')\""  # [win]
-
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
-
-  # requires:
-    # Put any additional test requirements here.
 
 about:
   home: https://github.com/cloudyr/aws.ec2metadata
   license: GPL (>= 2)
   summary: Retrieve Amazon EC2 instance metadata from within the running instance.
   license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
 
-# The original CRAN metadata for this package was:
-
-# Package: aws.ec2metadata
-# Type: Package
-# Title: Get EC2 Instance Metadata
-# Version: 0.1.4
-# Date: 2018-04-02
-# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com"))
-# Description: Retrieve Amazon EC2 instance metadata from within the running instance.
-# License: GPL (>= 2)
-# URL: https://github.com/cloudyr/aws.ec2metadata
-# BugReports: https://github.com/cloudyr/aws.ec2metadata/issues
-# Imports: curl, jsonlite
-# RoxygenNote: 6.0.1
-# NeedsCompilation: no
-# Packaged: 2018-04-02 21:28:34 UTC; THOMAS
-# Author: Thomas J. Leeper [aut, cre]
-# Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
-# Repository: CRAN
-# Date/Publication: 2018-04-03 07:45:54 UTC
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast

--- a/recipes/r-aws.s3/bld.bat
+++ b/recipes/r-aws.s3/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-aws.s3/build.sh
+++ b/recipes/r-aws.s3/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  mv DESCRIPTION DESCRIPTION.old
+  grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/aws.s3
+  mv * $PREFIX/lib/R/library/aws.s3
+fi

--- a/recipes/r-aws.s3/meta.yaml
+++ b/recipes/r-aws.s3/meta.yaml
@@ -16,15 +16,12 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  # If this is a new build for the same version, increment the build number.
   number: 0
 
-  # This is required to make R link correctly on Linux.
   rpaths:
     - lib/R/lib/
     - lib/
 
-# Suggests: testthat, datasets
 requirements:
   build:
 
@@ -46,15 +43,8 @@ requirements:
 
 test:
   commands:
-    # You can put additional test commands to be run here.
     - $R -e "library('aws.s3')"           # [not win]
     - "\"%R%\" -e \"library('aws.s3')\""  # [win]
-
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
-
-  # requires:
-    # Put any additional test requirements here.
 
 about:
   home: https://github.com/cloudyr/aws.s3
@@ -62,29 +52,14 @@ about:
   summary: A simple client package for the Amazon Web Services ('AWS') Simple Storage Service
     ('S3') 'REST' 'API' <https://aws.amazon.com/s3/>.
   license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
 
-# The original CRAN metadata for this package was:
-
-# Package: aws.s3
-# Type: Package
-# Title: 'AWS S3' Client Package
-# Version: 0.3.12
-# Date: 2018-05-25
-# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com", comment = c(ORCID = "0000-0003-4097-6326")), person("Boettiger", "Carl", role = "ctb"), person("Andrew", "Martin", role = "ctb"), person("Mark", "Thompson", role = "ctb"), person("Tyler", "Hunt", role = "ctb"), person("Steven", "Akins", role = "ctb"), person("Bao", "Nguyen", role = "ctb"), person("Thierry", "Onkelinx", role = "ctb"))
-# Description: A simple client package for the Amazon Web Services ('AWS') Simple Storage Service ('S3') 'REST' 'API' <https://aws.amazon.com/s3/>.
-# License: GPL (>= 2)
-# URL: https://github.com/cloudyr/aws.s3
-# BugReports: https://github.com/cloudyr/aws.s3/issues
-# Imports: utils, tools, httr, xml2 (> 1.0.0), base64enc, digest, aws.signature (>= 0.3.7)
-# Suggests: testthat, datasets
-# RoxygenNote: 6.0.1
-# NeedsCompilation: no
-# Packaged: 2018-05-25 08:29:49 UTC; THOMAS
-# Author: Thomas J. Leeper [aut, cre] (<https://orcid.org/0000-0003-4097-6326>), Boettiger Carl [ctb], Andrew Martin [ctb], Mark Thompson [ctb], Tyler Hunt [ctb], Steven Akins [ctb], Bao Nguyen [ctb], Thierry Onkelinx [ctb]
-# Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
-# Repository: CRAN
-# Date/Publication: 2018-05-25 09:33:38 UTC
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast

--- a/recipes/r-aws.s3/meta.yaml
+++ b/recipes/r-aws.s3/meta.yaml
@@ -1,0 +1,90 @@
+{% set version = '0.3.12' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-aws.s3
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: aws.s3_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/aws.s3_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/aws.s3/aws.s3_{{ version }}.tar.gz
+  sha256: 348fbbd976b5bcfbb60024864b5859fa3fce6071d5204667ff158296614cd1f9
+
+build:
+  merge_build_host: True  # [win]
+  # If this is a new build for the same version, increment the build number.
+  number: 0
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+# Suggests: testthat, datasets
+requirements:
+  build:
+
+  host:
+    - r-base
+    - r-aws.signature >=0.3.7
+    - r-base64enc
+    - r-digest
+    - r-httr
+    - r-xml2 >1.0.0
+
+  run:
+    - r-base
+    - r-aws.signature >=0.3.7
+    - r-base64enc
+    - r-digest
+    - r-httr
+    - r-xml2 >1.0.0
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('aws.s3')"           # [not win]
+    - "\"%R%\" -e \"library('aws.s3')\""  # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: https://github.com/cloudyr/aws.s3
+  license: GPL (>= 2)
+  summary: A simple client package for the Amazon Web Services ('AWS') Simple Storage Service
+    ('S3') 'REST' 'API' <https://aws.amazon.com/s3/>.
+  license_family: GPL3
+
+# The original CRAN metadata for this package was:
+
+# Package: aws.s3
+# Type: Package
+# Title: 'AWS S3' Client Package
+# Version: 0.3.12
+# Date: 2018-05-25
+# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"), email = "thosjleeper@gmail.com", comment = c(ORCID = "0000-0003-4097-6326")), person("Boettiger", "Carl", role = "ctb"), person("Andrew", "Martin", role = "ctb"), person("Mark", "Thompson", role = "ctb"), person("Tyler", "Hunt", role = "ctb"), person("Steven", "Akins", role = "ctb"), person("Bao", "Nguyen", role = "ctb"), person("Thierry", "Onkelinx", role = "ctb"))
+# Description: A simple client package for the Amazon Web Services ('AWS') Simple Storage Service ('S3') 'REST' 'API' <https://aws.amazon.com/s3/>.
+# License: GPL (>= 2)
+# URL: https://github.com/cloudyr/aws.s3
+# BugReports: https://github.com/cloudyr/aws.s3/issues
+# Imports: utils, tools, httr, xml2 (> 1.0.0), base64enc, digest, aws.signature (>= 0.3.7)
+# Suggests: testthat, datasets
+# RoxygenNote: 6.0.1
+# NeedsCompilation: no
+# Packaged: 2018-05-25 08:29:49 UTC; THOMAS
+# Author: Thomas J. Leeper [aut, cre] (<https://orcid.org/0000-0003-4097-6326>), Boettiger Carl [ctb], Andrew Martin [ctb], Mark Thompson [ctb], Tyler Hunt [ctb], Steven Akins [ctb], Bao Nguyen [ctb], Thierry Onkelinx [ctb]
+# Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2018-05-25 09:33:38 UTC
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/recipes/r-aws.signature/bld.bat
+++ b/recipes/r-aws.signature/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-aws.signature/build.sh
+++ b/recipes/r-aws.signature/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  mv DESCRIPTION DESCRIPTION.old
+  grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/aws.signature
+  mv * $PREFIX/lib/R/library/aws.signature
+fi

--- a/recipes/r-aws.signature/meta.yaml
+++ b/recipes/r-aws.signature/meta.yaml
@@ -16,15 +16,12 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  # If this is a new build for the same version, increment the build number.
   number: 0
 
-  # This is required to make R link correctly on Linux.
   rpaths:
     - lib/R/lib/
     - lib/
 
-# Suggests: testthat, aws.ec2metadata (>= 0.1.3)
 requirements:
   build:
 
@@ -40,15 +37,8 @@ requirements:
 
 test:
   commands:
-    # You can put additional test commands to be run here.
     - $R -e "library('aws.signature')"           # [not win]
     - "\"%R%\" -e \"library('aws.signature')\""  # [win]
-
-  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
-  # in the recipe that will be run at test time.
-
-  # requires:
-    # Put any additional test requirements here.
 
 about:
   home: https://github.com/cloudyr/aws.signature
@@ -59,29 +49,14 @@ about:
     files, and 'EC2' instance metadata. For use on 'EC2', users will need to install
     the suggested package 'aws.ec2metadata' <https://cran.r-project.org/package=aws.ec2metadata>.
   license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
 
-# The original CRAN metadata for this package was:
-
-# Package: aws.signature
-# Type: Package
-# Title: Amazon Web Services Request Signatures
-# Version: 0.4.1
-# Date: 2018-04-09
-# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),  email = "thosjleeper@gmail.com", comment = c(ORCID = "0000-0003-4097-6326")) )
-# Description: Generates version 2 and version 4 request signatures for Amazon Web Services ('AWS') <https://aws.amazon.com/> Application Programming Interfaces ('APIs') and provides a mechanism for retrieving credentials from environment variables, 'AWS' credentials files, and 'EC2' instance metadata. For use on 'EC2', users will need to install the suggested package 'aws.ec2metadata' <https://cran.r-project.org/package=aws.ec2metadata>.
-# License: GPL (>= 2)
-# Imports: digest, base64enc
-# Suggests: testthat, aws.ec2metadata (>= 0.1.3)
-# URL: https://github.com/cloudyr/aws.signature
-# BugReports: https://github.com/cloudyr/aws.signature/issues
-# RoxygenNote: 6.0.1
-# NeedsCompilation: no
-# Packaged: 2018-04-09 20:01:56 UTC; THOMAS
-# Author: Thomas J. Leeper [aut, cre] (<https://orcid.org/0000-0003-4097-6326>)
-# Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
-# Repository: CRAN
-# Date/Publication: 2018-04-09 20:33:04 UTC
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast

--- a/recipes/r-aws.signature/meta.yaml
+++ b/recipes/r-aws.signature/meta.yaml
@@ -1,0 +1,87 @@
+{% set version = '0.4.1' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-aws.signature
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: aws.signature_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/aws.signature_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/aws.signature/aws.signature_{{ version }}.tar.gz
+  sha256: 3255c8e88e8a7ce51ffc6032e21c3a3398b7654d79e83d5d5b6310f3b8048d24
+
+build:
+  merge_build_host: True  # [win]
+  # If this is a new build for the same version, increment the build number.
+  number: 0
+
+  # This is required to make R link correctly on Linux.
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+# Suggests: testthat, aws.ec2metadata (>= 0.1.3)
+requirements:
+  build:
+
+  host:
+    - r-base
+    - r-base64enc
+    - r-digest
+
+  run:
+    - r-base
+    - r-base64enc
+    - r-digest
+
+test:
+  commands:
+    # You can put additional test commands to be run here.
+    - $R -e "library('aws.signature')"           # [not win]
+    - "\"%R%\" -e \"library('aws.signature')\""  # [win]
+
+  # You can also put a file called run_test.py, run_test.sh, or run_test.bat
+  # in the recipe that will be run at test time.
+
+  # requires:
+    # Put any additional test requirements here.
+
+about:
+  home: https://github.com/cloudyr/aws.signature
+  license: GPL (>= 2)
+  summary: Generates version 2 and version 4 request signatures for Amazon Web Services ('AWS')
+    <https://aws.amazon.com/> Application Programming Interfaces ('APIs') and provides
+    a mechanism for retrieving credentials from environment variables, 'AWS' credentials
+    files, and 'EC2' instance metadata. For use on 'EC2', users will need to install
+    the suggested package 'aws.ec2metadata' <https://cran.r-project.org/package=aws.ec2metadata>.
+  license_family: GPL3
+
+# The original CRAN metadata for this package was:
+
+# Package: aws.signature
+# Type: Package
+# Title: Amazon Web Services Request Signatures
+# Version: 0.4.1
+# Date: 2018-04-09
+# Authors@R: c(person("Thomas J.", "Leeper", role = c("aut", "cre"),  email = "thosjleeper@gmail.com", comment = c(ORCID = "0000-0003-4097-6326")) )
+# Description: Generates version 2 and version 4 request signatures for Amazon Web Services ('AWS') <https://aws.amazon.com/> Application Programming Interfaces ('APIs') and provides a mechanism for retrieving credentials from environment variables, 'AWS' credentials files, and 'EC2' instance metadata. For use on 'EC2', users will need to install the suggested package 'aws.ec2metadata' <https://cran.r-project.org/package=aws.ec2metadata>.
+# License: GPL (>= 2)
+# Imports: digest, base64enc
+# Suggests: testthat, aws.ec2metadata (>= 0.1.3)
+# URL: https://github.com/cloudyr/aws.signature
+# BugReports: https://github.com/cloudyr/aws.signature/issues
+# RoxygenNote: 6.0.1
+# NeedsCompilation: no
+# Packaged: 2018-04-09 20:01:56 UTC; THOMAS
+# Author: Thomas J. Leeper [aut, cre] (<https://orcid.org/0000-0003-4097-6326>)
+# Maintainer: Thomas J. Leeper <thosjleeper@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2018-04-09 20:33:04 UTC
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
r-aws.s3: Amazon Simple Storage Service (S3) API Client
required by r-aws.s3: r-aws.signature: Amazon Web Services Request Signatures
suggested by r-aws.signature: r-aws.ec2metadata: Access to EC2 Instance Metadata

r-aws.ec2metadata is only suggested by r-aws.signature:
If R is running on an EC2 instance, the role profile credentials provided by aws.ec2metadata are used by r-aws.signature, if the aws.ec2metadata package is installed.

Cloudyr r-awspack with all cloudyr r-aws.* packages is not ready yet because of missing dependencies (r-tuner).