### PR TITLE
Add conda recipe for pymt_child

### DIFF
--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -13,7 +13,7 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
-    build:
+  build:
     - {{ compiler('c') }}
   host:
     - python

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -36,7 +36,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: Child landscape evolution model wrapped as a PyMT plugins
+  summary: Child landscape evolution model wrapped as a PyMT plugin
   dev_url: http://github.com/mcflugen/pymt_child
 
 extra:

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
+  skip: True  # [win or linux]
 
 requirements:
   build:

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/mcflugen/pymt_child/archive/v{{ version }}.tar.gz
-  sha256: eebeef4dbf19c932ca06a6a343c021f0da04e7250d88f2c0f0414d09cff539bb
+  sha256: a9c69c988a9d791f557fc74ab48e98039b0c6a6ca832073e1f260e0713b48ef3
 
 build:
   number: 0
@@ -25,7 +25,6 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - pymt
     - child
 
 test:

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/mcflugen/pymt_child/archive/v{{ version }}.tar.gz
-  sha256: a9c69c988a9d791f557fc74ab48e98039b0c6a6ca832073e1f260e0713b48ef3
+  sha256: 62d85268a420b5b424ffbef14a1735a6f8641ceb5f6185748a918de5e8eae2d5
 
 build:
   number: 0

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/mcflugen/pymt_child/archive/v{{ version }}.tar.gz
-  sha256: 62d85268a420b5b424ffbef14a1735a6f8641ceb5f6185748a918de5e8eae2d5
+  sha256: ec2fe44a8a942c797a4c3bbc87d40e8421e89dfe1394799621be8d8f02b91b5f
 
 build:
   number: 0

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.1.1" %}
+
+package:
+  name: pymt_child
+  version: {{ version }}
+
+source:
+  url: https://github.com/mcflugen/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: eebeef4dbf19c932ca06a6a343c021f0da04e7250d88f2c0f0414d09cff539bb
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+    build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy =1.11
+    - model_metadata
+    - child
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pymt
+    - child
+
+test:
+  imports:
+    - pymt_child
+
+about:
+  home: http://github.com/mcflugen/pymt_child
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Child landscape evolution model wrapped as a PyMT plugins
+  dev_url: http://github.com/mcflugen/pymt_child
+
+extra:
+  recipe-maintainers:
+    - mcflugen

--- a/recipes/pymt_child/meta.yaml
+++ b/recipes/pymt_child/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/mcflugen/{{ name }}/archive/v{{ version }}.tar.gz
+  url: https://github.com/mcflugen/pymt_child/archive/v{{ version }}.tar.gz
   sha256: eebeef4dbf19c932ca06a6a343c021f0da04e7250d88f2c0f0414d09cff539bb
 
 build:


### PR DESCRIPTION
This pull request adds a conda recipe for the `pymt_child` package, which brings the child C++ library into Python as a plugin for the `pymt` modeling framework.
