### PR TITLE
Add celery-singleton and celery-eternal

### DIFF
--- a/recipes/celery-eternal/meta.yaml
+++ b/recipes/celery-eternal/meta.yaml
@@ -46,4 +46,3 @@ about:
 extra:
   recipe-maintainers:
     - duncanmmacleod
-    - lpsinger

--- a/recipes/celery-eternal/meta.yaml
+++ b/recipes/celery-eternal/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "celery-eternal" %}
+{% set version = "0.0.3" %}
+{% set sha256 = "37dc9f19fc947ea5eb93f3388cdab667b492e94ffa7fa85b2c1d3612579e4672" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools >=30.3.0
+  run:
+    - python
+    - celery >=4.1.0
+    - celery-singleton >=0.1.1
+    - redis-py >=2.10.5
+
+test:
+  imports:
+    - celery_eternal
+  requires:
+    - pytest
+  commands:
+    - python -m pytest --pyargs celery_eternal
+
+about:
+  home: https://celery-eternal.readthedocs.io
+  doc_url: https://celery-eternal.readthedocs.io
+  dev_url: https://github.com/lpsinger/celery-eternal
+  license: GPLv2+
+  license_family: GPL
+  license_file: LICENSE.md
+  summary: Celery task subclass for jobs that should run forever
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - lpsinger

--- a/recipes/celery-singleton/meta.yaml
+++ b/recipes/celery-singleton/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "celery-singleton" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a6741832bd19d20228b2eacc145cc549510cb2423ee2b2ae08a0b974b876d584
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+  run:
+    - python
+    - celery >=4.0.0
+    - redis >=2.10.5
+
+test:
+  imports:
+    - celery_singleton
+
+about:
+  home: https://github.com/steinitzu/celery-singleton
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Prevent duplicate celery tasks
+  description: |
+    Duplicate tasks clogging up your message broker?
+    Do time based rate limits make you feel icky? Look no further!
+    This is a baseclass for celery tasks that ensures only one instance of
+    the task can be queued or running at any given time.
+    Uses the task's name+arguments to determine uniqueness.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds recipes for [`celery-singleton`](https://github.com/steinitzu/celery-singleton) and [`celery-eternal`](https://celery-eternal.readthedocs.io).

**I am not a developer, or maintainer, of either of these**, but @lpsinger is the main developer of `celery-eternal`, so I have named him as co-maintainer of that recipe. I hope that's ok Leo!?

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
