### PR TITLE
Add lalinspiral

### DIFF
--- a/recipes/lalinspiral/build.sh
+++ b/recipes/lalinspiral/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Configure, build, and test a LALSuite subpackage (e.g. `lal`), including
+# the SWIG interface files, but without any actual language bindings
+#
+# This script installs to a dummy location, which is then copied into
+# the host env by install-c.sh
+
+set -e
+
+./configure \
+	--prefix="${PREFIX}" \
+	--enable-swig-iface \
+	--disable-swig-octave \
+	--disable-swig-python \
+	--disable-python \
+	--disable-gcc-flags \
+	--enable-silent-rules
+make -j ${CPU_COUNT}
+make -j ${CPU_COUNT} check

--- a/recipes/lalinspiral/install-c.sh
+++ b/recipes/lalinspiral/install-c.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+source activate "${PREFIX}"
+make install

--- a/recipes/lalinspiral/install-python.sh
+++ b/recipes/lalinspiral/install-python.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+. activate "${PREFIX}"
+
+pushd ${SRC_DIR}
+
+# configure only python bindings and pure-python extras
+./configure \
+	--prefix=$PREFIX \
+	--disable-swig-iface \
+	--enable-swig-python \
+	--enable-python \
+	--disable-doxygen \
+	--disable-gcc-flags \
+	--enable-silent-rules || { cat config.log; exit 1; }
+
+# build
+make -j ${CPU_COUNT} -C swig
+make -j ${CPU_COUNT} -C python
+
+# install
+make -j ${CPU_COUNT} -C swig install-exec-am  # swig bindings
+make -j ${CPU_COUNT} -C python install  # pure-python extras
+
+popd

--- a/recipes/lalinspiral/meta.yaml
+++ b/recipes/lalinspiral/meta.yaml
@@ -1,0 +1,112 @@
+{% set name = "lalinspiral" %}
+{% set version = "1.8.0" %}
+{% set sha256 = "c031d878e7c06bf2c0b8ab56f6cf3a29ced4a6e85e3daab42a4101d27999b2ed" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.xz
+  url: http://software.ligo.org/lscsoft/source/lalsuite/{{ name }}-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - pkg-config
+    - make
+    - {{ compiler('c') }}
+  host:
+    - swig >=3.0.7
+    - gsl
+    - metaio
+    - lal >=6.19.0
+    - lalframe >=1.4.0
+    - lalmetaio >=1.4.0
+    - lalsimulation >=1.8.0
+
+outputs:
+  - name: lalinspiral
+    script: install-c.sh
+    requirements:
+      host:
+        - {{ compiler('c') }}
+        - make
+        - swig >=3.0.7
+        - gsl
+        - metaio
+        - lal >=6.19.0
+        - lalframe >=1.4.0
+        - lalmetaio >=1.4.0
+        - lalsimulation >=1.8.0
+      run:
+        - gsl
+        - metaio
+        - lal >=6.19.0
+        - lalframe >=1.4.0
+        - lalmetaio >=1.4.0
+        - lalsimulation >=1.8.0
+    test:
+      commands:
+        - lalinspiral_version --verbose
+    about:
+      home: https://wiki.ligo.org/DASWG/LALSuite
+      license: GPLv3
+      license_family: GPL
+      license_file: COPYING
+      summary: LSC Algorithm Inspiral Library
+      description: |
+        The LSC Algorithm Inspiral Library for gravitational wave data analysis.
+        This package contains the shared-object libraries needed to run
+        applications that use the LAL Inspiral library.
+
+  - name: python-lalinspiral
+    script: install-python.sh
+    requirements:
+      host:
+        - {{ compiler('c') }}
+        - make
+        - pkg-config
+        - swig >=3.0.7
+        - {{ pin_subpackage('lalinspiral', exact=True) }}
+        - python
+        - numpy
+      run:
+        - {{ pin_subpackage('lalinspiral', exact=True) }}
+        - python
+        - {{ pin_compatible('numpy') }}
+        - python-lal >=6.19.0
+        - python-lalframe >=1.4.0
+        - python-lalmetaio >=1.4.0
+        - python-lalsimulation >=1.8.0
+        - python-lalburst
+    test:
+      imports:
+        - lalinspiral
+        - lalinspiral.inspinjfind
+        - lalinspiral.sbank
+        - lalinspiral.thinca
+    about:
+      home: https://wiki.ligo.org/DASWG/LALSuite
+      license: GPLv3
+      license_family: GPL
+      license_file: COPYING
+      summary: LSC Algorithm Inspiral Library
+      description: |
+        The LSC Algorithm Inspiral Library for gravitational wave data analysis.
+        This package contains the python bindings.
+
+about:
+  home: https://wiki.ligo.org/DASWG/LALSuite
+  license: GPLv3
+  license_family: GPL
+  summary: LSC Algorithm Inspiral Library
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - skymoo


### PR DESCRIPTION
This PR adds a recipe for `lalinspiral`, building the `lalinspiral` and `python-lalinspiral` packages, used in GW astrophysics.

cc: @skymoo as co-maintainer.