### PR TITLE
add wget recipe

### DIFF
--- a/recipes/wget/meta.yaml
+++ b/recipes/wget/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "wget" %}
+{% set version = "3.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: 35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061
+
+build:
+  noarch: python
+  number: 0
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv'
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - wget
+
+about:
+  home: https://bitbucket.org/techtonik/python-wget/src
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
+  license_family: PUBLIC-DOMAIN
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
+  summary: 'pure python download utility'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    pure python download utility
+  dev_url: https://bitbucket.org/techtonik/python-wget/src
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - anatoly techtonik

--- a/recipes/wget/meta.yaml
+++ b/recipes/wget/meta.yaml
@@ -21,31 +21,19 @@ requirements:
     - python
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - wget
 
 about:
   home: https://bitbucket.org/techtonik/python-wget/src
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGLP.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
   license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
   license_family: PUBLIC-DOMAIN
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
   summary: 'pure python download utility'
 
-  # The remaining entries in this section are optional, but recommended
   description: |
     pure python download utility
   dev_url: https://bitbucket.org/techtonik/python-wget/src
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - anatoly techtonik


### PR DESCRIPTION
`wget` is a pure python download utility.
When I run `conda smithy recipe-lint wget` from terminal, it shows `wget is in fine form`. I do not know why the linter check does not pass.