### PR TITLE
Add dask-image

### DIFF
--- a/recipes/dask-image/meta.yaml
+++ b/recipes/dask-image/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "dask-image" %}
+{% set version = "0.1.1" %}
+{% set sha256 = "e6294ac577a8fc0abec2b97a2c42d404f599feac61d6899bdf1bf2b7cfb0e015" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - pip
+    - python
+    - setuptools
+
+  run:
+    - python
+    - dask >=0.13.0
+    - numpy >=1.11.3
+    - scipy >=0.19.1
+    - pims >=0.4.1
+
+test:
+  source_files:
+    - tests
+
+  imports:
+    - dask_image
+
+  requires:
+    - pytest >=3.0.5
+    - scikit-image >=0.12.3
+
+  commands:
+    - pytest
+
+about:
+  home: https://github.com/dask/dask-image
+  license: BSD 3-Clause
+  license_file: LICENSE.txt
+  summary: Distributed image processing
+  doc_url: https://dask-image.readthedocs.io/
+  dev_url: https://github.com/dask/dask-image
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
Creates a package for [`dask-image`]( https://pypi.org/project/dask-image ), a distributed image processing.