### PR TITLE
Add Python package sos

### DIFF
--- a/recipes/sos/meta.yaml
+++ b/recipes/sos/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 470b891468c988885a3eada407cd85644c3ddf15a3b9d1a0993bffab755fbdee
 
 build:
+  noarch: python
   number: 0
   entry_points:
     - sos=sos.__main__:main
@@ -28,7 +29,7 @@ requirements:
     - pydot
     - pydotplus
     - pygments
-    - python
+    - python >=3.6
     - pyyaml
     - pyzmq
     - setuptools
@@ -43,7 +44,7 @@ requirements:
     - pydot
     - pydotplus
     - pygments
-    - python
+    - python >=3.6
     - pyyaml
     - pyzmq
     - setuptools
@@ -62,11 +63,13 @@ about:
   home: https://github.com/vatlab/SoS
   license: BSD
   license_family: BSD
-  license_file: 
-  summary: Script of Scripts (SoS): an interactive, cross-platform, and cross-language workflow system for reproducible data analysis
-  doc_url: 
-  dev_url: 
+  license_file: LICENSE
+  summary: "Script of Scripts (SoS): an interactive, cross-platform, and cross-language workflow system for reproducible data analysis"
+  doc_url: https://vatlab.github.io/sos-docs/
+
 
 extra:
   recipe-maintainers:
-    - your-github-id-here
+    - BoPeng
+    - gaow
+    - jdblischak

--- a/recipes/sos/meta.yaml
+++ b/recipes/sos/meta.yaml
@@ -19,21 +19,8 @@ build:
 
 requirements:
   host:
-    - fasteners
-    - jinja2
-    - nbformat
-    - networkx
-    - pexpect
     - pip
-    - psutil
-    - pydot
-    - pydotplus
-    - pygments
     - python >=3.6
-    - pyyaml
-    - pyzmq
-    - setuptools
-    - tqdm
   run:
     - fasteners
     - jinja2

--- a/recipes/sos/meta.yaml
+++ b/recipes/sos/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "sos" %}
+{% set version = "0.17.7" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 470b891468c988885a3eada407cd85644c3ddf15a3b9d1a0993bffab755fbdee
+
+build:
+  number: 0
+  entry_points:
+    - sos=sos.__main__:main
+    - sos-runner=sos.__main__:sosrunner
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - fasteners
+    - jinja2
+    - nbformat
+    - networkx
+    - pexpect
+    - pip
+    - psutil
+    - pydot
+    - pydotplus
+    - pygments
+    - python
+    - pyyaml
+    - pyzmq
+    - setuptools
+    - tqdm
+  run:
+    - fasteners
+    - jinja2
+    - nbformat
+    - networkx
+    - pexpect
+    - psutil
+    - pydot
+    - pydotplus
+    - pygments
+    - python
+    - pyyaml
+    - pyzmq
+    - setuptools
+    - tqdm
+
+test:
+  imports:
+    - sos
+    - sos.docker
+    - sos.singularity
+  commands:
+    - sos --help
+    - sos-runner --help
+
+about:
+  home: https://github.com/vatlab/SoS
+  license: BSD
+  license_family: BSD
+  license_file: 
+  summary: Script of Scripts (SoS): an interactive, cross-platform, and cross-language workflow system for reproducible data analysis
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here


### PR DESCRIPTION
This package does not need to be compiled, but it requires `python >=3.6`. Thus I made it a noarch recipe using version constraints as recommended in the [documentation](https://conda-forge.org/docs/meta.html#building-noarch-packages).

Links: [PyPI](https://pypi.org/project/sos/), [GitHub](https://github.com/vatlab/SoS)
cc: @BoPeng, @gaow
xref: https://github.com/vatlab/SoS/issues/896, https://github.com/vatlab/SoS/issues/1096, https://github.com/bioconda/bioconda-recipes/pull/9457