### PR TITLE
Add conda recipe for CHILD landscape evolution model

### DIFF
--- a/recipes/child/build.sh
+++ b/recipes/child/build.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+export CXXFLAGS="-std=c++11"
+
+cd Child/Code && mkdir _build && cd _build
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="$CXXFLAGS -O3"
+make -j$CPU_COUNT all
+make -j$CPU_COUNT install

--- a/recipes/child/meta.yaml
+++ b/recipes/child/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "18.08" %}
+
+package:
+  name: child
+  version: {{ version }}
+
+source:
+  url: https://github.com/childmodel/child/archive/v{{ version }}.tar.gz
+  sha256: bfffd8bf8f71556d4c64c09ff8eed286daa6b8e0dfa702dd20fab6c4301ded07
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('cxx') }}
+  run:
+    - libgcc
+
+test:
+  commands:
+    - child --help
+    - child --version
+
+about:
+  home: http://csdms.colorado.edu/wiki/Model:CHILD
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: The CHILD Landscape Evolution Model
+  description: |
+    CHILD computes the time evolution of a topographic surface z(x,y,t)
+    by fluvial and hillslope erosion and sediment transport.
+  doc_url: http://csdms.colorado.edu/wiki/Model:CHILD
+  dev_url: https://github.com/childmodel/child
+
+extra:
+  recipe-maintainers:
+    - mcflugen

--- a/recipes/child/meta.yaml
+++ b/recipes/child/meta.yaml
@@ -9,14 +9,13 @@ source:
   sha256: bfffd8bf8f71556d4c64c09ff8eed286daa6b8e0dfa702dd20fab6c4301ded07
 
 build:
+  skip: True  # [win]
   number: 0
 
 requirements:
   build:
-    - cmake
     - {{ compiler('cxx') }}
-  run:
-    - libgcc
+    - cmake
 
 test:
   commands:

--- a/recipes/child/meta.yaml
+++ b/recipes/child/meta.yaml
@@ -7,6 +7,9 @@ package:
 source:
   url: https://github.com/childmodel/child/archive/v{{ version }}.tar.gz
   sha256: bfffd8bf8f71556d4c64c09ff8eed286daa6b8e0dfa702dd20fab6c4301ded07
+  patches:
+  - runtime_exception.patch  # [linux]
+
 
 build:
   skip: True  # [win]

--- a/recipes/child/meta.yaml
+++ b/recipes/child/meta.yaml
@@ -8,8 +8,7 @@ source:
   url: https://github.com/childmodel/child/archive/v{{ version }}.tar.gz
   sha256: bfffd8bf8f71556d4c64c09ff8eed286daa6b8e0dfa702dd20fab6c4301ded07
   patches:
-  - runtime_exception.patch  # [linux]
-
+    - runtime_exception.patch  # [linux]
 
 build:
   skip: True  # [win]

--- a/recipes/child/runtime_exception.patch
+++ b/recipes/child/runtime_exception.patch
@@ -1,0 +1,12 @@
+diff --git a/Child/Code/ChildInterface/bmi_model.cpp b/Child/Code/ChildInterface/bmi_model.cpp
+index 4c2e714..4f071f9 100644
+--- a/Child/Code/ChildInterface/bmi_model.cpp
++++ b/Child/Code/ChildInterface/bmi_model.cpp
+@@ -1,6 +1,6 @@
+ #include <stdio.h>
+ #include <string.h>
+-
++#include <stdexcept>
+ 
+ #include "bmi_model.h"
+ 


### PR DESCRIPTION
This pull request adds a recipe for the CHILD landscape evolution model.

> Tucker, G., Lancaster, S., Gasparini, N. and Bras, R., 2001. The channel-hillslope integrated landscape development model (CHILD). In Landscape erosion and evolution modeling (pp. 349-388). Springer, Boston, MA.

CHILD computes the time evolution of a topographic surface *z(x,y,t)* by fluvial and hillslope erosion and sediment transport.