### PR TITLE
Commitng radical.pilot recipe

### DIFF
--- a/recipes/radical.pilot/meta.yaml
+++ b/recipes/radical.pilot/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "radical.pilot" %}
+{% set version = "0.50.1" %}
+{% set sha256 = "65aef696c32c091b621a449f91966cbbe3ae53da4918e0079e3a3669a96dd655" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed  .
+  skip: True  # [py3k or win]
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - saga-python
+    - pymongo 2.8
+    - radical.utils
+    - msgpack-python
+    - pyzmq
+    - python-hostlist
+    - ntplib
+    
+test:
+  imports:
+    - radical.pilot
+  
+about:
+  home: http://radical-cybertools.github.io/radical-pilot/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: 'RADICAL-Pilot (RP) is a Pilot Job system written in Python'
+  description: |
+    RADICAL-Pilot is a flexible Pilot System that provides a simple and scalable 
+    approach for executing many concurrent simulations and their data requirements 
+    on clusters, grids, and clouds. RADICAL-Pilot is written in Python, and as such 
+    is easily deployable into user space. It allows user-level control of Pilots 
+    and supports a wide range of application types.
+  dev_url: https://github.com/radical-cybertools/radical.pilot
+
+extra:
+  recipe-maintainers:
+    - andre-merzky
+    - iparask


### PR DESCRIPTION
This the recipe for radical.pilot. This framework is used to executed many task workloads on HPC systems by researchers. With this recipe, we finally bring it to `conda-forge` which will allow better support from use case that mainly use this channel for development, such as `MDAnalysis`.