### PR TITLE
add paramnb and parambokeh

### DIFF
--- a/recipes/parambokeh/meta.yaml
+++ b/recipes/parambokeh/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.2.3" %}
+
+package:
+  name: parambokeh
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/p/parambokeh/parambokeh-{{ version }}.tar.gz
+  sha256: 1b406581b85df5d955de8e744fce969b67e36e95ea3e3c496ec8e4e72029feaf
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+
+requirements:
+  host:
+    - pip
+    - python
+    - pyct-core >=0.4.4
+  run:
+    - python
+    - param >=1.7.0
+    - bokeh >=0.12.10
+
+test:
+  imports:
+    - parambokeh
+
+about:
+  home: https://github.com/ioam/parambokeh
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Summary of the package
+  doc_url: https://parambokeh.pyviz.org/
+  dev_url: https://github.com/ioam/parambokeh
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/paramnb/meta.yaml
+++ b/recipes/paramnb/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "2.0.4" %}
+
+package:
+  name: paramnb
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/paramnb/paramnb-{{ version }}.tar.gz
+  sha256: 202240be9e290c3eba1e7e0a0563d10184634c87a8faabffa348baa3e8ad36cc
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+    - pyct-core >=0.4.4
+  run:
+    - python
+    - param >=1.7.0
+    - ipywidgets >=5.2.2
+
+test:
+  imports:
+    - paramnb
+
+about:
+  home: https://github.com/ioam/paramnb
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: Generate ipywidgets from Parameterized objects in the notebook
+  doc_url: https://paramnb.pyviz.org/
+  dev_url: https://github.com/ioam/paramnb
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
@philippjfr and @ceball I'm working on some of the recipes on the `pyviz/earthsim` stack that @rsignell-usgs needs for a workshop and I have few questions for you :grimacing: 

1. Do you have a list of pyviz members Github-IDs that would like to be added as maintainers for these recipes?
2. The [`gssha` recipe in the `pyviz` channel](https://anaconda.org/pyviz/gssha/files) references to a local source and the home URL is broken, where can I find the source distribution for that package?
3. panel is on PyPI :tada: but there is no [source distribution there](https://pypi.org/project/panel/#files) :cry: and the home link is http://pyviz.org, where can I get the source for this on too?

I have `parambokeh 2.0.3` and `paramnb 2.0.4`, from PyPI, in this PR and I'm working on another one for `filigree`. I appreciate if you can take a quick look to check if everything is OK here.