### PR TITLE
Add r-shinycssloaders

### DIFF
--- a/recipes/r-shinycssloaders/bld.bat
+++ b/recipes/r-shinycssloaders/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-shinycssloaders/build.sh
+++ b/recipes/r-shinycssloaders/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/shinycssloaders
+  mv * $PREFIX/lib/R/library/shinycssloaders
+fi

--- a/recipes/r-shinycssloaders/meta.yaml
+++ b/recipes/r-shinycssloaders/meta.yaml
@@ -1,0 +1,60 @@
+{% set version = '0.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-shinycssloaders
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: shinycssloaders_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/shinycssloaders_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/shinycssloaders/shinycssloaders_{{ version }}.tar.gz
+  sha256: e4890ceeea49c9186cf2edc98c4ca55bbc562ab9cde240a53666b0534fd5ffae
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-digest
+    - r-glue
+    - r-shiny
+  run:
+    - r-base
+    - r-digest
+    - r-glue
+    - r-shiny
+
+test:
+  commands:
+    - $R -e "library('shinycssloaders')"           # [not win]
+    - "\"%R%\" -e \"library('shinycssloaders')\""  # [win]
+
+about:
+  home: https://github.com/andrewsali/shinycssloaders
+  license: GPL-3
+  summary: Create a lightweight Shiny wrapper for the css-loaders created by Luke Hass <https://github.com/lukehaas/css-loaders>.
+    Wrapping a Shiny output will automatically show a loader when the output is (re)calculating.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast
+    - halldc


### PR DESCRIPTION
Adding a recipe for the [shinycssloaders](https://cran.r-project.org/package=shinycssloaders) R package. This was created using the [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).