### PR TITLE
findutils v4.6.0

### DIFF
--- a/recipes/findutils/build.sh
+++ b/recipes/findutils/build.sh
@@ -21,7 +21,7 @@ sed -i.bak -e 's@mktemp -d@mktemp -d \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/test
 sed -i.bak -e 's@mktemp@mktemp \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/test_escapechars.sh
 sed -i.bak -e 's@mktemp@mktemp \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/test_inode.sh
 
-make check -j${CPU_COUNT} || (cat find/testsuite/test-suite.log; echo "TMPDIR: $TMPDIR"; ls -lhd $TMPDIR;t=$(mktemp -d); ls -lhd $t; echo tjo > $t/test;  exit 1)
+make check -j${CPU_COUNT}
 make install
 
 

--- a/recipes/findutils/build.sh
+++ b/recipes/findutils/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+autoreconf -fiv
+./configure --prefix="$PREFIX"
+make -j${CPU_COUNT}
+
+#Disabling ahistorical strftime tests
+sed -i.bak -e '120,126 s@.*/\* ! \*/@@' tests/test-strftime.c
+
+#ensure tests are executable
+chmod +x find/testsuite/{sv-48030-exec-plus-bug.sh,sv-48180-refuse-noop.sh}
+
+#make mktemp commands osx compatible
+
+sed -i.bak -e 's@mktemp -d@mktemp -d \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/sv-34079.sh
+sed -i.bak -e 's@mktemp -d@mktemp -d \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/sv-34976-execdir-fd-leak.sh
+sed -i.bak -e 's@mktemp -d@mktemp -d \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/sv-48030-exec-plus-bug.sh
+sed -i.bak -e 's@mktemp -d@mktemp -d \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/sv-48180-refuse-noop.sh
+sed -i.bak -e 's@mktemp -d@mktemp -d \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/sv-bug-32043.sh
+
+sed -i.bak -e 's@mktemp@mktemp \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/test_escapechars.sh
+sed -i.bak -e 's@mktemp@mktemp \${TMPDIR:-/tmp}/tmp.XXXXXXXXXX@' find/testsuite/test_inode.sh
+
+make check -j${CPU_COUNT} || (cat find/testsuite/test-suite.log; echo "TMPDIR: $TMPDIR"; ls -lhd $TMPDIR;t=$(mktemp -d); ls -lhd $t; echo tjo > $t/test;  exit 1)
+make install
+
+

--- a/recipes/findutils/findutils-4.4.2-xautofs.patch
+++ b/recipes/findutils/findutils-4.4.2-xautofs.patch
@@ -1,0 +1,132 @@
+From 17e470dc1acca4824b70328d733d5f99c12d0d65 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Wed, 11 May 2011 16:46:45 +0200
+Subject: [PATCH 3/4] findutils-4.4.2-xautofs.patch
+
+---
+ doc/find.texi  |    4 ++++
+ find/defs.h    |    3 +++
+ find/find.1    |    3 +++
+ find/ftsfind.c |    6 ++++++
+ find/parser.c  |   11 ++++++++++-
+ find/util.c    |    1 +
+ 6 files changed, 27 insertions(+), 1 deletions(-)
+
+diff --git a/doc/find.texi b/doc/find.texi
+index c584298..9731b71 100644
+--- a/doc/find.texi
++++ b/doc/find.texi
+@@ -1446,6 +1446,10 @@ them.
+ There are two ways to avoid searching certain filesystems.  One way is
+ to tell @code{find} to only search one filesystem:
+ 
++@deffn Option -xautofs
++Don't descend directories on autofs filesystems.
++@end deffn
++
+ @deffn Option -xdev
+ @deffnx Option -mount
+ Don't descend directories on other filesystems.  These options are
+diff --git a/find/defs.h b/find/defs.h
+index 11d1d00..f95ce72 100644
+--- a/find/defs.h
++++ b/find/defs.h
+@@ -557,6 +557,9 @@ struct options
+   /* If true, don't cross filesystem boundaries. */
+   bool stay_on_filesystem;
+ 
++  /* If true, don't descend directories on autofs filesystems. */
++  bool bypass_autofs;
++
+   /* If true, we ignore the problem where we find that a directory entry
+    * no longer exists by the time we get around to processing it.
+    */
+diff --git a/find/find.1 b/find/find.1
+index e851f82..a4799ff 100644
+--- a/find/find.1
++++ b/find/find.1
+@@ -520,6 +520,9 @@ to stat them; this gives a significant increase in search speed.
+ .IP "\-version, \-\-version"
+ Print the \fBfind\fR version number and exit.
+ 
++.IP \-xautofs
++Don't descend directories on autofs filesystems.
++
+ .IP \-xdev
+ Don't descend directories on other filesystems.
+ 
+diff --git a/find/ftsfind.c b/find/ftsfind.c
+index 9fdb8ef..bd7cc37 100644
+--- a/find/ftsfind.c
++++ b/find/ftsfind.c
+@@ -485,6 +485,12 @@ consider_visiting (FTS *p, FTSENT *ent)
+ 	}
+     }
+ 
++  if (options.bypass_autofs &&
++      0 == strcmp ("autofs", filesystem_type (&statbuf, ent->fts_name)))
++    {
++      fts_set(p, ent, FTS_SKIP); /* descend no further */
++    }
++
+   if ( (ent->fts_info == FTS_D) && !options.do_dir_first )
+     {
+       /* this is the preorder visit, but user said -depth */
+diff --git a/find/parser.c b/find/parser.c
+index 52a1ef6..995aec3 100644
+--- a/find/parser.c
++++ b/find/parser.c
+@@ -146,6 +146,7 @@ static bool parse_user          (const struct parser_table*, char *argv[], int *
+ static bool parse_version       (const struct parser_table*, char *argv[], int *arg_ptr);
+ static bool parse_wholename     (const struct parser_table*, char *argv[], int *arg_ptr);
+ static bool parse_xdev          (const struct parser_table*, char *argv[], int *arg_ptr);
++static bool parse_xautofs       (const struct parser_table*, char *argv[], int *arg_ptr);
+ static bool parse_ignore_race   (const struct parser_table*, char *argv[], int *arg_ptr);
+ static bool parse_noignore_race (const struct parser_table*, char *argv[], int *arg_ptr);
+ static bool parse_warn          (const struct parser_table*, char *argv[], int *arg_ptr);
+@@ -306,6 +307,7 @@ static struct parser_table const parse_table[] =
+   PARSE_TEST_NP    ("wholename",             wholename), /* GNU, replaced -path, but anyway -path will soon be in POSIX */
+   {ARG_TEST,       "writable",               parse_accesscheck, pred_writable}, /* GNU, 4.3.0+ */
+   PARSE_OPTION     ("xdev",                  xdev), /* POSIX */
++  PARSE_OPTION     ("xautofs",               xautofs),
+   PARSE_TEST       ("xtype",                 xtype),	     /* GNU */
+ #ifdef UNIMPLEMENTED_UNIX
+   /* It's pretty ugly for find to know about archive formats.
+@@ -1239,7 +1241,7 @@ operators (decreasing precedence; -and is implicit where no others are given):\n
+ positional options (always true): -daystart -follow -regextype\n\n\
+ normal options (always true, specified before other expressions):\n\
+       -depth --help -maxdepth LEVELS -mindepth LEVELS -mount -noleaf\n\
+-      --version -xdev -ignore_readdir_race -noignore_readdir_race\n"));
++      --version -xautofs -xdev -ignore_readdir_race -noignore_readdir_race\n"));
+   puts (_("\
+ tests (N can be +N or -N or N): -amin N -anewer FILE -atime N -cmin N\n\
+       -cnewer FILE -ctime N -empty -false -fstype TYPE -gid N -group NAME\n\
+@@ -2683,6 +2685,13 @@ parse_xdev (const struct parser_table* entry, char **argv, int *arg_ptr)
+ }
+ 
+ static bool
++parse_xautofs (const struct parser_table* entry, char **argv, int *arg_ptr)
++{
++  options.bypass_autofs = true;
++  return parse_noop (entry, argv, arg_ptr);
++}
++
++static bool
+ parse_ignore_race (const struct parser_table* entry, char **argv, int *arg_ptr)
+ {
+   options.ignore_readdir_race = true;
+diff --git a/find/util.c b/find/util.c
+index 8577396..4d45f84 100644
+--- a/find/util.c
++++ b/find/util.c
+@@ -1017,6 +1017,7 @@ set_option_defaults (struct options *p)
+ 
+   p->full_days = false;
+   p->stay_on_filesystem = false;
++  p->bypass_autofs = false;
+   p->ignore_readdir_race = false;
+ 
+   if (p->posixly_correct)
+-- 
+1.7.4.4
+

--- a/recipes/findutils/findutils-4.5.13-warnings.patch
+++ b/recipes/findutils/findutils-4.5.13-warnings.patch
@@ -1,0 +1,53 @@
+From 690d4bd9f29a805999a3ce4651dac9585ccc9917 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Wed, 11 May 2011 16:46:57 +0200
+Subject: [PATCH 1/2] findutils-4.5.7-warnings.patch
+
+---
+ xargs/xargs.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/xargs/xargs.c b/xargs/xargs.c
+index 5e373f2..c0a8676 100644
+--- a/xargs/xargs.c
++++ b/xargs/xargs.c
+@@ -1289,7 +1289,8 @@ xargs_do_exec (struct buildcmd_control *ctl, void *usercontext, int argc, char *
+ 		 * utility if we run it, for POSIX compliance on the
+ 		 * handling of exit values.
+ 		 */
+-		write (fd[1], &errno, sizeof (int));
++		int sink = write (fd[1], &errno, sizeof (int));
++		(void) sink;
+ 	      }
+ 
+ 	    close (fd[1]);
+-- 
+1.7.1
+
+
+From c5654b9ca5f50daa1ca406ebd7b4546f24d00db6 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Mon, 23 Sep 2013 15:04:03 +0200
+Subject: [PATCH 2/2] parser: silence a [-Wmaybe-uninitialized] GCC warning
+
+... caused by a missing model of error()
+---
+ find/parser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/find/parser.c b/find/parser.c
+index 89d8bcf..8c399d7 100644
+--- a/find/parser.c
++++ b/find/parser.c
+@@ -2723,7 +2723,7 @@ insert_type (char **argv, int *arg_ptr,
+ 	     const struct parser_table *entry,
+ 	     PRED_FUNC which_pred)
+ {
+-  mode_t type_cell;
++  mode_t type_cell /* to silence GCC warning */ = 0;
+   struct predicate *our_pred;
+   float rate = 0.5;
+   const char *typeletter;
+-- 
+1.9.3
+

--- a/recipes/findutils/findutils-4.6.0-exec-args.patch
+++ b/recipes/findutils/findutils-4.6.0-exec-args.patch
@@ -1,0 +1,226 @@
+From 443166adaf1c8b91e16a716f3b13f47493b895cc Mon Sep 17 00:00:00 2001
+From: Bernhard Voelker <mail@bernhard-voelker.de>
+Date: Tue, 31 May 2016 10:38:52 +0200
+Subject: [PATCH] Fix bug #48030: find: -exec + does not pass all arguments in
+ certain cases
+
+When the -exec arguments buffer (usually 128k) is full and the given
+command has been executed with all that arguments, find(1) missed to
+execute the command yet another time if only 1 another file would have
+to be processed.
+Both find(1), i.e., nowadays FTS-version, and oldfind are affected.
+This bug was present since the implementation of '-exec +' in 2005,
+see commit FINDUTILS_4_2_11-1-25-gf0a6ac6.
+
+* lib/buildcmd.c (bc_push_arg): Move the assignment to set 'state->todo'
+to 1 down after the immediate execution which resets that flag.
+* find/testsuite/sv-48030-exec-plus-bug.sh: Add a test.
+* find/testsuite/Makefile.am (test_shell_progs): Reference the test.
+* NEWS (Bug Fixes): Mention the fix.
+
+Reported by Joe Philip Ninan <indiajoe@gmail.com> in
+https://savannah.gnu.org/bugs/?48030
+
+Upstream-commit: 8cdc9767e305c9566f537af9d1acf71d1bc6ee8e
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ find/testsuite/Makefile.am               |   3 +-
+ find/testsuite/sv-48030-exec-plus-bug.sh | 143 +++++++++++++++++++++++++++++++
+ lib/buildcmd.c                           |  10 +--
+ 3 files changed, 150 insertions(+), 6 deletions(-)
+ create mode 100644 find/testsuite/sv-48030-exec-plus-bug.sh
+
+diff --git a/find/testsuite/Makefile.am b/find/testsuite/Makefile.am
+index c1369c3..ab5dbe8 100644
+--- a/find/testsuite/Makefile.am
++++ b/find/testsuite/Makefile.am
+@@ -258,7 +258,8 @@ test_escapechars.sh \
+ test_escape_c.sh \
+ test_inode.sh \
+ sv-34079.sh \
+-sv-34976-execdir-fd-leak.sh
++sv-34976-execdir-fd-leak.sh \
++sv-48030-exec-plus-bug.sh
+ 
+ EXTRA_DIST = $(EXTRA_DIST_EXP) $(EXTRA_DIST_XO) $(EXTRA_DIST_GOLDEN) \
+ 	$(test_shell_progs) binary_locations.sh checklists.py
+diff --git a/find/testsuite/sv-48030-exec-plus-bug.sh b/find/testsuite/sv-48030-exec-plus-bug.sh
+new file mode 100755
+index 0000000..4dbf149
+--- /dev/null
++++ b/find/testsuite/sv-48030-exec-plus-bug.sh
+@@ -0,0 +1,143 @@
++#! /bin/sh
++# Copyright (C) 2016 Free Software Foundation, Inc.
++#
++# This program is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++#
++
++# This test verifies that find invokes the given command for the
++# multiple-argument sytax '-exec CMD {} +'.  Between FINDUTILS-4.2.12
++# and v4.6.0, find(1) would have failed to execute CMD another time
++# if there was only one last single file argument.
++
++testname="$(basename $0)"
++
++. "${srcdir}"/binary_locations.sh
++
++die() {
++  echo "$@" >&2
++  exit 1
++}
++
++# This is used to simplify checking of the return value
++# which is useful when ensuring a command fails as desired.
++# I.e., just doing `command ... &&fail=1` will not catch
++# a segfault in command for example.  With this helper you
++# instead check an explicit exit code like
++#   returns_ 1 command ... || fail
++returns_ () {
++  # Disable tracing so it doesn't interfere with stderr of the wrapped command
++  { set +x; } 2>/dev/null
++
++  local exp_exit="$1"
++  shift
++  "$@"
++  test $? -eq $exp_exit && ret_=0 || ret_=1
++
++  set -x
++  { return $ret_; } 2>/dev/null
++}
++
++# Define the nicest compare available (borrowed from gnulib).
++if diff_out_=`exec 2>/dev/null; diff -u "$0" "$0" < /dev/null` \
++   && diff -u Makefile "$0" 2>/dev/null | grep '^[+]#!' >/dev/null; then
++  # diff accepts the -u option and does not (like AIX 7 'diff') produce an
++  # extra space on column 1 of every content line.
++  if test -z "$diff_out_"; then
++    compare () { diff -u "$@"; }
++  else
++    compare ()
++    {
++      if diff -u "$@" > diff.out; then
++        # No differences were found, but Solaris 'diff' produces output
++        # "No differences encountered". Hide this output.
++        rm -f diff.out
++        true
++      else
++        cat diff.out
++        rm -f diff.out
++        false
++      fi
++    }
++  fi
++elif diff_out_=`exec 2>/dev/null; diff -c "$0" "$0" < /dev/null`; then
++  if test -z "$diff_out_"; then
++    compare () { diff -c "$@"; }
++  else
++    compare ()
++    {
++      if diff -c "$@" > diff.out; then
++        # No differences were found, but AIX and HP-UX 'diff' produce output
++        # "No differences encountered" or "There are no differences between the
++        # files.". Hide this output.
++        rm -f diff.out
++        true
++      else
++        cat diff.out
++        rm -f diff.out
++        false
++      fi
++    }
++  fi
++elif cmp -s /dev/null /dev/null 2>/dev/null; then
++  compare () { cmp -s "$@"; }
++else
++  compare () { cmp "$@"; }
++fi
++
++DIR='RashuBug'
++# Name of the CMD to execute: the file name must be 6 characters long
++# (to trigger the bug in combination with the test files).
++CMD='tstcmd'
++
++# Create test files.
++make_test_data() {
++  # Create the CMD script and check that it works.
++  mkdir "$DIR" 'bin' \
++    && echo 'printf "%s\n" "$@"' > "bin/$CMD" \
++    && chmod +x "bin/$CMD" \
++    && PATH="$PWD/bin:$PATH" \
++    && [ $( "${ftsfind}" bin -maxdepth 0 -exec "$CMD" '{}' + ) = 'bin' ] \
++    || return 1
++
++  # Create expected output file - also used for creating the test data.
++  { seq -f "${DIR}/abcdefghijklmnopqrstuv%04g" 901 &&
++    seq -f "${DIR}/abcdefghijklmnopqrstu%04g" 902 3719
++  } > exp2 \
++    && LC_ALL=C sort exp2 > exp \
++    && rm exp2 \
++    || return 1
++
++  # Create test files, and check if test data has been created correctly.
++  xargs touch < exp \
++    && [ -f "${DIR}/abcdefghijklmnopqrstu3719" ] \
++    && [ 3719 = $( "${ftsfind}" "$DIR" -type f | wc -l ) ] \
++    || return 1
++}
++
++set -x
++tmpdir="$(mktemp -d)" \
++  && cd "$tmpdir" \
++  && make_test_data "${tmpdir}" \
++  || die "FAIL: failed to set up the test in ${tmpdir}"
++
++fail=0
++for exe in "${ftsfind}" "${oldfind}"; do
++  "$exe" "$DIR" -type f -exec "$CMD" '{}' + > out || fail=1
++  LC_ALL=C sort out > out2 || fail=1
++  compare exp out2 || fail=1
++done
++
++cd ..
++rm -rf "${tmpdir}" || exit 1
++exit $fail
+diff --git a/lib/buildcmd.c b/lib/buildcmd.c
+index a58f67e..27e9ce5 100644
+--- a/lib/buildcmd.c
++++ b/lib/buildcmd.c
+@@ -356,11 +356,6 @@ bc_push_arg (struct buildcmd_control *ctl,
+ 
+   assert (arg != NULL);
+ 
+-  if (!initial_args)
+-    {
+-      state->todo = 1;
+-    }
+-
+   if (!terminate)
+     {
+       if (state->cmd_argv_chars + len + pfxlen > ctl->arg_max)
+@@ -380,6 +375,11 @@ bc_push_arg (struct buildcmd_control *ctl,
+             bc_do_exec (ctl, state);
+     }
+ 
++  if (!initial_args)
++    {
++      state->todo = 1;
++    }
++
+   if (state->cmd_argc >= state->cmd_argv_alloc)
+     {
+       /* XXX: we could use extendbuf() here. */
+-- 
+2.5.5
+

--- a/recipes/findutils/findutils-4.6.0-fts-update.patch
+++ b/recipes/findutils/findutils-4.6.0-fts-update.patch
@@ -1,0 +1,990 @@
+From f3337786e55909538aacfd7c29b1cf58ff444fbf Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Mon, 12 Feb 2018 12:45:36 +0100
+Subject: [PATCH 1/4] import gnulib's FTS module from upstream commit 281b825e
+
+---
+ gl/lib/fts.c  | 424 +++++++++++++++++++++++++++++-----------------------------
+ gl/lib/fts_.h |  10 +-
+ 2 files changed, 221 insertions(+), 213 deletions(-)
+
+diff --git a/gl/lib/fts.c b/gl/lib/fts.c
+index c91d7a1..bfa73e3 100644
+--- a/gl/lib/fts.c
++++ b/gl/lib/fts.c
+@@ -1,6 +1,6 @@
+ /* Traverse a file hierarchy.
+ 
+-   Copyright (C) 2004-2015 Free Software Foundation, Inc.
++   Copyright (C) 2004-2018 Free Software Foundation, Inc.
+ 
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+@@ -13,7 +13,7 @@
+    GNU General Public License for more details.
+ 
+    You should have received a copy of the GNU General Public License
+-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+ 
+ /*-
+  * Copyright (c) 1990, 1993, 1994
+@@ -46,9 +46,9 @@
+ 
+ #include <config.h>
+ 
+-#if defined(LIBC_SCCS) && !defined(lint)
++#if defined LIBC_SCCS && !defined GCC_LINT && !defined lint
+ static char sccsid[] = "@(#)fts.c       8.6 (Berkeley) 8/14/94";
+-#endif /* LIBC_SCCS and not lint */
++#endif
+ 
+ #include "fts_.h"
+ 
+@@ -71,11 +71,7 @@ static char sccsid[] = "@(#)fts.c       8.6 (Berkeley) 8/14/94";
+ 
+ #if ! _LIBC
+ # include "fcntl--.h"
+-# include "dirent--.h"
+-# include "unistd--.h"
+-/* FIXME - use fcntl(F_DUPFD_CLOEXEC)/openat(O_CLOEXEC) once they are
+-   supported.  */
+-# include "cloexec.h"
++# include "flexmember.h"
+ # include "openat.h"
+ # include "same-inode.h"
+ #endif
+@@ -202,6 +198,14 @@ enum Fts_stat
+     while (false)
+ #endif
+ 
++#ifndef FALLTHROUGH
++# if __GNUC__ < 7
++#  define FALLTHROUGH ((void) 0)
++# else
++#  define FALLTHROUGH __attribute__ ((__fallthrough__))
++# endif
++#endif
++
+ static FTSENT   *fts_alloc (FTS *, const char *, size_t) internal_function;
+ static FTSENT   *fts_build (FTS *, int) internal_function;
+ static void      fts_lfree (FTSENT *) internal_function;
+@@ -296,14 +300,13 @@ static DIR *
+ internal_function
+ opendirat (int fd, char const *dir, int extra_flags, int *pdir_fd)
+ {
+-  int new_fd = openat (fd, dir,
+-                       (O_RDONLY | O_DIRECTORY | O_NOCTTY | O_NONBLOCK
+-                        | extra_flags));
++  int open_flags = (O_RDONLY | O_CLOEXEC | O_DIRECTORY | O_NOCTTY
++                    | O_NONBLOCK | extra_flags);
++  int new_fd = openat (fd, dir, open_flags);
+   DIR *dirp;
+ 
+   if (new_fd < 0)
+     return NULL;
+-  set_cloexec_flag (new_fd, true);
+   dirp = fdopendir (new_fd);
+   if (dirp)
+     *pdir_fd = new_fd;
+@@ -366,15 +369,13 @@ static int
+ internal_function
+ diropen (FTS const *sp, char const *dir)
+ {
+-  int open_flags = (O_SEARCH | O_DIRECTORY | O_NOCTTY | O_NONBLOCK
++  int open_flags = (O_SEARCH | O_CLOEXEC | O_DIRECTORY | O_NOCTTY | O_NONBLOCK
+                     | (ISSET (FTS_PHYSICAL) ? O_NOFOLLOW : 0)
+                     | (ISSET (FTS_NOATIME) ? O_NOATIME : 0));
+ 
+   int fd = (ISSET (FTS_CWDFD)
+             ? openat (sp->fts_cwd_fd, dir, open_flags)
+             : open (dir, open_flags));
+-  if (0 <= fd)
+-    set_cloexec_flag (fd, true);
+   return fd;
+ }
+ 
+@@ -470,6 +471,7 @@ fts_open (char * const *argv,
+                 if ((parent = fts_alloc(sp, "", 0)) == NULL)
+                         goto mem2;
+                 parent->fts_level = FTS_ROOTPARENTLEVEL;
++                parent->fts_n_dirs_remaining = -1;
+           }
+ 
+         /* The classic fts implementation would call fts_stat with
+@@ -656,39 +658,139 @@ fts_close (FTS *sp)
+         return (0);
+ }
+ 
++/* Minimum link count of a traditional Unix directory.  When leaf
++   optimization is OK and MIN_DIR_NLINK <= st_nlink, then st_nlink is
++   an upper bound on the number of subdirectories (counting "." and
++   "..").  */
++enum { MIN_DIR_NLINK = 2 };
++
++/* Whether leaf optimization is OK for a directory.  */
++enum leaf_optimization
++  {
++    /* st_nlink is not reliable for this directory's subdirectories.  */
++    NO_LEAF_OPTIMIZATION,
++
++    /* Leaf optimization is OK, but is not useful for avoiding stat calls.  */
++    OK_LEAF_OPTIMIZATION,
++
++    /* Leaf optimization is not only OK: it is useful for avoiding
++       stat calls, because dirent.d_type does not work.  */
++    NOSTAT_LEAF_OPTIMIZATION
++  };
++
+ #if defined __linux__ \
+   && HAVE_SYS_VFS_H && HAVE_FSTATFS && HAVE_STRUCT_STATFS_F_TYPE
+ 
+ # include <sys/vfs.h>
+ 
+ /* Linux-specific constants from coreutils' src/fs.h */
+-# define S_MAGIC_TMPFS 0x1021994
++# define S_MAGIC_AFS 0x5346414F
+ # define S_MAGIC_NFS 0x6969
++# define S_MAGIC_PROC 0x9FA0
+ # define S_MAGIC_REISERFS 0x52654973
++# define S_MAGIC_TMPFS 0x1021994
+ # define S_MAGIC_XFS 0x58465342
+-# define S_MAGIC_PROC 0x9FA0
+ 
+-/* Return false if it is easy to determine the file system type of
+-   the directory on which DIR_FD is open, and sorting dirents on
+-   inode numbers is known not to improve traversal performance with
+-   that type of file system.  Otherwise, return true.  */
++# ifdef HAVE___FSWORD_T
++typedef __fsword_t fsword;
++# else
++typedef long int fsword;
++# endif
++
++/* Map a stat.st_dev number to a file system type number f_ftype.  */
++struct dev_type
++{
++  dev_t st_dev;
++  fsword f_type;
++};
++
++/* Use a tiny initial size.  If a traversal encounters more than
++   a few devices, the cost of growing/rehashing this table will be
++   rendered negligible by the number of inodes processed.  */
++enum { DEV_TYPE_HT_INITIAL_SIZE = 13 };
++
++static size_t
++dev_type_hash (void const *x, size_t table_size)
++{
++  struct dev_type const *ax = x;
++  uintmax_t dev = ax->st_dev;
++  return dev % table_size;
++}
++
+ static bool
+-dirent_inode_sort_may_be_useful (int dir_fd)
++dev_type_compare (void const *x, void const *y)
++{
++  struct dev_type const *ax = x;
++  struct dev_type const *ay = y;
++  return ax->st_dev == ay->st_dev;
++}
++
++/* Return the file system type of P, or 0 if not known.
++   Try to cache known values.  */
++
++static fsword
++filesystem_type (FTSENT const *p)
++{
++  FTS *sp = p->fts_fts;
++  Hash_table *h = sp->fts_leaf_optimization_works_ht;
++  struct dev_type *ent;
++  struct statfs fs_buf;
++
++  /* If we're not in CWDFD mode, don't bother with this optimization,
++     since the caller is not serious about performance.  */
++  if (!ISSET (FTS_CWDFD))
++    return 0;
++
++  if (! h)
++    h = sp->fts_leaf_optimization_works_ht
++      = hash_initialize (DEV_TYPE_HT_INITIAL_SIZE, NULL, dev_type_hash,
++                         dev_type_compare, free);
++  if (h)
++    {
++      struct dev_type tmp;
++      tmp.st_dev = p->fts_statp->st_dev;
++      ent = hash_lookup (h, &tmp);
++      if (ent)
++        return ent->f_type;
++    }
++
++  /* Look-up failed.  Query directly and cache the result.  */
++  if (fstatfs (p->fts_fts->fts_cwd_fd, &fs_buf) != 0)
++    return 0;
++
++  if (h)
++    {
++      struct dev_type *t2 = malloc (sizeof *t2);
++      if (t2)
++        {
++          t2->st_dev = p->fts_statp->st_dev;
++          t2->f_type = fs_buf.f_type;
++
++          ent = hash_insert (h, t2);
++          if (ent)
++            fts_assert (ent == t2);
++          else
++            free (t2);
++        }
++    }
++
++  return fs_buf.f_type;
++}
++
++/* Return false if it is easy to determine the file system type of the
++   directory P, and sorting dirents on inode numbers is known not to
++   improve traversal performance with that type of file system.
++   Otherwise, return true.  */
++static bool
++dirent_inode_sort_may_be_useful (FTSENT const *p)
+ {
+   /* Skip the sort only if we can determine efficiently
+      that skipping it is the right thing to do.
+      The cost of performing an unnecessary sort is negligible,
+      while the cost of *not* performing it can be O(N^2) with
+      a very large constant.  */
+-  struct statfs fs_buf;
+-
+-  /* If fstatfs fails, assume sorting would be useful.  */
+-  if (fstatfs (dir_fd, &fs_buf) != 0)
+-    return true;
+ 
+-  /* FIXME: what about when f_type is not an integral type?
+-     deal with that if/when it's encountered.  */
+-  switch (fs_buf.f_type)
++  switch (filesystem_type (p))
+     {
+     case S_MAGIC_TMPFS:
+     case S_MAGIC_NFS:
+@@ -701,133 +803,58 @@ dirent_inode_sort_may_be_useful (int dir_fd)
+     }
+ }
+ 
+-/* Given a file descriptor DIR_FD open on a directory D,
+-   return true if it is valid to apply the leaf-optimization
+-   technique of counting directories in D via stat.st_nlink.  */
+-static bool
+-leaf_optimization_applies (int dir_fd)
++/* Given an FTS entry P for a directory D,
++   return true if it is both useful and valid to apply leaf optimization.
++   The optimization is useful only for file systems that lack usable
++   dirent.d_type info.  The optimization is valid if an st_nlink value
++   of at least MIN_DIR_NLINK is an upper bound on the number of
++   subdirectories of D, counting "." and ".."  as subdirectories.  */
++static enum leaf_optimization
++leaf_optimization (FTSENT const *p)
+ {
+-  struct statfs fs_buf;
+-
+-  /* If fstatfs fails, assume we can't use the optimization.  */
+-  if (fstatfs (dir_fd, &fs_buf) != 0)
+-    return false;
+-
+-  /* FIXME: do we need to detect AFS mount points?  I doubt it,
+-     unless fstatfs can report S_MAGIC_REISERFS for such a directory.  */
+-
+-  switch (fs_buf.f_type)
++  switch (filesystem_type (p))
+     {
+-    case S_MAGIC_NFS:
+-      /* NFS provides usable dirent.d_type but not necessarily for all entries
+-         of large directories.  See <https://bugzilla.redhat.com/1252549>.  */
+-      return true;
+-
+-      /* List here the file system types that lack usable dirent.d_type
++      /* List here the file system types that may lack usable dirent.d_type
+          info, yet for which the optimization does apply.  */
+     case S_MAGIC_REISERFS:
+-    case S_MAGIC_XFS:
+-      return true;
+-
++    case S_MAGIC_XFS: /* XFS lacked it until 2013-08-22 commit.  */
++      return NOSTAT_LEAF_OPTIMIZATION;
++
++    case 0:
++      /* Leaf optimization is unsafe if the file system type is unknown.  */
++      FALLTHROUGH;
++    case S_MAGIC_AFS:
++      /* Although AFS mount points are not counted in st_nlink, they
++         act like directories.  See <https://bugs.debian.org/143111>.  */
++      FALLTHROUGH;
++    case S_MAGIC_NFS:
++      /* NFS provides usable dirent.d_type but not necessarily for all entries
++         of large directories, so as per <https://bugzilla.redhat.com/1252549>
++         NFS should return true.  However st_nlink values are not accurate on
++         all implementations as per <https://bugzilla.redhat.com/1299169>.  */
++      FALLTHROUGH;
+     case S_MAGIC_PROC:
+-      /* Explicitly listing this or any other file system type for which
+-         the optimization is not applicable is not necessary, but we leave
+-         it here to document the risk.  Per http://bugs.debian.org/143111,
+-         /proc may have bogus stat.st_nlink values.  */
+-      /* fall through */
++      /* Per <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=143111> /proc
++         may have bogus stat.st_nlink values.  */
++      return NO_LEAF_OPTIMIZATION;
++
+     default:
+-      return false;
++      return OK_LEAF_OPTIMIZATION;
+     }
+ }
+ 
+ #else
+ static bool
+-dirent_inode_sort_may_be_useful (int dir_fd _GL_UNUSED) { return true; }
+-static bool
+-leaf_optimization_applies (int dir_fd _GL_UNUSED) { return false; }
+-#endif
+-
+-/* link-count-optimization entry:
+-   map a stat.st_dev number to a boolean: leaf_optimization_works */
+-struct LCO_ent
+-{
+-  dev_t st_dev;
+-  bool opt_ok;
+-};
+-
+-/* Use a tiny initial size.  If a traversal encounters more than
+-   a few devices, the cost of growing/rehashing this table will be
+-   rendered negligible by the number of inodes processed.  */
+-enum { LCO_HT_INITIAL_SIZE = 13 };
+-
+-static size_t
+-LCO_hash (void const *x, size_t table_size)
+-{
+-  struct LCO_ent const *ax = x;
+-  return (uintmax_t) ax->st_dev % table_size;
+-}
+-
+-static bool
+-LCO_compare (void const *x, void const *y)
++dirent_inode_sort_may_be_useful (FTSENT const *p _GL_UNUSED)
+ {
+-  struct LCO_ent const *ax = x;
+-  struct LCO_ent const *ay = y;
+-  return ax->st_dev == ay->st_dev;
++  return true;
+ }
+-
+-/* Ask the same question as leaf_optimization_applies, but query
+-   the cache first (FTS.fts_leaf_optimization_works_ht), and if necessary,
+-   update that cache.  */
+-static bool
+-link_count_optimize_ok (FTSENT const *p)
++static enum leaf_optimization
++leaf_optimization (FTSENT const *p _GL_UNUSED)
+ {
+-  FTS *sp = p->fts_fts;
+-  Hash_table *h = sp->fts_leaf_optimization_works_ht;
+-  struct LCO_ent tmp;
+-  struct LCO_ent *ent;
+-  bool opt_ok;
+-  struct LCO_ent *t2;
+-
+-  /* If we're not in CWDFD mode, don't bother with this optimization,
+-     since the caller is not serious about performance. */
+-  if (!ISSET(FTS_CWDFD))
+-    return false;
+-
+-  /* map st_dev to the boolean, leaf_optimization_works */
+-  if (h == NULL)
+-    {
+-      h = sp->fts_leaf_optimization_works_ht
+-        = hash_initialize (LCO_HT_INITIAL_SIZE, NULL, LCO_hash,
+-                           LCO_compare, free);
+-      if (h == NULL)
+-        return false;
+-    }
+-  tmp.st_dev = p->fts_statp->st_dev;
+-  ent = hash_lookup (h, &tmp);
+-  if (ent)
+-    return ent->opt_ok;
+-
+-  /* Look-up failed.  Query directly and cache the result.  */
+-  t2 = malloc (sizeof *t2);
+-  if (t2 == NULL)
+-    return false;
+-
+-  /* Is it ok to perform the optimization in the dir, FTS_CWD_FD?  */
+-  opt_ok = leaf_optimization_applies (sp->fts_cwd_fd);
+-  t2->opt_ok = opt_ok;
+-  t2->st_dev = p->fts_statp->st_dev;
+-
+-  ent = hash_insert (h, t2);
+-  if (ent == NULL)
+-    {
+-      /* insertion failed */
+-      free (t2);
+-      return false;
+-    }
+-  fts_assert (ent == t2);
+-
+-  return opt_ok;
++  return NO_LEAF_OPTIMIZATION;
+ }
++#endif
+ 
+ /*
+  * Special case of "/" at the end of the file name so that slashes aren't
+@@ -1014,13 +1041,11 @@ check_for_dir:
+                     if (p->fts_statp->st_size == FTS_STAT_REQUIRED)
+                       {
+                         FTSENT *parent = p->fts_parent;
+-                        if (FTS_ROOTLEVEL < p->fts_level
+-                            /* ->fts_n_dirs_remaining is not valid
+-                               for command-line-specified names.  */
+-                            && parent->fts_n_dirs_remaining == 0
++                        if (parent->fts_n_dirs_remaining == 0
+                             && ISSET(FTS_NOSTAT)
+                             && ISSET(FTS_PHYSICAL)
+-                            && link_count_optimize_ok (parent))
++                            && (leaf_optimization (parent)
++                                == NOSTAT_LEAF_OPTIMIZATION))
+                           {
+                             /* nothing more needed */
+                           }
+@@ -1029,7 +1054,8 @@ check_for_dir:
+                             p->fts_info = fts_stat(sp, p, false);
+                             if (S_ISDIR(p->fts_statp->st_mode)
+                                 && p->fts_level != FTS_ROOTLEVEL
+-                                && parent->fts_n_dirs_remaining)
++                                && 0 < parent->fts_n_dirs_remaining
++                                && parent->fts_n_dirs_remaining != (nlink_t) -1)
+                                   parent->fts_n_dirs_remaining--;
+                           }
+                       }
+@@ -1298,8 +1324,6 @@ fts_build (register FTS *sp, int type)
+         bool descend;
+         bool doadjust;
+         ptrdiff_t level;
+-        nlink_t nlinks;
+-        bool nostat;
+         size_t len, maxlen, new_len;
+         char *cp;
+         int dir_fd;
+@@ -1369,24 +1393,6 @@ fts_build (register FTS *sp, int type)
+            sorting, yet not so large that we risk exhausting memory.  */
+         max_entries = sp->fts_compar ? SIZE_MAX : FTS_MAX_READDIR_ENTRIES;
+ 
+-        /*
+-         * Nlinks is the number of possible entries of type directory in the
+-         * directory if we're cheating on stat calls, 0 if we're not doing
+-         * any stat calls at all, (nlink_t) -1 if we're statting everything.
+-         */
+-        if (type == BNAMES) {
+-                nlinks = 0;
+-                /* Be quiet about nostat, GCC. */
+-                nostat = false;
+-        } else if (ISSET(FTS_NOSTAT) && ISSET(FTS_PHYSICAL)) {
+-                nlinks = (cur->fts_statp->st_nlink
+-                          - (ISSET(FTS_SEEDOT) ? 0 : 2));
+-                nostat = true;
+-        } else {
+-                nlinks = -1;
+-                nostat = false;
+-        }
+-
+         /*
+          * If we're going to need to stat anything or we want to descend
+          * and stay in the directory, chdir.  If this fails we keep going,
+@@ -1408,15 +1414,22 @@ fts_build (register FTS *sp, int type)
+                the required dirp and dir_fd.  */
+             descend = true;
+           }
+-        else if (nlinks || type == BREAD) {
++        else
++          {
++            /* Try to descend unless it is a names-only fts_children,
++               or the directory is known to lack subdirectories.  */
++            descend = (type != BNAMES
++                       && ! (ISSET (FTS_NOSTAT) && ISSET (FTS_PHYSICAL)
++                             && ! ISSET (FTS_SEEDOT)
++                             && cur->fts_statp->st_nlink == MIN_DIR_NLINK
++                             && (leaf_optimization (cur)
++                                 != NO_LEAF_OPTIMIZATION)));
++            if (descend || type == BREAD)
++              {
+                 if (ISSET(FTS_CWDFD))
+-                  {
+-                    dir_fd = dup (dir_fd);
+-                    if (0 <= dir_fd)
+-                      set_cloexec_flag (dir_fd, true);
+-                  }
++                  dir_fd = fcntl (dir_fd, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
+                 if (dir_fd < 0 || fts_safe_changedir(sp, cur, dir_fd, NULL)) {
+-                        if (nlinks && type == BREAD)
++                        if (descend && type == BREAD)
+                                 cur->fts_errno = errno;
+                         cur->fts_flags |= FTS_DONTCHDIR;
+                         descend = false;
+@@ -1426,8 +1439,8 @@ fts_build (register FTS *sp, int type)
+                         cur->fts_dirp = NULL;
+                 } else
+                         descend = true;
+-        } else
+-                descend = false;
++              }
++          }
+ 
+         /*
+          * Figure out the max file name length that can be stored in the
+@@ -1458,11 +1471,19 @@ fts_build (register FTS *sp, int type)
+         tail = NULL;
+         nitems = 0;
+         while (cur->fts_dirp) {
+-                bool is_dir;
+                 size_t d_namelen;
++                __set_errno (0);
+                 struct dirent *dp = readdir(cur->fts_dirp);
+-                if (dp == NULL)
++                if (dp == NULL) {
++                        if (errno) {
++                                cur->fts_errno = errno;
++                                /* If we've not read any items yet, treat
++                                   the error as if we can't access the dir.  */
++                                cur->fts_info = (continue_readdir || nitems)
++                                                ? FTS_ERR : FTS_DNR;
++                        }
+                         break;
++                }
+                 if (!ISSET(FTS_SEEDOT) && ISDOT(dp->d_name))
+                         continue;
+ 
+@@ -1550,19 +1571,10 @@ mem1:                           saved_errno = errno;
+                            to caller, when possible.  */
+                         set_stat_type (p->fts_statp, D_TYPE (dp));
+                         fts_set_stat_required(p, !skip_stat);
+-                        is_dir = (ISSET(FTS_PHYSICAL)
+-                                  && DT_MUST_BE(dp, DT_DIR));
+                 } else {
+                         p->fts_info = fts_stat(sp, p, false);
+-                        is_dir = (p->fts_info == FTS_D
+-                                  || p->fts_info == FTS_DC
+-                                  || p->fts_info == FTS_DOT);
+                 }
+ 
+-                /* Decrement link count if applicable. */
+-                if (nlinks > 0 && is_dir)
+-                        nlinks -= nostat;
+-
+                 /* We walk in directory order so "ls -f" doesn't get upset. */
+                 p->fts_link = NULL;
+                 if (head == NULL)
+@@ -1621,7 +1633,8 @@ mem1:                           saved_errno = errno;
+ 
+         /* If didn't find anything, return NULL. */
+         if (!nitems) {
+-                if (type == BREAD)
++                if (type == BREAD
++                    && cur->fts_info != FTS_DNR && cur->fts_info != FTS_ERR)
+                         cur->fts_info = FTS_DP;
+                 fts_lfree(head);
+                 return (NULL);
+@@ -1633,8 +1646,7 @@ mem1:                           saved_errno = errno;
+            inode numbers.  */
+         if (nitems > _FTS_INODE_SORT_DIR_ENTRIES_THRESHOLD
+             && !sp->fts_compar
+-            && ISSET (FTS_CWDFD)
+-            && dirent_inode_sort_may_be_useful (sp->fts_cwd_fd)) {
++            && dirent_inode_sort_may_be_useful (cur)) {
+                 sp->fts_compar = fts_compare_ino;
+                 head = fts_sort (sp, head, nitems);
+                 sp->fts_compar = NULL;
+@@ -1757,7 +1769,7 @@ fd_ring_check (FTS const *sp)
+   I_ring fd_w = sp->fts_fd_ring;
+ 
+   int cwd_fd = sp->fts_cwd_fd;
+-  cwd_fd = dup (cwd_fd);
++  cwd_fd = fcntl (cwd_fd, F_DUPFD_CLOEXEC, STDERR_FILENO + 1);
+   char *dot = getcwdat (cwd_fd, NULL, 0);
+   error (0, 0, "===== check ===== cwd: %s", dot);
+   free (dot);
+@@ -1766,7 +1778,8 @@ fd_ring_check (FTS const *sp)
+       int fd = i_ring_pop (&fd_w);
+       if (0 <= fd)
+         {
+-          int parent_fd = openat (cwd_fd, "..", O_SEARCH | O_NOATIME);
++          int open_flags = O_SEARCH | O_CLOEXEC | O_NOATIME;
++          int parent_fd = openat (cwd_fd, "..", open_flags);
+           if (parent_fd < 0)
+             {
+               // Warn?
+@@ -1795,7 +1808,6 @@ internal_function
+ fts_stat(FTS *sp, register FTSENT *p, bool follow)
+ {
+         struct stat *sbp = p->fts_statp;
+-        int saved_errno;
+ 
+         if (p->fts_level == FTS_ROOTLEVEL && ISSET(FTS_COMFOLLOW))
+                 follow = true;
+@@ -1807,13 +1819,12 @@ fts_stat(FTS *sp, register FTSENT *p, bool follow)
+          */
+         if (ISSET(FTS_LOGICAL) || follow) {
+                 if (stat(p->fts_accpath, sbp)) {
+-                        saved_errno = errno;
+                         if (errno == ENOENT
+                             && lstat(p->fts_accpath, sbp) == 0) {
+                                 __set_errno (0);
+                                 return (FTS_SLNONE);
+                         }
+-                        p->fts_errno = saved_errno;
++                        p->fts_errno = errno;
+                         goto err;
+                 }
+         } else if (fstatat(sp->fts_cwd_fd, p->fts_accpath, sbp,
+@@ -1824,8 +1835,11 @@ err:            memset(sbp, 0, sizeof(struct stat));
+         }
+ 
+         if (S_ISDIR(sbp->st_mode)) {
+-                p->fts_n_dirs_remaining = (sbp->st_nlink
+-                                           - (ISSET(FTS_SEEDOT) ? 0 : 2));
++                p->fts_n_dirs_remaining
++                  = ((sbp->st_nlink < MIN_DIR_NLINK
++                      || p->fts_level <= FTS_ROOTLEVEL)
++                     ? -1
++                     : sbp->st_nlink - (ISSET (FTS_SEEDOT) ? 0 : MIN_DIR_NLINK));
+                 if (ISDOT(p->fts_name)) {
+                         /* Command-line "." and ".." are real directories. */
+                         return (p->fts_level == FTS_ROOTLEVEL ? FTS_D : FTS_DOT);
+@@ -1914,17 +1928,7 @@ fts_alloc (FTS *sp, const char *name, register size_t namelen)
+          * The file name is a variable length array.  Allocate the FTSENT
+          * structure and the file name in one chunk.
+          */
+-        len = offsetof(FTSENT, fts_name) + namelen + 1;
+-        /* Align the allocation size so that it works for FTSENT,
+-           so that trailing padding may be referenced by direct access
+-           to the flexible array members, without triggering undefined behavior
+-           by accessing bytes beyond the heap allocation.  This implicit access
+-           was seen for example with ISDOT() and GCC 5.1.1 at -O2.
+-           Do not use alignof (FTSENT) here, since C11 prohibits
+-           taking the alignment of a structure containing a flexible
+-           array member.  */
+-        len += alignof (max_align_t) - 1;
+-        len &= ~ (alignof (max_align_t) - 1);
++        len = FLEXSIZEOF(FTSENT, fts_name, namelen + 1);
+         if ((p = malloc(len)) == NULL)
+                 return (NULL);
+ 
+diff --git a/gl/lib/fts_.h b/gl/lib/fts_.h
+index b9a3f12..70cc9e3 100644
+--- a/gl/lib/fts_.h
++++ b/gl/lib/fts_.h
+@@ -1,6 +1,6 @@
+ /* Traverse a file hierarchy.
+ 
+-   Copyright (C) 2004-2015 Free Software Foundation, Inc.
++   Copyright (C) 2004-2018 Free Software Foundation, Inc.
+ 
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+@@ -13,7 +13,7 @@
+    GNU General Public License for more details.
+ 
+    You should have received a copy of the GNU General Public License
+-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
++   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+ 
+ /*
+  * Copyright (c) 1989, 1993
+@@ -220,7 +220,11 @@ typedef struct _ftsent {
+         ptrdiff_t fts_level;            /* depth (-1 to N) */
+ 
+         size_t fts_namelen;             /* strlen(fts_name) */
+-        nlink_t fts_n_dirs_remaining;   /* count down from st_nlink */
++
++        /* If not (nlink_t) -1, an upper bound on the number of
++           remaining subdirectories of interest.  If this becomes
++           zero, some work can be avoided.  */
++        nlink_t fts_n_dirs_remaining;
+ 
+ # define FTS_D           1              /* preorder directory */
+ # define FTS_DC          2              /* directory that causes cycles */
+-- 
+2.13.6
+
+
+From ea88dd373c60feab541fe037369805f326dc3494 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Mon, 12 Feb 2018 18:58:30 +0100
+Subject: [PATCH 2/4] fts: remove dependency on gnulib's fleximember.h
+
+... by reverting upstream commit edb9d82948cb23f67a19e1b435047a0570225df3
+---
+ gl/lib/fts.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/gl/lib/fts.c b/gl/lib/fts.c
+index bfa73e3..c37ebe2 100644
+--- a/gl/lib/fts.c
++++ b/gl/lib/fts.c
+@@ -71,7 +71,6 @@ static char sccsid[] = "@(#)fts.c       8.6 (Berkeley) 8/14/94";
+ 
+ #if ! _LIBC
+ # include "fcntl--.h"
+-# include "flexmember.h"
+ # include "openat.h"
+ # include "same-inode.h"
+ #endif
+@@ -1928,7 +1927,17 @@ fts_alloc (FTS *sp, const char *name, register size_t namelen)
+          * The file name is a variable length array.  Allocate the FTSENT
+          * structure and the file name in one chunk.
+          */
+-        len = FLEXSIZEOF(FTSENT, fts_name, namelen + 1);
++        len = offsetof(FTSENT, fts_name) + namelen + 1;
++        /* Align the allocation size so that it works for FTSENT,
++           so that trailing padding may be referenced by direct access
++           to the flexible array members, without triggering undefined behavior
++           by accessing bytes beyond the heap allocation.  This implicit access
++           was seen for example with ISDOT() and GCC 5.1.1 at -O2.
++           Do not use alignof (FTSENT) here, since C11 prohibits
++           taking the alignment of a structure containing a flexible
++           array member.  */
++        len += alignof (max_align_t) - 1;
++        len &= ~ (alignof (max_align_t) - 1);
+         if ((p = malloc(len)) == NULL)
+                 return (NULL);
+ 
+-- 
+2.13.6
+
+
+From 9c1720c99bbf8998dfdaa5976bca8bdc6d93f8e7 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 5 Apr 2018 08:48:01 -0700
+Subject: [PATCH 3/4] fts: treat CIFS like NFS
+
+Problem reported by Kamil Dudka in:
+https://lists.gnu.org/r/bug-gnulib/2018-04/msg00015.html
+* lib/fts.c (S_MAGIC_CIFS): New macro.
+(dirent_inode_sort_may_be_useful, leaf_optimization):
+Treat CIFS like NFS.
+
+Upstream-commit: 2e53df541a30d438859087ed4b5a396e04697b9b
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/lib/fts.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/gl/lib/fts.c b/gl/lib/fts.c
+index c37ebe2..508ceac 100644
+--- a/gl/lib/fts.c
++++ b/gl/lib/fts.c
+@@ -684,6 +684,7 @@ enum leaf_optimization
+ 
+ /* Linux-specific constants from coreutils' src/fs.h */
+ # define S_MAGIC_AFS 0x5346414F
++# define S_MAGIC_CIFS 0xFF534D42
+ # define S_MAGIC_NFS 0x6969
+ # define S_MAGIC_PROC 0x9FA0
+ # define S_MAGIC_REISERFS 0x52654973
+@@ -791,8 +792,9 @@ dirent_inode_sort_may_be_useful (FTSENT const *p)
+ 
+   switch (filesystem_type (p))
+     {
+-    case S_MAGIC_TMPFS:
++    case S_MAGIC_CIFS:
+     case S_MAGIC_NFS:
++    case S_MAGIC_TMPFS:
+       /* On a file system of any of these types, sorting
+          is unnecessary, and hence wasteful.  */
+       return false;
+@@ -826,6 +828,10 @@ leaf_optimization (FTSENT const *p)
+       /* Although AFS mount points are not counted in st_nlink, they
+          act like directories.  See <https://bugs.debian.org/143111>.  */
+       FALLTHROUGH;
++    case S_MAGIC_CIFS:
++      /* Leaf optimization causes 'find' to abort.  See
++         <https://lists.gnu.org/r/bug-gnulib/2018-04/msg00015.html>.  */
++      FALLTHROUGH;
+     case S_MAGIC_NFS:
+       /* NFS provides usable dirent.d_type but not necessarily for all entries
+          of large directories, so as per <https://bugzilla.redhat.com/1252549>
+-- 
+2.14.3
+
+
+From ff64329a046e76ba553c15373ed61bbed814d286 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Wed, 11 Apr 2018 12:50:35 -0700
+Subject: [PATCH 4/4] fts: fix bug in find across filesystems
+
+This fixes a bug I introduced last summer.
+Problem reported by Kamil Dudka in:
+https://lists.gnu.org/r/bug-gnulib/2018-04/msg00033.html
+* lib/fts.c (filesystem_type, dirent_inode_sort_may_be_useful)
+(leaf_optimization):
+New arg for file descriptor.  All callers changed.
+(fts_build): Check for whether inodes should be sorted
+before closing the directory.
+
+Upstream-commit: 81b8c0d3be98f5a77403599de3d06329b3e7673e
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/lib/fts.c | 55 +++++++++++++++++++++++++++++++------------------------
+ 1 file changed, 31 insertions(+), 24 deletions(-)
+
+diff --git a/gl/lib/fts.c b/gl/lib/fts.c
+index 508ceac..175f12a 100644
+--- a/gl/lib/fts.c
++++ b/gl/lib/fts.c
+@@ -725,11 +725,12 @@ dev_type_compare (void const *x, void const *y)
+   return ax->st_dev == ay->st_dev;
+ }
+ 
+-/* Return the file system type of P, or 0 if not known.
++/* Return the file system type of P with file descriptor FD, or 0 if not known.
++   If FD is negative, P's file descriptor is unavailable.
+    Try to cache known values.  */
+ 
+ static fsword
+-filesystem_type (FTSENT const *p)
++filesystem_type (FTSENT const *p, int fd)
+ {
+   FTS *sp = p->fts_fts;
+   Hash_table *h = sp->fts_leaf_optimization_works_ht;
+@@ -755,7 +756,7 @@ filesystem_type (FTSENT const *p)
+     }
+ 
+   /* Look-up failed.  Query directly and cache the result.  */
+-  if (fstatfs (p->fts_fts->fts_cwd_fd, &fs_buf) != 0)
++  if (fd < 0 || fstatfs (fd, &fs_buf) != 0)
+     return 0;
+ 
+   if (h)
+@@ -777,12 +778,12 @@ filesystem_type (FTSENT const *p)
+   return fs_buf.f_type;
+ }
+ 
+-/* Return false if it is easy to determine the file system type of the
+-   directory P, and sorting dirents on inode numbers is known not to
+-   improve traversal performance with that type of file system.
+-   Otherwise, return true.  */
++/* Return true if sorting dirents on inode numbers is known to improve
++   traversal performance for the directory P with descriptor DIR_FD.
++   Return false otherwise.  When in doubt, return true.
++   DIR_FD is negative if unavailable.  */
+ static bool
+-dirent_inode_sort_may_be_useful (FTSENT const *p)
++dirent_inode_sort_may_be_useful (FTSENT const *p, int dir_fd)
+ {
+   /* Skip the sort only if we can determine efficiently
+      that skipping it is the right thing to do.
+@@ -790,7 +791,7 @@ dirent_inode_sort_may_be_useful (FTSENT const *p)
+      while the cost of *not* performing it can be O(N^2) with
+      a very large constant.  */
+ 
+-  switch (filesystem_type (p))
++  switch (filesystem_type (p, dir_fd))
+     {
+     case S_MAGIC_CIFS:
+     case S_MAGIC_NFS:
+@@ -804,16 +805,17 @@ dirent_inode_sort_may_be_useful (FTSENT const *p)
+     }
+ }
+ 
+-/* Given an FTS entry P for a directory D,
++/* Given an FTS entry P for a directory with descriptor DIR_FD,
+    return true if it is both useful and valid to apply leaf optimization.
+    The optimization is useful only for file systems that lack usable
+    dirent.d_type info.  The optimization is valid if an st_nlink value
+    of at least MIN_DIR_NLINK is an upper bound on the number of
+-   subdirectories of D, counting "." and ".."  as subdirectories.  */
++   subdirectories of D, counting "." and ".."  as subdirectories.
++   DIR_FD is negative if unavailable.  */
+ static enum leaf_optimization
+-leaf_optimization (FTSENT const *p)
++leaf_optimization (FTSENT const *p, int dir_fd)
+ {
+-  switch (filesystem_type (p))
++  switch (filesystem_type (p, dir_fd))
+     {
+       /* List here the file system types that may lack usable dirent.d_type
+          info, yet for which the optimization does apply.  */
+@@ -850,12 +852,13 @@ leaf_optimization (FTSENT const *p)
+ 
+ #else
+ static bool
+-dirent_inode_sort_may_be_useful (FTSENT const *p _GL_UNUSED)
++dirent_inode_sort_may_be_useful (FTSENT const *p _GL_UNUSED,
++                                 int dir_fd _GL_UNUSED)
+ {
+   return true;
+ }
+ static enum leaf_optimization
+-leaf_optimization (FTSENT const *p _GL_UNUSED)
++leaf_optimization (FTSENT const *p _GL_UNUSED, int dir_fd _GL_UNUSED)
+ {
+   return NO_LEAF_OPTIMIZATION;
+ }
+@@ -1049,7 +1052,7 @@ check_for_dir:
+                         if (parent->fts_n_dirs_remaining == 0
+                             && ISSET(FTS_NOSTAT)
+                             && ISSET(FTS_PHYSICAL)
+-                            && (leaf_optimization (parent)
++                            && (leaf_optimization (parent, sp->fts_cwd_fd)
+                                 == NOSTAT_LEAF_OPTIMIZATION))
+                           {
+                             /* nothing more needed */
+@@ -1334,6 +1337,7 @@ fts_build (register FTS *sp, int type)
+         int dir_fd;
+         FTSENT *cur = sp->fts_cur;
+         bool continue_readdir = !!cur->fts_dirp;
++        bool sort_by_inode = false;
+         size_t max_entries;
+ 
+         /* When cur->fts_dirp is non-NULL, that means we should
+@@ -1427,7 +1431,7 @@ fts_build (register FTS *sp, int type)
+                        && ! (ISSET (FTS_NOSTAT) && ISSET (FTS_PHYSICAL)
+                              && ! ISSET (FTS_SEEDOT)
+                              && cur->fts_statp->st_nlink == MIN_DIR_NLINK
+-                             && (leaf_optimization (cur)
++                             && (leaf_optimization (cur, dir_fd)
+                                  != NO_LEAF_OPTIMIZATION)));
+             if (descend || type == BREAD)
+               {
+@@ -1588,6 +1592,15 @@ mem1:                           saved_errno = errno;
+                         tail->fts_link = p;
+                         tail = p;
+                 }
++
++                /* If there are many entries, no sorting function has been
++                   specified, and this file system is of a type that may be
++                   slow with a large number of entries, arrange to sort the
++                   directory entries on increasing inode numbers.  */
++                if (nitems == _FTS_INODE_SORT_DIR_ENTRIES_THRESHOLD
++                    && !sp->fts_compar)
++                  sort_by_inode = dirent_inode_sort_may_be_useful (cur, dir_fd);
++
+                 ++nitems;
+                 if (max_entries <= nitems) {
+                         /* When there are too many dir entries, leave
+@@ -1645,13 +1658,7 @@ mem1:                           saved_errno = errno;
+                 return (NULL);
+         }
+ 
+-        /* If there are many entries, no sorting function has been specified,
+-           and this file system is of a type that may be slow with a large
+-           number of entries, then sort the directory entries on increasing
+-           inode numbers.  */
+-        if (nitems > _FTS_INODE_SORT_DIR_ENTRIES_THRESHOLD
+-            && !sp->fts_compar
+-            && dirent_inode_sort_may_be_useful (cur)) {
++        if (sort_by_inode) {
+                 sp->fts_compar = fts_compare_ino;
+                 head = fts_sort (sp, head, nitems);
+                 sp->fts_compar = NULL;
+-- 
+2.14.3
+

--- a/recipes/findutils/findutils-4.6.0-gnulib-fflush.patch
+++ b/recipes/findutils/findutils-4.6.0-gnulib-fflush.patch
@@ -1,0 +1,142 @@
+From 80cdfba079627e15129a926a133825b961d41e36 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Mon, 5 Mar 2018 10:56:29 -0800
+Subject: [PATCH] fflush: adjust to glibc 2.28 libio.h removal
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem reported by Daniel P. Berrangé in:
+https://lists.gnu.org/r/bug-gnulib/2018-03/msg00000.html
+* lib/fflush.c (clear_ungetc_buffer_preserving_position)
+(disable_seek_optimization, rpl_fflush):
+* lib/fpurge.c (fpurge):
+* lib/freadahead.c (freadahead):
+* lib/freading.c (freading):
+* lib/fseeko.c (fseeko):
+* lib/stdio-impl.h (_IO_IN_BACKUP) [_IO_EOF_SEEN]:
+Define if not already defined.
+
+Upstream-commit: 4af4a4a71827c0bc5e0ec67af23edef4f15cee8e
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/lib/fflush.c     | 6 +++---
+ gl/lib/fpurge.c     | 2 +-
+ gl/lib/freadahead.c | 2 +-
+ gl/lib/freading.c   | 2 +-
+ gl/lib/fseeko.c     | 4 ++--
+ gl/lib/stdio-impl.h | 6 ++++++
+ 6 files changed, 14 insertions(+), 8 deletions(-)
+
+diff --git a/gl/lib/fflush.c b/gl/lib/fflush.c
+index 5ae3e41..7a82470 100644
+--- a/gl/lib/fflush.c
++++ b/gl/lib/fflush.c
+@@ -33,7 +33,7 @@
+ #undef fflush
+ 
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+ /* Clear the stream's ungetc buffer, preserving the value of ftello (fp).  */
+ static void
+@@ -72,7 +72,7 @@ clear_ungetc_buffer (FILE *fp)
+ 
+ #endif
+ 
+-#if ! (defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
++#if ! (defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */)
+ 
+ # if (defined __sferror || defined __DragonFly__ || defined __ANDROID__) && defined __SNPT
+ /* FreeBSD, NetBSD, OpenBSD, DragonFly, Mac OS X, Cygwin, Android */
+@@ -148,7 +148,7 @@ rpl_fflush (FILE *stream)
+   if (stream == NULL || ! freading (stream))
+     return fflush (stream);
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+ 
+   clear_ungetc_buffer_preserving_position (stream);
+ 
+diff --git a/gl/lib/fpurge.c b/gl/lib/fpurge.c
+index f313b22..ecdf82d 100644
+--- a/gl/lib/fpurge.c
++++ b/gl/lib/fpurge.c
+@@ -62,7 +62,7 @@ fpurge (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   fp->_IO_read_end = fp->_IO_read_ptr;
+   fp->_IO_write_ptr = fp->_IO_write_base;
+   /* Avoid memory leak when there is an active ungetc buffer.  */
+diff --git a/gl/lib/freadahead.c b/gl/lib/freadahead.c
+index 094daab..3f8101e 100644
+--- a/gl/lib/freadahead.c
++++ b/gl/lib/freadahead.c
+@@ -25,7 +25,7 @@
+ size_t
+ freadahead (FILE *fp)
+ {
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_write_ptr > fp->_IO_write_base)
+     return 0;
+   return (fp->_IO_read_end - fp->_IO_read_ptr)
+diff --git a/gl/lib/freading.c b/gl/lib/freading.c
+index 0512b19..8c48fe4 100644
+--- a/gl/lib/freading.c
++++ b/gl/lib/freading.c
+@@ -31,7 +31,7 @@ freading (FILE *fp)
+   /* Most systems provide FILE as a struct and the necessary bitmask in
+      <stdio.h>, because they need it for implementing getc() and putc() as
+      fast macros.  */
+-# if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++# if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   return ((fp->_flags & _IO_NO_WRITES) != 0
+           || ((fp->_flags & (_IO_NO_READS | _IO_CURRENTLY_PUTTING)) == 0
+               && fp->_IO_read_base != NULL));
+diff --git a/gl/lib/fseeko.c b/gl/lib/fseeko.c
+index 1c65d2a..9026408 100644
+--- a/gl/lib/fseeko.c
++++ b/gl/lib/fseeko.c
+@@ -47,7 +47,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+ #endif
+ 
+   /* These tests are based on fpurge.c.  */
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+   if (fp->_IO_read_end == fp->_IO_read_ptr
+       && fp->_IO_write_ptr == fp->_IO_write_base
+       && fp->_IO_save_base == NULL)
+@@ -123,7 +123,7 @@ fseeko (FILE *fp, off_t offset, int whence)
+           return -1;
+         }
+ 
+-#if defined _IO_ftrylockfile || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
++#if defined _IO_EOF_SEEN || __GNU_LIBRARY__ == 1 /* GNU libc, BeOS, Haiku, Linux libc5 */
+       fp->_flags &= ~_IO_EOF_SEEN;
+       fp->_offset = pos;
+ #elif defined __sferror || defined __DragonFly__ || defined __ANDROID__
+diff --git a/gl/lib/stdio-impl.h b/gl/lib/stdio-impl.h
+index 502d891..ea38ee2 100644
+--- a/gl/lib/stdio-impl.h
++++ b/gl/lib/stdio-impl.h
+@@ -18,6 +18,12 @@
+    the same implementation of stdio extension API, except that some fields
+    have different naming conventions, or their access requires some casts.  */
+ 
++/* Glibc 2.28 made _IO_IN_BACKUP private.  For now, work around this
++   problem by defining it ourselves.  FIXME: Do not rely on glibc
++   internals.  */
++#if !defined _IO_IN_BACKUP && defined _IO_EOF_SEEN
++# define _IO_IN_BACKUP 0x100
++#endif
+ 
+ /* BSD stdio derived implementations.  */
+ 
+-- 
+2.16.2
+

--- a/recipes/findutils/findutils-4.6.0-gnulib-makedev.patch
+++ b/recipes/findutils/findutils-4.6.0-gnulib-makedev.patch
@@ -1,0 +1,80 @@
+From 80628047a6cc83f82e0c410a82b8f7facd9d50f2 Mon Sep 17 00:00:00 2001
+From: Eric Blake <eblake@redhat.com>
+Date: Wed, 14 Sep 2016 19:21:42 -0500
+Subject: [PATCH] mountlist: include sysmacros.h for glibc
+
+On Fedora rawhide (glibc 2.25), './gnulib-tool --test mountlist'
+reports:
+../../gllib/mountlist.c: In function 'read_file_system_list':
+../../gllib/mountlist.c:534:13: warning: '__makedev_from_sys_types' is deprecated:
+  In the GNU C Library, `makedev' is defined by <sys/sysmacros.h>.
+  For historical compatibility, it is currently defined by
+  <sys/types.h> as well, but we plan to remove this soon.
+  To use `makedev', include <sys/sysmacros.h> directly.
+  If you did not intend to use a system-defined macro `makedev',
+  you should #undef it after including <sys/types.h>.
+  [-Wdeprecated-declarations]
+             me->me_dev = makedev (devmaj, devmin);
+             ^~
+In file included from /usr/include/features.h:397:0,
+                 from /usr/include/sys/types.h:25,
+                 from ./sys/types.h:28,
+                 from ../../gllib/mountlist.h:23,
+                 from ../../gllib/mountlist.c:20:
+/usr/include/sys/sysmacros.h:89:1: note: declared here
+ __SYSMACROS_DEFINE_MAKEDEV (__SYSMACROS_FST_IMPL_TEMPL)
+ ^
+
+Fix it by including the right headers.  We also need a fix to
+autoconf's AC_HEADER_MAJOR, but that's a separate patch.
+
+* m4/mountlist.m4 (gl_PREREQ_MOUTLIST_EXTRA): Include
+AC_HEADER_MAJOR.
+* lib/mountlist.c (includes): Use correct headers.
+
+Signed-off-by: Eric Blake <eblake@redhat.com>
+
+Upstream-commit: 4da63c5881f60f71999a943612da9112232b9161
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/lib/mountlist.c | 6 ++++++
+ gl/m4/mountlist.m4 | 3 ++-
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/gl/lib/mountlist.c b/gl/lib/mountlist.c
+index c3d2852..0b6f92e 100644
+--- a/gl/lib/mountlist.c
++++ b/gl/lib/mountlist.c
+@@ -37,6 +37,12 @@
+ # include <sys/param.h>
+ #endif
+ 
++#if MAJOR_IN_MKDEV
++# include <sys/mkdev.h>
++#elif MAJOR_IN_SYSMACROS
++# include <sys/sysmacros.h>
++#endif
++
+ #if defined MOUNTED_GETFSSTAT   /* OSF_1 and Darwin1.3.x */
+ # if HAVE_SYS_UCRED_H
+ #  include <grp.h> /* needed on OSF V4.0 for definition of NGROUPS,
+diff --git a/gl/m4/mountlist.m4 b/gl/m4/mountlist.m4
+index ec58dc8..82b2dcb 100644
+--- a/gl/m4/mountlist.m4
++++ b/gl/m4/mountlist.m4
+@@ -1,4 +1,4 @@
+-# serial 11
++# serial 12
+ dnl Copyright (C) 2002-2006, 2009-2015 Free Software Foundation, Inc.
+ dnl This file is free software; the Free Software Foundation
+ dnl gives unlimited permission to copy and/or distribute it,
+@@ -15,5 +15,6 @@ AC_DEFUN([gl_PREREQ_MOUNTLIST_EXTRA],
+ [
+   dnl Note gl_LIST_MOUNTED_FILE_SYSTEMS checks for mntent.h, not sys/mntent.h.
+   AC_CHECK_HEADERS([sys/mntent.h])
++  AC_HEADER_MAJOR()dnl for use of makedev ()
+   gl_FSTYPENAME
+ ])
+-- 
+2.16.2
+

--- a/recipes/findutils/findutils-4.6.0-internal-noop.patch
+++ b/recipes/findutils/findutils-4.6.0-internal-noop.patch
@@ -1,0 +1,195 @@
+From d844b7bbf3952998a906f21ba432aa62a3b9c7c6 Mon Sep 17 00:00:00 2001
+From: Bernhard Voelker <mail@bernhard-voelker.de>
+Date: Tue, 14 Jun 2016 20:49:42 +0200
+Subject: [PATCH] Fix bug #48180: find: avoid segfault for internal '-noop'
+ option
+
+The pseudo-option '-noop' was never meant to be exposed to the user
+interface.  If specified by the user, find(1) segfaulted.
+Bug introduced in commit FINDUTILS_4_3_0-1-12-g6b8a4db.
+
+* find/parser.c (struct parser_table): Rename the parser_name element of
+the ARG_NOOP entry from 'noop' to '--noop', thus indicating its pure
+internal character.
+(found_parser): Return NULL when the user has passed the '---noop' option;
+the caller does the error handling.
+* find/testsuite/sv-48180-refuse-noop.sh: Add test.
+* find/testsuite/Makefile.am (test_shell_progs): Reference the test.
+* NEWS (Bug fixes): Document the fix.
+
+Reported by Tavian Barnes <tavianator@tavianator.com> in
+    https://savannah.gnu.org/bugs/?48180
+
+Upstream-commit: 595060f28eb5f658fa8d98970959c617fab0f078
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ find/parser.c                          |   6 +-
+ find/testsuite/Makefile.am             |   3 +-
+ find/testsuite/sv-48180-refuse-noop.sh | 117 +++++++++++++++++++++++++++++++++
+ 3 files changed, 124 insertions(+), 2 deletions(-)
+ create mode 100644 find/testsuite/sv-48180-refuse-noop.sh
+
+diff --git a/find/parser.c b/find/parser.c
+index 2d45349..697b2a2 100644
+--- a/find/parser.c
++++ b/find/parser.c
+@@ -321,7 +321,8 @@ static struct parser_table const parse_table[] =
+    */
+   {ARG_TEST, "false",                 parse_false,   pred_false}, /* GNU */
+   {ARG_TEST, "true",                  parse_true,    pred_true }, /* GNU */
+-  {ARG_NOOP, "noop",                  NULL,          pred_true }, /* GNU, internal use only */
++  /* Internal pseudo-option, therefore 3 minus: ---noop.  */
++  {ARG_NOOP, "--noop",                NULL,          pred_true }, /* GNU, internal use only */
+ 
+   /* Various other cases that don't fit neatly into our macro scheme. */
+   {ARG_TEST, "help",                  parse_help,    NULL},       /* GNU */
+@@ -596,6 +597,9 @@ found_parser (const char *original_arg, const struct parser_table *entry)
+    */
+   if (entry->type != ARG_POSITIONAL_OPTION)
+     {
++      if (entry->type == ARG_NOOP)
++        return NULL;  /* internal use only, trap -noop here.  */
++
+       /* Something other than -follow/-daystart.
+        * If this is an option, check if it followed
+        * a non-option and if so, issue a warning.
+diff --git a/find/testsuite/Makefile.am b/find/testsuite/Makefile.am
+index ab5dbe8..1371c70 100644
+--- a/find/testsuite/Makefile.am
++++ b/find/testsuite/Makefile.am
+@@ -259,7 +259,8 @@ test_escape_c.sh \
+ test_inode.sh \
+ sv-34079.sh \
+ sv-34976-execdir-fd-leak.sh \
+-sv-48030-exec-plus-bug.sh
++sv-48030-exec-plus-bug.sh \
++sv-48180-refuse-noop.sh
+ 
+ EXTRA_DIST = $(EXTRA_DIST_EXP) $(EXTRA_DIST_XO) $(EXTRA_DIST_GOLDEN) \
+ 	$(test_shell_progs) binary_locations.sh checklists.py
+diff --git a/find/testsuite/sv-48180-refuse-noop.sh b/find/testsuite/sv-48180-refuse-noop.sh
+new file mode 100755
+index 0000000..974f0f0
+--- /dev/null
++++ b/find/testsuite/sv-48180-refuse-noop.sh
+@@ -0,0 +1,117 @@
++#! /bin/sh
++# Copyright (C) 2016 Free Software Foundation, Inc.
++#
++# This program is free software: you can redistribute it and/or modify
++# it under the terms of the GNU General Public License as published by
++# the Free Software Foundation, either version 3 of the License, or
++# (at your option) any later version.
++#
++# This program is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with this program.  If not, see <http://www.gnu.org/licenses/>.
++#
++
++# This test verifies that find refuses the internal -noop, ---noop option.
++# Between findutils-4.3.1 and 4.6, find dumped core ($? = 139).
++
++testname="$(basename $0)"
++
++. "${srcdir}"/binary_locations.sh
++
++die() {
++  echo "$@" >&2
++  exit 1
++}
++
++# This is used to simplify checking of the return value
++# which is useful when ensuring a command fails as desired.
++# I.e., just doing `command ... &&fail=1` will not catch
++# a segfault in command for example.  With this helper you
++# instead check an explicit exit code like
++#   returns_ 1 command ... || fail
++returns_ () {
++  # Disable tracing so it doesn't interfere with stderr of the wrapped command
++  { set +x; } 2>/dev/null
++
++  local exp_exit="$1"
++  shift
++  "$@"
++  test $? -eq $exp_exit && ret_=0 || ret_=1
++
++  set -x
++  { return $ret_; } 2>/dev/null
++}
++
++# Define the nicest compare available (borrowed from gnulib).
++if diff_out_=`exec 2>/dev/null; diff -u "$0" "$0" < /dev/null` \
++   && diff -u Makefile "$0" 2>/dev/null | grep '^[+]#!' >/dev/null; then
++  # diff accepts the -u option and does not (like AIX 7 'diff') produce an
++  # extra space on column 1 of every content line.
++  if test -z "$diff_out_"; then
++    compare () { diff -u "$@"; }
++  else
++    compare ()
++    {
++      if diff -u "$@" > diff.out; then
++        # No differences were found, but Solaris 'diff' produces output
++        # "No differences encountered". Hide this output.
++        rm -f diff.out
++        true
++      else
++        cat diff.out
++        rm -f diff.out
++        false
++      fi
++    }
++  fi
++elif diff_out_=`exec 2>/dev/null; diff -c "$0" "$0" < /dev/null`; then
++  if test -z "$diff_out_"; then
++    compare () { diff -c "$@"; }
++  else
++    compare ()
++    {
++      if diff -c "$@" > diff.out; then
++        # No differences were found, but AIX and HP-UX 'diff' produce output
++        # "No differences encountered" or "There are no differences between the
++        # files.". Hide this output.
++        rm -f diff.out
++        true
++      else
++        cat diff.out
++        rm -f diff.out
++        false
++      fi
++    }
++  fi
++elif cmp -s /dev/null /dev/null 2>/dev/null; then
++  compare () { cmp -s "$@"; }
++else
++  compare () { cmp "$@"; }
++fi
++
++set -x
++tmpdir="$(mktemp -d)" \
++  && cd "$tmpdir" \
++  || die "FAIL: failed to set up the test in ${tmpdir}"
++
++fail=0
++# Exercise both the previous name of the pseudo-option '-noop',
++# and the now renamed '---noop' option for both find executables.
++for exe in "${ftsfind}" "${oldfind}"; do
++  for opt in 'noop' '--noop'; do
++    out="${exe}${opt}.out"
++    err="${exe}${opt}.err"
++    returns_ 1 "$exe" "-${opt}" >"$out" 2> "$err" || fail=1
++    compare /dev/null "$out" || fail=1
++    grep "find: unknown predicate .-${opt}." "$err" \
++      || { cat "$err"; fail=1; }
++  done
++done
++
++cd ..
++rm -rf "$tmpdir" || exit 1
++exit $fail
+-- 
+2.5.5
+

--- a/recipes/findutils/findutils-4.6.0-leaf-opt.patch
+++ b/recipes/findutils/findutils-4.6.0-leaf-opt.patch
@@ -1,0 +1,83 @@
+From 1328926a705fdb4728c1f255dd368de928736d39 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Fri, 25 Sep 2015 16:09:39 +0200
+Subject: [PATCH 1/2] fts: introduce the FTS_NOLEAF flag
+
+The flag is needed to implement the -noleaf option of find.
+* lib/fts.c (link_count_optimize_ok): Implement the FTS_NOLEAF flag.
+* lib/fts_.h (FTS_NOLEAF): New macro, shifted conflicting constants.
+---
+ gl/lib/fts.c  |  4 ++++
+ gl/lib/fts_.h | 12 +++++++++---
+ 2 files changed, 13 insertions(+), 3 deletions(-)
+
+diff --git a/gl/lib/fts.c b/gl/lib/fts.c
+index d2d404f..808466f 100644
+--- a/gl/lib/fts.c
++++ b/gl/lib/fts.c
+@@ -736,6 +736,10 @@ filesystem_type (FTSENT const *p)
+   struct dev_type *ent;
+   struct statfs fs_buf;
+ 
++  if (ISSET(FTS_NOLEAF))
++    /* leaf optimization explicitly disabled by the FTS_NOLEAF flag */
++    return 0;
++
+   /* If we're not in CWDFD mode, don't bother with this optimization,
+      since the caller is not serious about performance.  */
+   if (!ISSET (FTS_CWDFD))
+diff --git a/gl/lib/fts_.h b/gl/lib/fts_.h
+index 63d4b74..f1d519b 100644
+--- a/gl/lib/fts_.h
++++ b/gl/lib/fts_.h
+@@ -155,10 +155,16 @@ typedef struct {
+      from input path names during fts_open initialization.  */
+ # define FTS_VERBATIM   0x1000
+ 
+-# define FTS_OPTIONMASK 0x1fff          /* valid user option mask */
++  /* Disable leaf optimization (which eliminates stat() calls during traversal,
++     based on the count of nested directories stored in stat.st_nlink of each
++     directory).  Note that the optimization is by default enabled only for
++     selected file systems, and only if the FTS_CWDFD flag is set.  */
++# define FTS_NOLEAF     0x2000
+ 
+-# define FTS_NAMEONLY   0x2000          /* (private) child names only */
+-# define FTS_STOP       0x4000          /* (private) unrecoverable error */
++# define FTS_OPTIONMASK 0x3fff          /* valid user option mask */
++
++# define FTS_NAMEONLY   0x4000          /* (private) child names only */
++# define FTS_STOP       0x8000          /* (private) unrecoverable error */
+         int fts_options;                /* fts_open options, global flags */
+ 
+         /* Map a directory's device number to a boolean.  The boolean is
+-- 
+2.5.0
+
+
+From c186934e6e37ddadf7511abb9b1045192757618e Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Fri, 25 Sep 2015 19:13:15 +0200
+Subject: [PATCH 2/2] ftsfind: propagate the -noleaf option to FTS
+
+* find/ftsfind.c (find): Propagate the -noleaf option to FTS.
+---
+ find/ftsfind.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/find/ftsfind.c b/find/ftsfind.c
+index 5159470..e34b672 100644
+--- a/find/ftsfind.c
++++ b/find/ftsfind.c
+@@ -559,6 +559,9 @@ find (char *arg)
+   if (options.stay_on_filesystem)
+     ftsoptions |= FTS_XDEV;
+ 
++  if (options.no_leaf_check)
++    ftsoptions |= FTS_NOLEAF;
++
+   p = fts_open (arglist, ftsoptions, NULL);
+   if (NULL == p)
+     {
+-- 
+2.5.0
+

--- a/recipes/findutils/findutils-4.6.0-man-exec.patch
+++ b/recipes/findutils/findutils-4.6.0-man-exec.patch
@@ -1,0 +1,44 @@
+From a8ff1e964b2b8cd0b60362c76bd92795cee6b3c3 Mon Sep 17 00:00:00 2001
+From: Kamil Dudka <kdudka@redhat.com>
+Date: Sun, 17 Apr 2016 22:36:13 +0200
+Subject: [PATCH] doc: clarify exit status handling of -exec command {} +
+
+* find/find.1 (-exec): Explain how exit status is propagated if the
+-exec command {} + syntax is used.
+(-execdir): Likewise.
+
+Reported at https://bugzilla.redhat.com/1325049
+
+Upstream-commit: ae424b959c5e9bd23f9f686cb34653bc4cd1270e
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ find/find.1 | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/find/find.1 b/find/find.1
+index a36a0bc..c4aaf17 100644
+--- a/find/find.1
++++ b/find/find.1
+@@ -1069,6 +1069,9 @@ command line is built in much the same way that
+ .B xargs
+ builds its command lines.  Only one instance of `{}' is allowed within
+ the command.  The command is executed in the starting directory.  If
++any invocation returns a non-zero value as exit status, then
++.B find
++returns a non-zero exit status.  If
+ .B find
+ encounters an error, this can sometimes cause an
+ immediate exit, so some pending commands may not be run
+@@ -1104,6 +1107,9 @@ appropriately-named file in a directory in which you will run
+ The same applies to having entries in
+ .B $PATH
+ which are empty or which are not absolute directory names.  If
++any invocation returns a non-zero value as exit status, then
++.B find
++returns a non-zero exit status.  If
+ .B find
+ encounters an error, this can sometimes cause an
+ immediate exit, so some pending commands may not be run
+-- 
+2.5.5
+

--- a/recipes/findutils/findutils-4.6.0-mbrtowc-tests.patch
+++ b/recipes/findutils/findutils-4.6.0-mbrtowc-tests.patch
@@ -1,0 +1,35 @@
+From 06a46ba755195810f2aeda01b12d1ccfe7c2dcfd Mon Sep 17 00:00:00 2001
+From: Daiki Ueno <ueno@gnu.org>
+Date: Mon, 28 Dec 2015 06:27:42 +0900
+Subject: [PATCH] maint: fix operator precedence in mbrtowc test
+
+This is a fix for test breakage introduced by commit 45228d96; the
+equality expression must be parenthesized when negated with '!',
+otherwise we always get:
+
+  test-mbrtowc.c:49: assertion 'ret == (size_t)(-2)' failed
+
+* m4/mbrtowc.m4 (gl_MBRTOWC_EMPTY_INPUT): Negate the entire expression.
+
+Upstream-commit: 1f63650823cebf52044df840c81062ccb52163a2
+Signed-off-by: Kamil Dudka <kdudka@redhat.com>
+---
+ gl/m4/mbrtowc.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gl/m4/mbrtowc.m4 b/gl/m4/mbrtowc.m4
+index deb9f06..be2e9d6 100644
+--- a/gl/m4/mbrtowc.m4
++++ b/gl/m4/mbrtowc.m4
+@@ -569,7 +569,7 @@ changequote([,])dnl
+            int
+            main (void)
+            {
+-             return ! mbrtowc (&wc, "", 0, &mbs) == (size_t) -2;
++             return mbrtowc (&wc, "", 0, &mbs) != (size_t) -2;
+            }]])],
+         [gl_cv_func_mbrtowc_empty_input=yes],
+         [gl_cv_func_mbrtowc_empty_input=no],
+-- 
+2.5.0
+

--- a/recipes/findutils/findutils-4.6.0-test-lock.patch
+++ b/recipes/findutils/findutils-4.6.0-test-lock.patch
@@ -1,0 +1,29 @@
+From 129f23ce758620fade812baab811379ce8454048 Mon Sep 17 00:00:00 2001
+From: rpm-build <rpm-build>
+Date: Fri, 27 Jan 2017 11:44:41 +0100
+Subject: [PATCH] test-lock: disable the rwlock test
+
+It hangs indefinitely if the system rwlock implementation does not
+prevent writer starvation (and glibc does not implement it).
+
+Bug: http://www.mail-archive.com/bug-gnulib@gnu.org/msg33017.html
+---
+ tests/test-lock.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tests/test-lock.c b/tests/test-lock.c
+index a992f64..fd9c014 100644
+--- a/tests/test-lock.c
++++ b/tests/test-lock.c
+@@ -42,7 +42,7 @@
+    Uncomment some of these, to verify that all tests crash if no locking
+    is enabled.  */
+ #define DO_TEST_LOCK 1
+-#define DO_TEST_RWLOCK 1
++#define DO_TEST_RWLOCK 0
+ #define DO_TEST_RECURSIVE_LOCK 1
+ #define DO_TEST_ONCE 1
+ 
+-- 
+2.7.4
+

--- a/recipes/findutils/meta.yaml
+++ b/recipes/findutils/meta.yaml
@@ -10,6 +10,7 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  #patches taken from the Fedora fc28 rpm build process
   patches:
     - findutils-4.6.0-mbrtowc-tests.patch
     - findutils-4.6.0-gnulib-fflush.patch

--- a/recipes/findutils/meta.yaml
+++ b/recipes/findutils/meta.yaml
@@ -11,6 +11,7 @@ source:
   url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   #patches taken from the Fedora fc28 rpm build process
+  #https://src.fedoraproject.org/cgit/rpms/findutils.git/plain/<<patch name>>?id=97ba2d7a
   patches:
     - findutils-4.6.0-mbrtowc-tests.patch
     - findutils-4.6.0-gnulib-fflush.patch

--- a/recipes/findutils/meta.yaml
+++ b/recipes/findutils/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "findutils" %}
+{% set version = "4.6.0" %}
+{% set sha256 = "ded4c9f73731cd48fec3b6bdaccce896473b6d8e337e9612e16cf1431bb1169d" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - findutils-4.6.0-mbrtowc-tests.patch
+    - findutils-4.6.0-gnulib-fflush.patch
+    - findutils-4.4.2-xautofs.patch
+    - findutils-4.5.13-warnings.patch
+    - findutils-4.6.0-man-exec.patch
+    - findutils-4.6.0-exec-args.patch
+    - findutils-4.6.0-gnulib-makedev.patch
+    - findutils-4.6.0-internal-noop.patch
+    - findutils-4.6.0-test-lock.patch
+    - findutils-4.6.0-fts-update.patch
+    - findutils-4.6.0-leaf-opt.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+  script_env:
+    - TMPDIR
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - gettext
+    - autoconf
+    - automake
+    - texinfo
+  run:
+    - gettext
+
+test:
+  commands:
+    - find --version
+    - find --help
+    - locate --version
+    - locate --help
+    - updatedb --version
+    - updatedb --help
+    - xargs --version
+    - xargs --help
+
+about:
+  home: https://www.gnu.org/software/findutils/
+  license: GPL-3.0
+  license_family: GPL
+  license_file: COPYING
+  summary: |
+    The GNU Find Utilities are the basic directory searching utilities of
+    the GNU operating system.
+  doc_url: https://www.gnu.org/software/findutils/manual/find.html
+  dev_url: http://savannah.gnu.org/projects/findutils/
+  description: |
+    The GNU Find Utilities are the basic directory searching utilities of
+    the GNU operating system. These programs are typically used in conjunction
+    with other programs to provide modular and powerful directory search and
+    file locating capabilities to other commands.
+extra:
+  recipe-maintainers:
+    - karl616


### PR DESCRIPTION
I realized that there are bioconda tools depending on findutils. This becomes apparent first when then are containerized. The package triggering this for me was cromwell, which makes use of the `find -empty` flag that is not present in the busybox implementation