### PR TITLE
Pin conda-build to 3.13.0 because version 3.14.0 and 3.14.1 are broken

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - cmd: appveyor-retry conda.exe update --yes --quiet conda
 
 
-    - cmd: appveyor-retry conda.exe install --yes --quiet conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build
+    - cmd: appveyor-retry conda.exe install --yes --quiet conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build=3.13.0
 
     - cmd: appveyor-retry run_conda_forge_build_setup
 

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -40,7 +40,7 @@ conda clean --lock
 # Ensure that `noarch` exists otherwise `conda` won't think this channel is valid.
 conda index /home/conda/staged-recipes/build_artifacts/noarch
 
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build=3.13.0
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -29,7 +29,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build=3.13.0
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.


### PR DESCRIPTION
This is just a work around for now, since in ``conda-build`` ``3.14.1`` this problem was not fixed and it may take a while.