### PR TITLE
Add snapshottest

### DIFF
--- a/recipes/snapshottest/meta.yaml
+++ b/recipes/snapshottest/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - pip
     - python
-    - termcolor
   run:
     - python
     - six >=1.10.0

--- a/recipes/snapshottest/meta.yaml
+++ b/recipes/snapshottest/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - pip
     - python
-    - six >=1.10.0
     - termcolor
   run:
     - python

--- a/recipes/snapshottest/meta.yaml
+++ b/recipes/snapshottest/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "snapshottest" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 215c28eb397fd171a25a0e7d8b7b82d39619bf38d0e44de97c38842e8495b40c
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - pip
+    - python
+    - six >=1.10.0
+    - termcolor
+  run:
+    - python
+    - six >=1.10.0
+    - termcolor
+
+test:
+  requires:
+    - django
+    - nose
+    - pytest
+
+  imports:
+    - snapshottest
+    - snapshottest.django
+    - snapshottest.nose
+    - snapshottest.pytest
+
+about:
+  home: https://github.com/syrusakbary/snapshottest
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Snapshot Testing utils for Python'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    Snapshot testing is a way to test your APIs without writing actual test cases.
+
+      1. A snapshot is a single state of your API, saved in a file.
+      2. You have a set of snapshots for your API endpoints.
+      3. Once you add a new feature, you can generate automatically new snapshots
+         for the updated API.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Adds [snapshottest](https://pypi.org/project/snapshottest), a test dependency of [graphene](https://github.com/conda-forge/graphene-feedstock/pull/11).

Somewhat ironically, not running the tests for this, as there are no tags from which to draw canonical tests for a version.