### PR TITLE
New recipe FreeCADNoUI

### DIFF
--- a/recipes/freecadnoui/meta.yaml
+++ b/recipes/freecadnoui/meta.yaml
@@ -28,8 +28,8 @@ test:
     - FreeCAD
 about:
   home: http://github.com/Lordling/FreeCADNoUI
-  license: GNU Library General Public License
-  license_family: GNU
+  license: GNU Library General Public
+  license_family: GPL
   license_file: LICENSE.txt
   summary: 'A build for automated FreeCAD functionality without GUI activation.'
 

--- a/recipes/freecadnoui/meta.yaml
+++ b/recipes/freecadnoui/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "freecadnoui" %}
+{% set version = "1.0" %}
+
+package:
+  name: {{ freecadnoui }}
+  version: {{ 1.0 }}
+
+source:
+  url: https://github.com/Lordling/FreeCADNoUI/archive/freecadnoui.tar.gz
+  sha256: 2654ad8f76ca8f13d6854db200943da5a837458275c42e9e839abc4134fc7f3f
+  
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx')}}
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - FreeCAD
+about:
+  home: http://github.com/Lordling/FreeCADNoUI
+  license: GNU Library General Public License
+  license_family: GNU
+  license_file: LICENSE.txt
+  summary: 'A build for automated FreeCAD functionality without GUI activation.'
+
+  description: |
+    freecadnoui is a simple recipe for utilizing FreeCAD scripting functions
+    without activating the graphical UI.
+  doc_url: https://www.freecadweb.org/wiki/
+  dev_url: https://github.com/Lordling/FreeCADNoUI
+
+extra:
+  recipe-maintainers:
+    - Lordling


### PR DESCRIPTION
A recipe of the FreeCAD python library with lines pertaining to UI triggering removed, so that one may access python scripting functions without activating the GUI; for performance reasons. 