### PR TITLE
package fastrlock

### DIFF
--- a/recipes/fastrlock/meta.yaml
+++ b/recipes/fastrlock/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastrlock" %}
-{% set version = "0.3.0" %}
+{% set version = "0.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/fastrlock/meta.yaml
+++ b/recipes/fastrlock/meta.yaml
@@ -1,18 +1,13 @@
 {% set name = "fastrlock" %}
-{% set version = "0.3" %}
+{% set version = "0.4" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # I don't know what version upstream will call it, but I tagged mine as 0.3.1
-  # While we wait for
-  # https://github.com/scoder/fastrlock/pull/5
-  url: https://github.com/hmaarrfk/fastrlock/archive/0.3.1.tar.gz
-  fn: fastrlock-0,3,1.tar.gz
-  sha256: 2935132d5922d5ac507be15ae06e5cb0df6c9785568f1abd2349495f2816b7d4
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6abdbb35205792e2d2a8c441aaa41a613d43ee2d88b3af4fd9735ae7a5f7db6b
 
 build:
   number: 0

--- a/recipes/fastrlock/meta.yaml
+++ b/recipes/fastrlock/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  # We need to pass --with-cython to force cython to regenerate
+  # We need to pass --with-cython to force cython to regenerate the .c file
   script: "{{ PYTHON }} -m pip install . --global-option=\"--with-cython\" --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:

--- a/recipes/fastrlock/meta.yaml
+++ b/recipes/fastrlock/meta.yaml
@@ -1,0 +1,70 @@
+{% set name = "fastrlock" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  #url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # I don't know what version upstream will call it, but I tagged mine as 0.3.1
+  # While we wait for
+  # https://github.com/scoder/fastrlock/pull/5
+  url: https://github.com/hmaarrfk/fastrlock/archive/0.3.1.tar.gz
+  fn: fastrlock-0,3,1.tar.gz
+  sha256: 2935132d5922d5ac507be15ae06e5cb0df6c9785568f1abd2349495f2816b7d4
+
+build:
+  number: 0
+  # We need to pass --with-cython to force cython to regenerate
+  # But using --global-option wasn't working. Maybe somebody can help
+  script: "{{ PYTHON }} -m pip install . --global-option=\"--with-cython\" --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+  host:
+    - python
+    - pip
+    - cython
+  run:
+    - python
+
+test:
+  # test scripts are not installed with the package
+  # only check for existance
+  imports:
+    - fastrlock
+
+about:
+  home: https://github.com/scoder/fastrlock
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'This is a C-level implementation of a fast, re-entrant, optimistic lock for CPython'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    This is a C-level implementation of a fast, re-entrant,
+    optimistic lock for CPython. It is a drop-in replacement for
+    threading.RLock. FastRLock is implemented in Cython and also provides a
+    C-API for direct use from Cython code via from fastrlock cimport rlock.
+
+    Under normal conditions, it is about 10x faster than threading.RLock in
+    Python 2.7 because it avoids all locking unless two or more threads try to
+    acquire it at the same time. Under congestion, it is still about 10% faster
+    than RLock due to being implemented in Cython.
+
+    This is mostly equivalent to the revised RLock implementation in Python
+    3.2, but still faster due to being implemented in Cython. Note that the
+    threading.RLock implementation in Python 3.4 and later tends to be as fast
+    or even faster than the lock provided by this package, when called through
+    the Python API. FastRLock is still faster also on these systems when called
+    through its Cython API.
+
+  dev_url: https://github.com/scoder/fastrlock
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/fastrlock/meta.yaml
+++ b/recipes/fastrlock/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   # We need to pass --with-cython to force cython to regenerate
-  # But using --global-option wasn't working. Maybe somebody can help
   script: "{{ PYTHON }} -m pip install . --global-option=\"--with-cython\" --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
@@ -27,8 +26,6 @@ requirements:
     - python
 
 test:
-  # test scripts are not installed with the package
-  # only check for existance
   imports:
     - fastrlock
 
@@ -38,8 +35,6 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: 'This is a C-level implementation of a fast, re-entrant, optimistic lock for CPython'
-
-  # The remaining entries in this section are optional, but recommended
   description: |
     This is a C-level implementation of a fast, re-entrant,
     optimistic lock for CPython. It is a drop-in replacement for
@@ -57,7 +52,6 @@ about:
     or even faster than the lock provided by this package, when called through
     the Python API. FastRLock is still faster also on these systems when called
     through its Cython API.
-
   dev_url: https://github.com/scoder/fastrlock
 
 extra:


### PR DESCRIPTION
@jakirkham you probably got this far, but here is my attempt

The sdist is missing a file. 

https://github.com/scoder/fastrlock/pull/5

We also need to pass an option to the setup script, to ensure that it regenerates new c code with cython.

I keep getting: 
```
    gcc: error: unrecognized command line option ‘-fno-plt’
```
