### PR TITLE
Add heudiconv

### DIFF
--- a/recipes/heudiconv/meta.yaml
+++ b/recipes/heudiconv/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "heudiconv" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "ef1e2a889a2c0eb4943c965f32c58e804a3d27aa3a71ba99a97d4592379e6eea" %}
+
+package:
+  name: '{{ name }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.tar.gz'
+  url: 'https://github.com/nipy/heudiconv/archive/v{{ version }}.tar.gz'
+  sha256: '{{ sha256 }}'
+
+build:
+  number: 0
+  entry_points:
+    - heudiconv=heudiconv.cli.run:main
+    - heudiconv_monitor=heudiconv.cli.monitor:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - nibabel
+    - nipype
+    - pathlib
+    - pip
+    - pydicom
+  run:
+    - python
+    - dcm2niix
+    - dcmstack
+    - nibabel
+    - nipype
+    - pathlib
+    - pydicom
+    - rdflib
+test:
+  imports:
+    - heudiconv
+    - heudiconv.cli
+    - heudiconv.external
+    - heudiconv.external.tests
+    - heudiconv.heuristics
+  commands:
+    - heudiconv --help
+    - heudiconv_monitor --help
+
+about:
+  home: https://github.com/nipy/heudiconv
+  license: Apache 2.0
+  license_family: APACHE
+  license_file: 'LICENSE'
+  summary: Heuristic DICOM Converter
+  description: 'Convert DICOM dirs based on heuristic info - HeuDiConv
+    uses the dcmstack package and dcm2niix tool to convert DICOM directories or
+    tarballs into collections of NIfTI files following pre-defined heuristic(s).
+    '
+  doc_url: 'https://github.com/nipy/heudiconv'
+  dev_url: 'https://github.com/nipy/heudiconv'
+
+extra:
+  recipe-maintainers:
+    - 'kastman'
+    - 'yarikoptic'

--- a/recipes/heudiconv/meta.yaml
+++ b/recipes/heudiconv/meta.yaml
@@ -63,3 +63,4 @@ extra:
   recipe-maintainers:
     - 'kastman'
     - 'yarikoptic'
+    - 'mgxd'

--- a/recipes/heudiconv/meta.yaml
+++ b/recipes/heudiconv/meta.yaml
@@ -45,7 +45,6 @@ test:
     - heudiconv.heuristics
   commands:
     - heudiconv --help
-    - heudiconv_monitor --help
 
 about:
   home: https://github.com/nipy/heudiconv


### PR DESCRIPTION
Here's a first try for heudiconv. It specifically does **not** test the heuristics_monitor script, which requires inotify and tinydb (inotify at least is pip-installable only and has no conda package).

Since monitor is a specialized sub-function, I think it's ok to leave out, but let me know if you think it's worth inclucding.