### PR TITLE
Add r-countrycode

### DIFF
--- a/recipes/r-countrycode/bld.bat
+++ b/recipes/r-countrycode/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-countrycode/build.sh
+++ b/recipes/r-countrycode/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/countrycode
+  mv * $PREFIX/lib/R/library/countrycode
+fi

--- a/recipes/r-countrycode/meta.yaml
+++ b/recipes/r-countrycode/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = '1.00.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-countrycode
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: countrycode_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/countrycode_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/countrycode/countrycode_{{ version }}.tar.gz
+  sha256: 460360f46ac1a7236f67eaefaf3ccd42799996588b8ee20288bb2f72dc9251ac
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('countrycode')"           # [not win]
+    - "\"%R%\" -e \"library('countrycode')\""  # [win]
+
+about:
+  home: https://github.com/vincentarelbundock/countrycode
+  license: GPL-3
+  summary: Standardize country names, convert them into one of eleven coding schemes, convert
+    between coding schemes, and assign region descriptors.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast
+    - halldc


### PR DESCRIPTION
Adding a recipe for the [countrycode](https://cran.r-project.org/package=countrycode) R package. This was created using the [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).