### PR TITLE
Fix building recipes and their dependencies at the same time

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -105,7 +105,7 @@ def build_folders(recipes_dir, folders, arch, channel_urls):
 
     G = construct_graph(recipes_dir, worker=worker, run='build',
                         conda_resolve=conda_resolve, folders=folders,
-                        finalize=False)
+                        config=config, finalize=False)
     order = list(nx.topological_sort(G))
     order.reverse()
 

--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -105,7 +105,7 @@ def build_folders(recipes_dir, folders, arch, channel_urls):
 
     G = construct_graph(recipes_dir, worker=worker, run='build',
                         conda_resolve=conda_resolve, folders=folders,
-                        config=config, finalize=False)
+                        finalize=False)
     order = list(nx.topological_sort(G))
     order.reverse()
 

--- a/.ci_support/compute_build_graph.py
+++ b/.ci_support/compute_build_graph.py
@@ -200,7 +200,7 @@ _rendered_recipes = {}
 
 
 @conda_interface.memoized
-def _get_or_render_metadata(meta_file_or_recipe_dir, worker, finalize, config=None):
+def _get_or_render_metadata(meta_file_or_recipe_dir, worker, finalize):
     global _rendered_recipes
     platform = worker['platform']
     arch = str(worker['arch'])
@@ -209,14 +209,14 @@ def _get_or_render_metadata(meta_file_or_recipe_dir, worker, finalize, config=No
         _rendered_recipes[(meta_file_or_recipe_dir, platform, arch)] = \
                             api.render(meta_file_or_recipe_dir, platform=platform, arch=arch,
                                        verbose=False, permit_undefined_jinja=True,
-                                       bypass_env_check=True, config=config, finalize=finalize)
+                                       bypass_env_check=True, config=None, finalize=finalize)
     return _rendered_recipes[(meta_file_or_recipe_dir, platform, arch)]
 
 
 def add_recipe_to_graph(recipe_dir, graph, run, worker, conda_resolve,
                         recipes_dir=None, config=None, finalize=False):
     try:
-        rendered = _get_or_render_metadata(recipe_dir, worker, config=config, finalize=finalize)
+        rendered = _get_or_render_metadata(recipe_dir, worker, finalize=finalize)
     except (IOError, SystemExit):
         log.warn('invalid recipe dir: %s - skipping', recipe_dir)
         return None

--- a/.ci_support/compute_build_graph.py
+++ b/.ci_support/compute_build_graph.py
@@ -230,7 +230,7 @@ def add_recipe_to_graph(recipe_dir, graph, run, worker, conda_resolve,
 
         if name not in graph.nodes():
             graph.add_node(name, meta=metadata, worker=worker)
-            add_dependency_nodes_and_edges(name, graph, run, worker, conda_resolve,
+            add_dependency_nodes_and_edges(name, graph, run, worker, conda_resolve, config=config,
                                         recipes_dir=recipes_dir, finalize=finalize)
 
         # # add the test equivalent at the same time.  This is so that expanding can find it.
@@ -436,7 +436,7 @@ def _buildable(name, version, recipes_dir, worker, config, finalize):
 
 
 def add_dependency_nodes_and_edges(node, graph, run, worker, conda_resolve, recipes_dir=None,
-                                   finalize=False):
+                                   finalize=False, config=None):
     '''add build nodes for any upstream deps that are not yet installable
 
     changes graph in place.
@@ -461,7 +461,7 @@ def add_dependency_nodes_and_edges(node, graph, run, worker, conda_resolve, reci
                 #                  " available) can't produce desired version ({})."
                 #                  .format(dep, version))
             dep_name = add_recipe_to_graph(recipe_dir, graph, 'build', worker,
-                                            conda_resolve, recipes_dir, finalize=finalize)
+                                            conda_resolve, recipes_dir, config=config, finalize=finalize)
             if not dep_name:
                 raise ValueError("Tried to build recipe {0} as dependency, which is skipped "
                                  "in meta.yaml".format(recipe_dir))

--- a/.ci_support/compute_build_graph.py
+++ b/.ci_support/compute_build_graph.py
@@ -200,7 +200,7 @@ _rendered_recipes = {}
 
 
 @conda_interface.memoized
-def _get_or_render_metadata(meta_file_or_recipe_dir, worker, finalize):
+def _get_or_render_metadata(meta_file_or_recipe_dir, worker, finalize, config=None):
     global _rendered_recipes
     platform = worker['platform']
     arch = str(worker['arch'])
@@ -209,14 +209,14 @@ def _get_or_render_metadata(meta_file_or_recipe_dir, worker, finalize):
         _rendered_recipes[(meta_file_or_recipe_dir, platform, arch)] = \
                             api.render(meta_file_or_recipe_dir, platform=platform, arch=arch,
                                        verbose=False, permit_undefined_jinja=True,
-                                       bypass_env_check=True, config=None, finalize=finalize)
+                                       bypass_env_check=True, config=config, finalize=finalize)
     return _rendered_recipes[(meta_file_or_recipe_dir, platform, arch)]
 
 
 def add_recipe_to_graph(recipe_dir, graph, run, worker, conda_resolve,
                         recipes_dir=None, config=None, finalize=False):
     try:
-        rendered = _get_or_render_metadata(recipe_dir, worker, finalize=finalize)
+        rendered = _get_or_render_metadata(recipe_dir, worker, config=config, finalize=finalize)
     except (IOError, SystemExit):
         log.warn('invalid recipe dir: %s - skipping', recipe_dir)
         return None


### PR DESCRIPTION
There seems to be a bug in #7116 that causes the graph building to fail when dependencies are added at the same time as the "main" recipe. See [this build](https://circleci.com/gh/conda-forge/staged-recipes/33163?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) from #7414 for an example.

This PR appears to fix it, though I don't understand what is happening well enough to know if this is the "correct" fix.