### PR TITLE
Add conda recipe for pymt_cem.

### DIFF
--- a/recipes/pymt_cem/meta.yaml
+++ b/recipes/pymt_cem/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.1.2" %}
+
+package:
+  name: pymt_cem
+  version: {{ version }}
+
+source:
+  url: https://github.com/pymt-lab/pymt_cem/archive/v{{ version }}.tar.gz
+  sha256: 18f6ffd1a138e286d8ba7e1480756195fcd40052441a0138fad7530194adf3f2
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy =1.11
+    - model_metadata
+    - cem
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - cem
+
+test:
+  imports:
+    - pymt_cem
+
+about:
+  home: https://github.com/pymt-lab/pymt_cem
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: CEM components wrapped as PyMT plugins.
+  dev_url: https://github.com/pymt-lab/pymt_cem
+
+extra:
+  recipe-maintainers:
+    - mcflugen


### PR DESCRIPTION
This pull request adds a *conda* recipe for the `pymt_cem` package, which brings the *CEM* C libraries into Python as plugins for the `pymt` modeling framework.

