### PR TITLE
New recipe for r-xmlparsedata

### DIFF
--- a/recipes/r-xmlparsedata/bld.bat
+++ b/recipes/r-xmlparsedata/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-xmlparsedata/build.sh
+++ b/recipes/r-xmlparsedata/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/xmlparsedata
+  mv * $PREFIX/lib/R/library/xmlparsedata
+fi

--- a/recipes/r-xmlparsedata/build.sh
+++ b/recipes/r-xmlparsedata/build.sh
@@ -5,4 +5,30 @@ if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $
 else
   mkdir -p $PREFIX/lib/R/library/xmlparsedata
   mv * $PREFIX/lib/R/library/xmlparsedata
+  if [[ $target_platform == osx-64 ]]; then
+    pushd $PREFIX
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd $libdir || exit 1
+          for SHARED_LIB in $(find . -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R"); do
+            echo "fixing SHARED_LIB $SHARED_LIB"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "$PREFIX"/lib/libomp.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "$PREFIX"/lib/libgcc_s.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "$PREFIX"/sysroot/usr/lib/libiconv.2.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "$PREFIX"/sysroot/usr/lib/libncurses.5.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "$PREFIX"/sysroot/usr/lib/libicucore.A.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "$PREFIX"/lib/libexpat.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "$PREFIX"/lib/libcurl.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+          done
+        popd
+      done
+    popd
+  fi
 fi

--- a/recipes/r-xmlparsedata/meta.yaml
+++ b/recipes/r-xmlparsedata/meta.yaml
@@ -7,7 +7,6 @@ package:
   version: {{ version|replace("-", "_") }}
 
 source:
-  fn: xmlparsedata_{{ version }}.tar.gz
   url:
     - {{ cran_mirror }}/src/contrib/xmlparsedata_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/xmlparsedata/xmlparsedata_{{ version }}.tar.gz
@@ -16,14 +15,14 @@ source:
 build:
   merge_build_host: True  # [win]
   number: 0
-  skip: true  # [win32]
+  noarch: generic
   rpaths:
     - lib/R/lib/
     - lib/
 
 requirements:
   build:
-    - {{posix}}zip               # [win]
+
   host:
     - r-base
   run:

--- a/recipes/r-xmlparsedata/meta.yaml
+++ b/recipes/r-xmlparsedata/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = '1.0.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-xmlparsedata
+  version: {{ version|replace("-", "_") }}
+
+source:
+  fn: xmlparsedata_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/xmlparsedata_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/xmlparsedata/xmlparsedata_{{ version }}.tar.gz
+  sha256: 50b2cca032a4986d8b603a282847c50f7571c76284a9b0a229938c969e25eeda
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [win32]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('xmlparsedata')"           # [not win]
+    - "\"%R%\" -e \"library('xmlparsedata')\""  # [win]
+
+about:
+  home: https://github.com/r-lib/xmlparsedata#readme
+  license: MIT
+  summary: Convert the output of 'utils::getParseData()' to an 'XML' tree, that one can search
+    via 'XPath', and easier to manipulate in general.
+  license_family: MIT
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast
+    - russHyde


### PR DESCRIPTION
No conda-forge recipe for xmlparsedata existed
(see https://cran.r-project.org/web/packages/xmlparsedata/index.html)

The package has no dependencies other than R >= 3.

Recipe was made using the `conda_r_skeleton_helper` python script.