### PR TITLE
Add bcrypt recipe

### DIFF
--- a/recipes/bcrypt/meta.yaml
+++ b/recipes/bcrypt/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "bcrypt" %}
+{% set version = "3.1.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 67ed1a374c9155ec0840214ce804616de49c3df9c5bc66740687c1c9b1cd9e8d
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: False
+  script: "{{ PYTHON }} -m pip install . -vvv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - cffi >=1.1
+    - six >=1.4.1
+  run:
+    - python
+    - cffi >=1.1
+    - six >=1.4.1
+
+test:
+  imports:
+    - bcrypt
+    - bcrypt._bcrypt
+
+about:
+  home: https://github.com/pyca/bcrypt
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Modern password hashing for your software and your servers'
+  description: |
+    Modern password hashing for your software and your servers
+  doc_url: https://pypi.org/project/bcrypt/
+  dev_url: https://github.com/pyca/bcrypt
+
+extra:
+  recipe-maintainers:
+    - beenje


### PR DESCRIPTION
This recipe is adapted from https://github.com/ContinuumIO/anaconda-recipes/tree/master/bcrypt

I modified it slightly to follow conda-forge guidelines (like using pip).

1. I see that many anaconda recipes set `detect_binary_files_with_prefix: False `
Is that really required?

2. I'm not familiar with windows. I'm not sure what the following in bld.bat does:
if "%PY3K%"=="1" (
    rd /s /q %SP_DIR%\cffi
)
Is that required on conda-forge?