### PR TITLE
Add model_metadata package

### DIFF
--- a/recipes/model_metadata/meta.yaml
+++ b/recipes/model_metadata/meta.yaml
@@ -1,20 +1,17 @@
-{% set name = "model_metadata" %}
 {% set version = "0.3.3" %}
-{% set build = "0" %}
 
 package:
-  name: {{ name|lower }}
+  name: model_metadata
   version: {{ version }}
 
 source:
-  url: https://github.com/csdms/{{ name }}/archive/v{{ version }}.tar.gz
-  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/csdms/model_metadata/archive/v{{ version }}.tar.gz
   sha256: 303743c017a017ee684085db759cb61079da43d8dc9c4eff7301a8f84f981f62
 
 build:
   noarch: python
-  number: {{ build }}
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   entry_points:
     - mmd = model_metadata.cli.main:main
     - mmd-dump = model_metadata.cli.main_dump:main
@@ -24,10 +21,8 @@ build:
 
 requirements:
   build:
-    - setuptools
-    - pip
     - python
-
+    - pip
   run:
     - python
     - packaging

--- a/recipes/model_metadata/meta.yaml
+++ b/recipes/model_metadata/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "model_metadata" %}
+{% set version = "0.3.3" %}
+{% set build = "0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/csdms/{{ name }}/archive/v{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  sha256: 303743c017a017ee684085db759cb61079da43d8dc9c4eff7301a8f84f981f62
+
+build:
+  noarch: python
+  number: {{ build }}
+  script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - mmd = model_metadata.cli.main:main
+    - mmd-dump = model_metadata.cli.main_dump:main
+    - mmd-find = model_metadata.cli.main_find:main
+    - mmd-install = model_metadata.cli.main_install:main
+    - mmd-stage = model_metadata.cli.main_stage:main
+
+requirements:
+  build:
+    - setuptools
+    - pip
+    - python
+
+  run:
+    - python
+    - packaging
+    - pyyaml
+    - six
+    - jinja2
+    - scripting
+    - binaryornot
+
+test:
+  requires:
+    - nose
+  commands:
+    - nosetests --with-doctest model_metadata
+
+about:
+  home: http://github.com/csdms/model_metadata
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Tools for working with CSDMS Model Metadata
+  description: |
+    The CSDMS model_metadata Python package provides tools for working
+    with CSDMS Model Metadata. Contained within this package are tools for
+    (1) parsing model metadata, (2) staging model simulations, (3)
+    validating model input parameters, and (4) running model simulations.
+  dev_url: http://github.com/csdms/model_metadata
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds `model_metadata`, a Python package for working with metadata describing numerical models in the Earth sciences.