### PR TITLE
Add SatPy recipe

### DIFF
--- a/recipes/satpy/meta.yaml
+++ b/recipes/satpy/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - dask >=0.17.1
     - h5py
     - netcdf4
+    - pyspectral
 
 test:
   imports:

--- a/recipes/satpy/meta.yaml
+++ b/recipes/satpy/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = "satpy" %}
+{% set version = "0.9.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "bced4d4a87f4b24860287ef8689454a893d731a07d16cf75a849fb53c7bd5411" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - numpy >=1.4.1
+    - pillow
+    - pyresample >=1.10.0
+    - trollsift
+    - trollimage >=1.5.1
+    - pykdtree
+    - six
+    - pyyaml
+    - xarray >=0.10.1
+    - dask >=0.17.1
+    - h5py
+    - netcdf4
+
+test:
+  imports:
+    - satpy
+    - satpy.composites
+    - satpy.enhancements
+    - satpy.readers
+    - satpy.tests
+    - satpy.tests.compositor_tests
+    - satpy.tests.reader_tests
+    - satpy.tests.writer_tests
+    - satpy.writers
+  requires:
+    - behave
+    - h5py
+    - imageio
+    - libtiff
+    - netcdf4
+    - pyhdf
+
+about:
+  home: https://github.com/pytroll/satpy
+  license: GPL-3.0
+  license_family: GPL3
+  license_file: 'LICENSE.txt'
+  summary: Meteorological processing package
+  description: |
+      Python package for reading and manipulating meteorological remote
+      sensing data and writing it to various image and data file formats.
+  doc_url: 'http://satpy.readthedocs.io/en/latest/'
+  dev_url: 'https://github.com/pytroll/satpy'
+
+extra:
+  recipe-maintainers:
+    - djhoese
+    - mraspaud
+    - adybbroe
+    - pnuu


### PR DESCRIPTION
I finally released satpy 0.9 so I can now make this recipe. I'm presenting on satpy at scipy 2018 so I was hoping I could get this added and built before then.

The recipe maintainers are the same as the other pytroll packages (trollimage, pyspectral, etc). @pnuu @adybbroe @mraspaud I'm not sure if you need to give explicit permission to be added to this recipe as maintainers but please comment your approval below.