### PR TITLE
add recipe for building ggalluvial in conda

### DIFF
--- a/recipes/r-ggalluvial/bld.bat
+++ b/recipes/r-ggalluvial/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-ggalluvial/build.sh
+++ b/recipes/r-ggalluvial/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/ggalluvial
+  mv * $PREFIX/lib/R/library/ggalluvial
+  if [[ $target_platform == osx-64 ]]; then
+    pushd $PREFIX
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd $libdir || exit 1
+          for SHARED_LIB in $(find . -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R"); do
+            echo "fixing SHARED_LIB $SHARED_LIB"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "$PREFIX"/lib/libomp.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "$PREFIX"/lib/libgcc_s.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "$PREFIX"/sysroot/usr/lib/libiconv.2.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "$PREFIX"/sysroot/usr/lib/libncurses.5.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "$PREFIX"/sysroot/usr/lib/libicucore.A.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "$PREFIX"/lib/libexpat.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "$PREFIX"/lib/libcurl.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+          done
+        popd
+      done
+    popd
+  fi
+fi

--- a/recipes/r-ggalluvial/meta.yaml
+++ b/recipes/r-ggalluvial/meta.yaml
@@ -24,7 +24,7 @@ requirements:
   build:
     - {{posix}}zip               # [win]
   host:
-    - r-base >=3.3.0
+    - r-base
     - r-dplyr
     - r-ggplot2
     - r-lazyeval
@@ -32,7 +32,7 @@ requirements:
     - r-tidyr
     - r-tidyselect
   run:
-    - r-base >=3.3.0
+    - r-base
     - r-dplyr
     - r-ggplot2
     - r-lazyeval

--- a/recipes/r-ggalluvial/meta.yaml
+++ b/recipes/r-ggalluvial/meta.yaml
@@ -1,0 +1,66 @@
+{% set version = '0.9.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggalluvial
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggalluvial_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggalluvial/ggalluvial_{{ version }}.tar.gz
+  sha256: 49ea3c5dec8b0627b65a749cf545c54b5a71a7ef19c8692988362b2db311ca34
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+  host:
+    - r-base >=3.3.0
+    - r-dplyr
+    - r-ggplot2
+    - r-lazyeval
+    - r-rlang
+    - r-tidyr
+    - r-tidyselect
+  run:
+    - r-base >=3.3.0
+    - r-dplyr
+    - r-ggplot2
+    - r-lazyeval
+    - r-rlang
+    - r-tidyr
+    - r-tidyselect
+
+test:
+  commands:
+    - $R -e "library('ggalluvial')"           # [not win]
+    - "\"%R%\" -e \"library('ggalluvial')\""  # [win]
+
+about:
+  home: http://corybrunson.github.io/ggalluvial/
+  license: GPL-3
+  summary: Alluvial diagrams use x-splines, sometimes augmented with stacked histograms, to visualize
+    multi-dimensional or repeated-measures data with categorical or ordinal variables.
+    This package provides ggplot2 layers to produce alluvial diagrams from tidy data.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'  # [unix]
+  license_file: '{{ environ["PREFIX"] }}\R\share\licenses\GPL-3'  # [win]
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast
+    - russHyde


### PR DESCRIPTION
This PR relates to the [CRAN](https://cran.r-project.org/web/packages/ggalluvial/index.html) package `ggalluvial`.

The conda recipe for this R-package was created using the R-skeleton helpers
for conda-forge (see: https://github.com/bgruening/conda_r_skeleton_helper).

In addition, I set a min-version for r-base (>= 3.3.0 in the build/run sections of meta.yaml) for consistency with the CRAN dependencies.

All dependencies are already available on conda-forge