### PR TITLE
Add RPCQ

### DIFF
--- a/recipes/rpcq/meta.yaml
+++ b/recipes/rpcq/meta.yaml
@@ -16,14 +16,14 @@ build:
 
 requirements:
   host:
-    - python>=3.6.0
+    - python  >=3.6.0
     - pip
   run:
     - python
     - future
-    - msgpack-python>=0.5.2
+    - msgpack-python  >=0.5.2
     - python-rapidjson
-    - pyzmq>=17
+    - pyzmq  >=17
     - ruamel.yaml
     - typing
 

--- a/recipes/rpcq/meta.yaml
+++ b/recipes/rpcq/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "rpcq" %}
+{% set version = "2.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7100ba0856edfc789232fd714a303a849b1e186e0a4a54f96696b0eac97ec848
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - future
+    - msgpack-python>=0.5.2
+    - python-rapidjson
+    - pyzmq>=17
+    - ruamel.yaml
+    - typing
+
+test:
+  imports:
+    - rpcq
+
+about:
+  home: https://www.rigetti.com
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'The RPC framework and message specification for Rigetti QCS'
+  dev_url: https://github.com/rigetticomputing/rpcq
+
+extra:
+  recipe-maintainers:
+    - mpharrigan
+    - karalekas

--- a/recipes/rpcq/meta.yaml
+++ b/recipes/rpcq/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python
+    - python>=3.6.0
     - pip
   run:
     - python


### PR DESCRIPTION
The RPC framework to be used by the forthcoming release of [pyquil](https://github.com/rigetticomputing/pyquil/) to send programs to our quantum computers

cc @karalekas 