### PR TITLE
Add gpstime

### DIFF
--- a/recipes/gpstime/meta.yaml
+++ b/recipes/gpstime/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "gpstime" %}
+{% set version = "0.3.2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  git_url: https://git.ligo.org/cds/gpstime.git
+  git_tag: {{ version }}
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: true  # [win]
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - setuptools
+    - python-dateutil
+    - requests
+    - coreutils  # [osx]
+
+test:
+  imports:
+    - gpstime
+  requires:
+    - pytest
+  commands:
+    - pytest --pyargs gpstime.test
+    - gpstime --help
+    - ietf-leap-seconds --help
+
+about:
+  home: https://git.ligo.org/cds/gpstime
+  dev_url: https://git.ligo.org/cds/gpstime
+  license: Other
+  license_family: GPL
+  license_file: COPYING
+  summary: GPS-aware datetime module
+  description: |
+    This package provides a gpstime package, including a gpstime subclass
+    of the built-in datetime class with the addition of GPS access and
+    conversion methods.
+
+    Leap second data is provided by the ietf_leap_seconds module that
+    helps automatically maintain a local copy of the IETF leap second
+    list:
+
+      https://www.ietf.org/timezones/data/leap-seconds.list
+
+    A command-line GPS data conversion utility that uses the gpstime
+    module is also included.  It is a rough work-alike to "tconvert".
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/gpstime/meta.yaml
+++ b/recipes/gpstime/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   skip: true  # [win]
 

--- a/recipes/gpstime/meta.yaml
+++ b/recipes/gpstime/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - setuptools
     - python-dateutil
     - requests
-    - coreutils  # [osx]
+    - coreutils
 
 test:
   imports:


### PR DESCRIPTION
This PR adds `gpstime`, a GPS-aware datetime module used in GW astrophysics.