### PR TITLE
Drop `sudo: false` from `.travis.yml`             [skip lint]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ jobs:
 
     - if: (fork IN (false)) AND (NOT (type IN (pull_request)))
       os: linux
-      sudo: false
-
-sudo: false
 
 env:
     global:


### PR DESCRIPTION
As noted in recent Travis CI announcements (most notably the linked blog below), support for `sudo: false` on Linux workers is being dropped. All user will be migrated to Linux virtual-machines. This makes the needed change to the Travis CI configuration file as part of this migration effort.

ref: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration