### PR TITLE
Fix toolchain fortran compiler typo

### DIFF
--- a/.ci_support/azure-linux-64.yaml
+++ b/.ci_support/azure-linux-64.yaml
@@ -3,7 +3,7 @@ c_compiler:
 cxx_compiler:
   - toolchain_cxx
 fortran_compiler:
-  - toolchain_fortran
+  - toolchain_fort
 channel_sources:
   - conda-forge,defaults
 docker_image:

--- a/.ci_support/azure-osx-64.yaml
+++ b/.ci_support/azure-osx-64.yaml
@@ -3,6 +3,6 @@ c_compiler:
 cxx_compiler:
   - toolchain_cxx
 fortran_compiler:
-  - toolchain_fortran
+  - toolchain_fort
 channel_sources:
   - conda-forge,defaults


### PR DESCRIPTION
the toolchain package for fortran is called toolchain_fort and not toolchain_fortran