### PR TITLE
Pin conda-build to 3.16

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - cmd: appveyor-retry conda.exe update --yes --quiet conda
 
 
-    - cmd: appveyor-retry conda.exe install --yes --quiet conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build>=3.16
+    - cmd: appveyor-retry conda.exe install --yes --quiet conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build=3.16
 
     - cmd: appveyor-retry run_conda_forge_build_setup
 

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -40,7 +40,7 @@ conda clean --lock
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build=3.16
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -29,7 +29,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build=3.16
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.


### PR DESCRIPTION
We are currently experiencing problems with conda-build 3.17 
which is preventing packages in staged-recipes to build correctly.

This PR is a temporary work-around to pin the build environments to
conda-build 3.16

cf: conda/conda-build#3292
ping: @conda-forge/core