### PR TITLE
Add gwpy

### DIFF
--- a/recipes/gwpy/meta.yaml
+++ b/recipes/gwpy/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gwpy" %}
-{% set version = "0.11.0" %}
-{% set sha256 = "47a17967508f006cee9c1c4a62cceff4d6d9870096cad9eedf9f1a4af788ba17" %}
+{% set version = "0.12.0" %}
+{% set sha256 = "fd05cfba0a720c11a19694268b42da5f36ca52b7e77d605946fbbecc7ca5b162" %}
 
 package:
   name: {{ name }}
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   # skip build on windows due to issues with ligo-segments
@@ -23,28 +24,46 @@ requirements:
     - setuptools
     - pip
   run:
-    - python
+    - python >=2.7
     - six >=1.5
     - python-dateutil
-    - numpy >=1.7.1,<1.15.0
+    - enum34  # [py2k]
+    - numpy >=1.7.1
     - scipy >=0.12.1
-    - matplotlib >=1.2.0
+    - matplotlib >=1.2.0,!=2.1.0,!=2.1.1
     - astropy >=1.1.1
     - h5py >=1.3
     - ligo-segments >=1.0.0
     - tqdm >=4.10.0
-    - python-lal  # [not win]
-    - ligotimegps  # [win]
+    - ligotimegps >=1.2.1
 
 test:
   requires:
     - pytest >=3.1
-    - freezegun
-    - sqlparse
+    - freezegun >=0.2.3
+    - sqlparse >=0.2.0
     - beautifulsoup4
     - mock  # [py2k]
+  imports:
+    - gwpy
+    - gwpy.astro
+    - gwpy.cli
+    - gwpy.detector
+    - gwpy.frequencyseries
+    - gwpy.io
+    - gwpy.plot
+    - gwpy.segments
+    - gwpy.signal
+    - gwpy.spectrogram
+    - gwpy.table
+    - gwpy.tests
+    - gwpy.time
+    - gwpy.timeseries
+    - gwpy.types
+    - gwpy.utils
   commands:
     - python -m pytest --pyargs {{ name }}
+    - gwpy-plot --help
 
 about:
   home: https://gwpy.github.io

--- a/recipes/gwpy/meta.yaml
+++ b/recipes/gwpy/meta.yaml
@@ -13,7 +13,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:

--- a/recipes/gwpy/meta.yaml
+++ b/recipes/gwpy/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "gwpy" %}
+{% set version = "0.11.0" %}
+{% set sha256 = "47a17967508f006cee9c1c4a62cceff4d6d9870096cad9eedf9f1a4af788ba17" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - six>=1.5
+    - python-dateutil
+    - numpy>=1.7.1
+    - scipy>=0.12.1
+    - matplotlib>=1.2.0
+    - astropy>=1.1.1
+    - h5py>=1.3
+    - ligo-segments>=1.0.0
+    - tqdm>=4.10.0
+    - lal  # [not win]
+    - ligotimegps  # [win]
+
+test:
+  requires:
+    - pytest>=3.1
+    - freezegun
+    - sqlparse
+    - beautifulsoup4
+    - mock  # [py2k]
+  commands:
+    - python -m pytest --pyargs {{ name }}
+
+about:
+  home: https://gwpy.github.io
+  license: GPLv3
+  license_family: GPL
+  license_file: LICENSE
+  summary: A python package for gravitational-wave astrophysics
+  description: |
+    GWpy is a collaboration-driven Python package providing tools for
+    studying data from ground-based gravitational-wave detectors.
+
+    GWpy provides a user-friendly, intuitive interface to the common
+    time-domain and frequency-domain data produced by the LIGO and Virgo
+    observatories and their analyses, with easy-to-follow tutorials at each
+    step.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/gwpy/meta.yaml
+++ b/recipes/gwpy/meta.yaml
@@ -13,7 +13,9 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  # skip build on windows due to issues with ligo-segments
+  skip: true  # [win]
 
 requirements:
   host:
@@ -22,21 +24,21 @@ requirements:
     - pip
   run:
     - python
-    - six>=1.5
+    - six >=1.5
     - python-dateutil
-    - numpy>=1.7.1
-    - scipy>=0.12.1
-    - matplotlib>=1.2.0
-    - astropy>=1.1.1
-    - h5py>=1.3
-    - ligo-segments>=1.0.0
-    - tqdm>=4.10.0
+    - numpy >=1.7.1,<1.15.0
+    - scipy >=0.12.1
+    - matplotlib >=1.2.0
+    - astropy >=1.1.1
+    - h5py >=1.3
+    - ligo-segments >=1.0.0
+    - tqdm >=4.10.0
     - python-lal  # [not win]
     - ligotimegps  # [win]
 
 test:
   requires:
-    - pytest>=3.1
+    - pytest >=3.1
     - freezegun
     - sqlparse
     - beautifulsoup4

--- a/recipes/gwpy/meta.yaml
+++ b/recipes/gwpy/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - h5py>=1.3
     - ligo-segments>=1.0.0
     - tqdm>=4.10.0
-    - lal  # [not win]
+    - python-lal  # [not win]
     - ligotimegps  # [win]
 
 test:


### PR DESCRIPTION
This PR adds [gwpy](//pypi.org/project/gwpy), a Python package for gravitational-wave astrophysics. This recipe is unix-only until ligo-segments-1.0.2 is available for conda, due to issues with ligo-segments on windows.