### PR TITLE
update whole index instead of just noarch

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -26,12 +26,12 @@ def build_all(recipes_dir, arch):
     channel_urls = ['local', 'conda-forge', 'defaults']
 
     # ensure that noarch path exists and is indexed for newer conda (4.4+)
-    noarch_path = os.path.join(sys.exec_prefix, 'conda-bld', 'noarch')
+    index_path = os.path.join(sys.exec_prefix, 'conda-bld')
     try:
-        os.makedirs(noarch_path)
+        os.makedirs(os.path.join(index_path, 'noarch'))
     except:
         pass
-    conda_build.api.update_index(noarch_path)
+    conda_build.api.update_index(index_path)
     index = conda_build.conda_interface.get_index(channel_urls=channel_urls)
     conda_resolve = conda_build.conda_interface.Resolve(index)
 


### PR DESCRIPTION
Handle this warning:

> WARNING:conda_build.index:The update_index function has changed to index all subdirs at once.  You're pointing it at a single subdir.  Please update your code to point it at the channel root, rather than a subdir.