### PR TITLE
add recipe for pyimgur

### DIFF
--- a/recipes/pyimgur/meta.yaml
+++ b/recipes/pyimgur/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "pyimgur" %}
+{% set version = "0.6.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # url: https://github.com/Damgaard/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: f776ca7f14663bd9ac14a1380db62c87ed32231d159d2d167ad1cb817dcb9144
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - requests
+
+test:
+  # Currently test files are not included in source dist so only check import
+  imports:
+    - pyimgur
+
+about:
+  home: http://github.com/Damgaard/PyImgur
+  license: GPL-3.0
+  license_family: GPL
+  license_file: COPYING
+  summary: 'The simple way of using Imgur.'
+  description: |
+    The simple way of using Imgur.
+
+    You can upload images, download images, read comments, update your albums,
+    message people and more. In fact, you can do almost everything via PyImgur
+    that you can via the webend.
+  doc_url: https://pyimgur.readthedocs.org/
+  dev_url: https://github.com/Damgaard/PyImgur
+
+extra:
+  recipe-maintainers:
+    - megies


### PR DESCRIPTION
Source dist currently does not contain a license file (GPLv3). What's the easiest way to include it via recipe commands (or scripts)?