### PR TITLE
Add r-rpostgres

### DIFF
--- a/recipes/r-rpostgres/bld.bat
+++ b/recipes/r-rpostgres/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-rpostgres/build.sh
+++ b/recipes/r-rpostgres/build.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
   export DISABLE_AUTOBREW=1
-
-  if [[ $target_platform =~ linux.* ]]; then
-    # force linking to libgfortran and not libgfortran-ng
-    LIBGFORTRAN_PREFIX=$(jq -r ".extracted_package_dir" $PREFIX/conda-meta/libgfortran-3.*.json)
-    LDFLAGS=$($R CMD CONFIG LDFLAGS | sed "s|$PREFIX/lib|$LIBGFORTRAN_PREFIX/lib|g")
-
-    # cannot edit $SRC_DIR/src/Makevars.in as it will then fail a checksum
-    mkdir -p ~/.R
-    echo "LDFLAGS=$LDFLAGS" >> ~/.R/Makevars
-  fi
-
   $R CMD INSTALL --build .
 else
   mkdir -p $PREFIX/lib/R/library/RPostgres

--- a/recipes/r-rpostgres/build.sh
+++ b/recipes/r-rpostgres/build.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
   export DISABLE_AUTOBREW=1
+
+  if [[ $target_platform =~ linux.* ]]; then
+    # force linking to libgfortran and not libgfortran-ng
+    LIBGFORTRAN_PREFIX=$(jq -r ".extracted_package_dir" $PREFIX/conda-meta/libgfortran-3.*.json)
+    LDFLAGS=$($R CMD CONFIG LDFLAGS | sed "s|$PREFIX/lib|$LIBGFORTRAN_PREFIX/lib|g")
+
+    # cannot edit $SRC_DIR/src/Makevars.in as it will then fail a checksum
+    mkdir -p ~/.R
+    echo "LDFLAGS=$LDFLAGS" >> ~/.R/Makevars
+  fi
+
   $R CMD INSTALL --build .
 else
   mkdir -p $PREFIX/lib/R/library/RPostgres

--- a/recipes/r-rpostgres/build.sh
+++ b/recipes/r-rpostgres/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/RPostgres
+  mv * $PREFIX/lib/R/library/RPostgres
+fi

--- a/recipes/r-rpostgres/meta.yaml
+++ b/recipes/r-rpostgres/meta.yaml
@@ -34,8 +34,6 @@ requirements:
     - {{posix}}automake-wrapper  # [win]
     - {{posix}}pkg-config
     - {{posix}}make
-    - {{posix}}sed  # [win]
-    - {{posix}}coreutils  # [win]
     - {{posix}}coreutils         # [win]
     - {{posix}}zip               # [win]
   host:
@@ -52,7 +50,6 @@ requirements:
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
-    - libgfortran-ng                # [not win]
     - r-bh
     - r-dbi >=1.0.0
     - r-rcpp >=0.11.4.2
@@ -61,7 +58,7 @@ requirements:
     - r-hms
     - r-plogr >=0.2.0
     - r-withr
-    - libpq
+    - postgresql
 
 test:
   commands:

--- a/recipes/r-rpostgres/meta.yaml
+++ b/recipes/r-rpostgres/meta.yaml
@@ -1,0 +1,86 @@
+{% set version = '1.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rpostgres
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: RPostgres_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/RPostgres_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/RPostgres/RPostgres_{{ version }}.tar.gz
+  sha256: d1fc96d426cfb25c8dd0076bf8b672b37059c45078cd58e62f6cb664d6a445e8
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('cxx') }}      # [not win]
+    - {{native}}toolchain        # [win]
+    - {{posix}}filesystem        # [win]
+    - {{posix}}sed               # [win]
+    - {{posix}}grep              # [win]
+    - {{posix}}autoconf
+    - {{posix}}automake          # [not win]
+    - {{posix}}automake-wrapper  # [win]
+    - {{posix}}pkg-config
+    - {{posix}}make
+    - {{posix}}sed  # [win]
+    - {{posix}}coreutils  # [win]
+    - {{posix}}coreutils         # [win]
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-bh
+    - r-dbi >=1.0.0
+    - r-rcpp >=0.11.4.2
+    - r-bit64
+    - r-blob >=1.1.1
+    - r-hms
+    - r-plogr >=0.2.0
+    - r-withr
+    - postgresql
+  run:
+    - r-base
+    - {{native}}gcc-libs         # [win]
+    - r-bh
+    - r-dbi >=1.0.0
+    - r-rcpp >=0.11.4.2
+    - r-bit64
+    - r-blob >=1.1.1
+    - r-hms
+    - r-plogr >=0.2.0
+    - r-withr
+    - libpq
+
+test:
+  commands:
+    - $R -e "library('RPostgres')"           # [not win]
+    - "\"%R%\" -e \"library('RPostgres')\""  # [win]
+
+about:
+  home: https://github.com/r-dbi/RPostgres
+  license: GPL-2
+  summary: ' Fully ''DBI''-compliant ''Rcpp''-backed interface to ''PostgreSQL'' <https://www.postgresql.org/>,
+    an open-source relational database.'
+  license_family: GPL2
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-2'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - halldc

--- a/recipes/r-rpostgres/meta.yaml
+++ b/recipes/r-rpostgres/meta.yaml
@@ -36,7 +36,6 @@ requirements:
     - {{posix}}make
     - {{posix}}coreutils         # [win]
     - {{posix}}zip               # [win]
-    - jq  # [linux]
   host:
     - r-base
     - r-bh

--- a/recipes/r-rpostgres/meta.yaml
+++ b/recipes/r-rpostgres/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - {{posix}}make
     - {{posix}}coreutils         # [win]
     - {{posix}}zip               # [win]
+    - jq  # [linux]
   host:
     - r-base
     - r-bh
@@ -58,7 +59,7 @@ requirements:
     - r-hms
     - r-plogr >=0.2.0
     - r-withr
-    - postgresql
+    - libpq
 
 test:
   commands:

--- a/recipes/r-rpostgres/meta.yaml
+++ b/recipes/r-rpostgres/meta.yaml
@@ -52,6 +52,7 @@ requirements:
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
+    - libgfortran                # [not win]
     - r-bh
     - r-dbi >=1.0.0
     - r-rcpp >=0.11.4.2
@@ -66,12 +67,15 @@ test:
   commands:
     - $R -e "library('RPostgres')"           # [not win]
     - "\"%R%\" -e \"library('RPostgres')\""  # [win]
+    - conda inspect linkages -p $PREFIX r-rpostgres  # [not win]
+    - conda inspect objects -p $PREFIX r-rpostgres  # [osx]
 
 about:
   home: https://github.com/r-dbi/RPostgres
   license: GPL-2
-  summary: ' Fully ''DBI''-compliant ''Rcpp''-backed interface to ''PostgreSQL'' <https://www.postgresql.org/>,
-    an open-source relational database.'
+  summary: |
+    Fully 'DBI'-compliant 'Rcpp'-backed interface to 'PostgreSQL' <https://www.postgresql.org/>,
+    an open-source relational database.
   license_family: GPL2
   license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'  # [unix]
   license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-2'  # [win]

--- a/recipes/r-rpostgres/meta.yaml
+++ b/recipes/r-rpostgres/meta.yaml
@@ -52,7 +52,7 @@ requirements:
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
-    - libgfortran                # [not win]
+    - libgfortran-ng                # [not win]
     - r-bh
     - r-dbi >=1.0.0
     - r-rcpp >=0.11.4.2


### PR DESCRIPTION
Adding a recipe for the [RPostgres](https://github.com/r-dbi/RPostgres) R package.

This was created using the [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper), and then `postgresql` was added to the `host` requirements and `libpq` was added to the `run` requirements.