### PR TITLE
New recipe: p11-kit 0.23.14; cryptography dependency

### DIFF
--- a/recipes/p11-kit/build.sh
+++ b/recipes/p11-kit/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure --prefix=$PREFIX
+make
+make install

--- a/recipes/p11-kit/meta.yaml
+++ b/recipes/p11-kit/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = "0.23.14" %}
+{% set sha256 = "1cb9fa6d237539f25f62f4c3d4ec71a1c8e0772957ec45ec5af92134129e0d70" %}
+
+package:
+  name: p11-kit
+  version: {{ version }}
+
+build:
+  number: 0
+
+source:
+  url: https://github.com/p11-glue/p11-kit/releases/download/{{ version }}/p11-kit-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - libffi
+    - libtasn1
+  run:
+    - libffi
+    - libtasn1
+
+test:
+  commands:
+    - p11-kit -h
+
+about:
+  home: https://github.com/p11-glue/p11-kit
+  license: MIT
+  license_file: COPYING
+  summary: Provides a way to load and enumerate PKCS#11 modules
+
+extra:
+  recipe-maintainers:
+    - chapmanb

--- a/recipes/p11-kit/meta.yaml
+++ b/recipes/p11-kit/meta.yaml
@@ -5,12 +5,12 @@ package:
   name: p11-kit
   version: {{ version }}
 
-build:
-  number: 0
-
 source:
   url: https://github.com/p11-glue/p11-kit/releases/download/{{ version }}/p11-kit-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+
+build:
+  number: 0
 
 requirements:
   build:

--- a/recipes/p11-kit/meta.yaml
+++ b/recipes/p11-kit/meta.yaml
@@ -11,6 +11,10 @@ source:
 
 build:
   number: 0
+  # Windows: libtasn1 not available
+  # OSX: libtasn1 not found despite dependency: 
+  # https://travis-ci.org/conda-forge/staged-recipes/builds/440551277#L564
+  skip: true  # [not linux]
 
 requirements:
   build:


### PR DESCRIPTION
p11-kit is a dependency for cgpBigWig (https://github.com/cancerit/cgpBigWig)
which we'll include in bioconda