### PR TITLE
Add conda recipe for pymt_hydrotrend.

### DIFF
--- a/recipes/pymt_hydrotrend/meta.yaml
+++ b/recipes/pymt_hydrotrend/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [win]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/pymt_hydrotrend/meta.yaml
+++ b/recipes/pymt_hydrotrend/meta.yaml
@@ -37,9 +37,6 @@ test:
   imports:
     - pymt
     - pymt_hydrotrend
-  commands:
-    - config_file=$(mmd-stage Hydrotrend . > MANIFEST && mmd-query Hydrotrend --var=run.config_file.path)
-    - bmi-test pymt_hydrotrend.bmi:Hydrotrend --infile=$config_file --manifest=MANIFEST -v
 
 about:
   home: https://github.com/mcflugen/pymt_hydrotrend

--- a/recipes/pymt_hydrotrend/meta.yaml
+++ b/recipes/pymt_hydrotrend/meta.yaml
@@ -31,9 +31,6 @@ requirements:
     - hydrotrend 
 
 test:
-  requires:
-    - bmi-tester
-    - model_metadata
   imports:
     - pymt
     - pymt_hydrotrend

--- a/recipes/pymt_hydrotrend/meta.yaml
+++ b/recipes/pymt_hydrotrend/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = "0.1.1" %}
+
+package:
+  name: pymt_hydrotrend
+  version: {{ version }}
+
+source:
+  url: https://github.com/mcflugen/pymt_hydrotrend/archive/v{{ version }}.tar.gz
+  sha256: c8b252552aa3e82e71f091d7848f7a8d927b7a9796bf4260be76a02e9d56aa49
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy 1.11.*
+    - model_metadata
+    - hydrotrend 
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pymt
+    - hydrotrend 
+
+test:
+  requires:
+    - bmi-tester
+    - model_metadata
+  imports:
+    - pymt
+    - pymt_hydrotrend
+  commands:
+    - config_file=$(mmd-stage Hydrotrend . > MANIFEST && mmd-query Hydrotrend --var=run.config_file.path)
+    - bmi-test pymt_hydrotrend.bmi:Hydrotrend --infile=$config_file --manifest=MANIFEST -v
+
+about:
+  home: https://github.com/mcflugen/pymt_hydrotrend
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python package that wraps the hydrotrend BMI.
+  dev_url: https://github.com/mcflugen/pymt_hydrotrend
+
+extra:
+  recipe-maintainers:
+    - mcflugen

--- a/recipes/pymt_hydrotrend/meta.yaml
+++ b/recipes/pymt_hydrotrend/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [win]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:


### PR DESCRIPTION
This pull request adds a conda recipe for `pymt_hydrotrend`, a plugin to the [`pymt`](https://github.com/conda-forge/pymt-feedstock) for the [`hydrotrend`](https://github.com/conda-forge/hydrotrend-feedstock) water-balance model.