### PR TITLE
Add ldas-tools-al

### DIFF
--- a/recipes/ldas-tools-al/build.sh
+++ b/recipes/ldas-tools-al/build.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 ./configure \
-    CXXFLAGS="${CXXFLAGS} --std=c++14" \
     --prefix=${PREFIX} \
-    --disable-tcl \
-    --with-optimization=extreme \
+    --with-optimization=high \
     --without-doxygen
 make -j ${CPU_COUNT}
 make -j ${CPU_COUNT} check

--- a/recipes/ldas-tools-al/build.sh
+++ b/recipes/ldas-tools-al/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+./configure \
+    CXXFLAGS="${CXXFLAGS} --std=c++14" \
+    --prefix=${PREFIX} \
+    --disable-tcl \
+    --with-optimization=extreme \
+    --without-doxygen
+make -j ${CPU_COUNT}
+make -j ${CPU_COUNT} check
+make -j ${CPU_COUNT} install

--- a/recipes/ldas-tools-al/meta.yaml
+++ b/recipes/ldas-tools-al/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "ldas-tools-al" %}
+{% set version = "2.6.0" %}
+{% set sha256 = "10d23dcbb342dd8cf6157c8b793c74210cd9d9124302a6f2c5f28ec7a801a5b9" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - zlib
+    - swig
+    - boost-cpp
+    - openssl
+  run:
+    - zlib
+    - openssl
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/ldastoolsal/ldas_types.h  # [not win]
+    - test -f ${PREFIX}/lib/libldastoolsal${SHLIB_EXT}  # [not win]
+    - test -f ${PREFIX}/lib/pkgconfig/ldastoolsal.pc  # [not win]
+
+about:
+  home: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+  doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+  dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+  license: GPLv2
+  license_family: GPL
+  license_file: COPYING
+  summary: LDAS tools abstraction toolkit
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros


### PR DESCRIPTION
This PR provides `ldas-tools-al`, the abstraction library for the `ldastools` suite used in GW astrophysics.