### PR TITLE
Added recipe for qpdf

### DIFF
--- a/recipes/qpdf/build.sh
+++ b/recipes/qpdf/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export CFLAGS="-I$PREFIX/include"
+export LDFLAGS="-L$PREFIX/lib"
+
+./autogen.sh
+./configure --prefix="${PREFIX}"
+make install

--- a/recipes/qpdf/meta.yaml
+++ b/recipes/qpdf/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "qpdf" %}
+{% set version = "8.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/qpdf/qpdf/archive/release-qpdf-{{version}}.tar.gz
+  sha256: cb9c3fbad2cbe322ae7670c28fde7fc1ff0cd66785d83fa3759dd9bffec47018
+
+build:
+  number: 0
+  skip: True  # [Win]
+
+requirements:
+  host:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - automake
+    - autoconf
+    - zlib
+    - jpeg
+  run:
+    - zlib
+    - jpeg
+
+test:
+  commands:
+    - qpdf --help
+
+about:
+  home: https://sourceforge.net/projects/qpdf/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: 'Command-line program that does structural, content-preserving transformations on PDF files'
+  description: |
+    With QPDF, it is possible to copy objects from one PDF file into another and to manipulate the list of pages in a PDF file.
+    This makes it possible to merge and split PDF files. The QPDF library also makes it possible for you to create PDF files from scratch.
+    In this mode, you are responsible for supplying all the contents of the file, while the QPDF library takes care off all the syntactical representation of the objects, creation of cross references tables and, if you use them, object streams, encryption, linearization, and other syntactic details.
+  doc_url: http://qpdf.sourceforge.net/files/qpdf-manual.html
+  dev_url: https://github.com/qpdf/qpdf
+
+extra:
+  recipe-maintainers:
+    - jenzopr


### PR DESCRIPTION
Dear all,

I added a recipe for qpdf (https://github.com/qpdf/qpdf), which is used for compressing vignette PDFs in R packages.
I started the build for Linux and OSX, but plan to extend it to Win as well.

Maybe someone can comment on pinning/not pinning zlib here.

Thanks!
Jens