### PR TITLE
Add Jupyterlab-git

### DIFF
--- a/recipes/jupyterlab-git/bld.bat
+++ b/recipes/jupyterlab-git/bld.bat
@@ -1,0 +1,11 @@
+:: Packs and installs the extension, nodejs extension rebuild is done automatically
+:: on jupyterlab startup, when the new extension is detected or was removed
+CALL "%PREFIX%\Scripts\jupyter-labextension" install . --no-build || EXIT /B 1
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+
+"%PYTHON%" -m pip install . --no-deps --ignore-installed -vvv || EXIT /B 1
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%
+
+:: Shared file not to be included.
+del /Q "%PREFIX%\share\jupyter\lab\settings\build_config.json" || EXIT /B 1
+IF %ERRORLEVEL% NEQ 0 EXIT /B %ERRORLEVEL%

--- a/recipes/jupyterlab-git/build.sh
+++ b/recipes/jupyterlab-git/build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+# Packs and installs the extension, nodejs extension rebuild is done automatically
+# on jupyterlab startup, when the new extension is detected or was removed.
+"${PREFIX}/bin/jupyter" labextension install . --no-build
+
+"${PYTHON}" -m pip install . --no-deps --ignore-installed -vvv
+
+# Shared file not to be included.
+rm -f "${PREFIX}/share/jupyter/lab/settings/build_config.json"

--- a/recipes/jupyterlab-git/meta.yaml
+++ b/recipes/jupyterlab-git/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "jupyterlab-git" %}
+{% set version = "0.4.4" %}
+{% set sha256 = "a1ea23fbdf38fd90fa5839f72710cd6f00f2cb10b308f75a411a63b0832d4feb" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jupyterlab/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+
+requirements:
+  build:
+    - nodejs
+  host:
+    - jupyterlab
+    - pip
+    - psutil
+    - python >=3.5
+  run:
+    - jupyterlab
+    - nodejs
+    - psutil
+    - python >=3.5
+
+test:
+  imports:
+    - jupyterlab_git
+  commands:
+    - jupyter labextension list
+    - jupyter lab build
+
+about:
+  home: https://github.com/jupyterlab/jupyterlab-git
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: A Git extension for JupyterLab
+  description: A JupyterLab extension for version control using git
+  dev_url: https://github.com/jupyterlab/jupyterlab-git
+
+extra:
+  recipe-maintainers:
+    - dbast


### PR DESCRIPTION
`python >=3.5` is done instead of `skip: True  # [py2k]`, because of noarch to force the noarch build with python3 (there is no recent jupyterlab version for python2). Setting only a minimum required jupyterlab version would not help as any python2 build attempt would fail. Instead requesting python3 is doing the job.

Tagging some teams for review: @conda-forge/help-python @conda-forge/jupyterlab 

Thanks!