### PR TITLE
Add r-promises

### DIFF
--- a/recipes/r-promises/bld.bat
+++ b/recipes/r-promises/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-promises/build.sh
+++ b/recipes/r-promises/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/promises
+  mv * $PREFIX/lib/R/library/promises
+fi

--- a/recipes/r-promises/meta.yaml
+++ b/recipes/r-promises/meta.yaml
@@ -1,0 +1,73 @@
+{% set version = '1.0.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-promises
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: promises_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/promises_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/promises/promises_{{ version }}.tar.gz
+  sha256: c2dbc7734adf009377a41e570dfe0d82afb91335c9d0ca1ef464b9bdcca65558
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('cxx') }}      # [not win]
+    - {{native}}toolchain        # [win]
+    - {{posix}}filesystem        # [win]
+    - {{posix}}make
+    - {{posix}}sed  # [win]
+    - {{posix}}coreutils  # [win]
+    - {{posix}}sed               # [win]
+    - {{posix}}coreutils         # [win]
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-r6
+    - r-rcpp
+    - r-later
+    - r-magrittr
+    - r-rlang
+  run:
+    - r-base
+    - {{native}}gcc-libs         # [win]
+    - r-r6
+    - r-rcpp
+    - r-later
+    - r-magrittr
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('promises')"           # [not win]
+    - "\"%R%\" -e \"library('promises')\""  # [win]
+
+about:
+  home: https://rstudio.github.io/promises, https://github.com/rstudio/promises
+  license: MIT
+  summary: Provides fundamental abstractions for doing asynchronous programming in R using promises.
+    Asynchronous programming is useful for allowing a single R process to orchestrate
+    multiple tasks in the background while also attending to something else. Semantics
+    are similar to 'JavaScript' promises, but with a syntax that is idiomatic R.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - halldc


### PR DESCRIPTION
Adding a recipe for the [promises](https://rstudio.github.io/promises/) R package. This was created using the [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).

This is needed by https://github.com/conda-forge/r-shiny-feedstock/pull/2.