### PR TITLE
New recipe: bravado-core for swagger support

### DIFF
--- a/recipes/bravado-core/meta.yaml
+++ b/recipes/bravado-core/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "bravado-core" %}
+{% set version = "5.0.4" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4547625f3581e3cc056c70bfd9b813b648b39a07753bab682b71f0940e3efff5
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - jsonref
+    - jsonschema[format] >=2.5.1
+    - msgpack-python
+    - pip
+    - python
+    - python-dateutil
+    - pytz
+    - pyyaml
+    - simplejson
+    - six
+    - swagger-spec-validator >=2.0.1
+  run:
+    - jsonref
+    - jsonschema[format] >=2.5.1
+    - msgpack-python
+    - python
+    - python-dateutil
+    - pytz
+    - pyyaml
+    - simplejson
+    - six
+    - swagger-spec-validator >=2.0.1
+
+test:
+  imports:
+    - bravado_core
+
+about:
+  home: https://github.com/Yelp/bravado-core
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Library for adding Swagger support to clients and servers
+
+extra:
+  recipe-maintainers:
+    - chapmanb


### PR DESCRIPTION
Dependency for bravado as first steps towards supporting wes-server
in bioconda. bravado recipe to follow after this dependency available.