### PR TITLE
Pin conda-build to 3.16 to fix feedstock creation

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -35,7 +35,7 @@ bash ~/miniconda.sh -b -p ~/miniconda
 )
 source ~/miniconda/bin/activate root
 
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-smithy=3.* conda-forge-pinning git=2.12.2
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-smithy=3.* conda-forge-pinning git=2.12.2 conda-build=3.16
 
 conda info
 conda config --get


### PR DESCRIPTION
This temporarily pins `conda-build` to 3.16 to get feedstock creation working again.