### PR TITLE
Create Yamlordereddictloader feedstock

### DIFF
--- a/recipes/yamlordereddictloader/meta.yaml
+++ b/recipes/yamlordereddictloader/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "yamlordereddictloader" %}
+{% set version = "0.4.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7f30f0b99ea3f877f7cb340c570921fa9d639b7f69cba18be051e27f8de2080e
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
+
+requirements:
+  host:
+    - pip
+    - pip
+    - python
+    - pyyaml
+  run:
+    - python
+    - pyyaml
+
+about:
+  home: https://github.com/fmenabe/python-yamlordereddictloader
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: YAML loader and dump for PyYAML allowing to keep keys order.
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here

--- a/recipes/yamlordereddictloader/meta.yaml
+++ b/recipes/yamlordereddictloader/meta.yaml
@@ -10,12 +10,12 @@ source:
   sha256: 7f30f0b99ea3f877f7cb340c570921fa9d639b7f69cba18be051e27f8de2080e
 
 build:
+  noarch: generic
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv "
 
 requirements:
   host:
-    - pip
     - pip
     - python
     - pyyaml
@@ -27,11 +27,9 @@ about:
   home: https://github.com/fmenabe/python-yamlordereddictloader
   license: MIT
   license_family: MIT
-  license_file: 
+  license_file: LICENSE
   summary: YAML loader and dump for PyYAML allowing to keep keys order.
-  doc_url: 
-  dev_url: 
 
 extra:
   recipe-maintainers:
-    - your-github-id-here
+    - PertuyF

--- a/recipes/yamlordereddictloader/meta.yaml
+++ b/recipes/yamlordereddictloader/meta.yaml
@@ -27,7 +27,7 @@ about:
   home: https://github.com/fmenabe/python-yamlordereddictloader
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: LICENSE.txt
   summary: YAML loader and dump for PyYAML allowing to keep keys order.
 
 extra:


### PR DESCRIPTION
Create Yamlordereddictloader recipe using `conda skeletong pypi yamlordereddictloader`.

License file should be OK.
Please verify `noarch: generic` is suitable.

This feedstock is required for https://github.com/bioconda/bioconda-recipes/pull/12270