### PR TITLE
Add ldas-tools-framecpp

### DIFF
--- a/recipes/ldas-tools-framecpp/build.sh
+++ b/recipes/ldas-tools-framecpp/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+./configure \
+    --prefix=${PREFIX} \
+    --disable-warnings-as-errors \
+    --with-optimization=high \
+    --without-doxygen \
+    --without-boost-unit-test-framework
+make -j ${CPU_COUNT}
+make -j ${CPU_COUNT} check
+make -j ${CPU_COUNT} install

--- a/recipes/ldas-tools-framecpp/meta.yaml
+++ b/recipes/ldas-tools-framecpp/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "ldas-tools-framecpp" %}
+{% set version = "2.6.2" %}
+{% set sha256 = "fb6f4913cf2282707336ccb12d8d4d392fb9bc69a4af7f78e8a4dbdc471f7cbe" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - zlib
+    - boost-cpp
+    - openssl
+    - ldas-tools-al >=2.6.0
+  run:
+    - zlib
+    - openssl
+    - ldas-tools-al >=2.6.0
+
+test:
+  commands:
+    - framecpp_checksum --help
+    - framecpp_compressor --help
+    - framecpp_dump_channel --help
+    - framecpp_dump_objects --help
+    - framecpp_dump_toc --help
+    - framecpp_fix_metadata --help
+    - framecpp_query --help
+    - framecpp_sample --help
+    - framecpp_transform --help
+    - framecpp_verify --help
+
+about:
+  home: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-framecpp/framecpp/html/
+  dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+  doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-framecpp/framecpp/html/
+  license: GPLv2
+  license_family: GPL
+  license_file: COPYING
+  summary: LDAS tools libframecpp toolkit runtime files
+  description: |
+    This provides the runtime libraries for the framecpp library.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros


### PR DESCRIPTION
This PR adds `ldas-tools-framecpp`, the GWF I/O library, part of the `ldastools` suite used in GW astrophysics.