### PR TITLE
Add paintera recipe

### DIFF
--- a/recipes/paintera/meta.yaml
+++ b/recipes/paintera/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "paintera" %}
+{% set version = "0.8.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: paintera
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install --no-deps -vvv ."
+  skip: True  # [py2k]
+  entry_points:
+    - paintera                = paintera:jgo_paintera
+    - paintera-show-container = paintera:jgo_paintera_show_container
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - jgo
+    - psutil
+
+test:
+  commands:
+    - test -f ${CONDA_PREFIX}/bin/paintera  # [unix]
+    - if not exist %CONDA_PREFIX%\\bin\\paintera exit 1  # [win]
+
+
+about:
+  home: https://github.com/saalfeldlab/paintera
+  license: GPL-2.0
+  summary: "Visualization tool for 3D volumetric data and proof-reading in segmentation/reconstruction with a primary focus on neuron reconstruction from electron micrographs in connectomics."
+  doc_url: https://github.com/saalfeldlab/paintera
+  dev_url: https://github.com/saalfeldlab/paintera
+
+extra:
+  recipe-maintainers:
+    - hanslovsky

--- a/recipes/paintera/paintera/paintera.py
+++ b/recipes/paintera/paintera/paintera.py
@@ -1,0 +1,71 @@
+import jgo.jgo
+import os
+import psutil
+import sys
+
+__paintera_version__                   = '0.8.2'
+__slf4j_version__                      = '1.7.25'
+
+__paintera_show_container__            = '@PainteraShowContainer'
+
+repositories = {
+    'saalfeldlab'   : 'https://saalfeldlab.github.io/maven',
+    'imagej.public' : 'https://maven.imagej.net/content/groups/public'
+    }
+
+def add_jvm_args_as_necessary(argv, set_gc_option=True):
+    gc_option = '-XX:+UseConcMarkSweepGC'
+
+    if set_gc_option and not gc_option in argv:
+        argv += [gc_option]
+
+    for arg in argv:
+        if '-Xmx' in arg:
+            return argv
+
+    total_memory  = psutil.virtual_memory().total
+    exponent      = 3 if total_memory > 2*1024**3 else 2
+    memory_unit   = 'G' if exponent == 3 else 'M'
+    max_heap_size = os.getenv(
+        'PAINTERA_MAX_HEAP_SIZE',
+        '{}{}'.format(max(total_memory // (1024**exponent) // 2, 1), memory_unit))
+
+    argv = ['-Xmx{}'.format(max_heap_size)] + argv
+
+    return argv
+
+
+def jgo_paintera():
+    argv               = sys.argv[1:]
+    double_dash_index  = [i for (i, arg) in enumerate(argv) if arg == '--'][0] if '--' in argv else -1
+    jgo_and_jvm_argv   = ([] if double_dash_index < 0 else argv[:double_dash_index]) + ['--ignore-jgorc']
+    repository_strings = ['-r'] + ['{}={}'.format(k, v) for (k, v) in repositories.items()]
+    endpoint           = ['org.janelia.saalfeldlab:paintera:{}+{}'.format(__paintera_version__, os.getenv('PAINTERA_SLF4J_BINDING', 'org.slf4j:slf4j-simple:{}'.format(__slf4j_version__)))]
+    paintera_argv      = argv if double_dash_index < 0 else argv[double_dash_index+1:]
+    argv               = add_jvm_args_as_necessary(jgo_and_jvm_argv, set_gc_option=True) + repository_strings + endpoint + paintera_argv
+
+    jgo.jgo.jgo_main(argv)
+
+def jgo_paintera_show_container():
+    argv               = sys.argv[1:]
+    double_dash_index  = [i for (i, arg) in enumerate(argv) if arg == '--'][0] if '--' in argv else -1
+    jgo_and_jvm_argv   = ([] if double_dash_index < 0 else argv[:double_dash_index]) + ['--ignore-jgorc']
+    repository_strings = ['-r'] + ['{}={}'.format(k, v) for (k, v) in repositories.items()]
+    endpoint           = ['org.janelia.saalfeldlab:paintera:{}:{}+{}'.format(__paintera_version__, __paintera_show_container__, os.getenv('PAINTERA_SLF4J_BINDING', 'org.slf4j:slf4j-simple:{}'.format(__slf4j_version__)))]
+    paintera_argv      = argv if double_dash_index < 0 else argv[double_dash_index+1:]
+    argv               = add_jvm_args_as_necessary(jgo_and_jvm_argv, set_gc_option=True) + repository_strings + endpoint + paintera_argv
+
+    jgo.jgo.jgo_main(argv)
+
+def jgo_paintera_conversion_helper():
+    argv                   = sys.argv[1:]
+    double_dash_index      = [i for (i, arg) in enumerate(argv) if arg == '--'][0] if '--' in argv else -1
+    jgo_and_jvm_argv       = ([] if double_dash_index < 0 else argv[:double_dash_index]) + ['--ignore-jgorc']
+    repository_strings     = ['-r'] + ['{}={}'.format(k, v) for (k, v) in repositories.items()]
+    endpoint               = ['org.janelia.saalfeldlab:paintera-conversion-helper:{}'.format(__paintera_conversion_helper_version__)]
+    spark_master           = ['-Dspark.master={}'.format(os.getenv('SPARK_MASTER', 'local[*]'))]
+    conversion_helper_argv = argv if double_dash_index < 0 else argv[double_dash_index+1:]
+    argv                   = add_jvm_args_as_necessary(jgo_and_jvm_argv + spark_master, set_gc_option=True) + repository_strings + endpoint + conversion_helper_argv
+
+    jgo.jgo.jgo_main(argv)
+

--- a/recipes/paintera/paintera/setup.py
+++ b/recipes/paintera/paintera/setup.py
@@ -1,0 +1,19 @@
+from distutils.core import setup
+from distutils.command.build_py import build_py
+
+setup(
+    name='paintera',
+    version='0.8.2',
+    author='Philipp Hanslovsky',
+    author_email='hanslovskyp@janelia.hhmi.org',
+    description='paintera',
+    url='https://github.com/saalfeldlab/paintera',
+    py_modules=['paintera'],
+    entry_points={
+        'console_scripts': [
+            'paintera=paintera:jgo_paintera',
+            'paintera-show-container=paintera:jgo_paintera_show_container',
+        ]
+    },
+    install_requires=['jgo', 'psutil', 'paintera-conversion-helper']
+)


### PR DESCRIPTION
With [`jgo`](https://github.com/conda-forge/jgo-feedstock) now available on `conda-forge` I would like to migrate [Paintera](https://github.com/saalfeldlab/paintera) from my personal channel to `conda-forge`, as well. *Paintera is a general visualization tool for 3D volumetric data and proof-reading in segmentation/reconstruction with a primary focus on neuron reconstruction from electron micrographs in connectomics.* Although written in Java, distribution through conda is the way to go for us.