### PR TITLE
Add conda recipe for pymt_sedflux.

### DIFF
--- a/recipes/pymt_sedflux/meta.yaml
+++ b/recipes/pymt_sedflux/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/mcflugen/pymt_sedflux/archive/v{{ version }}.tar.gz
-  sha256: cace3101a7cc621fcf61bc71216be471b2159b14f95c715b9dc050606ee9b5fc
+  sha256: 2638e6b7f307a533758f44b8e83ad25d1cd6180887b36bf6757f47f535946150
 
 build:
   number: 0

--- a/recipes/pymt_sedflux/meta.yaml
+++ b/recipes/pymt_sedflux/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   skip: True  # [win]
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
     - python
     - pip
     - cython
-    - numpy 1.11.*
+    - numpy =1.11
     - model_metadata
     - sedflux
 

--- a/recipes/pymt_sedflux/meta.yaml
+++ b/recipes/pymt_sedflux/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: pymt_sedflux
+  version: {{ version }}
+
+source:
+  url: https://github.com/mcflugen/pymt_sedflux/archive/v{{ version }}.tar.gz
+  sha256: cace3101a7cc621fcf61bc71216be471b2159b14f95c715b9dc050606ee9b5fc
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy 1.11.*
+    - model_metadata
+    - sedflux
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pymt
+    - sedflux
+
+test:
+  imports:
+    - pymt
+    - pymt_sedflux
+
+about:
+  home: https://github.com/mcflugen/pymt_sedflux
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: sedflux components wrapped as PyMT plugins.
+  dev_url: https://github.com/mcflugen/pymt_sedflux
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a conda recipe for the `pymt_sedflux` package, which brings the sedflux c libraries into Python as plugins for the pymt modeling framework.