### PR TITLE
Skip noarch recipes on Travis and AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,6 +29,13 @@ install:
              for /f "tokens=*" %%a in ('git ls-tree --name-only master -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
     - cmd: cd ..
 
+    # Find the noarch recipes in this PR and remove them.
+    - cmd: echo Finding noarch recipes and removing them.
+    - cmd: cd recipes
+    - cmd: |
+             for /f "tokens=*" %%a in ('grep -l "noarch:" */meta.yaml') do rmdir /s /q %%a && echo Removing recipe: %%a
+    - cmd: cd ..
+
     # Remove cygwin (and therefore the git that comes with it).
     - cmd: rmdir C:\cygwin /s /q
 

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -40,5 +40,13 @@ git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf {} && echo Remov
 popd > /dev/null
 echo ""
 
+# Find the noarch recipes in this PR and remove them.
+echo ""
+echo "Finding noarch recipes and removing them from the build."
+pushd ./recipes > /dev/null
+grep -l 'noarch:' */meta.yaml | xargs dirname | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
+popd > /dev/null
+echo ""
+
 # We just want to build all of the recipes.
 python .ci_support/build_all.py ./recipes


### PR DESCRIPTION
Noarch recipes are currently built unnecessarily in PRs to staged-recipes. This uses up CI time and also causes failures (since the recipes are only intended to run on CircleCI).

The bash code for Travis should work fine. However, I wasn't able to thoroughly test the code for AppVeyor. I based it off of the line to remove recipes in master, but I couldn't execute that code on my local Windows 10 machine (using either Command Shell or PowerShell). I confirmed that `grep -l "noarch:" */meta.yaml` will return the list of `meta.yaml` files that contain "noarch:", but I couldn't figure out how to pipe it to `dirname`.

cc: @CJ-Wright @bgruening 
xref: https://github.com/conda-forge/conda-forge.github.io/issues/683