### PR TITLE
Add conda recipe for pymt package.

### DIFF
--- a/recipes/pymt/meta.yaml
+++ b/recipes/pymt/meta.yaml
@@ -1,0 +1,74 @@
+{% set version = "0.2.3" %}
+
+package:
+  name: pymt
+  version: {{ version }}
+
+source:
+  url: https://github.com/csdms/pymt/archive/v{{ version }}.tar.gz
+  sha256: f684f2e96f00b9a28fc03ad159834160234d4107b8743f06c39be69a2d0d9be6
+
+build:
+  number: 0
+  skip: True  # [win]
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - xarray
+    - shapely
+    - netcdf4
+    - pyyaml
+    - esmpy
+    - cfunits
+    - jinja2
+    - model_metadata
+    - scripting
+    - landlab
+
+test:
+  requires:
+    - pytest
+  imports:
+    - pymt
+  commands:
+    - pytest --pyargs pymt --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
+
+about:
+  home: https://github.com/csdms/pymt
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python package that provides services for coupling BMI components
+  description: |
+    PyMT is an Open Source Python package, developed by the Community
+    Surface Dynamics Modeling System, that provides the necessary
+    tools used for the coupling of models that expose the Basic
+    Modeling Interface (BMI). It contains,
+    *  Tools necessary for coupling models of disparate time and space
+       scales (including grid mappers)
+    *  Time-steppers that coordinate the sequencing of coupled models
+    *  Exchange of data between BMI-enabled models
+    *  Wrappers that automatically load BMI-enabled models into the
+       PyMT framework
+    *  Utilities that support open-source interfaces (UGRID, SGRID,
+       CSDMS Standard Names, etc.)
+    *  A collection of community-submitted models, written in a variety
+       of programming languages, from a variety of process domains - but
+       all usable from within the Python programming language
+    *  A plug-in framework for adding additional BMI-enabled models to
+       the framework
+  doc_url: https://pymt.readthedocs.io
+  dev_url: https://github.com/csdms/pymt
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a recipe for the pymt package. pymt provides tools necessary for model coupling in the Earth Sciences within a Python environment.