### PR TITLE
New recipe: jsonref; bravado dependency

### DIFF
--- a/recipes/jsonref/meta.yaml
+++ b/recipes/jsonref/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "jsonref" %}
+{% set version = "0.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 56e0ce228798bdecadff865c142741b1ffdd57a5e9c40c40ec2b641d7c430ad3
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - jsonref
+
+about:
+  home: http://github.com/gazpachoking/jsonref
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: An implementation of JSON Reference for Python
+
+extra:
+  recipe-maintainers:
+    - chapmanb


### PR DESCRIPTION
Missing dependency for bravado-core (#6370), building
block for bravado swagger support.