### PR TITLE
Added R package vdiffr

### DIFF
--- a/recipes/r-vdiffr/bld.bat
+++ b/recipes/r-vdiffr/bld.bat
@@ -1,2 +1,0 @@
-"%R%" CMD INSTALL --build .
-IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-vdiffr/bld.bat
+++ b/recipes/r-vdiffr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-vdiffr/build.sh
+++ b/recipes/r-vdiffr/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/vdiffr
+  mv * $PREFIX/lib/R/library/vdiffr
+fi

--- a/recipes/r-vdiffr/meta.yaml
+++ b/recipes/r-vdiffr/meta.yaml
@@ -1,0 +1,86 @@
+{% set version = '0.2.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-vdiffr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: vdiffr_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/vdiffr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/vdiffr/vdiffr_{{ version }}.tar.gz
+  sha256: 807a624cee4e1f5238e1ba302062cbc84dcc504789d28613958dd3ead7b65f67
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('cxx') }}      # [not win]
+    - {{native}}toolchain        # [win]
+    - {{posix}}filesystem        # [win]
+    - {{posix}}make
+    - {{posix}}sed  # [win]
+    - {{posix}}coreutils  # [win]
+  host:
+    - r-base
+    - r-r6
+    - r-rcpp
+    - r-devtools
+    - r-fontquiver >=0.2.0
+    - r-gdtools >=0.1.2
+    - r-glue
+    - r-htmlwidgets >=0.6
+    - r-purrr >=0.2.0
+    - r-rlang
+    - r-shiny
+    - r-svglite >=1.2.0
+    - r-testthat >=1.0.0
+    - r-xml2
+  run:
+    - r-base
+    - {{native}}gcc-libs         # [win]
+    - r-r6
+    - r-rcpp
+    - r-devtools
+    - r-fontquiver >=0.2.0
+    - r-gdtools >=0.1.2
+    - r-glue
+    - r-htmlwidgets >=0.6
+    - r-purrr >=0.2.0
+    - r-rlang
+    - r-shiny
+    - r-svglite >=1.2.0
+    - r-testthat >=1.0.0
+    - r-xml2
+
+test:
+  commands:
+    - $R -e "library('vdiffr')"           # [not win]
+    - "\"%R%\" -e \"library('vdiffr')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=vdiffr
+  license: GPL-3
+  summary: An extension to the 'testthat' package that makes it easy to add graphical unit tests.
+    It provides a Shiny application to manage the test cases.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - jenzopr

--- a/recipes/r-vdiffr/meta.yaml
+++ b/recipes/r-vdiffr/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   merge_build_host: True  # [win]
   number: 0
-  skip: true  # [win32]
+  skip: true  # [win]
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
Here I package vdiffr, an extension to the 'testthat' package that makes it easy to add graphical unit tests.

Local conda-build failed because of missing packages that actually should be available (have been rendered tonight). Lets try here.

Best,
Jens