### PR TITLE
Add jupytext from PyPI

### DIFF
--- a/recipes/jupytext/meta.yaml
+++ b/recipes/jupytext/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "jupytext" %}
+{% set version = "0.8.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 05203c7efc0c7de6947a401538045a42deddbe0b01ed304905f1c9e293d0e742
+
+build:
+  number: 0
+  entry_points:
+    - jupytext = jupytext.cli:jupytext
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - mock
+    - nbformat >=4.0.0
+    - pip
+    - python
+    - pyyaml
+    - testfixtures
+  run:
+    - mock
+    - nbformat >=4.0.0
+    - python
+    - pyyaml
+    - testfixtures
+
+test:
+  imports:
+    - jupytext
+    - tests
+  commands:
+    - jupytext --help
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/mwouts/jupytext
+  license: MIT
+  license_family: MIT
+  license_file:
+  summary: Jupyter notebooks as Markdown documents, Julia, Python or R scripts
+  doc_url:
+  dev_url:
+
+extra:
+  recipe-maintainers:
+    - grst
+    - mwouts


### PR DESCRIPTION
This PR adds jupytext to conda forge. 
Jupytext is a python package that allows to edit text files (e.g. markdown) as notebooks in Jupyter notebook and Jupyter lab. 

Ref. https://github.com/mwouts/jupytext/issues/102
