### PR TITLE
add initial recipe for snowflake-connector-python 1.6.12

### DIFF
--- a/recipes/snowflake-connector-python/meta.yaml
+++ b/recipes/snowflake-connector-python/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
   host:

--- a/recipes/snowflake-connector-python/meta.yaml
+++ b/recipes/snowflake-connector-python/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "snowflake-connector-python" %}
+{% set version = "1.6.12" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 36b9b1e79a97cdbe8dc254d8d96e629a85dfeb5d54e6b713844fa6275fd82b39
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - azure-common <2
+    - azure-nspkg <3
+    - azure-storage >0.34.2,<=0.36.0
+    - boto3 >=1.4.4,<1.10.0
+    - botocore >=1.5.0,<1.13.0
+    - certifi
+    - future
+    - six
+    - pytz
+    - pycryptodomex >=3.2,!=3.5.0
+    - pyOpenSSL >=16.2.0
+    - cffi >=1.9
+    - cryptography >=1.8.2
+    - ijson
+    - pyjwt
+    - pyasn1 >=0.2.1,<0.5.0          #[py27]
+    - pyasn1-modules >=0.0.8,<0.3.0  #[py27]
+
+test:
+  imports:
+    - snowflake
+
+about:
+  home: https://github.com/snowflakedb/snowflake-connector-python
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: 'Snowflake Connector for Python'
+  description: |
+    The Snowflake Connector for Python provides an interface for 
+    developing Python applications that can connect to Snowflake 
+    and perform all standard operations. It provides a programming 
+    alternative to developing applications in Java or C/C++ using 
+    the Snowflake JDBC or ODBC drivers.
+  doc_url: https://docs.snowflake.net/manuals/user-guide/python-connector.html
+  dev_url: https://github.com/snowflakedb/snowflake-connector-python
+
+extra:
+  recipe-maintainers:
+    - hajapy

--- a/recipes/snowflake-connector-python/meta.yaml
+++ b/recipes/snowflake-connector-python/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 36b9b1e79a97cdbe8dc254d8d96e629a85dfeb5d54e6b713844fa6275fd82b39
 
 build:
-  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vvv"
 
@@ -35,8 +34,8 @@ requirements:
     - cryptography >=1.8.2
     - ijson
     - pyjwt
-    - pyasn1 >=0.2.1,<0.5.0          #[py27]
-    - pyasn1-modules >=0.0.8,<0.3.0  #[py27]
+    - pyasn1 >=0.2.1,<0.5.0  # [py27]
+    - pyasn1-modules >=0.0.8,<0.3.0  # [py27]
 
 test:
   imports:

--- a/recipes/snowflake-connector-python/meta.yaml
+++ b/recipes/snowflake-connector-python/meta.yaml
@@ -11,7 +11,12 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . -vvv"
+  entry_points:
+    - snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
+    - snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main
+    - snowflake-dump-certs = snowflake.connector.tool.dump_certs:main
+    - snowflake-export-certs = snowflake.connector.tool.export_certs:main
 
 requirements:
   host:

--- a/recipes/snowflake-connector-python/meta.yaml
+++ b/recipes/snowflake-connector-python/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
   entry_points:
     - snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
     - snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main


### PR DESCRIPTION
The Snowflake Connector for Python provides an interface for developing Python applications that can connect to Snowflake and perform all standard operations. It provides a programming alternative to developing applications in Java or C/C++ using the Snowflake JDBC or ODBC drivers.

The connector is a native, pure Python package that has no dependencies on JDBC or ODBC. 