### PR TITLE
Add recipe for markdown_strings

### DIFF
--- a/recipes/markdown_strings/meta.yaml
+++ b/recipes/markdown_strings/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "markdown_strings" %}
+{% set version = "3.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 141e55d48742d6c19b09500bb71760f3aa04b6532c5d7725b9a030ce90663708
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+  imports:
+    - markdown_strings
+
+about:
+  home: https://github.com/awesmubarak/markdown_strings/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'This package allows the creation of markdown-compliant strings.'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    Markdown is a markup language with plain text formatting syntax. This 
+    package allows the creation of markdown-compliant strings.
+
+extra:
+  recipe-maintainers:
+    - pvanheus

--- a/recipes/markdown_strings/meta.yaml
+++ b/recipes/markdown_strings/meta.yaml
@@ -34,7 +34,6 @@ about:
   license_file: LICENSE.txt
   summary: 'This package allows the creation of markdown-compliant strings.'
 
-  # The remaining entries in this section are optional, but recommended
   description: |
     Markdown is a markup language with plain text formatting syntax. This 
     package allows the creation of markdown-compliant strings.

--- a/recipes/markdown_strings/run_test.py
+++ b/recipes/markdown_strings/run_test.py
@@ -1,0 +1,16 @@
+import markdown_strings as ms
+
+def test_header():
+  assert ms.header('header', 1) == '# header'
+
+def test_italics():
+  assert ms.italics('italics') == '_italics_'
+
+def test_bold():
+  assert ms.bold('bold') == '**bold**'
+
+def test_inline_code():
+  assert ms.inline_code('code') == '`code`'
+
+def test_code_block():
+  assert ms.code_block('This is a block of code', 'python') == '```python\\nThis is a block of code\\n```'


### PR DESCRIPTION
This is a small Python package that provides functions for creating Markdown-formatted strings.