### PR TITLE
Return to conda-smithy stable

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -35,7 +35,7 @@ bash ~/miniconda.sh -b -p ~/miniconda
 )
 source ~/miniconda/bin/activate root
 
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-smithy=3.* conda-forge-pinning git=2.12.2 pip
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-smithy=3.* conda-forge-pinning git=2.12.2
 
 conda info
 conda config --get
@@ -44,8 +44,6 @@ set +x
 mkdir -p ~/.conda-smithy
 echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
 set -x
-
-pip install git+https://github.com/conda-forge/conda-smithy
 
 python .travis_scripts/create_feedstocks.py || {
     python .travis_scripts/trigger_travis_build.py "conda-forge/staged-recipes";


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/staged-recipes/pull/6306 ).

Now that the new conda-smithy has been released and things appear to be working again, return to the latest stable conda-smithy release.