### PR TITLE
Pin conda-forge-ci-setup to 2.*

### DIFF
--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -29,7 +29,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet conda-forge-ci-setup conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -29,7 +29,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet conda-forge-ci-setup conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.


### PR DESCRIPTION
@conda-forge/core is there a reason for the pinning for conda-forge-ci-setup? This seems to be a remaining difference between the `staged-recipes` repo and the rendered repos.


<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
