### PR TITLE
Add lunr.py 0.5.4

### DIFF
--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -32,11 +32,11 @@ test:
   source_files:
     - src/tests
   requires:
+    - mock
     - nltk >=3.2.5
-    - pytest
+    - nodejs >8,<9
     - pytest
     - pytest-timeout
-    - mock
   imports:
     - lunr
     - lunr.builder
@@ -62,7 +62,14 @@ test:
     - lunr.utils
     - lunr.vector
   commands:
-    - cd src && cd test && python -m pytest -m "not coverage"
+    - cd src
+    - cd tests
+    - cd acceptance_tests
+    - cd javascript
+    - npm install
+    - cd ..
+    - cd ..
+    - pytest
 
 about:
   home: https://github.com/yeraydiazdiaz/lunr.py

--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "lunr" %}
+{% set version = "0.5.3" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 43143c7f857af9147b3e2621ec273c6b783b8eda65e8c2d5dcd4973c43b46254
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - future
+    - python
+    - six
+test:
+  imports:
+    - lunr
+
+about:
+  home: https://github.com/yeraydiazdiaz/lunr.py
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A Python implementation of Lunr.js
+  doc_url: https://lunr.readthedocs.io
+  description: >
+    This Python version of Lunr.js aims to bring the simple and powerful full
+    text search capabilities into Python guaranteeing results as close as the
+    original implementation as possible.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lunr" %}
-{% set version = "0.5.3" %}
+{% set version = "0.5.4" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 43143c7f857af9147b3e2621ec273c6b783b8eda65e8c2d5dcd4973c43b46254
+    sha256: 185254a6776d0d1758531dab32823cdbb8327be0158731dbd55b6943f2062387
     folder: dist
   - url: https://github.com/yeraydiazdiaz/lunr.py/archive/v{{ version }}.tar.gz
-    sha256: e115b9dd482ee233679bfa94cc72639324a9a08fcc0e04e07029bf362e15c17c
+    sha256: cb2cec0875970f680d8a20399052890acb3d7d18b769078471fabb2a00a80646
     folder: src
 
 build:
@@ -24,10 +24,10 @@ requirements:
     - pip
     - python
   run:
+    - enum34  # [py<34]
     - future >=0.16.0
     - python
     - six >=1.11.0
-    - enum34  # [py<34]
 test:
   source_files:
     - src/tests
@@ -61,15 +61,6 @@ test:
     - lunr.trimmer
     - lunr.utils
     - lunr.vector
-  commands:
-    - cd src
-    - cd tests
-    - cd acceptance_tests
-    - cd javascript
-    - npm install
-    - cd ..
-    - cd ..
-    - pytest
 
 about:
   home: https://github.com/yeraydiazdiaz/lunr.py

--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - six >=1.11.0
     - enum34  # [py<34]
 test:
-  src_files:
+  source_files:
     - src/tests
   requires:
     - nltk >=3.2.5

--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -6,12 +6,18 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 43143c7f857af9147b3e2621ec273c6b783b8eda65e8c2d5dcd4973c43b46254
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 43143c7f857af9147b3e2621ec273c6b783b8eda65e8c2d5dcd4973c43b46254
+    folder: dist
+  - url: https://github.com/yeraydiazdiaz/lunr.py/archive/v{{ version }}.tar.gz
+    sha256: e115b9dd482ee233679bfa94cc72639324a9a08fcc0e04e07029bf362e15c17c
+    folder: src
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script:
+    - cd dist
+    - {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
 requirements:
   host:
@@ -23,8 +29,14 @@ requirements:
     - six >=1.11.0
     - enum34  # [py<34]
 test:
+  src_files:
+    - src/tests
   requires:
     - nltk >=3.2.5
+    - pytest
+    - pytest
+    - pytest-timeout
+    - mock
   imports:
     - lunr
     - lunr.builder
@@ -49,12 +61,14 @@ test:
     - lunr.trimmer
     - lunr.utils
     - lunr.vector
+  commands:
+    - cd src && cd test && python -m pytest -m "not coverage"
 
 about:
   home: https://github.com/yeraydiazdiaz/lunr.py
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: dist/LICENSE
   summary: A Python implementation of Lunr.js
   doc_url: https://lunr.readthedocs.io
   description: >

--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
@@ -19,12 +18,13 @@ requirements:
     - pip
     - python
   run:
-    - future
+    - future >=0.16.0
     - python
-    - six
+    - six >=1.11.0
+    - enum34  # [py<34]
 test:
   requires:
-    - nltk
+    - nltk >=3.2.5
   imports:
     - lunr
     - lunr.builder

--- a/recipes/lunr/meta.yaml
+++ b/recipes/lunr/meta.yaml
@@ -23,8 +23,32 @@ requirements:
     - python
     - six
 test:
+  requires:
+    - nltk
   imports:
     - lunr
+    - lunr.builder
+    - lunr.exceptions
+    - lunr.field_ref
+    - lunr.idf
+    - lunr.index
+    - lunr.languages
+    - lunr.languages.stemmer
+    - lunr.languages.trimmer
+    - lunr.match_data
+    - lunr.pipeline
+    - lunr.query
+    - lunr.query_lexer
+    - lunr.query_parser
+    - lunr.stemmer
+    - lunr.stop_word_filter
+    - lunr.token
+    - lunr.token_set
+    - lunr.token_set_builder
+    - lunr.tokenizer
+    - lunr.trimmer
+    - lunr.utils
+    - lunr.vector
 
 about:
   home: https://github.com/yeraydiazdiaz/lunr.py

--- a/recipes/lunr/run_test.bat
+++ b/recipes/lunr/run_test.bat
@@ -1,0 +1,10 @@
+@ECHO ON
+cd src\tests\acceptance_tests\javascript
+
+CALL npm install || EXIT /B 1
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+
+cd ..\..
+
+CALL pytest -k "not language_support" || EXIT /B 1
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%

--- a/recipes/lunr/run_test.sh
+++ b/recipes/lunr/run_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+cd src/tests/acceptance_tests/javascript
+npm install
+cd ../..
+pytest


### PR DESCRIPTION
This adds [lunr](https://pypi.org/project/lunr/), a(nother) python full-text search library.

Can't be `noarch: python` because of `enum34`. Tested building locally on linux on various pythons...