### PR TITLE
bAdd snakemake to conda-forge

### DIFF
--- a/recipes/snakemake-minimal/meta.yaml
+++ b/recipes/snakemake-minimal/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "snakemake-minimal" %}
+{% set version = "5.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/s/snakemake/snakemake-{{ version }}.tar.gz
+  sha256: 612a16f2bba580c47183e4f752ed40b034852541ca3e96e480d01fb30ad9570c
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . -vvv"
+  entry_points:
+    - snakemake = snakemake:main
+    - snakemake-bash-completion = snakemake:bash_completion
+
+requirements:
+  host:
+    - python >=3
+    - pip
+    - setuptools
+    # - wrapt
+    # - requests
+    # - ratelimiter
+    # - configargparse
+    # - appdirs
+    # - datrie
+  run:
+    - python >=3
+    - wrapt
+    - requests >=2.8.1
+    - ratelimiter
+    - pyyaml
+    - configargparse
+    - appdirs
+    - datrie
+    - jsonschema
+    - docutils
+    - gitpython
+
+test:
+  imports:
+    - snakemake
+  commands:
+    - snakemake --version
+    - snakemake --version | grep "{{ version }}"
+
+about:
+  home: https://snakemake.readthedocs.io
+  license: MIT
+  license_family: MIT
+  summary: Snakemake - a pythonic workflow system
+  description: |
+    Snakemake is a workflow management system that aims to reduce the complexity of creating workflows 
+    by providing a fast and comfortable execution environment, together with a clean and readable 
+    specification language in Python style. Snakemake workflows are essentially Python scripts extended 
+    by declarative code to define rules. Rules describe how to create output files from input files.  
+  doc_url: https://snakemake.readthedocs.io/en/stable/
+  dev_url: https://bitbucket.org/snakemake/snakemake/
+
+extra:
+  identifiers:
+    - doi:10.1093/bioinformatics/bts480
+    - biotools:Snakemake
+  recipe-maintainers:
+    - melund

--- a/recipes/snakemake/meta.yaml
+++ b/recipes/snakemake/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "snakemake" %}
+{% set version = "5.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 612a16f2bba580c47183e4f752ed40b034852541ca3e96e480d01fb30ad9570c
+
+build:
+  number: 0
+  noarch: python
+
+
+requirements:
+  host:
+    - python >= 3
+  run:
+    - python >=3
+    - snakemake-minimal ={{ version }}
+    # optional dependencies needed for the full experience
+    - dropbox >=7.2.1
+    - ftputil >=3.2
+    - filechunkio >=1.6
+    - pysftp >=0.2.8
+    - psutil
+    - aioeasywebdav
+    - pandas
+    - ratelimiter
+    - configargparse
+    - python-irodsclient
+    - google-cloud-storage
+    - boto3
+    - jsonschema
+    - jinja2
+    - pygraphviz
+    - networkx >=2.0
+
+test:
+  imports:
+    - snakemake
+  commands:
+    - snakemake --version
+    - snakemake --version | grep "{{ version }}"
+
+about:
+  home: https://snakemake.readthedocs.io
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: Snakemake - a pythonic workflow system
+  description: |
+    Snakemake is a workflow management system that aims to reduce the complexity of creating workflows 
+    by providing a fast and comfortable execution environment, together with a clean and readable 
+    specification language in Python style. Snakemake workflows are essentially Python scripts extended 
+    by declarative code to define rules. Rules describe how to create output files from input files.  
+  doc_url: https://snakemake.readthedocs.io/en/stable/
+  dev_url: https://bitbucket.org/snakemake/snakemake/
+
+extra:
+  identifiers:
+    - doi:10.1093/bioinformatics/bts480
+    - biotools:Snakemake
+  recipe-maintainers:
+    - melund


### PR DESCRIPTION
This is mostly a direct port of the bioconda recipe for snakemake. 

Bioconda doesn't seemto build windows packages, so I thought it would be nice to get snakemake into conda-forge.

It needs a package datrie (#7053), which is only in defaults and not conda-forge. So this recipe may not work until #7053 is merged. 