### PR TITLE
A matplotlib metapackage

### DIFF
--- a/recipes/matplotlib/meta.yaml
+++ b/recipes/matplotlib/meta.yaml
@@ -1,0 +1,23 @@
+{% set version = "3.0.0" %}
+
+package:
+  name: matplotlib
+  version: {{ version }}
+
+build:
+  number: 0
+  skip: true  # [py<35]
+
+requirements:
+  run:
+    - matplotlib-core
+    - pyqt  # [not osx]
+
+test: {}
+
+about:
+  home: http://matplotlib.org/
+  license: PSF-based
+  license_url: https://matplotlib.org/users/license.html
+  license_family: PSF
+  summary: A metapackage for matplotlib


### PR DESCRIPTION
Now that matplotlib 3.0.0 has been released, I’d like to push forward the idea of splitting a `matplotlib-core` package that does not depend on `pyqt` off of `matplotlib`. This was discussed on conda-forge/matplotlib-feedstock#2 and conda-forge/matplotlib-feedstock#157. [My suggestion](https://github.com/conda-forge/matplotlib-feedstock/pull/157#issuecomment-414150325) was to rename `matplotlib(-feedstock)` to `matplotlib-core(-feedstock)`, remove the pyqt dependency from it, and to add a matplotlib metapackage that depends on the new `matplotlib-core` and `pyqt`.

This pull request adds the metapackage, but could of course only be merged after the rename.

