### PR TITLE
Add conda recipe for landlab package.

### DIFF
--- a/recipes/landlab/meta.yaml
+++ b/recipes/landlab/meta.yaml
@@ -33,7 +33,6 @@ requirements:
     - six
     - pyyaml
     - statsmodels
-    - nose
 
 test:
   requires:

--- a/recipes/landlab/meta.yaml
+++ b/recipes/landlab/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "landlab" %}
+{% set version = "1.5.2" %}
+
+package:
+  name: landlab
+  version: {{ version }}
+
+source:
+  url: https://github.com/landlab/landlab/archive/v{{ version }}.tar.gz
+  sha256: 130dd5281254444c74ce252272db9f8cc3f9df78de42bc0538edbc899ca92c42
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy 1.11.*
+  run:
+    - python
+    - cython
+    - numpy >=1.11,<1.14
+    - scipy
+    - xarray
+    - matplotlib
+    - numpydoc
+    - netcdf4
+    - six
+    - pyyaml
+    - statsmodels
+    - nose
+
+test:
+  requires:
+    - pytest <3.7.2
+  imports:
+    - landlab
+  commands:
+    - pytest --pyargs landlab --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
+
+about:
+  home: http://landlab.github.io
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: A python toolkit for modeling earth surface processes
+  description: |
+    Landlab creates an environment in which scientists can build
+    a numerical landscape model without having to code all of the
+    individual components. Landscape models compute flows of mass,
+    such as water, sediment, glacial ice, volcanic material, or
+    landslide debris, across a gridded terrain surface. Landscape
+    models have a number of commonalities, such as operating on a
+    grid of points and routing material across the grid. Scientists
+    who want to use a landscape model often build their own unique
+    model from the ground up, re-coding the basic building blocks
+    of their landscape model rather than taking advantage of codes
+    that have already been written.
+  doc_url: https://landlab.readthedocs.io
+  dev_url: https://github.com/landlab/landlab
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a recipe for the *landlab* package. *landlab* is a python toolkit for building Earth-surface process models. This pull request is meant to replace #6572 as it has updated metadata, points to a newer version, and (should! it does for us, anyway) build for Linux, Mac, and Windows.

Note that I've limited *pytest* to v3.7.2 as the latest version (v3.7.3) seems to have a bug that causes it to not function on Mac OSX. This limitation should be removed with the next release of *pytest*.