### PR TITLE
Fix version checks in xmitgcm

### DIFF
--- a/recipes/xmitgcm/meta.yaml
+++ b/recipes/xmitgcm/meta.yaml
@@ -21,8 +21,8 @@ requirements:
     - pytest-runner
   run:
     - python
-    - xarray >= 0.10.1
-    - dask >= 0.12
+    - xarray >=0.10.1
+    - dask >=0.12
     - numpy
 
 test:


### PR DESCRIPTION
These had an extra space after the comparison checks that was not caughtby `conda-build`, but was caught during feedstock conversion. This removes them.

xref: https://github.com/conda-forge/staged-recipes/pull/6373

cc @raphaeldussin @synapticarbors