### PR TITLE
Add bash-git-prompt

### DIFF
--- a/recipes/bash-git-prompt/activate-bash-git-prompt.sh
+++ b/recipes/bash-git-prompt/activate-bash-git-prompt.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+GIT_PROMPT_ONLY_IN_REPO=1
+GIT_PROMPT_FETCH_REMOTE_STATUS=0
+source "$CONDA_PREFIX/share/bash-git-prompt/gitprompt.sh"

--- a/recipes/bash-git-prompt/bld.bat
+++ b/recipes/bash-git-prompt/bld.bat
@@ -1,0 +1,8 @@
+copy "%RECIPE_DIR%\build.sh" .
+set PREFIX=%PREFIX:\=/%
+bash -lc "./build.sh" || goto :error
+goto :EOF
+
+:error
+echo Failed with error #%errorlevel%.
+exit 1

--- a/recipes/bash-git-prompt/build.sh
+++ b/recipes/bash-git-prompt/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+# See https://github.com/magicmonty/bash-git-prompt/blob/master/bash-git-prompt.rb
+
+mkdir -p "${PREFIX}/share/bash-git-prompt"
+
+install \
+  gitprompt.sh \
+  gitprompt.fish \
+  git-prompt-help.sh \
+  gitstatus.py \
+  gitstatus.sh \
+  gitstatus_pre-1.7.10.sh \
+  prompt-colors.sh \
+  "${PREFIX}/share/bash-git-prompt/"
+
+mkdir -p "${PREFIX}/share/bash-git-prompt/themes"
+cp themes/*.bgptheme themes/Custom.bgptemplate "${PREFIX}/share/bash-git-prompt/themes/"
+
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+cp "${RECIPE_DIR}/activate-${PKG_NAME}.sh" "${PREFIX}/etc/conda/activate.d/activate-${PKG_NAME}.sh"

--- a/recipes/bash-git-prompt/meta.yaml
+++ b/recipes/bash-git-prompt/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "bash-git-prompt" %}
+{% set version = "2.7.1" %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/magicmonty/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 5e5fc6f5133b65760fede8050d4c3bc8edb8e78bc7ce26c16db442aa94b8a709
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  build:
+    - {{posix}}coreutils
+
+test:
+  commands:
+    - bash -c "source $CONDA_PREFIX/etc/conda/activate.d/activate-{{ name }}.sh && git_prompt_help"
+
+about:
+  home: https://github.com/magicmonty/bash-git-prompt
+  license: BSD-2-Clause
+  summary: An informative and fancy bash prompt for Git users
+  description: Bash prompt for Git users, that is activated by environment
+    activation on unix. Requires git provided by the system or the conda
+    environment.
+  license_family: BSD
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - dbast


### PR DESCRIPTION
This enables `An informative and fancy bash prompt for Git users` via package installation and environment activation only (at least on unix). I was first not sure if that is possible ... seems like it is. The automation of something that is part of more and more dev environments.

Thus an environment.yml can describe everything from language interpreters / compilers, packages to a complete development environment including IDEs, tools and a fancy bash-git prompt.

After the tools are already there, git, git-lfs, git-annex, lazygit ... bash-git-prompt was missing so far :) (and maybe grv).

Two specifics:
* no deactivation on environment deactivation, to be `clean`, starting a new shell is required: There is a command `git_prompt_toggle`, which does not work, as it restores the prompt before bash-git-prompt activation not before environment activation. 
* afaik no automatic activation on windows via package installation only: requires m2-bash/git-bash + sourcing `gitprompt.sh` via `~/.bashrc` or `~/.bash_profile`, which are both outside of a conda environment (or something different when working with cmd.exe only). That information could be added to description.

Ready for review @conda-forge/staged-recipes 

Also tagging @conda-forge/git and @conda-forge/git-lfs Somebody maybe interested to co-maintain this?

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
