### PR TITLE
Add a recipe for python-jsonrpc-server

### DIFF
--- a/recipes/python-jsonrpc-server/meta.yaml
+++ b/recipes/python-jsonrpc-server/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "python-jsonrpc-server" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ebebaa68b732c9d0aa024ffba2c3baca8b5704530f81d5a894a1ab6981b492c7
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - jsonrpc
+    - jsonrpc.dispatchers
+
+about:
+  home: https://github.com/palantir/python-jsonrpc-server
+  license: MIT
+  license_family: MIT
+  summary: 'A Python 2.7 and 3.4+ server implementation of the JSON RPC 2.0 protocol.'
+  dev_url: https://github.com/palantir/python-jsonrpc-server
+
+extra:
+  recipe-maintainers:
+    - ccordoba12
+    - andfoy


### PR DESCRIPTION
This is a new dependency of python-language-server.

That's why PR https://github.com/conda-forge/python-language-server-feedstock/pull/11 is failing. I thought it was because the `jsonrpc` package was outdated.