### PR TITLE
Add r-later

### DIFF
--- a/recipes/r-later/bld.bat
+++ b/recipes/r-later/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-later/build.sh
+++ b/recipes/r-later/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/later
+  mv * $PREFIX/lib/R/library/later
+fi

--- a/recipes/r-later/meta.yaml
+++ b/recipes/r-later/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = '0.7.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-later
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: later_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/later_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/later/later_{{ version }}.tar.gz
+  sha256: 5c57148c255ee5da61cb748550b73bad7094f4e045b99b362473be5e3dbc4212
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('cxx') }}      # [not win]
+    - {{native}}toolchain        # [win]
+    - {{posix}}filesystem        # [win]
+    - {{posix}}make
+    - {{posix}}sed  # [win]
+    - {{posix}}coreutils  # [win]
+    - {{posix}}sed               # [win]
+    - {{posix}}coreutils         # [win]
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-bh
+    - r-rcpp >=0.12.9
+    - r-rlang
+  run:
+    - r-base
+    - {{native}}gcc-libs         # [win]
+    - r-bh
+    - r-rcpp >=0.12.9
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('later')"           # [not win]
+    - "\"%R%\" -e \"library('later')\""  # [win]
+
+about:
+  home: https://github.com/r-lib/later
+  license: GPL (>= 2)
+  summary: Executes arbitrary R or C functions some time after the current time, after the R
+    execution stack has emptied.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - halldc


### PR DESCRIPTION
Adding a recipe for the [later](https://cran.r-project.org/package=later) R package. This was created using the [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).

This is needed by https://github.com/conda-forge/staged-recipes/pull/6591.

I found the license confusing - should this be GPL-2 or GPL-3?