### PR TITLE
Add Python package sos-pbs

### DIFF
--- a/recipes/sos-pbs/meta.yaml
+++ b/recipes/sos-pbs/meta.yaml
@@ -10,17 +10,16 @@ source:
   sha256: 867d36aa6e3897e5586b01c911a7cd728d1c8307926fb7df468ad43d72e808b5
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
 
 requirements:
   host:
     - pip
-    - python
-    - setuptools
-    - sos >=0.17.0
+    - python >=3.6
   run:
-    - python
+    - python >=3.6
     - setuptools
     - sos >=0.17.0
 
@@ -32,11 +31,12 @@ about:
   home: https://github.com/vatlab/SOS
   license: BSD
   license_family: BSD
-  license_file: 
+  license_file: LICENSE
   summary: PBS task engine for Script of Scripts (SoS)
-  doc_url: 
-  dev_url: 
+  doc_url: https://vatlab.github.io/sos-docs/
 
 extra:
   recipe-maintainers:
-    - your-github-id-here
+    - BoPeng
+    - gaow
+    - jdblischak

--- a/recipes/sos-pbs/meta.yaml
+++ b/recipes/sos-pbs/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "sos-pbs" %}
+{% set version = "0.17.5" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 867d36aa6e3897e5586b01c911a7cd728d1c8307926fb7df468ad43d72e808b5
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - sos >=0.17.0
+  run:
+    - python
+    - setuptools
+    - sos >=0.17.0
+
+test:
+  imports:
+    - sos_pbs
+
+about:
+  home: https://github.com/vatlab/SOS
+  license: BSD
+  license_family: BSD
+  license_file: 
+  summary: PBS task engine for Script of Scripts (SoS)
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here


### PR DESCRIPTION
Adds noarch recipe for PyPI package that requires `python >=3.6`.

Links: [PyPI](https://pypi.org/project/sos-pbs/), [GitHub](https://github.com/vatlab/sos-pbs)
cc: @BoPeng, @gaow
xref: https://github.com/conda-forge/staged-recipes/pull/7126