### PR TITLE
Add recipe for Verde

### DIFF
--- a/recipes/verde/meta.yaml
+++ b/recipes/verde/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "verde" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9cf26255a7a0639ea10181331b9e5b0e17b380edabb9d0aa9df16df4d92503f7
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+    - numpy
+    - scipy
+    - pandas
+    - xarray
+    - scikit-learn
+    - pooch
+
+test:
+  requires:
+    - pytest
+    - pyproj
+  imports:
+    - verde
+  commands:
+    - pytest --pyargs verde.tests.test_minimal
+
+about:
+  home: http://github.com/fatiando/verde
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: "Processing and gridding spatial data using Green's functions"
+  description: |
+    Verde is a Python library for processing spatial data (bathymetry, geophysics
+    surveys, etc) and interpolating it on regular grids (i.e., *gridding*).
+    Most gridding methods in Verde use a Green's functions approach.
+    A linear model is estimated based on the input data and then used to predict
+    data on a regular grid (or in a scatter, a profile, as derivatives).
+    The models are Green's functions from (mostly) elastic deformation theory.
+    This approach is very similar to *machine learning* so we implement gridder
+    classes that are similar to `scikit-learn <http://scikit-learn.org/>`__
+    regression classes.
+    The API is not 100% compatible but it should look familiar to those with some
+    scikit-learn experience.
+  doc_url: https://www.fatiando.org/verde
+  dev_url: https://github.com/fatiando/verde
+
+extra:
+  recipe-maintainers:
+    - leouieda


### PR DESCRIPTION
Builds a `noarch: python` package for [Verde](https://github.com/fatiando/verde).