### PR TITLE
Add shellingham (required for regro update of click-completion)

### DIFF
--- a/recipes/shellingham/meta.yaml
+++ b/recipes/shellingham/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "shellingham" %}
+{% set version = "1.2.7" %}
+
+package:
+  name: "{{ name }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f56b5547ed84296318c21162ce345d83dd5e4755a0e4f57daee1948479f47119
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - shellingham
+    - shellingham.posix
+
+about:
+  home: https://github.com/sarugaku/shellingham
+  license: ISC (ISCL)
+  license_family: OTHER
+  license_file: LICENSE
+  summary: Shellingham detects what shell the current Python executable is running in.
+
+extra:
+  recipe-maintainers:
+    - epruesse


### PR DESCRIPTION
Required for update of `click-completion` to 0.5 (conda-forge/click-completion-feedstock#4)