### PR TITLE
Adding r-juniperkernel

### DIFF
--- a/recipes/r-juniperkernel/bld.bat
+++ b/recipes/r-juniperkernel/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-juniperkernel/build.sh
+++ b/recipes/r-juniperkernel/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/JuniperKernel
+  mv * $PREFIX/lib/R/library/JuniperKernel
+  if [[ $target_platform == osx-64 ]]; then
+    pushd $PREFIX
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd $libdir || exit 1
+          for SHARED_LIB in $(find . -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R"); do
+            echo "fixing SHARED_LIB $SHARED_LIB"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "$PREFIX"/lib/R/lib/libR.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "$PREFIX"/lib/libomp.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "$PREFIX"/lib/libquadmath.0.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "$PREFIX"/lib/libgfortran.3.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "$PREFIX"/lib/libgcc_s.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "$PREFIX"/sysroot/usr/lib/libiconv.2.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "$PREFIX"/sysroot/usr/lib/libncurses.5.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "$PREFIX"/sysroot/usr/lib/libicucore.A.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "$PREFIX"/lib/libexpat.1.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "$PREFIX"/lib/libcurl.4.dylib $SHARED_LIB || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "$PREFIX"/lib/libc++.1.dylib $SHARED_LIB || true
+          done
+        popd
+      done
+    popd
+  fi
+fi

--- a/recipes/r-juniperkernel/meta.yaml
+++ b/recipes/r-juniperkernel/meta.yaml
@@ -43,7 +43,6 @@ requirements:
     - r-jsonlite
     - r-pbdzmq >=0.3_2
     - r-repr
-    - openblas                   # [not win]
   run:
     - r-base
     - {{native}}gcc-libs         # [win]
@@ -53,7 +52,6 @@ requirements:
     - r-jsonlite
     - r-pbdzmq >=0.3_2
     - r-repr
-    - openblas                   # [not win]
 
 test:
   commands:

--- a/recipes/r-juniperkernel/meta.yaml
+++ b/recipes/r-juniperkernel/meta.yaml
@@ -1,0 +1,86 @@
+{% set version = '1.4.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-juniperkernel
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/JuniperKernel_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/JuniperKernel/JuniperKernel_{{ version }}.tar.gz
+  sha256: f6458915d529b670296734c942193b827def9c41bedc46cf95527302b9a3f0fd
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  skip: true  # [linux]
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('cxx') }}      # [not win]
+    - {{native}}toolchain        # [win]
+    - {{posix}}filesystem        # [win]
+    - {{posix}}sed               # [win]
+    - {{posix}}grep              # [win]
+    - {{posix}}autoconf
+    - {{posix}}automake          # [not win]
+    - {{posix}}automake-wrapper  # [win]
+    - {{posix}}pkg-config
+    - {{posix}}make
+    - {{posix}}coreutils         # [win]
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-rcpp >=0.11.0
+    - r-data.table
+    - r-gdtools >=0.1.6
+    - r-jsonlite
+    - r-pbdzmq >=0.3_2
+    - r-repr
+    - openblas                   # [not win]
+  run:
+    - r-base
+    - {{native}}gcc-libs         # [win]
+    - r-rcpp >=0.11.0
+    - r-data.table
+    - r-gdtools >=0.1.6
+    - r-jsonlite
+    - r-pbdzmq >=0.3_2
+    - r-repr
+    - openblas                   # [not win]
+
+test:
+  commands:
+    - $R -e "library('JuniperKernel')"           # [not win]
+    - "\"%R%\" -e \"library('JuniperKernel')\""  # [win]
+
+about:
+  home: https://github.com/JuniperKernel/JuniperKernel
+  license: GPL (>= 2)
+  summary: Provides a full implementation of the 'Jupyter' <http://jupyter.org/> messaging protocol
+    in C++ by leveraging 'Rcpp' and 'Xeus' <https://github.com/QuantStack/xeus>. 'Jupyter'
+    supplies an interactive computing environment and a messaging protocol defined over
+    'ZeroMQ' for multiple programming languages. This package implements the 'Jupyter'
+    kernel interface so that 'R' is exposed to this interactive computing environment.
+    'ZeroMQ' functionality is provided by the 'pbdZMQ' package. 'Xeus' is a C++ library
+    that facilitates the implementation of kernels for 'Jupyter'. Additionally, 'Xeus'
+    provides an interface to libraries that exist in the 'Jupyter' ecosystem for building
+    widgets, plotting, and more <https://blog.jupyter.org/interactive-workflows-for-c-with-jupyter-fe9b54227d92>.
+    'JuniperKernel' uses 'Xeus' as a library for the 'Jupyter' messaging protocol.
+  license_family: GPL3
+  license_file: '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak
+    - cbrueffer
+    - dbast


### PR DESCRIPTION
Linux build is disabled, because it requires newer compilers, but can be enabled after feedstock conversion.