### PR TITLE
Add sleekxmpp and ligo-lvalert

### DIFF
--- a/recipes/ligo-lvalert/meta.yaml
+++ b/recipes/ligo-lvalert/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "ligo-lvalert" %}
+{% set version = "1.5.3" %}
+{% set sha256 = "4978166f8c142aa8cc909f88a37d0d27f65ebfae0426dfa28ccdb3e2f87b526b" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  entry_points:
+    - lvalert = ligo.lvalert.tool:main
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - six
+    - ligo-common
+    - sleekxmpp
+    - m2crypto
+    - dnspython
+    - numpy
+
+test:
+  imports:
+    - ligo.lvalert
+    - ligo.lvalert.tool
+    - ligo.lvalert.utils
+    - ligo.lvalert.version
+  commands:
+    - lvalert --help
+
+about:
+  home: https://wiki.ligo.org/DASWG/LVAlert
+  dev_url: https://git.ligo.org/lscsoft/lvalert
+  license: GPLv2+
+  license_family: GPL
+  license_file: COPYING
+  summary: LVAlert Client Tools
+  description: |
+    LVAlert is an XMPP-based alert system. This package provides client
+    tools for interacting with the LVAlert jabber server.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - tprestegard
+    - aepace

--- a/recipes/sleekxmpp/meta.yaml
+++ b/recipes/sleekxmpp/meta.yaml
@@ -1,0 +1,142 @@
+{% set name = "sleekxmpp" %}
+{% set version = "1.3.3" %}
+{% set sha256 = "d213c1de71d92505f95ced0460ee0f84fdc4ddcacb7d7dd343739ed4028e5569" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - dnspython
+    - pyasn1
+    - pyasn1-modules
+
+test:
+  imports:
+    - sleekxmpp
+    - sleekxmpp.stanza
+    - sleekxmpp.test
+    - sleekxmpp.roster
+    - sleekxmpp.util
+    - sleekxmpp.util.sasl
+    - sleekxmpp.xmlstream
+    - sleekxmpp.xmlstream.matcher
+    - sleekxmpp.xmlstream.handler
+    - sleekxmpp.plugins
+    - sleekxmpp.plugins.xep_0004
+    - sleekxmpp.plugins.xep_0004.stanza
+    - sleekxmpp.plugins.xep_0009
+    - sleekxmpp.plugins.xep_0009.stanza
+    - sleekxmpp.plugins.xep_0012
+    - sleekxmpp.plugins.xep_0013
+    - sleekxmpp.plugins.xep_0016
+    - sleekxmpp.plugins.xep_0020
+    - sleekxmpp.plugins.xep_0027
+    - sleekxmpp.plugins.xep_0030
+    - sleekxmpp.plugins.xep_0030.stanza
+    - sleekxmpp.plugins.xep_0033
+    - sleekxmpp.plugins.xep_0047
+    - sleekxmpp.plugins.xep_0048
+    - sleekxmpp.plugins.xep_0049
+    - sleekxmpp.plugins.xep_0050
+    - sleekxmpp.plugins.xep_0054
+    - sleekxmpp.plugins.xep_0059
+    - sleekxmpp.plugins.xep_0060
+    - sleekxmpp.plugins.xep_0060.stanza
+    - sleekxmpp.plugins.xep_0065
+    - sleekxmpp.plugins.xep_0066
+    - sleekxmpp.plugins.xep_0071
+    - sleekxmpp.plugins.xep_0077
+    - sleekxmpp.plugins.xep_0078
+    - sleekxmpp.plugins.xep_0080
+    - sleekxmpp.plugins.xep_0084
+    - sleekxmpp.plugins.xep_0085
+    - sleekxmpp.plugins.xep_0086
+    - sleekxmpp.plugins.xep_0091
+    - sleekxmpp.plugins.xep_0092
+    - sleekxmpp.plugins.xep_0095
+    - sleekxmpp.plugins.xep_0096
+    - sleekxmpp.plugins.xep_0107
+    - sleekxmpp.plugins.xep_0108
+    - sleekxmpp.plugins.xep_0115
+    - sleekxmpp.plugins.xep_0118
+    - sleekxmpp.plugins.xep_0122
+    - sleekxmpp.plugins.xep_0128
+    - sleekxmpp.plugins.xep_0131
+    - sleekxmpp.plugins.xep_0152
+    - sleekxmpp.plugins.xep_0153
+    - sleekxmpp.plugins.xep_0172
+    - sleekxmpp.plugins.xep_0184
+    - sleekxmpp.plugins.xep_0186
+    - sleekxmpp.plugins.xep_0191
+    - sleekxmpp.plugins.xep_0196
+    - sleekxmpp.plugins.xep_0198
+    - sleekxmpp.plugins.xep_0199
+    - sleekxmpp.plugins.xep_0202
+    - sleekxmpp.plugins.xep_0203
+    - sleekxmpp.plugins.xep_0221
+    - sleekxmpp.plugins.xep_0224
+    - sleekxmpp.plugins.xep_0231
+    - sleekxmpp.plugins.xep_0235
+    - sleekxmpp.plugins.xep_0249
+    - sleekxmpp.plugins.xep_0257
+    - sleekxmpp.plugins.xep_0258
+    - sleekxmpp.plugins.xep_0279
+    - sleekxmpp.plugins.xep_0280
+    - sleekxmpp.plugins.xep_0297
+    - sleekxmpp.plugins.xep_0308
+    - sleekxmpp.plugins.xep_0313
+    - sleekxmpp.plugins.xep_0319
+    - sleekxmpp.plugins.xep_0323
+    - sleekxmpp.plugins.xep_0323.stanza
+    - sleekxmpp.plugins.xep_0325
+    - sleekxmpp.plugins.xep_0325.stanza
+    - sleekxmpp.plugins.xep_0332
+    - sleekxmpp.plugins.xep_0332.stanza
+    - sleekxmpp.plugins.google
+    - sleekxmpp.plugins.google.gmail
+    - sleekxmpp.plugins.google.auth
+    - sleekxmpp.plugins.google.settings
+    - sleekxmpp.plugins.google.nosave
+    - sleekxmpp.features
+    - sleekxmpp.features.feature_mechanisms
+    - sleekxmpp.features.feature_mechanisms.stanza
+    - sleekxmpp.features.feature_starttls
+    - sleekxmpp.features.feature_bind
+    - sleekxmpp.features.feature_session
+    - sleekxmpp.features.feature_rosterver
+    - sleekxmpp.features.feature_preapproval
+    - sleekxmpp.thirdparty
+
+about:
+  home: https://github.com/fritzy/SleekXMPP
+  license: MIT
+  license_family: MIT
+  summary: SleekXMPP is an elegant Python library for XMPP (aka Jabber, Google Talk, etc).
+  description: |
+    SleekXMPP is an MIT licensed XMPP library for Python 2.6/3.1+,
+    and is featured in examples in XMPP: The Definitive Guide
+    (http://oreilly.com/catalog/9780596521271) by Kevin Smith, Remko Tronçon,
+    and Peter Saint-Andre.
+    If you've arrived here from reading the Definitive Guide, please see
+    the notes on updating the examples to the latest version of SleekXMPP.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/sleekxmpp/meta.yaml
+++ b/recipes/sleekxmpp/meta.yaml
@@ -128,6 +128,7 @@ about:
   home: https://github.com/fritzy/SleekXMPP
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   summary: SleekXMPP is an elegant Python library for XMPP (aka Jabber, Google Talk, etc).
   description: |
     SleekXMPP is an MIT licensed XMPP library for Python 2.6/3.1+,


### PR DESCRIPTION
This PR adds two new recipes:

- [`sleekxmpp`](https://pypi.org/project/sleekxmpp/) - **I am not a developer or maintainer on this project**
- [`ligo-lvalert`](https://pypi.org/project/ligo-lvalert/) - used for event notifications in GW astrophysics

cc: @aepace, @tprestegard as co-maintainers of `ligo-lvalert`.