### PR TITLE
Add pickle5

### DIFF
--- a/recipes/pickle5/meta.yaml
+++ b/recipes/pickle5/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "pickle5" %}
+{% set version = "0.0.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 353593cbc2a505c6520ed533e59d86252d4daa0c1e22f4315abd3f1feccd4e07
+
+build:
+  number: 0
+  skip: true  # [py<36]
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - pickle5
+  commands:
+    - python -m pickle5.test.test_pickle
+
+about:
+  home: https://github.com/pitrou/pickle5-backport
+  license: PSF 2
+  license_file: LICENSE
+  summary: "Experimental backport of the pickle 5 protocol (PEP 574)"
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - pitrou


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/6314

Adds a `conda` package for `pickle5`, a proposal/future backport of [PEP 574]( https://www.python.org/dev/peps/pep-0574/ ).

cc @pitrou