### PR TITLE
Add aioftp (python asyncio ftp client/server)

### DIFF
--- a/recipes/aioftp/meta.yaml
+++ b/recipes/aioftp/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
 
 requirements:

--- a/recipes/aioftp/meta.yaml
+++ b/recipes/aioftp/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "aioftp" %}
+{% set version = "0.12.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 22d04c95c30e69a05dc35bc93c735b101662f5028aebe12d0038962bd9c0b956
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - pip
+    - python >=3.5.3
+  run:
+    - python >=3.5.3
+
+test:
+  imports:
+    - aioftp
+
+about:
+  home: http://aioftp.readthedocs.org/
+  license: Apache 2
+  license_family: APACHE
+  license_file: license.txt
+  summary: FTP client/server for Python asyncio
+  dev_url: https://github.com/aio-libs/aioftp
+
+extra:
+  recipe-maintainers:
+    - epruesse


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
This is from aio-lib, the project hosting aiohttp. It's also pretty much the only asyncio FTP protocol implementation I've found. For those of us who still need FTP occasionally...