### PR TITLE
Add gwosc

### DIFF
--- a/recipes/gwosc/meta.yaml
+++ b/recipes/gwosc/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "gwosc" %}
+{% set version = "0.3.2" %}
+{% set sha256 = "2bc3c25d1e684d365b39c860369b91c61f252a3c02d303583019efd67ca353b2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - six
+
+test:
+  requires:
+    - pytest
+  imports:
+    - gwosc
+  commands:
+    - python -m pytest --pyargs {{ name }}
+
+about:
+  home: https://gwosc.readthedocs.io
+  license: GPLv3
+  license_family: GPL
+  license_file: LICENSE
+  summary: A python interface to the GW Open Science data archive
+  description: |
+    The `gwosc` package provides an interface to querying the open data
+    releases hosted on <https://losc.ligo.org> from the LIGO and Virgo
+    gravitational-wave observatories.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds [`gwosc`](//gwosc.readthedocs.io), a python interface to the Gravitational-Wave Open Science Center data archive.