### PR TITLE
Add dqsegdb2

### DIFF
--- a/recipes/dqsegdb2/meta.yaml
+++ b/recipes/dqsegdb2/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "dqsegdb2" %}
+{% set version = "1.0.0" %}
+{% set sha256 = "828a1afd0af31b4fda2bba3427836aa5cf7fb751b636140ba6e8c48d1e6aac34" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: true  # [win]
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - ligo-segments
+    - gwdatafind
+
+test:
+  requires:
+    - pytest
+    - mock  # [py2k]
+  imports:
+    - dqsegdb2.api
+    - dqsegdb2.http
+    - dqsegdb2.query
+  commands:
+    - python -m pytest --pyargs dqsegdb2
+
+about:
+  home: https://dqsegdb2.readthedocs.io
+  doc_url: https://dqsegdb2.readthedocs.io
+  dev_url: https://github.com/duncanmmacleod/{{ name }}
+  license: GPLv3
+  license_file: LICENSE
+  license_family: GPL
+  summary: A simplified Python implementation of the DQSegDB API
+  description: |
+    This package only provides a query interface for `GET` requests for a
+    subset of information available from a DQSegDB server.
+    Any users wishing to make `POST` requests should refer to the official
+    DQSegDB Python client available from https://pypi.org/project/dqsegdb.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds `dqsegdb2`, a simplified Python client for DQSegDB queries (LIGO/Virgo astrophysics).