### PR TITLE
Add r-rmariadb

### DIFF
--- a/recipes/r-rmariadb/bld.bat
+++ b/recipes/r-rmariadb/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-rmariadb/build.sh
+++ b/recipes/r-rmariadb/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/RMariaDB
+  mv * $PREFIX/lib/R/library/RMariaDB
+fi

--- a/recipes/r-rmariadb/meta.yaml
+++ b/recipes/r-rmariadb/meta.yaml
@@ -1,0 +1,82 @@
+{% set version = '1.0.6' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rmariadb
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: RMariaDB_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/RMariaDB_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/RMariaDB/RMariaDB_{{ version }}.tar.gz
+  sha256: 51cc0b2cdf3aaf0cfc290d0b54eb533a7cffedaa4641a372426b0d98feebf2a6
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('cxx') }}      # [not win]
+    - {{native}}toolchain        # [win]
+    - {{posix}}filesystem        # [win]
+    - {{posix}}sed               # [win]
+    - {{posix}}grep              # [win]
+    - {{posix}}autoconf
+    - {{posix}}automake          # [not win]
+    - {{posix}}automake-wrapper  # [win]
+    - {{posix}}pkg-config
+    - {{posix}}make
+    - {{posix}}sed  # [win]
+    - {{posix}}coreutils  # [win]
+    - {{posix}}coreutils         # [win]
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-bh
+    - r-dbi >=1.0.0
+    - r-rcpp >=0.12.4
+    - r-bit64
+    - r-hms
+    - r-plogr
+    - mysql-connector-c
+  run:
+    - r-base
+    - {{native}}gcc-libs         # [win]
+    - r-bh
+    - r-dbi >=1.0.0
+    - r-rcpp >=0.12.4
+    - r-bit64
+    - r-hms
+    - r-plogr
+    - mysql-connector-c
+
+test:
+  commands:
+    - $R -e "library('RMariaDB')"           # [not win]
+    - "\"%R%\" -e \"library('RMariaDB')\""  # [win]
+
+about:
+  home: https://github.com/r-dbi/RMariaDB, https://downloads.mariadb.org/connector-c/
+  license: GPL-2
+  summary: Implements a 'DBI'-compliant interface to 'MariaDB' (<https://mariadb.org/>) and 'MySQL'
+    (<https://www.mysql.com/>) databases.
+  license_family: GPL2
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-2'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - halldc


### PR DESCRIPTION
Adding a recipe for the [RMariaDB](https://github.com/r-dbi/RMariaDB) R package.

This was created using the [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper), and then `mysql-connector-c` was added to the `host` and `run` requirements.