### PR TITLE
add bcrypt

### DIFF
--- a/recipes/bcrypt/meta.yaml
+++ b/recipes/bcrypt/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "bcrypt" %}
+{% set version = "3.1.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - cffi >=1.1
+  run:
+    - python
+    - cffi >=1.1
+    - six >=1.4.1
+
+test:
+  source_files:
+    - tests
+  imports:
+    - bcrypt
+    - bcrypt._bcrypt
+  requires:
+    - pytest >=3.2.1,!=3.3.0
+  commands:
+    - pytest tests
+
+about:
+  home: https://github.com/pyca/bcrypt/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Modern password hashing for your software and your servers'
+  description: |
+    Modern password hashing for your software and your servers
+  doc_url: https://github.com/pyca/bcrypt/
+  dev_url: https://github.com/pyca/bcrypt/
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland


### PR DESCRIPTION
Our `flask-bcrypt` recipe is currently pulling `bcrypt` in from `defaults`.