### PR TITLE
New twine dependencies: cmarkgfm and readme_renderer

### DIFF
--- a/recipes/cmarkgfm/meta.yaml
+++ b/recipes/cmarkgfm/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "cmarkgfm" %}
+{% set version = "0.4.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f20900f16377f2109783ae9348d34bc80530808439591c3d3df73d5c7ef1a00c
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}  # [not (win and py27)]
+  host:
+    - cffi >=1.0.0
+    - pip
+    - python
+    - m2w64-toolchain  # [win and py27]
+    - libpython        # [win and py27]
+  run:
+    - cffi >=1.0.0
+    - python
+    - m2w64-gcc-libs   # [win and py27]
+
+test:
+  imports:
+    - cmarkgfm
+
+about:
+  home: https://github.com/jonparrott/cmarkgfm
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Minimal bindings to GitHub's fork of cmark
+
+extra:
+  recipe-maintainers:
+    - jjhelmus

--- a/recipes/readme_renderer/meta.yaml
+++ b/recipes/readme_renderer/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "readme_renderer" %}
+{% set version = "22.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 237ca8705ffea849870de41101dba41543561da05c0ae45b2f1c547efa9843d2
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - bleach >=2.1.0
+    - cmarkgfm >=0.2.0
+    - docutils >=0.13.1
+    - future
+    - pygments
+    - python
+    - setuptools
+    - six
+
+test:
+  imports:
+    - readme_renderer
+    - readme_renderer.integration
+
+about:
+  home: https://github.com/pypa/readme_renderer
+  license: Apache Software
+  license_family: APACHE
+  license_file: LICENSE
+  summary: readme_renderer is a library for rendering "readme" descriptions for Warehouse
+
+extra:
+  recipe-maintainers:
+    - jjhelmus


### PR DESCRIPTION
Twine added a dependency on `readme_renderer`, pypa/twine#395, which in turn requires `cmarkgfm`.  This adds recipes for both.