### PR TITLE
SciPy Teen Track Curriculum

### DIFF
--- a/recipes/teentrack/meta.yaml
+++ b/recipes/teentrack/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/eqfinney/SciPy/blob/master/teentrack.tar.gz
+  url: https://github.com/eqfinney/SciPy/raw/master/teentrack.tar.gz
   sha256: fe18022b975357fb66381962a9d512f4522a5c80c80c776cfcf563ddd1c7002a
 
 build:

--- a/recipes/teentrack/meta.yaml
+++ b/recipes/teentrack/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "teentrack" %}
+{% set version = "0.2.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/eqfinney/SciPy/blob/master/teentrack.tar.gz
+  sha256: fe18022b975357fb66381962a9d512f4522a5c80c80c776cfcf563ddd1c7002a
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  skip: True [py<35]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - numpy 1.12.*
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - teentrack
+
+about:
+  home: https://github.com/eqfinney/SciPy/teentrack
+  license: MIT
+  license_family: MIT
+  license_file: README.txt
+  summary: 'Curriculum for the SciPy Teen Track'
+  description: |
+    teentrack includes the educational materials used for the SciPy Teen Track
+    in 2017-2018. Topics include Python fundamentals and exploratory data analysis
+    with NumPy and matplotlib. It is written using interactive Jupyter notebooks 
+    that students can use to explore content, as well as data students can explore 
+    with NumPy and matplotlib. It requires Jupyter notebooks to run, and full 
+    functionality depends on numpy and matplotlib.
+  doc_url: https://github.com/eqfinney/SciPy/blob/master/teentrack/README.md
+  dev_url: https://github.com/eqfinney/SciPy
+
+extra:
+  recipe-maintainers:
+    - eqfinney

--- a/recipes/teentrack/meta.yaml
+++ b/recipes/teentrack/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
-  skip: True [py<35]
+  skip: True  [ py<35 ]
 
 requirements:
   build:

--- a/recipes/teentrack/meta.yaml
+++ b/recipes/teentrack/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
-  skip: True  [ py<35 ]
+  skip: True  # [ py<35 ]
 
 requirements:
   build:

--- a/recipes/teentrack/meta.yaml
+++ b/recipes/teentrack/meta.yaml
@@ -11,18 +11,18 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
-  skip: True  # [ py<35 ]
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
-    - python
+    - python >=3.5
     - pip
     - numpy 1.12.*
   run:
-    - python
+    - python >=3.5
     - {{ pin_compatible('numpy') }}
 
 test:

--- a/recipes/teentrack/meta.yaml
+++ b/recipes/teentrack/meta.yaml
@@ -33,7 +33,6 @@ about:
   home: https://github.com/eqfinney/SciPy/teentrack
   license: MIT
   license_family: MIT
-  license_file: README.txt
   summary: 'Curriculum for the SciPy Teen Track'
   description: |
     teentrack includes the educational materials used for the SciPy Teen Track


### PR DESCRIPTION
Adding the Teen Track curriculum to conda-forge, primarily as a means of testing conda-forge and its relevant documentation. 