### PR TITLE
Add python-ligo-lw

### DIFF
--- a/recipes/python-ligo-lw/meta.yaml
+++ b/recipes/python-ligo-lw/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "python-ligo-lw" %}
+{% set version = "1.4.0" %}
+{% set sha256 = "da24692a15e7412b2ebfef2dac90d0af9aeb6da324daad773e8140256544ea0d" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - six
+    - pyyaml
+    - python-lal >=6.19.0
+    - lscsoft-glue
+
+test:
+  imports:
+    - ligo.lw
+    - ligo.lw.array
+    - ligo.lw.dbtables
+    - ligo.lw.ilwd
+    - ligo.lw.ligolw
+    - ligo.lw.lsctables
+    - ligo.lw.param
+    - ligo.lw.table
+    - ligo.lw.tokenizer
+    - ligo.lw.types
+    - ligo.lw.utils
+    - ligo.lw.utils.coincs
+    - ligo.lw.utils.ligolw_add
+    - ligo.lw.utils.ligolw_sqlite
+    - ligo.lw.utils.process
+    - ligo.lw.utils.search_summary
+    - ligo.lw.utils.segments
+    - ligo.lw.utils.time_slide
+  commands:
+    - ligolw_add --help
+    - ligolw_cut --help
+    - ligolw_print --help
+    - ligolw_sqlite --help
+
+about:
+  home: https://git.ligo.org/kipp.cannon/{{ name }}
+  license: GPLv3
+  license_family: GPL
+  license_file: LICENSE
+  summary: LIGO Light-Weight XML I/O Library
+  description: |
+    The LIGO Light-Weight XML format is widely used within gravitational-wave
+    data analysis pipelines.  This package provides a Python library to read,
+    write, and interact with documents in this format.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds [`python-ligo-lw`](https://pypi.org/project/python-ligo-lw/), an XML I/O library used in GW astrophysics.