### PR TITLE
Add recipe for pymemcache [skip appveyor]

### DIFF
--- a/recipes/pymemcache/meta.yaml
+++ b/recipes/pymemcache/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
 
 requirements:
   host:

--- a/recipes/pymemcache/meta.yaml
+++ b/recipes/pymemcache/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "pymemcache" %}
+{% set version = "1.4.4" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 822464a69449cb4a0a0025a5ed093c0848b445e2dacd7f57879d57805119a35e
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - six
+
+test:
+  imports:
+    - pymemcache
+    - pymemcache.client
+    - pymemcache.test
+
+about:
+  home: https://github.com/Pinterest/pymemcache
+  license: Apache
+  license_family: APACHE
+  license_file: LICENSE.txt
+  summary: A comprehensive, fast, pure Python memcached client
+
+extra:
+  recipe-maintainers:
+    - nicoddemus
+    - tadeu

--- a/recipes/pymemcache/meta.yaml
+++ b/recipes/pymemcache/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
   host:


### PR DESCRIPTION
This package is a requirement for `clcache>=4.2`.

@tadeu please ping here if you are OK being a maintainer here as well.