### PR TITLE
pshell recipe

### DIFF
--- a/recipes/pshell/meta.yaml
+++ b/recipes/pshell/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "1.0.0" %}
+
+package:
+  name: pshell
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/pshell/pshell-{{ version }}.tar.gz
+  sha256: 4f3d025268c32cdcdc8e1ec2082c71c462a833b186e0e4e98f773a016a496509
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+    - psutil >=3.2
+
+test:
+  imports:
+    - pshell
+  requires:
+    - pytest >=3.1
+
+about:
+  home: https://github.com/crusaderky/xarray_extras
+  license: Apache 2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: 'Python API to completely replace bash scripting'
+
+extra:
+  recipe-maintainers:
+    - crusaderky


### PR DESCRIPTION
pshell is a scripting API that aims to completely replace bash scripting.
Tried and tested at Legal & General UK since 2013.