### PR TITLE
Add compas_fab recipe

### DIFF
--- a/recipes/compas_fab/meta.yaml
+++ b/recipes/compas_fab/meta.yaml
@@ -34,8 +34,6 @@ test:
     - compas_fab.artists
     - compas_fab.backends
     - compas_fab.robots
-    - compas_fab.sensors
-    - compas_fab.utilities
 
 about:
   home: https://github.com/gramaziokohler/compas_fab

--- a/recipes/compas_fab/meta.yaml
+++ b/recipes/compas_fab/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "compas_fab" %}
+{% set version = "0.2.1" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "17719dfe35265f868f22fb12ae48bff4955cb58358997eb709783efb4ef7c09b" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - compas == 0.3.2
+    - roslibpy
+    - pyserial
+
+test:
+  imports:
+    - compas_fab
+    - compas_fab.artists
+    - compas_fab.backends
+    - compas_fab.robots
+    - compas_fab.sensors
+    - compas_fab.utilities
+
+about:
+  home: https://github.com/gramaziokohler/compas_fab
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Robotic fabrication package for the COMPAS Framework
+  description: |
+    Robotic fabrication package for the COMPAS Framework facilitating the
+    planning and execution of robotic fabrication processes. It provides
+    interfaces to existing software libraries and tools available in the
+    field of robotics (e.g. OMPL, ROS) and makes them accessible from within
+    the parametric design environment. The package builds upon
+    COMPAS (https://compas-dev.github.io/), an open-source Python-based
+    framework for collaboration and research in architecture, engineering
+    and digital fabrication.
+  doc_url: https://gramaziokohler.github.io/compas_fab
+  dev_url: https://github.com/gramaziokohler/compas_fab
+
+extra:
+  recipe-maintainers:
+    - gonzalocasas

--- a/recipes/compas_fab/meta.yaml
+++ b/recipes/compas_fab/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - setuptools
   run:
     - python
-    - COMPAS == 0.3.2
-    - roslibpy >= 0.3.0
+    - compas ==0.3.2
+    - roslibpy >=0.3.0
     - pyserial
 
 test:

--- a/recipes/compas_fab/meta.yaml
+++ b/recipes/compas_fab/meta.yaml
@@ -32,7 +32,6 @@ test:
   imports:
     - compas_fab
     - compas_fab.artists
-    - compas_fab.backends
     - compas_fab.robots
 
 about:

--- a/recipes/compas_fab/meta.yaml
+++ b/recipes/compas_fab/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - setuptools
   run:
     - python
-    - compas == 0.3.2
+    - COMPAS == 0.3.2
     - roslibpy >= 0.3.0
     - pyserial
 

--- a/recipes/compas_fab/meta.yaml
+++ b/recipes/compas_fab/meta.yaml
@@ -25,7 +25,7 @@ requirements:
   run:
     - python
     - compas == 0.3.2
-    - roslibpy
+    - roslibpy >= 0.3.0
     - pyserial
 
 test:

--- a/recipes/roslibpy/meta.yaml
+++ b/recipes/roslibpy/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "roslibpy" %}
+{% set version = "0.3.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "c8a8bac555331a819f8e099e2dfb860bd7f2e4aba601df9a7d8fee9e995ebe4d" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - autobahn >=17.10
+    - twisted >=17.9
+
+test:
+  imports:
+    - roslibpy
+
+about:
+  home: https://github.com/gramaziokohler/roslibpy
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python ROS Bridge library
+  description: |
+    Python ROS Bridge library allows to use Python and IronPython to interact
+    with ROS, the open-source robotic middleware. It uses WebSockets to
+    connect to rosbridge 2.0 and provides publishing, subscribing, service
+    calls, actionlib, TF, and other essential ROS functionality.
+    Unlike the rospy library, this does not require a local ROS environment,
+    allowing usage from platforms other than Linux.
+  doc_url: https://roslibpy.readthedocs.io
+  dev_url: https://github.com/gramaziokohler/roslibpy
+
+extra:
+  recipe-maintainers:
+    - gonzalocasas


### PR DESCRIPTION
A package for robotic fabrication that builds upon [COMPAS Framework](https://compas-dev.github.io/) ([already in conda](https://anaconda.org/conda-forge/compas)). The strict version pinning on the `compas` dependency is due to the fact that compas itself is still pre-1.0 release and the API is still very much in motion, with regular breaking changes.