### PR TITLE
Add py3c

### DIFF
--- a/recipes/py3c/bld.bat
+++ b/recipes/py3c/bld.bat
@@ -1,0 +1,15 @@
+:: Generate a Unixy path for bash.
+set "WIN_PREFIX=%PREFIX%"
+for /f "delims=" %%i in ('cygpath.exe -u -p "%LIBRARY_PREFIX%"') do (
+    set "UNIX_PREFIX=%%i"
+)
+
+:: Reuse the Unix build to get a Windows build simply.
+set "PREFIX=%UNIX_PREFIX%"
+bash -x %RECIPE_DIR%\build.sh
+if errorlevel 1 exit 1
+set "PREFIX=%WIN_PREFIX%"
+
+:: No need for pkg-config files on Windows.
+rmdir /s /q "%LIBRARY_PREFIX%\share"
+if errorlevel 1 exit 1

--- a/recipes/py3c/build.sh
+++ b/recipes/py3c/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+make install prefix="${PREFIX}"

--- a/recipes/py3c/meta.yaml
+++ b/recipes/py3c/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "1.0" %}
+
+package:
+  name: py3c
+  version: {{ version }}
+
+source:
+  url: https://github.com/encukou/py3c/archive/v{{ version }}.tar.gz
+  sha256: f97fbc2eb5187df2499c3d5cf6c23ee0dac046eb0a88d67eea5e444cf116cd8e
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - posix  # [win]
+  host:
+
+test:
+  commands:
+    - test -f "${PREFIX}/include/py3c.h"           # [unix]
+    - test -d "${PREFIX}/include/py3c"             # [unix]
+    - if not exist "%LIBRARY_INC%\\py3c.h" exit 1  # [win]
+    - if not exist "%LIBRARY_INC%\\py3c" exit 1    # [win]
+
+about:
+  home: https://github.com/encukou/py3c
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.MIT
+  summary: A Python 2/3 compatibility layer for C extensions
+
+  dev_url: https://github.com/encukou/py3c
+  doc_url: https://py3c.readthedocs.org/
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/5672

Adds a package for `py3c`, a header only compatibility layer for Python C-API code that has Python 2/3 compatibility or would like to achieve it simply.