### PR TITLE
Pip no deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Short answer: yes. Long answer: In principle, as long as your dependencies are i
 your user's conda channels they will be able to install your package. In practice, that is difficult
 to manage, and we strive to get all dependencies built in conda-forge.
 
-### 7. **When or why do I need to use `python -m pip install --no-deps --ignore-installed .`?**
+### 7. **When or why do I need to use `{{ PYTHON }} -m pip install --no-deps . -vv`?**
 
 This should be the default install line for most Python packages. This is preferable to `python setup.py` because it handles metadata in a `conda`-friendlier way. We also want to make sure dependencies are handled through `conda`, and `--no-deps` means most Python dependencies are needed only at `run` time, not `build`.
 

--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -32,7 +32,7 @@ build:
   # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
   # Once resolved, it should be removed.
-  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   build:

--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -30,7 +30,9 @@ build:
   # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
   # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
   # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
-  script: "{{ PYTHON }} -m pip install . -vvv"
+  # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
+  # Once resolved, it should be removed.
+  script: "{{ PYTHON }} -m pip install . --no-deps -vvv"
 
 requirements:
   build:


### PR DESCRIPTION
This enforces the cli use of --no-deps, since https://github.com/conda/conda-build/issues/3254 means that environment variable is not achieving the desired effect. 

It also makes two other minor changes: 

1. FAQ and example/meta.yaml are in agreement: closes https://github.com/conda-forge/staged-recipes/issues/7021
2. Example uses -vv instead of -vvv, the verbosity of -vvv is likely very rarely needed and makes the log files extremely large.