### PR TITLE
Add lalburst

### DIFF
--- a/recipes/lalburst/build.sh
+++ b/recipes/lalburst/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Configure, build, and test a LALSuite subpackage (e.g. `lal`), including
+# the SWIG interface files, but without any actual language bindings
+#
+# This script installs to a dummy location, which is then copied into
+# the host env by install-c.sh
+
+set -e
+
+./configure \
+	--prefix="${PREFIX}" \
+	--enable-swig-iface \
+	--disable-swig-octave \
+	--disable-swig-python \
+	--disable-python \
+	--disable-gcc-flags \
+	--enable-silent-rules
+make -j ${CPU_COUNT}
+make -j ${CPU_COUNT} check

--- a/recipes/lalburst/install-c.sh
+++ b/recipes/lalburst/install-c.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+source activate "${PREFIX}"
+make install

--- a/recipes/lalburst/install-python.sh
+++ b/recipes/lalburst/install-python.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+. activate "${PREFIX}"
+
+pushd ${SRC_DIR}
+
+# configure only python bindings and pure-python extras
+./configure \
+	--prefix=$PREFIX \
+	--disable-swig-iface \
+	--enable-swig-python \
+	--enable-python \
+	--disable-doxygen \
+	--disable-gcc-flags \
+	--enable-silent-rules || { cat config.log; exit 1; }
+
+# build
+make -j ${CPU_COUNT} -C swig
+make -j ${CPU_COUNT} -C python
+
+# test
+make -j ${CPU_COUNT} -C test check
+
+# install
+make -j ${CPU_COUNT} -C swig install-exec-am  # swig bindings
+make -j ${CPU_COUNT} -C python install  # pure-python extras
+
+popd

--- a/recipes/lalburst/meta.yaml
+++ b/recipes/lalburst/meta.yaml
@@ -1,0 +1,125 @@
+{% set name = "lalburst" %}
+{% set version = "1.5.0" %}
+{% set sha256 = "2918c61c8c767bfa1fc2d439e9b7ca15e0e7a186ec045a6b563f9dcb6c1a1ca2" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.xz
+  url: http://software.ligo.org/lscsoft/source/lalsuite/{{ name }}-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+  patches:
+    # patch relative imports of lalburst.git_version
+    - python3-git_version.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - make
+    - {{ compiler('c') }}
+  host:
+    - swig >=3.0.7
+    - gsl
+    - metaio
+    - lal >=6.19.0
+    - lalmetaio >=1.4.0
+    - lalsimulation >=1.8.0
+
+outputs:
+  - name: lalburst
+    script: install-c.sh
+    requirements:
+      host:
+        - {{ compiler('c') }}
+        - make
+        - swig >=3.0.7
+        - gsl
+        - metaio
+        - lal >=6.19.0
+        - lalmetaio >=1.4.0
+        - lalsimulation >=1.8.0
+      run:
+        - gsl
+        - metaio
+        - lal >=6.19.0
+        - lalmetaio >=1.4.0
+        - lalsimulation >=1.8.0
+    test:
+      commands:
+        - lalburst_version --verbose
+    about:
+      home: https://wiki.ligo.org/DASWG/LALSuite
+      license: GPLv3
+      license_family: GPL
+      license_file: COPYING
+      summary: LSC Algorithm Burst Library
+      description: |
+        The LSC Algorithm Burst Library for gravitational wave data analysis.
+        This package contains the shared-object libraries needed to run
+        applications that use the LAL Burst library.
+
+  - name: python-lalburst
+    script: install-python.sh
+    requirements:
+      host:
+        - {{ compiler('c') }}
+        - make
+        - pkg-config
+        - swig >=3.0.7
+        - {{ pin_subpackage('lalburst', exact=True) }}
+        - python
+        - numpy
+        - python-lal >=6.19.0
+        - python-lalmetaio >=1.4.0
+        - python-lalsimulation >=1.8.0
+      run:
+        - {{ pin_subpackage('lalburst', exact=True) }}
+        - python
+        - {{ pin_compatible('numpy') }}
+        - python-lal >=6.19.0
+        - python-lalmetaio >=1.4.0
+        - python-lalsimulation >=1.8.0
+        - matplotlib
+    test:
+      imports:
+        - lalburst
+        - lalburst.SimBurstUtils
+        - lalburst.SnglBurstUtils
+        - lalburst.binjfind
+        - lalburst.bucluster
+        - lalburst.burca
+        - lalburst.burca_tailor
+        - lalburst.cafe
+        - lalburst.calc_likelihood
+        - lalburst.cs_gamma
+        - lalburst.date
+        - lalburst.packing
+        - lalburst.snglcluster
+        - lalburst.snglcoinc
+        - lalburst.timeslides
+    about:
+      home: https://wiki.ligo.org/DASWG/LALSuite
+      license: GPLv3
+      license_family: GPL
+      license_file: COPYING
+      summary: LSC Algorithm Burst Library
+      description: |
+        The LSC Algorithm Burst Library for gravitational wave data analysis.
+        This package contains the python bindings.
+
+about:
+  home: https://wiki.ligo.org/DASWG/LALSuite
+  license: GPLv3
+  license_family: GPL
+  summary: LSC Algorithm Burst Library
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - skymoo

--- a/recipes/lalburst/python3-git_version.patch
+++ b/recipes/lalburst/python3-git_version.patch
@@ -1,0 +1,204 @@
+From 065f6bcc25b2a7ed46f9f2018b7f272f5d37932f Mon Sep 17 00:00:00 2001
+From: Duncan Macleod <duncan.macleod@ligo.org>
+Date: Tue, 2 Oct 2018 16:18:16 +0100
+Subject: [PATCH] lalburst: use relative imports
+
+fixes an `ImportError` when using python > 2
+---
+ lalburst/python/lalburst/SimBurstUtils.py   | 4 ++--
+ lalburst/python/lalburst/SnglBurstUtils.py  | 4 ++--
+ lalburst/python/lalburst/binjfind.py        | 4 ++--
+ lalburst/python/lalburst/bucluster.py       | 4 ++--
+ lalburst/python/lalburst/burca.py           | 4 ++--
+ lalburst/python/lalburst/burca_tailor.py    | 4 ++--
+ lalburst/python/lalburst/cafe.py            | 4 ++--
+ lalburst/python/lalburst/calc_likelihood.py | 4 ++--
+ lalburst/python/lalburst/packing.py         | 4 ++--
+ lalburst/python/lalburst/snglcluster.py     | 4 ++--
+ lalburst/python/lalburst/stringutils.py     | 4 ++--
+ lalburst/python/lalburst/timeslides.py      | 4 ++--
+ 12 files changed, 24 insertions(+), 24 deletions(-)
+
+diff --git a/lalburst/python/lalburst/SimBurstUtils.py b/lalburst/python/lalburst/SimBurstUtils.py
+index 0087947bd7..f2638d87d6 100644
+--- a/lalburst/python/lalburst/SimBurstUtils.py
++++ b/lalburst/python/lalburst/SimBurstUtils.py
+@@ -39,8 +39,8 @@ from . import SnglBurstUtils
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/SnglBurstUtils.py b/lalburst/python/lalburst/SnglBurstUtils.py
+index 77b33de0c9..304e9f552f 100644
+--- a/lalburst/python/lalburst/SnglBurstUtils.py
++++ b/lalburst/python/lalburst/SnglBurstUtils.py
+@@ -55,8 +55,8 @@ from glue.offsetvector import offsetvector
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/binjfind.py b/lalburst/python/lalburst/binjfind.py
+index 4fdefdf02d..5687036df0 100644
+--- a/lalburst/python/lalburst/binjfind.py
++++ b/lalburst/python/lalburst/binjfind.py
+@@ -55,8 +55,8 @@ from . import SimBurstUtils
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/bucluster.py b/lalburst/python/lalburst/bucluster.py
+index a348bdbc89..929bf94472 100644
+--- a/lalburst/python/lalburst/bucluster.py
++++ b/lalburst/python/lalburst/bucluster.py
+@@ -39,8 +39,8 @@ from . import snglcluster
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/burca.py b/lalburst/python/lalburst/burca.py
+index f62661c47d..1e029d505a 100644
+--- a/lalburst/python/lalburst/burca.py
++++ b/lalburst/python/lalburst/burca.py
+@@ -38,8 +38,8 @@ from . import snglcoinc
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/burca_tailor.py b/lalburst/python/lalburst/burca_tailor.py
+index 59e34ef2d2..5ef3a3cfd9 100644
+--- a/lalburst/python/lalburst/burca_tailor.py
++++ b/lalburst/python/lalburst/burca_tailor.py
+@@ -49,8 +49,8 @@ from .SimBurstUtils import MW_CENTER_J2000_RA_RAD, MW_CENTER_J2000_DEC_RAD
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/cafe.py b/lalburst/python/lalburst/cafe.py
+index 6e9df75ae8..6f0ae00f0c 100644
+--- a/lalburst/python/lalburst/cafe.py
++++ b/lalburst/python/lalburst/cafe.py
+@@ -46,8 +46,8 @@ from . import packing
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/calc_likelihood.py b/lalburst/python/lalburst/calc_likelihood.py
+index bf788708a1..0d6b5887be 100644
+--- a/lalburst/python/lalburst/calc_likelihood.py
++++ b/lalburst/python/lalburst/calc_likelihood.py
+@@ -36,8 +36,8 @@ from glue.text_progress_bar import ProgressBar
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/packing.py b/lalburst/python/lalburst/packing.py
+index 8cccf54de6..6378493ae0 100644
+--- a/lalburst/python/lalburst/packing.py
++++ b/lalburst/python/lalburst/packing.py
+@@ -30,8 +30,8 @@ This module provides bin packing utilities.
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/snglcluster.py b/lalburst/python/lalburst/snglcluster.py
+index cf040f7265..a7a22249c3 100644
+--- a/lalburst/python/lalburst/snglcluster.py
++++ b/lalburst/python/lalburst/snglcluster.py
+@@ -34,8 +34,8 @@ from glue.text_progress_bar import ProgressBar
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/stringutils.py b/lalburst/python/lalburst/stringutils.py
+index 15b0263c33..8fb473d2e6 100644
+--- a/lalburst/python/lalburst/stringutils.py
++++ b/lalburst/python/lalburst/stringutils.py
+@@ -53,8 +53,8 @@ from . import snglcoinc
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+diff --git a/lalburst/python/lalburst/timeslides.py b/lalburst/python/lalburst/timeslides.py
+index 0df3cb707c..6a4a495d5e 100644
+--- a/lalburst/python/lalburst/timeslides.py
++++ b/lalburst/python/lalburst/timeslides.py
+@@ -31,8 +31,8 @@ from glue import offsetvector
+ 
+ 
+ __author__ = "Kipp Cannon <kipp.cannon@ligo.org>"
+-from git_version import date as __date__
+-from git_version import version as __version__
++from .git_version import date as __date__
++from .git_version import version as __version__
+ 
+ 
+ #
+-- 
+2.18.0
+


### PR DESCRIPTION
This PR adds a recipe for `lalburst`, building the `lalburst` and `python-lalburst` packages, used in GW astrophysics.

cc: @skymoo as co-maintainer.