### PR TITLE
Add ldas-tools-al-swig

### DIFF
--- a/recipes/ldas-tools-al-swig/build.sh
+++ b/recipes/ldas-tools-al-swig/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mkdir -p build
+pushd build
+
+if [ "${PY3K}" -eq 1 ]; then
+	_PYTHON_BUILD_OPTS="-DENABLE_SWIG_PYTHON2=no -DENABLE_SWIG_PYTHON3=yes -DPYTHON3_EXECUTABLE=${PYTHON}"
+else
+	_PYTHON_BUILD_OPTS="-DENABLE_SWIG_PYTHON3=no -DENABLE_SWIG_PYTHON2=yes -DPYTHON2_EXECUTABLE=${PYTHON}"
+fi
+
+cmake .. \
+	${_PYTHON_BUILD_OPTS} \
+	-DCMAKE_INSTALL_PREFIX=${PREFIX}
+cmake --build . --config Release -- -j${CPU_COUNT}
+ctest -V
+cmake --build . --target install
+
+popd

--- a/recipes/ldas-tools-al-swig/meta.yaml
+++ b/recipes/ldas-tools-al-swig/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "ldas-tools-al-swig" %}
+{% set version = "2.6.4" %}
+{% set sha256 = "70c218dcdd000c9c6108b297e134b316a37d89fbd2627e1a47a459690c5a43d1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - make
+    - cmake >=3.6
+    - {{ compiler('cxx') }}
+  host:
+    - swig
+    - ldas-tools-al >=2.6.0
+    - ldas-tools-cmake >=1.0.3
+    - boost-cpp
+    - python
+  run:
+    - ldas-tools-al >=2.6.0
+    - python
+
+test:
+  imports:
+    - LDAStools
+
+outputs:
+  - name: python-ldas-tools-al
+    requirements:
+      host:
+        - ldas-tools-al >=2.6.0
+        - python
+        - numpy
+      run:
+        - ldas-tools-al >=2.6.0
+        - python
+        - {{ pin_compatible('numpy') }}
+    files:
+      - lib/python*/site-packages/LDAStools/__init__.py*
+      - lib/python*/site-packages/LDAStools/__pycache__/__init__.*.py*  # [not py27]
+    test:
+      imports:
+        - LDAStools
+    about:
+      home: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+      dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+      doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+      license: GPLv2
+      license_family: GPL
+      license_file: COPYING
+      summary: Python bindings for the LDAS Tools abstraction toolkit
+
+about:
+  home: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+  doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+  license: GPLv2
+  license_family: GPL
+  license_file: COPYING
+  summary: SWIG bindings for the LDAS Tools abstraction toolkit
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros

--- a/recipes/ldas-tools-al-swig/meta.yaml
+++ b/recipes/ldas-tools-al-swig/meta.yaml
@@ -56,15 +56,16 @@ outputs:
       home: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
       dev_url: https://git.ligo.org/ldastools/LDAS_Tools
       doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
-      license: GPLv2
+      license: GPLv3
       license_family: GPL
       license_file: COPYING
       summary: Python bindings for the LDAS Tools abstraction toolkit
 
 about:
   home: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
+  dev_url: https://git.ligo.org/ldastools/LDAS_Tools
   doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-al/ldastoolsal/html/
-  license: GPLv2
+  license: GPLv3
   license_family: GPL
   license_file: COPYING
   summary: SWIG bindings for the LDAS Tools abstraction toolkit


### PR DESCRIPTION
This PR adds the `ldas-tools-al-swig` recipe, which builds SWIG bindings for the [`ldas-tools-al`](https://anaconda.org/conda-forge/ldas-tools-al/) package. Currently only the Python bindings are built, but the recipe is constructed using `outputs` to make adding other language bindings easy in the future.

cc: @emaros