### PR TITLE
Add recipe for C++ library sdsl-lite

### DIFF
--- a/recipes/sdsl-lite/meta.yaml
+++ b/recipes/sdsl-lite/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "sdsl-lite" %}
+{% set version = "v2.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_rev: {{ version }}
+  git_url: https://github.com/simongog/{{ name|lower }}.git
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: ./install.sh
+
+requirements:
+  build:
+    - gcc-5 # [linux]
+    - clang >=3.2 # [osx]
+    - cmake
+
+  run:
+    - gcc-5 # [linux]
+    - clang >=3.2 # [osx]
+
+test:
+  source_files:
+    - Make.helper
+    - examples
+
+  commands:
+    - cd examples && make fm-index.x intersect.x
+
+about:
+  home: https://github.com/simongog/sdsl-lite
+  license: GPL-3
+  license_family: GPL
+  license_file: COPYING
+  summary: 'Succinct Data Structure Library for C++11'
+  description: |
+    The Succinct Data Structure Library (SDSL) is a powerful and flexible
+    C++11 library implementing succinct data structures. In total, the
+    library contains the highlights of 40 research publications. Succinct
+    data structures can represent an object (such as a bitvector or a tree)
+    in space close to the information-theoretic lower bound of the object
+    while supporting operations of the original object efficiently. The
+    theoretical time complexity of an operation performed on the classical
+    data structure and the equivalent succinct data structure are (most of
+    the time) identical.
+  doc_url: https://github.com/simongog/sdsl-lite/wiki
+  dev_url: https://github.com/simongog/sdsl-lite
+
+extra:
+  recipe-maintainers:
+    - johnlees


### PR DESCRIPTION
Builds the SDSL C++ library, and tests by compiling two of the examples

Things I wasn't 100% sure were right to do:
* I've used `git_url` as submodules are needed - can this be combined with a checksum?
* I used the compiler packages explicitly, as SDSL requires gcc >=4.9. Should I use clang like that for osx, or should I use that standard compiler?