### PR TITLE
Add gwdatafind

### DIFF
--- a/recipes/gwdatafind/meta.yaml
+++ b/recipes/gwdatafind/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   skip: true  # [win]
 
 requirements:

--- a/recipes/gwdatafind/meta.yaml
+++ b/recipes/gwdatafind/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "gwdatafind" %}
+{% set version = "1.0.0" %}
+{% set sha256 = "1441ad9dc445fc906bd3f589a059b878976958870cfad9ef20b9e2b8255378f4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+  skip: true  # [win]
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - six
+    - pyopenssl
+    - ligo-segments
+
+test:
+  requires:
+    - pytest
+    - mock  # [py2k]
+  imports:
+    - gwdatafind.http
+    - gwdatafind.ui
+    - gwdatafind.utils
+  commands:
+    - python -m pytest --pyargs gwdatafind
+    - python -m gwdatafind --help
+
+about:
+  home: https://gwdatafind.readthedocs.io
+  doc_url: https://gwdatafind.readthedocs.io
+  dev_url: https://git.ligo.org/lscsoft/{{ name }}
+  license: GPLv3
+  license_file: LICENSE
+  license_family: GPL
+  summary: The client library for the LIGO Data Replicator (LDR) service.
+  description: |
+    The DataFind service allows users to query for the location of
+    Gravitational-Wave Frame (GWF) files containing data from the current
+    gravitational-wave detectors.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
`gwdatafind` provides the client library for the LIGO Data Replicator (LDR) service.