### PR TITLE
Add root_numpy

### DIFF
--- a/recipes/root_numpy/meta.yaml
+++ b/recipes/root_numpy/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  # root5 is only available for python2.7 on unix
+  skip: true  # [win or py3k]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:

--- a/recipes/root_numpy/meta.yaml
+++ b/recipes/root_numpy/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "root_numpy" %}
+{% set version = "4.7.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: af033c8e84301034c3005cf92c12f7c3eaa8b61be442c2bc21dbb5362baec66f
+
+build:
+  number: 0
+  skip: true  # [win]
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - pip
+    - python
+    - root5
+    - numpy
+  run:
+    - python
+    - root5
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - root_numpy
+  requires:
+    - nose
+  commands:
+    - nosetests -s -v {{ name }}
+
+about:
+  home: http://scikit-hep.org/root_numpy
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE
+  doc_url: http://scikit-hep.org/root_numpy
+  dev_url: https://github.com/scikit-hep/root_numpy
+  summary: The interface between ROOT and NumPy
+  description: |
+    root_numpy is a Python extension module that provides an efficient
+    interface between ROOT and NumPy. root_numpy's internals are compiled
+    C++ and can therefore handle large amounts of data much faster than
+    equivalent pure Python implementations.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds a recipe for [`root_numpy`](https://pypi.org/project/root-numpy/). **I am not a contributor to root_numpy**, just a user, so I would happily cede this recipe to someone who actually knows what they are doing.