### PR TITLE
Libva for ffmpeg encoding in intel hardware

### DIFF
--- a/recipes/cmrt/build.sh
+++ b/recipes/cmrt/build.sh
@@ -1,0 +1,6 @@
+# https://01.org/linuxgraphics/documentation/build-guide-0
+
+export CFLAGS="${CFLAGS} -lrt"
+export CXXFLAGS="${CXXFLAGS} -lrt"
+./autogen.sh --prefix=$PREFIX
+make -j$(nproc) install

--- a/recipes/cmrt/meta.yaml
+++ b/recipes/cmrt/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "cmrt" %}
+{% set version = "1.0.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/intel/{{ name }}/archive/{{ version }}.tar.gz
+  fn: cmrt-{{ version }}.tar.gz
+  sha256: ca22e905a2717fc740e703e65a0061a0e11f4ea513ba970bbc10b3bd6d28e6e0
+
+build:
+  skip: True  # [not linux]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+  host:
+    - libdrm
+    - libva
+  run:
+    - libdrm
+    - libva
+
+test:
+  commands:
+    - test -f $PREFIX/include/cm_rt.h
+    - test -f $PREFIX/include/cm_rt_linux.h
+
+about:
+  home: https://github.com/intel/cmrt
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Media GPU kernel manager for Intel G45 & HD Graphics family'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    Overview
+    --------
+    Target:
+    One solution to expose Intel’s Gen GPU’s high performance through high
+    level language.
+
+    Features:
+    Interface between host program and driver
+    Manage Gen device
+    Manage surfaces
+    Manage media GPU kernels
+    Manage events
+    Manage threads
+    Manage execution
+    Prepare media GPU kernel arguments
+    Transfer data between system and GPU memory
+    Report errors
+
+    User:
+    Media and Graphics kernel developers.
+    General purpose GPU computing developers.
+
+    Components: CM runtime engine.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/intel-hybrid-driver/meta.yaml
+++ b/recipes/intel-hybrid-driver/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "intel-hybrid-driver" %}
+{% set version = "1.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/01org/{{ name }}/archive/{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
+  sha256: 16cd66872e8043ce6c0e9a016a043c460e8a180fdc520f31c1f97ffef7828d7b
+
+build:
+  skip: True  # [not linux]
+  number: 0
+  # https://01.org/linuxgraphics/documentation/build-guide-0
+  script:
+    - ./autogen.sh --prefix=$PREFIX
+    - make -j$(nproc) install
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+  host:
+    - libdrm
+    - cmrt
+  run:
+    - libdrm
+    - cmrt
+
+test:
+  commands:
+    - test -f $PREFIX/lib/dri/hybrid_drv_video.so
+
+about:
+  home: https://github.com/01org/intel-hybrid-driver
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'VA driver for Intel G45 & HD Graphics family'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    Overview
+    --------
+    libva-intel-hybrid-driver is the VA-API implementation for Intel G45 chipsets
+    and Intel HD Graphics for Intel Core processor family.
+
+    Platform definitions:
+    HSW: Haswell
+    BYT: Bay-Trail-M
+    BDW: Broadwell
+    BSW: Braswell
+
+    Codecs
+    ------
+    Hybrid VP8 Encoder
+    Hybrid VP9 Decoder
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/intel-vaapi-driver/meta.yaml
+++ b/recipes/intel-vaapi-driver/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "intel-vaapi-driver" %}
+{% set version = "2.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/intel/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.bz2
+  sha1: 0934f97ddcaf4e633f59d049226723239b645b33
+
+build:
+  skip: True  # [not linux]
+  number: 0
+  script:
+    - ./configure --prefix=$PREFIX --enable-hybrid-codec
+    - make -j$(nproc) install
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - pkg-config
+  host:
+    - intel-hybrid-driver
+  run:
+    - intel-hybrid-driver
+
+test:
+  commands:
+    - test -f $PREFIX/lib/dri/i965_drv_video.so
+
+about:
+  home: https://github.com/intel/intel-vaapi-driver
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'VA-API (Video Acceleration API) user mode driver for Intel GEN Graphics family'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    VA-API is an open-source library and API specification, which provides
+    access to graphics hardware acceleration capabilities for video processing.
+    It consists of a main library and driver-specific acceleration backends for
+    each supported hardware vendor.
+
+    The current video driver backend provides a bridge to the GEN GPUs through
+    the packaging of buffers and commands to be sent to the i915 driver for
+    exercising both hardware and shader functionality for video decode, encode,
+    and processing.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libdrm/meta.yaml
+++ b/recipes/libdrm/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "libdrm" %}
+{% set version = "2.4.96" %}
+
+# http://www.linuxfromscratch.org/blfs/view/8.2/x/libdrm.html
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://dri.freedesktop.org/libdrm/libdrm-{{ version }}.tar.gz
+  sha256: d2bba5ca2ddfbdbc0f9f981835d31e1af373b9c1851014826c9698f80373c1bb
+
+build:
+  skip: True  # [not linux]
+  number: 0
+  # For some reason, compiling with meson, the recommended way, doesn't
+  # correctly allow libva to find libdrm
+  script:
+    - ./configure --prefix={{ PREFIX }}
+    - make -j$(nproc) install
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - pkg-config
+  host:
+    - libpciaccess
+  run:
+    - libpciaccess
+
+test:
+  commands:
+    - test -f $PREFIX/include/xf86drm.h
+    - test -f $PREFIX/include/xf86drmMode.h
+    - test -f $PREFIX/include/libsync.h
+    - test -f $PREFIX/include/libkms/libkms.h
+    - test -d $PREFIX/include/libdrm
+    - test -f $PREFIX/lib/libdrm.so
+    - test -f $PREFIX/lib/libdrm.so.2
+
+about:
+  home: https://gitlab.freedesktop.org/mesa/drm
+  license: MIT?
+  license_family: MIT
+  # license_file: COPYING
+  summary: 'userspace library for drm'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    This  is libdrm,  a userspace  library for  accessing the  DRM, direct
+    rendering  manager, on  Linux,  BSD and  other  operating systems that
+    support the  ioctl interface.  The library  provides wrapper functions
+    for the  ioctls to avoid  exposing the kernel interface  directly, and
+    for chipsets with drm memory manager, support for tracking relocations
+    and  buffers.   libdrm  is  a  low-level library,  typically  used  by
+    graphics drivers  such as the Mesa  DRI drivers, the  X drivers, libva
+    and  similar projects.  New  functionality in  the kernel  DRM drivers
+    typically requires  a new  libdrm, but a  new libdrm will  always work
+    with an older kernel.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libpciaccess/build.sh
+++ b/recipes/libpciaccess/build.sh
@@ -1,0 +1,5 @@
+set -ex
+export ACLOCAL="aclocal -I ${PREFIX}/share/aclocal"
+autoreconf --install
+./autogen.sh --prefix=$PREFIX
+make install

--- a/recipes/libpciaccess/meta.yaml
+++ b/recipes/libpciaccess/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "libpciaccess" %}
+{% set version = "0.14" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://gitlab.freedesktop.org/xorg/lib/{{ name }}/-/archive/{{ name }}-{{ version }}/{{ name }}-{{ name }}-{{ version }}.tar.bz2
+  sha256: 85919d2786858624fa8156b7dd651e1e4b78539087bf608804fd8d7afe292e71
+
+build:
+  skip: True  # [not linux]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - libtool
+    - autoconf
+    - automake
+    - pkg-config
+  host:
+    # I had to install xutils-dev on ubuntu for this to work :/
+    - xorg-util-macros
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libpciaccess.a
+    - test -f $PREFIX/lib/libpciaccess.so
+    - test -f $PREFIX/lib/libpciaccess.so.0
+    - test -f $PREFIX/lib/pkgconfig/pciaccess.pc
+    - test -f $PREFIX/include/pciaccess.h
+
+about:
+  home: https://gitlab.freedesktop.org/xorg/lib/libpciaccess
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Generic PCI access library'
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libva-utils/build.sh
+++ b/recipes/libva-utils/build.sh
@@ -1,0 +1,9 @@
+# https://01.org/linuxgraphics/documentation/build-guide-0
+# Maybe these cflags can be removed with the new compilers
+set -ev
+CFLAGS="${CFLAGS} -std=c99"
+CXXFLAGS="${CXXFLAGS} -std=c99"
+
+./autogen.sh --prefix=$PREFIX
+make -j$(nproc) install
+set +ev

--- a/recipes/libva-utils/meta.yaml
+++ b/recipes/libva-utils/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "libva-utils" %}
+{% set version = "2.3.0" %}
+
+# Follow instructions here
+# https://gist.github.com/Brainiarc7/eb45d2e22afec7534f4a117d15fe6d89
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/intel/{{ name }}/archive/{{ version }}.tar.gz
+  fn: libva-utils-{{ version }}.tar.gz
+  sha256: f338497b867bbc9bf008e4892eaebda08955785dc7eb2005855bba5f1a20b037
+
+build:
+  skip: True  # [not linux]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+  host:
+    - libva
+    - intel-vaapi-driver
+  run:
+    - libva
+    - intel-vaapi-driver
+
+test:
+  commands:
+    # We can't actually run the bare vainfo command since it requires
+    # A disply which circleci doesn't have
+    - vainfo --help
+
+about:
+  home: https://github.com/intel/libva
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Libva is an implementation for VA-API (Video Acceleration API)'
+  description: |
+    libva-utils is a collection of utilities and examples to exercise VA-API in
+    accordance with the libva project. --enable-tests (default = no) provides a
+    suite of unit-tests based on Google Test Framework. A driver implementation
+    is necessary to properly operate.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libva/meta.yaml
+++ b/recipes/libva/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "libva" %}
+{% set version = "2.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/intel/{{ name }}/archive/{{ version }}.tar.gz
+  fn: libva-{{ version }}.tar.gz
+  sha256: 8d95e65c4d84d0f82097581e163d3770694c600cbb040ebd827f2d375e004f4b
+
+build:
+  skip: True  # [not linux]
+  number: 0
+  # https://01.org/linuxgraphics/documentation/build-guide-0
+  script:
+    - ./autogen.sh --prefix=$PREFIX
+    - make -j$(nproc) install
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+  host:
+    - libdrm
+    - mesalib
+  run:
+    - libdrm
+    - mesalib
+
+test:
+  commands:
+    - test -f $PREFIX/include/va/va.h
+    - test -f $PREFIX/lib/libva.so
+    - test -f $PREFIX/lib/libva.so.2
+    - test -f $PREFIX/lib/pkgconfig/libva.pc
+    - test -f $PREFIX/lib/pkgconfig/libva-drm.pc
+    - test -f $PREFIX/lib/libva-drm.so
+    - test -f $PREFIX/lib/libva-drm.so.2
+
+about:
+  home: https://github.com/intel/libva
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'Libva is an implementation for VA-API (Video Acceleration API)'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    VA-API is an open-source library and API specification, which provides
+    access to graphics hardware acceleration capabilities for video processing.
+    It consists of a main library and driver-specific acceleration backends
+    for each supported hardware vendor.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk


### PR DESCRIPTION
This PR packages

  - libva
  - libva-utils
  - libpciaccess
  - libdrm
  - intel-vaapi-driver
  - intel-hybrid-driver
  - cmrt

These are all necessary to get intel hardware encoding to work with FFMPEG