### PR TITLE
add scikit-video (to replace sk-video)

### DIFF
--- a/recipes/scikit-video/meta.yaml
+++ b/recipes/scikit-video/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "scikit-video" %}
 {% set version = "1.1.11" %}
-{% set sha256 = "5061d2aeae1892b73a97c89a82942b3e8eebf2fe23e59c60e06ede5f8a24ed1e" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 5061d2aeae1892b73a97c89a82942b3e8eebf2fe23e59c60e06ede5f8a24ed1e
 
 build:
   noarch: python
@@ -25,7 +23,7 @@ requirements:
     - scipy
   run:
     - python
-    - numpy
+    - {{ pin_compatible('numpy') }}
     - scipy
 
 test:

--- a/recipes/scikit-video/meta.yaml
+++ b/recipes/scikit-video/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "scikit-video" %}
+{% set version = "1.1.11" %}
+{% set sha256 = "5061d2aeae1892b73a97c89a82942b3e8eebf2fe23e59c60e06ede5f8a24ed1e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - numpy
+    - scipy
+  run:
+    - python
+    - numpy
+    - scipy
+
+test:
+  imports:
+    - skvideo
+    - skvideo.io
+    - skvideo.motion
+    - skvideo.measure
+    - skvideo.datasets
+    - skvideo.utils
+
+about:
+  home: https://github.com/scikit-video/scikit-video
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Video Processing in Python'
+
+  description: |
+    scikit-video is a Python module for video processing
+    built on top of scipy, numpy, and ffmpeg/libav
+  doc_url: http://www.scikit-video.org/
+  dev_url: https://github.com/scikit-video/scikit-video
+
+extra:
+  recipe-maintainers:
+    - carlodri


### PR DESCRIPTION
adding this recipe to replace the existing sk-video feedstock (copy&pasting from https://github.com/conda-forge/sk-video-feedstock/pull/7).

sk-video feedstock needs to be discontinued/archived.