### PR TITLE
New recipe: bravado -- swagger/OpenAPI REST support

### DIFF
--- a/recipes/bravado/meta.yaml
+++ b/recipes/bravado/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "bravado" %}
+{% set version = "10.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f3a72cae439209d4e29477dce44322fae358a8f824dd4f324179144b83fa5ada
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+  noarch: python
+
+requirements:
+  host:
+    - bravado-core >=5.0.1
+    - monotonic
+    - msgpack-python
+    - pip
+    - python
+    - python-dateutil
+    - pyyaml
+    - requests >=2.4
+    - six
+  run:
+    - bravado-core >=5.0.1
+    - monotonic
+    - msgpack-python
+    - python
+    - python-dateutil
+    - pyyaml
+    - requests >=2.4
+    - six
+
+test:
+  imports:
+    - bravado
+    - bravado.testing
+
+about:
+  home: https://github.com/Yelp/bravado
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Library for accessing Swagger-enabled API's
+
+extra:
+  recipe-maintainers:
+    - chapmanb
+    - marcelotrevisani


### PR DESCRIPTION
Follow up of #6371 and #6370. Final dependency for wes-server client support in bioconda.