### PR TITLE
add scheme for repodata hotfixing

### DIFF
--- a/recipes/conda-forge-repodata-patches/gen_patch_json.py
+++ b/recipes/conda-forge-repodata-patches/gen_patch_json.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from collections import defaultdict
+import json
+import os
+from os.path import join, dirname, isdir
+import sys
+import tqdm
+
+import requests
+
+CHANNEL_NAME = "conda-forge"
+CHANNEL_ALIAS = "https://conda-web.anaconda.org"
+SUBDIRS = (
+    "noarch",
+    "linux-64",
+    "linux-armv7l",
+    "linux-ppc64le",
+    "osx-64",
+    "win-32",
+    "win-64",
+)
+
+REMOVALS = {
+    "noarch": (
+        "sendgrid-5.3.0-py_0.tar.bz2",
+    ),
+    "linux-64": (
+        "airflow-with-gcp_api-1.9.0-1.tar.bz2",
+        "airflow-with-gcp_api-1.9.0-2.tar.bz2",
+        "airflow-with-gcp_api-1.9.0-3.tar.bz2",
+        "adios-1.13.1-py36hbecc8f4_0.tar.bz2",
+        "cookiecutter-1.4.0-0.tar.bz2",
+        "compliance-checker-2.2.0-0.tar.bz2",
+        "compliance-checker-3.0.3-py27_0.tar.bz2",
+        "compliance-checker-3.0.3-py35_0.tar.bz2",
+        "compliance-checker-3.0.3-py36_0.tar.bz2",
+        "doconce-1.0.0-py27_0.tar.bz2",
+        "doconce-1.0.0-py27_1.tar.bz2",
+        "doconce-1.0.0-py27_2.tar.bz2",
+        "doconce-1.0.0-py27_3.tar.bz2",
+        "doconce-1.0.0-py27_4.tar.bz2",
+        "doconce-1.4.0-py27_0.tar.bz2",
+        "doconce-1.4.0-py27_1.tar.bz2",
+        "gdk-pixbuf-2.36.9-0.tar.bz2",
+        "itk-4.12.0-py27_0.tar.bz2",
+        "itk-4.12.0-py35_0.tar.bz2",
+        "itk-4.12.0-py36_0.tar.bz2",
+        "itk-4.13.0-py27_0.tar.bz2",
+        "itk-4.13.0-py35_0.tar.bz2",
+        "itk-4.13.0-py36_0.tar.bz2",
+        "ecmwf_grib-1.14.7-np110py27_0.tar.bz2",
+        "ecmwf_grib-1.14.7-np110py27_1.tar.bz2",
+        "ecmwf_grib-1.14.7-np111py27_0.tar.bz2",
+        "ecmwf_grib-1.14.7-np111py27_1.tar.bz2",
+        "libtasn1-4.13-py36_0.tar.bz2",
+        "libgsasl-1.8.0-py36_1.tar.bz2",
+        "nipype-0.12.0-0.tar.bz2",
+        "nipype-0.12.0-py35_0.tar.bz2",
+        "postgis-2.4.3+9.6.8-0.tar.bz2",
+        "pyarrow-0.1.post-0.tar.bz2",
+        "pyarrow-0.1.post-1.tar.bz2",
+        "pygpu-0.6.5-0.tar.bz2",
+        "pytest-regressions-1.0.1-0.tar.bz2",
+        "rapidpy-2.5.2-py36_0.tar.bz2",
+        "smesh-8.3.0b0-1.tar.bz2",
+        "statuspage-0.3.3-0.tar.bz2",
+        "statuspage-0.4.0-0.tar.bz2",
+        "statuspage-0.4.1-0.tar.bz2",
+        "statuspage-0.5.0-0.tar.bz2",
+        "statuspage-0.5.1-0.tar.bz2",
+        "tokenize-rt-2.0.1-py27_0.tar.bz2",
+        "vaex-core-0.4.0-py27_0.tar.bz2",
+    ),
+    "osx-64": (
+        "adios-1.13.1-py36hbecc8f4_0.tar.bz2",
+        "airflow-with-gcp_api-1.9.0-1.tar.bz2",
+        "airflow-with-gcp_api-1.9.0-2.tar.bz2",
+        "arpack-3.6.1-blas_openblash1f444ea_0.tar.bz2",
+        "cookiecutter-1.4.0-0.tar.bz2",
+        "compliance-checker-2.2.0-0.tar.bz2",
+        "compliance-checker-3.0.3-py27_0.tar.bz2",
+        "compliance-checker-3.0.3-py35_0.tar.bz2",
+        "compliance-checker-3.0.3-py36_0.tar.bz2",
+        "doconce-1.0.0-py27_0.tar.bz2",
+        "doconce-1.0.0-py27_1.tar.bz2",
+        "doconce-1.0.0-py27_2.tar.bz2",
+        "doconce-1.0.0-py27_3.tar.bz2",
+        "doconce-1.0.0-py27_4.tar.bz2",
+        "doconce-1.4.0-py27_0.tar.bz2",
+        "doconce-1.4.0-py27_1.tar.bz2",
+        "ecmwf_grib-1.14.7-np110py27_0.tar.bz2",
+        "ecmwf_grib-1.14.7-np110py27_1.tar.bz2",
+        "ecmwf_grib-1.14.7-np111py27_0.tar.bz2",
+        "ecmwf_grib-1.14.7-np111py27_1.tar.bz2",
+        "flask-rest-orm-0.5.0-py35_0.tar.bz2",
+        "flask-rest-orm-0.5.0-py36_0.tar.bz2",
+        "itk-4.12.0-py27_0.tar.bz2",
+        "itk-4.12.0-py35_0.tar.bz2",
+        "itk-4.12.0-py36_0.tar.bz2",
+        "itk-4.13.0-py27_0.tar.bz2",
+        "itk-4.13.0-py35_0.tar.bz2",
+        "itk-4.13.0-py36_0.tar.bz2",
+        "lammps-2018.03.16-.tar.bz2",
+        "libtasn1-4.13-py36_0.tar.bz2",
+        "mpb-1.6.2-1.tar.bz2",
+        "nipype-0.12.0-0.tar.bz2",
+        "nipype-0.12.0-py35_0.tar.bz2",
+        "pygpu-0.6.5-0.tar.bz2",
+        "pytest-regressions-1.0.1-0.tar.bz2",
+        "reentry-1.1.0-py27_0.tar.bz2",
+        "resampy-0.2.0-py27_0.tar.bz2",
+        "statuspage-0.3.3-0.tar.bz2",
+        "statuspage-0.4.0-0.tar.bz2",
+        "statuspage-0.4.1-0.tar.bz2",
+        "statuspage-0.5.0-0.tar.bz2",
+        "statuspage-0.5.1-0.tar.bz2",
+        "sundials-3.1.0-blas_openblash0edd121_202.tar.bz2",
+        "vlfeat-0.9.20-h470a237_2.tar.bz2",
+        "xtensor-python-0.19.1-h3e44d54_0.tar.bz2",
+    ),
+    "win-32": (
+        "compliance-checker-2.2.0-0.tar.bz2",
+        "compliance-checker-3.0.3-py27_0.tar.bz2",
+        "compliance-checker-3.0.3-py35_0.tar.bz2",
+        "compliance-checker-3.0.3-py36_0.tar.bz2",
+        "cookiecutter-1.4.0-0.tar.bz2",
+        "doconce-1.0.0-py27_0.tar.bz2",
+        "doconce-1.0.0-py27_1.tar.bz2",
+        "doconce-1.0.0-py27_2.tar.bz2",
+        "doconce-1.0.0-py27_3.tar.bz2",
+        "doconce-1.0.0-py27_4.tar.bz2",
+        "doconce-1.4.0-py27_0.tar.bz2",
+        "doconce-1.4.0-py27_1.tar.bz2",
+        "glpk-4.59-py27_vc9_0.tar.bz2",
+        "glpk-4.59-py34_vc10_0.tar.bz2",
+        "glpk-4.59-py35_vc14_0.tar.bz2",
+        "glpk-4.60-py27_vc9_0.tar.bz2",
+        "glpk-4.60-py34_vc10_0.tar.bz2",
+        "glpk-4.60-py35_vc14_0.tar.bz2",
+        "glpk-4.61-py27_vc9_0.tar.bz2",
+        "glpk-4.61-py35_vc14_0.tar.bz2",
+        "glpk-4.61-py36_0.tar.bz2",
+        "libspatialindex-1.8.5-py27_0.tar.bz2",
+        "liknorm-1.3.7-py27_1.tar.bz2",
+        "liknorm-1.3.7-py35_1.tar.bz2",
+        "liknorm-1.3.7-py36_1.tar.bz2",
+        "nlopt-2.4.2-0.tar.bz2",
+        "pygpu-0.6.5-0.tar.bz2",
+
+    ),
+    "win-64": (
+        "compliance-checker-2.2.0-0.tar.bz2",
+        "compliance-checker-3.0.3-py27_0.tar.bz2",
+        "compliance-checker-3.0.3-py35_0.tar.bz2",
+        "compliance-checker-3.0.3-py36_0.tar.bz2",
+        "cookiecutter-1.4.0-0.tar.bz2",
+        "doconce-1.0.0-py27_0.tar.bz2",
+        "doconce-1.0.0-py27_1.tar.bz2",
+        "doconce-1.0.0-py27_2.tar.bz2",
+        "doconce-1.0.0-py27_3.tar.bz2",
+        "doconce-1.0.0-py27_4.tar.bz2",
+        "doconce-1.4.0-py27_0.tar.bz2",
+        "doconce-1.4.0-py27_1.tar.bz2",
+        "glpk-4.59-py27_vc9_0.tar.bz2",
+        "glpk-4.59-py34_vc10_0.tar.bz2",
+        "glpk-4.59-py35_vc14_0.tar.bz2",
+        "glpk-4.60-py27_vc9_0.tar.bz2",
+        "glpk-4.60-py34_vc10_0.tar.bz2",
+        "glpk-4.60-py35_vc14_0.tar.bz2",
+        "glpk-4.61-py27_vc9_0.tar.bz2",
+        "glpk-4.61-py35_vc14_0.tar.bz2",
+        "glpk-4.61-py36_0.tar.bz2",
+        "itk-4.13.0-py35_0.tar.bz2",
+        "libspatialindex-1.8.5-py27_0.tar.bz2",
+        "liknorm-1.3.7-py27_1.tar.bz2",
+        "liknorm-1.3.7-py35_1.tar.bz2",
+        "liknorm-1.3.7-py36_1.tar.bz2",
+        "nlopt-2.4.2-0.tar.bz2",
+        "pygpu-0.6.5-0.tar.bz2",
+        "pytest-regressions-1.0.1-0.tar.bz2",
+    ),
+}
+
+
+def _patch_repodata(repodata, subdir):
+    index = repodata["packages"]
+    instructions = {
+        "patch_instructions_version": 1,
+        "packages": defaultdict(dict),
+        "revoke": [],
+        "remove": [],
+    }
+
+    instructions["remove"].extend(REMOVALS.get(subdir, ()))
+
+    if subdir.startswith("win-"):
+        python_vc_deps = {
+            '2.6': 'vc 9.*',
+            '2.7': 'vc 9.*',
+            '3.3': 'vc 10.*',
+            '3.4': 'vc 10.*',
+            '3.5': 'vc 14.*',
+            '3.6': 'vc 14.*',
+            '3.7': 'vc 14.*',
+        }
+        for fn, record in index.items():
+            record_name = record['name']
+            if record_name == 'python':
+                # remove the track_features key
+                if 'track_features' in record:
+                    instructions["packages"][fn]['track_features'] = None
+                # add a vc dependency
+                if not any(d.startswith('vc') for d in record['depends']):
+                    depends = record['depends']
+                    depends.append(python_vc_deps[record['version'][:3]])
+                    instructions["packages"][fn]['depends'] = depends
+            elif 'vc' in record.get('features', ''):
+                # remove vc from the features key
+                vc_version = _extract_and_remove_vc_feature(record)
+                if vc_version:
+                    instructions["packages"][fn]['features'] = record.get('features', None)
+                    # add a vc dependency
+                    if not any(d.startswith('vc') for d in record['depends']):
+                        depends = record['depends']
+                        depends.append('vc %d.*' % vc_version)
+                        instructions["packages"][fn]['depends'] = depends
+
+    def rename_dependency(fn, record, old_name, new_name):
+        depends = record["depends"]
+        dep_idx = next(
+            (q for q, dep in enumerate(depends) if dep.split(' ')[0] == old_name),
+            None
+        )
+        if dep_idx:
+            parts = depends[dep_idx].split(" ")
+            remainder = (" " + " ".join(parts[1:])) if len(parts) > 1 else ""
+            depends[dep_idx] = new_name + remainder
+            instructions["packages"][fn]['depends'] = depends
+
+    proj4_fixes = {"cartopy", "cdo", "gdal", "libspatialite", "pynio", "qgis"}
+    for fn, record in index.items():
+        record_name = record["name"]
+        if record_name == "twisted":
+            # remove dependency from constrains
+            new_constrains = [dep for dep in record.get('constrains', ())
+                              if not dep.startswith("pyobjc-framework-cococa")]
+            if new_constrains != record.get('constrains', ()):
+                instructions["packages"][fn]['constrains'] = new_constrains
+        if record_name in proj4_fixes:
+            rename_dependency(fn, record, "proj.4", "proj4")
+        if record_name == "airflow-with-async":
+            rename_dependency(fn, record, "evenlet", "eventlet")
+        if record_name == "iris":
+            rename_dependency(fn, record, "nc_time_axis", "nc-time-axis")
+        if record_name == "r-base" and not any(dep.startswith("_r-mutex ") for dep in record["depends"]):
+            depends = record["depends"]
+            depends.append("_r-mutex 1.* anacondar_1")
+            instructions["packages"][fn]["depends"] = depends
+        if record_name == "blas" and record["track_features"] == "blas_openblas":
+            instructions["packages"][fn]["track_features"] = None
+        if "features" in record:
+            if "blas_openblas" in record["features"]:
+                # remove blas_openblas feature
+                instructions["packages"][fn]["features"] = _extract_feature(record, "blas_openblas")
+                if not any(d.startswith("blas ") for d in record["depends"]):
+                    depends = record['depends']
+                    depends.append("blas 1.* openblas")
+                    instructions["packages"][fn]["depends"] = depends
+        if "track_features" in record:
+            for feat in record["track_features"].split():
+                if feat.startswith(("rb2", "openjdk")):
+                    xtractd = record["track_features"] = _extract_track_feature(record, feat)
+                    instructions["packages"][fn]["track_features"] = xtractd
+
+    return instructions
+
+
+def _extract_and_remove_vc_feature(record):
+    features = record.get('features', '').split()
+    vc_features = tuple(f for f in features if f.startswith('vc'))
+    if not vc_features:
+        return None
+    non_vc_features = tuple(f for f in features if f not in vc_features)
+    vc_version = int(vc_features[0][2:])  # throw away all but the first
+    if non_vc_features:
+        record['features'] = ' '.join(non_vc_features)
+    else:
+        del record['features']
+    return vc_version
+
+
+def _extract_feature(record, feature_name):
+    features = record.get('features', '').split()
+    features.remove(feature_name)
+    return " ".join(features) or None
+
+
+def _extract_track_feature(record, feature_name):
+    features = record.get('track_features', '').split()
+    features.remove(feature_name)
+    return " ".join(features) or None
+
+
+def main():
+
+    base_dir = join(dirname(__file__), CHANNEL_NAME)
+
+    # Step 1. Collect initial repodata for all subdirs.
+    repodatas = {}
+    for subdir in tqdm.tqdm(SUBDIRS, desc="Downloading repodata"):
+        repodata_url = "/".join((CHANNEL_ALIAS, CHANNEL_NAME, subdir, "repodata.json"))
+        response = requests.get(repodata_url)
+        response.raise_for_status()
+        repodatas[subdir] = response.json()
+
+    # Step 2. Create all patch instructions.
+    prefix_dir = os.getenv("PREFIX")
+    for subdir in SUBDIRS:
+        prefix_subdir = join(prefix_dir, subdir)
+        if not isdir(prefix_subdir):
+            os.makedirs(prefix_subdir)
+        instructions = _patch_repodata(repodatas[subdir], subdir)
+        # output this to $PREFIX so that we bundle the JSON files
+        patch_instructions_path = join(prefix_subdir, "patch_instructions.json")
+        with open(patch_instructions_path, 'w') as fh:
+            json.dump(instructions, fh, indent=2, sort_keys=True, separators=(',', ': '))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/conda-forge-repodata-patches/meta.yaml
+++ b/recipes/conda-forge-repodata-patches/meta.yaml
@@ -1,0 +1,49 @@
+package:
+  name: conda-forge-repodata-patches
+  version: 20180828
+
+source:
+  path: .
+
+build:
+  noarch: generic
+  number: 0
+  script:
+    - python gen_patch_json.py
+
+requirements:
+  build:
+    - python 3.*
+    - requests
+    - tqdm
+
+test:
+  commands:
+    {% for subdir in ("noarch", "linux-64", "linux-armv7l", "linux-ppc64le", "osx-64", "win-32", "win-64") %}
+    - test -e $PREFIX/{{ subdir }}/patch_instructions.json
+    {% endfor %}
+
+about:
+  summary: generate tweaks to index metadata, hosted separately from anaconda.org index
+  home: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock
+  license: Public Domain
+
+extra:
+  recipe-maintainers:
+    - msarahan
+    - jjhelmus
+    - jakirkham
+    - isuruf
+    - CJ-Wright
+    - scopatz
+    - ericdill
+    - mbargull
+    - ocefpaf
+    - loriab
+    - synapticarbors
+    - bgruening
+    - mariusvniekerk
+    - mwcraig
+    - pelson
+    - dougalsutherland
+    - patricksnape

--- a/recipes/conda-forge-repodata-patches/readme.md
+++ b/recipes/conda-forge-repodata-patches/readme.md
@@ -1,0 +1,18 @@
+This scheme is ultimately meant to generate one file per subdir, ``patch_instructions.json``.  That file has entries by
+
+```
+instructions = {
+        "patch_instructions_version": 1,
+        "packages": defaultdict(dict),
+        "revoke": [],
+        "remove": [],
+    }
+```
+
+```revoke``` and ```remove``` are lists of filenames.  ```remove``` makes the file not show up in the index (it may still be downloadable with a direct URL to the file).  ```revoke``` makes packages uninstallable by adding an unsatisfiable dependency.  This can be made installable by including a channel that has that package (to be created by @jjhelmus).
+
+``packages`` is a dictionary, where keys are package filenames.  Values are dictionaries similar to the contents of each package in repodata.json.  Any values in provided in ``packages`` here overwrite the values in repodata.json.  Any value set to None is removed.
+
+A tool on our end will download this package when it sees updates to it, and will apply the patch_instructions.json to the repodata for the static repodata mirror that @kalefranz has proposed.
+
+cc @conda-forge/core - I tried to add everyone to maintainers.  My apologies if I overlooked anyone.


### PR DESCRIPTION
This scheme is ultimately meant to generate one file per subdir, ``patch_instructions.json``.  That file has entries by 

```
instructions = {
        "patch_instructions_version": 1,
        "packages": defaultdict(dict),
        "revoke": [],
        "remove": [],
    }
```

```revoke``` and ```remove``` are lists of filenames.  ```remove``` makes the file not show up in the index (it may still be downloadable with a direct URL to the file).  ```revoke``` makes packages uninstallable by adding an unsatisfiable dependency.  This can be made installable by including a channel that has that package (to be created by @jjhelmus).

``packages`` is a dictionary, where keys are package filenames.  Values are dictionaries similar to the contents of each package in repodata.json.  Any values in provided in ``packages`` here overwrite the values in repodata.json.  Any value set to None is removed.

A tool on our end will download this package when it sees updates to it, and will apply the patch_instructions.json to the repodata for the static repodata mirror that @kalefranz has proposed.

cc @conda-forge/core - I tried to add everyone to maintainers.  My apologies if I overlooked anyone.