### PR TITLE
Add conda recipe for sedflux.

### DIFF
--- a/recipes/sedflux/build.sh
+++ b/recipes/sedflux/build.sh
@@ -1,0 +1,6 @@
+export CXXFLAGS="-std=c++98"
+
+mkdir _build && cd _build
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_BUILD_TYPE=Release
+make all -j$CPU_COUNT
+make install

--- a/recipes/sedflux/meta.yaml
+++ b/recipes/sedflux/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "2.2.1" %}
+
+package:
+  name: sedflux
+  version: {{ version }}
+
+source:
+  url: https://github.com/mcflugen/sedflux/archive/v{{ version }}.tar.gz
+  sha256: 9e2ecf03ec8ef3fece0ffcb7e18892dd5dcb5b556b062967696d2d347a2eb411
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - cmake
+    - pkg-config
+    - {{ compiler('c') }}
+  host:
+    - glib
+  run:
+    - glib
+
+test:
+  commands:
+    - sedflux -h
+
+about:
+  home: https://github.com/mcflugen/sedflux
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A stratigraphic basin-filling model
+  description: |
+    Sedflux-2.0 is the newest version of the Sedflux basin-filling
+    model. Sedflux-2.0 provides a framework within which individual
+    process-response models of disparate time and space resolutions
+    communicate with one another to deliver multi grain sized
+    sediment load across a continental margin.
+  doc_url: http://sedflux.readthedocs.io/
+  dev_url: http://github.com/mcflugen/sedflux
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a conda recipe for the *sedflux* stratigraphic basin-filling model.

> Hutton, E.W. and Syvitski, J.P., 2008. Sedflux 2.0: An advanced process-response model that generates three-dimensional stratigraphy. Computers & Geosciences, 34(10), pp.1319-1337.

*Sedflux* provides a framework within which individual process-response models of disparate time and space resolutions communicate with one another to deliver multi grain sized sediment load across a continental margin.