### PR TITLE
Add pydot-ng for the Good of the Next Generation

### DIFF
--- a/recipes/pydot-ng/meta.yaml
+++ b/recipes/pydot-ng/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "pydot_ng" %}
+{% set version = "2.0.0" %}
+{% set sha256 = "8c8073b97aa7030c28118961e2c6c92f046e4cb57aeba7df87146f7baa6530c5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: true  # [win]
+
+requirements:
+  host:
+    - pip
+    - setuptools
+    - python
+    - pyparsing >=2.0.1
+  run:
+    - python
+    - pyparsing >=2.0.1
+    - graphviz
+
+test:
+  imports:
+    - pydot_ng
+
+about:
+  home: https://github.com/pydot/pydot-ng
+  license: MIT
+  license_file: LICENSE
+  summary: Python interface to Graphviz's Dot
+  description: |
+    This module provides with a full interface to create handle modify and
+    process graphs in Graphviz’s dot language.
+  doc_url: https://pypi.org/project/pydot-ng
+  dev_url: https://github.com/pydot/pydot-ng
+
+extra:
+  recipe-maintainers:
+    - leycec
+    - nehaljwani
+    - prmtl

--- a/recipes/pydot-ng/run_test.py
+++ b/recipes/pydot-ng/run_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+'''Minimalist unit testing of :mod:`pydot_ng`.'''
+
+# This unittest-based minimalist test suite is derived from the official
+# unittest-based test suite bundled with pydot-ng tarballs. The latter is not
+# installed along with pydot-ng and hence cannot be readily tested by the
+# conda-build test framework. Specifically, this script derives from the
+# "pydot-feedstock" variant of this script:
+#     https://github.com/conda-forge/pydot-feedstock/blob/master/recipe/run_test.py
+#
+# Running at least some unit tests is critical to assessing the usability of
+# pydot-ng on all available platforms -- notably Windows, which requires a
+# conda-specific patch ensuring compatibility with the "dot.bat" wrapper in the
+# conda-specific version of GraphViz. Import tests alone do not suffice.
+
+import argparse
+import os
+import pickle
+import sys
+
+import pydot_ng as pydot
+import unittest
+
+
+class TestGraphAPI(unittest.TestCase):
+
+    def setUp(self):
+
+        self._reset_graphs()
+
+
+    def _reset_graphs(self):
+
+        self.graph_directed = pydot.Graph('testgraph',
+                                          graph_type='digraph')
+
+
+    def test_keep_graph_type(self):
+
+        g = pydot.Dot(graph_name='Test', graph_type='graph')
+        self.assertEqual( g.get_type(), 'graph' )
+
+        g = pydot.Dot(graph_name='Test', graph_type='digraph')
+        self.assertEqual( g.get_type(), 'digraph' )
+
+
+    #FIXME: Uncomment after "pydot-ng" restores compliance with the modern
+    #"pydot" API. See also:  https://github.com/pydot/pydot-ng/issues/59
+    # def test_attribute_with_implicit_value(self):
+    #
+    #     d='digraph {\na -> b[label="hi", decorate];\n}'
+    #     graphs = pydot.graph_from_dot_data(d)
+    #     (g,) = graphs
+    #     attrs = g.get_edges()[0].get_attributes()
+    #
+    #     self.assertEqual( 'decorate' in attrs, True )
+
+
+    def test_graph_pickling(self):
+
+        g = pydot.Graph()
+        s = pydot.Subgraph("foo")
+        g.add_subgraph(s)
+        g.add_edge( pydot.Edge('A','B') )
+        g.add_edge( pydot.Edge('A','C') )
+        g.add_edge( pydot.Edge( ('D','E') ) )
+        g.add_node( pydot.Node( 'node!' ) )
+        pickle.dumps(g)
+
+
+    def test_multiple_graphs(self):
+        graph_data = 'graph A { a->b };\ngraph B {c->d}'
+        graphs = pydot.graph_from_dot_data(graph_data)
+        n = len(graphs)
+        assert n == 2, n
+        names = [g.get_name() for g in graphs]
+        assert names == ['A', 'B'], names
+
+
+    def test_executable_not_found_exception(self):
+
+        graph = pydot.Dot('graphname', graph_type='digraph')
+        self.assertRaises(Exception,  graph.create, prog='dothehe')
+
+
+    def test_dot_args(self):
+
+        g = pydot.Dot()
+        u = pydot.Node('a')
+        g.add_node(u)
+        g.write_svg('test.svg', prog=['twopi', '-Goverlap=scale'])
+
+
+def parse_args():
+    """Return arguments."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--no-check', action='store_true',
+        help=('do not require that no `setup.py` be present '
+              'in the current working directory.'))
+    args, unknown = parser.parse_known_args()
+    # avoid confusing `unittest`
+    sys.argv = [sys.argv[0]] + unknown
+    return args.no_check
+
+
+if __name__ == '__main__':
+    test_dir = os.path.dirname(sys.argv[0])
+    print('The tests are using `pydot_ng` from:  {pd}'.format(pd=pydot))
+    if sys.version_info >= (2, 7):
+        unittest.main(verbosity=2)
+    else:
+        unittest.main()


### PR DESCRIPTION
Greetings and wintry salutations, conda-forge komrads. This pull request creates a `pydot-ng` feedstock patterned off the [existing `pydot` feedstock](https://github.com/conda-forge/pydot-feedstock), which I (*somehow*) became a co-maintainer of. Why do these things keep happening to me. <sup>←rhetorical question</sup>

[`pydot-ng`](https://github.com/pydot/pydot-ng) is a drop-in replacement fork of [`pydot`](https://github.com/erocarrera/pydot), of course. Sadly, [the continued existence of `pydot` is currently in question](https://github.com/pydot/pydot-ng/pull/52#issuecomment-438502451). `pydot-ng` is intended to provide a well-maintained fallback for everyone in the Python graphing community until the dust fully settles. Thus, this pull request.

## What Happened to Windows Support?

[`pydot-ng`](https://github.com/pydot/pydot-ng) currently lacks support for Anaconda Graphviz. It is sad! After [vigorous debate and much moustache twirling](https://github.com/pydot/pydot-ng/pull/52), we're hoping to add built-in support for Anaconda Graphviz directly into [`pydot-ng`](https://github.com/pydot/pydot-ng) itself – probably in the upcoming 2.0.1 release. It is good!

Until that glorious day arrives, this recipe temporarily disables Windows support.

## Who's Responsible for This Mess?

I've responsibly added myself, @prmtl (i.e., the principal developer of [`pydot-ng`](https://github.com/pydot/pydot-ng)), and @nehaljwani (i.e., the principal maintainer of the [`pydot` feedstock](https://github.com/conda-forge/pydot-feedstock)) as co-maintainers.

Sorry, Nehal. If you're too busy, apathetic, and/or busy playing *Dragon Quest XI: Echoes of an Elusive Age,* I wouldn't blame you; just let me know and I'll strip you from the maintainers list.

Tests pass locally. Let's see what `conda-linter` thinks, shall we?