### PR TITLE
Add flask-caching

### DIFF
--- a/recipes/flask-caching/meta.yaml
+++ b/recipes/flask-caching/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
 
 requirements:

--- a/recipes/flask-caching/meta.yaml
+++ b/recipes/flask-caching/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 about:
   home: https://github.com/sh4nks/flask-caching
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: Adds caching support to your Flask application

--- a/recipes/flask-caching/meta.yaml
+++ b/recipes/flask-caching/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "Flask-Caching" %}
+{% set version = "1.3.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5af1759e5ae3424abec918537f0201a1476ae9442452bcb5c8787468a9de0f5a
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - flask
+    - werkzeug >=0.12
+
+test:
+  imports:
+    - flask_caching
+    - flask_caching.backends
+
+about:
+  home: https://github.com/sh4nks/flask-caching
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE
+  summary: Adds caching support to your Flask application
+  doc_url: https://pythonhosted.org/Flask-Caching
+  dev_url: https://github.com/sh4nks/flask-caching
+
+extra:
+  recipe-maintainers:
+    - halldc


### PR DESCRIPTION
Created using PyPI skeleton.

I am using `flask-caching v1.3.3` as the initial conda package version, because this is required by `airflow v1.10.0`. Once this is built, we can update to `flask-caching v1.4.0`.