### PR TITLE
Added recipe for mputil

### DIFF
--- a/recipes/mputil/meta.yaml
+++ b/recipes/mputil/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "mputil" %}
+{% set version = "0.1.1" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "6e510e587cd812055cd1b61eb311894bf5ed1ec1f81ad9b2b3413ef4df8aeb08" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - mputil
+
+about:
+  home: https://github.com/rasbt/mputil
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Utility functions for Python's multiprocessing module
+  description: mputil is a package that provides utility functions for Python''s multiprocessing standard library module
+  doc_url: https://github.com/rasbt/mputil
+  dev_url: https://github.com/rasbt/mputil
+
+extra:
+  recipe-maintainers:
+    - jenzopr


### PR DESCRIPTION
The package `mputil` provides *lazy* wrappers for pythons `multiprocessing.map` and `multiprocessing.imap`. These wrappers evaluate the "iterator" lazily (in contrast to `map` and `imap`), which can be desirable if the iterator or generator yields objects with large memory footprints.

Best,
Jens