### PR TITLE
Add recipe for pynvim

### DIFF
--- a/recipes/pynvim/meta.yaml
+++ b/recipes/pynvim/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "pynvim" %}
+{% set version = "0.3.1" %}
+{% set sha256 = "dd881595055869c2de770517d403faf40d31aa991db2472a1843ff17db47b0fb" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - msgpack-python >=0.5.0
+    - greenlet
+    - trollius  # [py27]
+    - pyuv >=1.0.0  # [win]
+
+test:
+  imports:
+    - pynvim
+    - pynvim.api
+    - pynvim.msgpack_rpc
+    - pynvim.msgpack_rpc.event_loop
+    - pynvim.plugin
+
+about:
+  home: http://github.com/neovim/pynvim
+  license: Apache-2.0
+  license_family: Apache
+  license_file: 'LICENSE'
+  summary: 'Python client to neovim'
+
+  description: |
+    Python client to neovim
+  dev_url: https://github.com/neovim/pynvim
+
+extra:
+  recipe-maintainers:
+    - curtisalexander
+    - xhochy


### PR DESCRIPTION
The `neovim` packages was renamed to `pynvim`. This is the same recipe just with the renamed packages.