### PR TITLE
Add conda recipe for pymt_permamodel.

### DIFF
--- a/recipes/pymt_permamodel/meta.yaml
+++ b/recipes/pymt_permamodel/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: pymt_permamodel
+  version: {{ version }}
+
+source:
+  url: https://github.com/mcflugen/pymt_permamodel/archive/v{{ version }}.tar.gz
+  sha256: 2b4fb2419f79accb140ec47bbf8f9cda2326aca2fe491433f4340ff714b2705d
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - permamodel
+
+test:
+  imports:
+    - pymt_permamodel
+
+about:
+  home: https://github.com/mcflugen/pymt_permamodel
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python package that wraps the permamodel BMI.
+  dev_url: https://github.com/mcflugen/pymt_permamodel
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a conda recipe for *pymt_permamodel* a collection of [*permamodel*](https://github.com/conda-forge/permamodel-feedstock) components as [*pymt*](https://github.com/conda-forge/pymt-feedstock) plugins.