### PR TITLE
Add pytest-clarify recipe [skip appveyor] [skip travis]

### DIFF
--- a/recipes/pytest-clarity/meta.yaml
+++ b/recipes/pytest-clarity/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "pytest-clarity" %}
+{% set version = "0.1.0a1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 8d6a36310e1babd019feed33d047284d129f05104cd78eb6e0d22d841839ebfb
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - pytest >=3.5.0
+    - python
+    - setuptools
+    - termcolor ==1.1.0
+
+test:
+  imports:
+    - pytest_clarity
+
+about:
+  home: https://github.com/darrenburns/pytest-clarity
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A plugin providing an alternative, colourful diff output for failing assertions.
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
noarch package, so skipping most CIs