### PR TITLE
Add standard_names package

### DIFF
--- a/recipes/standard_names/meta.yaml
+++ b/recipes/standard_names/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "0.2.4" %}
+
+package:
+  name: standard_names
+  version: {{ version }}
+
+source:
+  url: https://github.com/csdms/standard_names/archive/v{{ version }}.tar.gz
+  sha256: 20f53a9201b11f295d9f7b15fd96b217d4c3e2676d30f12e56033909c2bc8d49
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  entry_points:
+    - snbuild = standard_names.cmd.snbuild:run
+    - sndump = standard_names.cmd.sndump:run
+    - snscrape = standard_names.cmd.snscrape:run
+    - snsql = standard_names.cmd.snsql:run
+    - snvalidate = standard_names.cmd.snvalidate:run
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - pyyaml
+    - six
+
+test:
+  requires:
+    - pytest
+  imports:
+    - standard_names
+  commands:
+    - snbuild --help
+    - sndump --help
+    - snscrape --help
+    - snsql --help
+    - snvalidate --help
+    - pytest --pyargs standard_names --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
+
+about:
+  home: https://github.com/csdms/standard_names
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python utilities for working with CSDMS standard names.
+  description: |
+    The CSDMS Standard Names provide a comprehensive set of naming
+    rules and patterns that are not specific to any particular modeling
+    domain. They were also designed to have many other nice features
+    such as parsability and natural alphabetical grouping.
+  dev_url: https://github.com/csdms/standard_names
+
+extra:
+  recipe-maintainers:
+    - mcflugen

--- a/recipes/standard_names/meta.yaml
+++ b/recipes/standard_names/meta.yaml
@@ -52,6 +52,7 @@ about:
     rules and patterns that are not specific to any particular modeling
     domain. They were also designed to have many other nice features
     such as parsability and natural alphabetical grouping.
+  doc_url: https://standard-names.readthedocs.io
   dev_url: https://github.com/csdms/standard_names
 
 extra:


### PR DESCRIPTION
This pull request adds `standard_names`, a Python package to define, query, operate, and manipulate [CSDMS Standard Names](https://standard-names.readthedocs.io/), a controlled vocabulary for variable names in the Earth sciences.