### PR TITLE
WIP: Add emscripten

### DIFF
--- a/recipes/emscripten/build.sh
+++ b/recipes/emscripten/build.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Move source to the PREFIX
+mv "${SRC_DIR}" "${PREFIX}/emscripten"
+cd "${PREFIX}/emscripten"
+
+# Write the config file
+cat >${PREFIX}/emscripten/config <<EOF
+BINARYEN_ROOT = "${PREFIX}/bin"
+
+EMSCRIPTEN_ROOT = "${PREFIX}/emscripten"
+
+LLVM_ROOT = "${PREFIX}/bin"
+
+JAVA = "${PREFIX}/bin/java"
+
+NODE_JS = "${PREFIX}/bin/node"
+COMPILER_ENGINE = NODE_JS
+JS_ENGINES = [NODE_JS]
+
+TEMP_DIR = "${PREFIX}/emscripten/tmp"
+EOF
+
+# Write activate and deactivate scripts
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+cat >${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh <<EOF
+export EM_CONFIG="${PREFIX}/emscripten/config"
+export EM_CACHE="${PREFIX}/emscripten/cache"
+export EMCC_WASM_BACKEND=1
+EOF
+mkdir -p "${PREFIX}/etc/conda/deactivate.d"
+cat >${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.sh <<EOF
+unset EM_CONFIG
+unset EM_CACHE
+unset EMCC_WASM_BACKEND
+EOF
+
+# Run activate script
+source "${PREFIX}/etc/conda/activate.d/${PKG_NAME}_activate.sh"
+
+# Configure build chain
+export CC="${PREFIX}/bin/clang"
+export CXX="${PREFIX}/bin/clang++"
+export LD="${PREFIX}/bin/lld"
+
+# Prebuild some packages with Emscripten
+mkdir -p "${PREFIX}/emscripten/cache"
+mkdir -p "${PREFIX}/emscripten/tmp"
+${PYTHON} embuilder.py build       \
+	                      libc \
+
+# Add symlinks to `bin` for executables
+ln -s ${PREFIX}/emscripten/em++ ${PREFIX}/bin/em++
+
+# Run deactivate script
+source "${PREFIX}/etc/conda/deactivate.d/${PKG_NAME}_deactivate.sh"

--- a/recipes/emscripten/meta.yaml
+++ b/recipes/emscripten/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "1.37.27" %}
+
+package:
+  name: emscripten
+  version: {{ version }}
+
+source:
+  fn: emscripten-{{ version }}.tar.gz
+  url: https://github.com/kripken/emscripten/archive/{{ version }}.tar.gz
+  sha256: a345032415362a0a66e4886ecd751f6394237ff764b1f1c40dde25410792991c
+
+build:
+  number: 0
+  skip: true  # [win or py!=27]
+
+requirements:
+  host:
+    - binaryen
+    - clangdev
+    - lld
+    - libcxx
+    - python
+    - nodejs
+    - openjdk
+  run:
+    - binaryen
+    - clangdev
+    - lld
+    - libcxx
+    - python
+    - nodejs
+    - openjdk
+
+test:
+  commands:
+    - exit 0
+
+about:
+  home: https://github.com/kripken/emscripten
+  license: MIT/NCSA
+  license_file: LICENSE
+  summary: An LLVM-to-JavaScript Compiler
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/2507

This is still very much WIP. If other people want to hack on it, please feel free.

Creates a package for Emscripten, a C/C++ compiler to JavaScript/WebAssembly. The work here builds off of PR ( https://github.com/conda-forge/llvmdev-feedstock/pull/42 ) and others to use experimental WebAssembly support in the LLVM toolchain combined with Emscripten. This effectively uses Clang as the backend. Emscripten provides the standard libraries (e.g. `libc`, `libc++`, etc.) to be a useful compiler along with wrappers around common build tooling (e.g. `make`, `cmake`, etc.).

As Fastcomp is not built, Emscripten's asm.js support is not included. Though it could be if needed (I personally don't plan on taking that on). It is possible to convert WebAssembly to asm.js through various other tools like Binaryen and WABT to do this conversion (though it may require additional optimization).