### PR TITLE
Update script line in example to match docs

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -30,7 +30,7 @@ build:
   # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
   # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
   # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . -vvv"
 
 requirements:
   build:


### PR DESCRIPTION
There is a discrepancy between the `script` line in the `meta.yaml` and in the docs in terms of the arguments to pip:

https://conda-forge.org/docs/meta.html#use-pip

This PR brings the `example/meta.yaml` up-to-date to match the docs.

See: https://github.com/conda-forge/conda-forge.github.io/pull/653

@conda-forge/staged-recipes 