### PR TITLE
add recipe for tree

### DIFF
--- a/recipes/tree/build.sh
+++ b/recipes/tree/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+make
+
+mkdir -p ${PREFIX}/bin
+install tree ${PREFIX}/bin/tree
+
+mkdir -p ${PREFIX}/man/man1
+install doc/tree.1 ${PREFIX}/man/man1/tree.1
+

--- a/recipes/tree/meta.yaml
+++ b/recipes/tree/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "tree" %}
+{% set version = "1.8.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://mama.indstate.edu/users/ice/tree/src/tree-{{ version }}.tgz
+  sha256: 715d5d4b434321ce74706d0dd067505bb60c5ea83b5f0b3655dae40aa6f9b7c2
+
+build:
+  number: 0
+  skip: True #[win]
+  script: "make"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+test:
+  commands:
+    - tree --help
+
+about:
+  home: http://mama.indstate.edu/users/ice/tree/
+  license: GPL-2.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: Tree is a recursive directory listing command that produces a depth indented listing of files, which is colorized ala dircolors if the LS_COLORS environment variable is set and output is to tty.
+
+extra:
+  recipe-maintainers:
+    - grst

--- a/recipes/tree/meta.yaml
+++ b/recipes/tree/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True #[win]
+  skip: True  # [win]
   script: "make"
 
 requirements:

--- a/recipes/tree/meta.yaml
+++ b/recipes/tree/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: True  # [win]
-  script: "make"
 
 requirements:
   build:


### PR DESCRIPTION
Adds a recipe for the unix command `tree`

```
>tree staged-recipes 
staged-recipes
├── LICENSE.txt
├── README.md
└── recipes
    ├── example
    │   └── meta.yaml
    └── tree
        └── meta.yaml

3 directories, 4 files
```