### PR TITLE
Add r-cooccur

### DIFF
--- a/recipes/r-cooccur/bld.bat
+++ b/recipes/r-cooccur/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-cooccur/build.sh
+++ b/recipes/r-cooccur/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/cooccur
+  mv * $PREFIX/lib/R/library/cooccur
+fi

--- a/recipes/r-cooccur/meta.yaml
+++ b/recipes/r-cooccur/meta.yaml
@@ -1,0 +1,65 @@
+{% set version = '1.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+{% set cran_mirror = 'https://cran.r-project.org' %}
+
+package:
+  name: r-cooccur
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: cooccur_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/cooccur_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/cooccur/cooccur_{{ version }}.tar.gz
+  sha256: 7ba202803bb9aaf0b11862c13f2ffd631fad0c1bf831c8ff447b3812217c8af2
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+  host:
+    - r-base
+    - r-ggplot2
+    - r-gmp
+    - r-reshape2
+  run:
+    - r-base
+    - r-ggplot2
+    - r-gmp
+    - r-reshape2
+
+test:
+  commands:
+    - $R -e "library('cooccur')"           # [not win]
+    - "\"%R%\" -e \"library('cooccur')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=cooccur
+  license: GPL-2
+  summary: This R package applies the probabilistic model of species co-occurrence (Veech 2013)
+    to a set of species distributed among a set of survey or sampling sites. The algorithm
+    calculates the observed and expected frequencies of co-occurrence between each pair
+    of species. The expected frequency is based on the distribution of each species
+    being random and independent of the other species. The analysis returns the probabilities
+    that a more extreme (either low or high) value of co-occurrence could have been
+    obtained by chance. The package also includes functions for visualizing species
+    co-occurrence results and preparing data for downstream analyses.
+  license_family: GPL2
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-2'  # [win]
+
+extra:
+  recipe-maintainers:
+    - nick-youngblut
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer


### PR DESCRIPTION
Adding to conda-forge instead of bioconda due to bioconda's transition from conda-build v2 to v3. Arguably, this package could also be used for non-biological questions. 