### PR TITLE
recipe for lsof 4.89

### DIFF
--- a/recipes/lsof/build.sh
+++ b/recipes/lsof/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+./Configure -n $(uname|tr '[:upper:]' '[:lower:]')
+make -j${CPU_COUNT}
+mkdir -p $CONDA_PREFIX/bin/
+cp ./lsof $CONDA_PREFIX/bin/

--- a/recipes/lsof/meta.yaml
+++ b/recipes/lsof/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = 'lsof' %}
+{% set version = "4.89" %}
+{% set sha256 = "17688b122b9e0330042625ae6c15c4486699a11e2483e3d0e97ec1642b93d7b2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url:
+    - http://cdn-fastly.deb.debian.org/debian/pool/main/l/lsof/{{ name }}_{{ version }}+dfsg.orig.tar.gz
+    - http://http.debian.net/debian/pool/main/l/lsof/{{ name }}_{{ version }}+dfsg.orig.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  skip: true  # [not linux]
+  number: 0
+
+requirements:
+  build:
+    - perl
+
+test:
+  commands:
+    - lsof -v
+    - lsof .
+
+about:
+  home: http://people.freebsd.org/~abe/
+  license: BSD-compatible
+  license_family: BSD
+  summary: LiSt Open Files
+
+  description: |
+    The free, open-source, Unix administrative tool lsof (for LiSt Open Files)
+    displays information about files open to Unix processes.
+  doc_url: https://people.freebsd.org/~abe/
+
+extra:
+  recipe-maintainers:
+    - keuv-grvl


### PR DESCRIPTION
My previous attempt for this recipe gone wrong, I had to restart from the begining.

This recipe is only for Linux as a typo exist in one of the OSX-specific source file (`dialects/darwin/libproc/dfile.c:289:17`) preventing from compilation.