### PR TITLE
Add lpsolve55

### DIFF
--- a/recipes/lpsolve55/lpsolve_include_prefix.patch
+++ b/recipes/lpsolve55/lpsolve_include_prefix.patch
@@ -1,0 +1,13 @@
+diff --git a/extra/Python/pythonmod.h b/extra/Python/pythonmod.h
+index 9c8e5b0..8ac6a96 100644
+--- a/extra/Python/pythonmod.h
++++ b/extra/Python/pythonmod.h
+@@ -14,7 +14,7 @@
+ #include "numpy/arrayobject.h"
+ #endif
+ 
+-#include "lp_lib.h"
++#include "lpsolve/lp_lib.h"
+ 
+ #define quotechar "'"
+ #define drivername lpsolve

--- a/recipes/lpsolve55/malloc.patch
+++ b/recipes/lpsolve55/malloc.patch
@@ -1,0 +1,12 @@
+diff --git a/extra/Python/hash.c b/extra/Python/hash.c
+index b990f3f..6296b98 100644
+--- a/extra/Python/hash.c
++++ b/extra/Python/hash.c
+@@ -8,7 +8,6 @@
+ 
+ #include <sys/types.h>
+ #include <stdlib.h>
+-#include <malloc.h>
+ #include <string.h>
+ 
+ #include "hash.h"

--- a/recipes/lpsolve55/meta.yaml
+++ b/recipes/lpsolve55/meta.yaml
@@ -19,14 +19,13 @@ source:
 
 build:
   number: 0
-  script:
-    - cd extra/Python
-    - python setup.py install
+  script: "{{ PYTHON }} -m pip install extra/Python -vv"
 
 requirements:
   build:
     - {{ compiler('c') }}
   host:
+    - pip
     - python
     - numpy
     - lp_solve

--- a/recipes/lpsolve55/meta.yaml
+++ b/recipes/lpsolve55/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "5.5" %}
+
+package:
+  name: lpsolve55
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/chandu-atina/lp_solve_python_3x.git
+  git_rev: 3d6ed38d8c3cfb63a281f2cd74ec23d97131351c
+  patches:
+    # https://github.com/chandu-atina/lp_solve_python_3x/pull/2
+    - sitedir.patch
+
+    # ftbfs on osx
+    - malloc.patch
+
+    # specific include prefix in conda-forge
+    - lpsolve_include_prefix.patch
+
+build:
+  number: 0
+  script:
+    - cd extra/Python
+    - python setup.py install
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - numpy
+    - lp_solve
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - lp_solve
+
+test:
+  imports:
+    - lpsolve55
+
+about:
+  home: https://github.com/chandu-atina/lp_solve_python_3x
+  license: LGPL
+  license_file: LICENSE
+  summary: lpsolve python extension for python 2.x and python 3.x
+
+extra:
+  recipe-maintainers:
+    - jschueller

--- a/recipes/lpsolve55/sitedir.patch
+++ b/recipes/lpsolve55/sitedir.patch
@@ -1,0 +1,23 @@
+--- src/lp_solve_python_3x/extra/Python/setup.py.orig	2018-12-18 17:28:24.489631424 +0100
++++ src/lp_solve_python_3x/extra/Python/setup.py	2018-12-18 17:32:22.559018147 +0100
+@@ -2,16 +2,15 @@
+ from os import getenv
+ import sys
+ import os
++from distutils import sysconfig
++
+ p = sys.prefix
+ NUMPYPATH = '.'
+ if os.path.isdir(p + '/include/numpy'):
+   NUMPY = 'NUMPY'
+-elif os.path.isdir(p + '/Lib/site-packages/numpy/core/include/numpy'):
++elif os.path.isdir(sysconfig.get_python_lib() + '/numpy/core/include/numpy'):
+   NUMPY = 'NUMPY'
+-  NUMPYPATH = p + '/Lib/site-packages/numpy/core/include'
+-elif os.path.isdir(p + '/lib/python3.4/site-packages/numpy/core/include/numpy'):
+-  NUMPY = 'NUMPY'
+-  NUMPYPATH = p + '/lib/python3.4/site-packages/numpy/core/include'
++  NUMPYPATH = sysconfig.get_python_lib() + '/numpy/core/include'
+ else:
+   NUMPY = 'NONUMPY'
+ print ('numpy: ' + NUMPY)


### PR DESCRIPTION
There is a package lp_solve in conda-forge with the c library, this is a fork of the python bindings compatible with 3.x (upstream only provided 2.x and development stopped a long time ago).
Patches are reported upstream to the fork except for the lpsolve header location that is conda-forge specific.
