### PR TITLE
Add conda recipe for permamodel.

### DIFF
--- a/recipes/permamodel/meta.yaml
+++ b/recipes/permamodel/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "0.1.4" %}
+
+package:
+  name: permamodel
+  version: {{ version }}
+
+source:
+  url: https://github.com/mcflugen/permamodel/archive/v{{ version }}.tar.gz
+  sha256: 7e53d3212aa62f51ef48e2d75d762350bfec90bef1bdc2678a97dcb538c71cee
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - scipy
+    - netcdf4
+    - affine
+    - python-dateutil
+
+test:
+  imports:
+    - permamodel
+    - permamodel.components
+
+about:
+  home: https://github.com/permamodel/permamodel
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A collection of numerical permafrost models.
+  description: |
+    PermaModel project enables the broader use of permafrost models and
+    consists of several permafrost models representing a range of
+    capability and complexity. The PermaModel provides easy online access to
+    everyone who want to use permafrost models, but lack the expertise and
+    resources to develop them. It includes multiple sets of sample inputs
+    representing a variety of conditions and locations to enable immediate
+    use of any out of three permafrost models. It is built on the Community
+    Surface Dynamics Modeling System (CSDMS) Modeling Framework platform.
+    CSDMS provides an on-line environment where users can link and run models
+    from multiple Earth science disciplines. We hope that the simple user
+    interfaces, easy online access, open source models, and quick visualization
+    tools can make permafrost models accessible to a broad audience well
+    beyond the permafrost research community. These new easy-to-use modeling
+    tools could be useful to wide-range of users beyond the research community,
+    such as educators, students, and policy-makers.
+  dev_url: https://github.com/permamodel/permamodel
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a conda recipe for the *permamodel* package.

> Overeem, I., E. Jafarov, K. Wang, K. Schaefer, S. Stewart, G. Clow, M. Piper, and Y. Elshorbany (2018), A modeling toolbox for permafrost landscapes, Eos, 99, https://doi.org/10.1029/2018EO105155. Published on 28 September 2018.

*permamodel* is a Python package that makes it easier for researchers to explore predictions of how melting permafrost might affect carbon release, wetlands, and river deltas as they evolve and other interacting effects.

