### PR TITLE
Add donfig recipe

### DIFF
--- a/recipes/donfig/meta.yaml
+++ b/recipes/donfig/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "donfig" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 03f055f0ce3119a3be5d3d5121d37870720ab1a9c842878bce9a3454529bffdf
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - pyyaml
+  run:
+    - python
+    - pyyaml
+
+test:
+  imports:
+    - donfig
+    - donfig.tests
+  requires:
+    - pytest
+
+about:
+  home: https://github.com/pytroll/satpy
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Python package for configuring a python package
+  doc_url: https://donfig.readthedocs.io/en/latest/
+  dev_url: https://github.com/pytroll/donfig
+
+extra:
+  recipe-maintainers:
+    - djhoese
+    - mraspaud
+    - pnuu
+    - adybbroe
+    - mrocklin
+    - jcrist
+    - jhamman


### PR DESCRIPTION
This is a configuration helper package based on the config module in dask. I originally wanted to create this for use with the satpy library, but decided it would be best as a standalone library for everyone to use. I included the normal pytroll core devs as maintainers (@mraspaud @pnuu @adybbroe) but also the main dask contributors who worked on this (@mrocklin @jcrist @jhamman). If any of you don't want to be listed as maintainers let me know. To the dask devs, note that you are also listed in the [AUTHORS list](https://github.com/pytroll/donfig/blob/master/AUTHORS.md) on the main repository. Let me know if you have issues with anything.