### PR TITLE
Add kombine

### DIFF
--- a/recipes/kombine/meta.yaml
+++ b/recipes/kombine/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "kombine" %}
+{% set version = "0.8.3" %}
+{% set sha256 = "da7a9542600c81df4b2ede2772b730dacef61ea3bc19b495f4fa445ff2b92f75" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - numpy
+    - scipy
+
+test:
+  requires:
+    - nose
+  imports:
+    - kombine
+  commands:
+    - nosetests kombine
+
+about:
+  home: https://github.com/bfarr/kombine
+  license: GPLv3
+  license_family: GPL
+  license_file: LICENSE
+  summary: An embarrassingly parallel, kernel-density-based ensemble sampler
+  description: |
+    kombine is an ensemble sampler that uses a clustered
+    kernel-density-estimate proposal density, allowing for
+    massive parallelization and efficient sampling.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - bfarr


### PR DESCRIPTION
This PR adds [`kombine`](https://github.com/bfarr/kombine), an embarrassingly parallel, kernel-density-based ensemble sampler.

cc: @bfarr