### PR TITLE
[R4R] Add go-dep 0.5.0 module to conda-forge

### DIFF
--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -40,7 +40,7 @@ conda clean --lock
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -40,7 +40,7 @@ conda clean --lock
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/recipes/go-dep/conda_build_config.yaml
+++ b/recipes/go-dep/conda_build_config.yaml
@@ -1,0 +1,10 @@
+go_compiler:
+  - go-nocgo
+cgo_compiler:
+  - go-cgo
+goos:
+  - linux    # [linux]
+  - darwin   # [osx]
+  - windows  # [win]
+goarch:
+  - amd64

--- a/recipes/go-dep/conda_build_config.yaml
+++ b/recipes/go-dep/conda_build_config.yaml
@@ -13,5 +13,5 @@ target_goexe:
   -                            # [unix]
   - .exe                       # [win]
 target_gobin:
-  - ${PREFIX}/bin/             # [unix]
-  - %PREFIX%\bin\              # [win]
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]

--- a/recipes/go-dep/conda_build_config.yaml
+++ b/recipes/go-dep/conda_build_config.yaml
@@ -2,9 +2,16 @@ go_compiler:
   - go-nocgo
 cgo_compiler:
   - go-cgo
-goos:
-  - linux    # [linux]
-  - darwin   # [osx]
-  - windows  # [win]
-goarch:
-  - amd64
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - 386                        # [x86]
+  - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - ${PREFIX}/bin/             # [unix]
+  - %PREFIX%\bin\              # [win]

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -6,7 +6,7 @@
 {% set pkg_src = ('src/'+goname).replace("/",os.sep) %}
 
 package:
-  name: {{ name|lower }}
+  name: go-{{ name|lower }}
   version: {{ version }}
 
 source:

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - {{ compiler('go') }} >=1.11.3
 
 test:
-  requires:
+  requires:         # [win]
     - m2-coreutils  # [win]
   commands:
     - test -x ${PREFIX}/bin/dep

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -1,0 +1,46 @@
+{% set provider = "aws" %}
+{% set goname = "github.com/golang/dep" %}
+{% set version = "0.5.0" %}
+
+{% set name = goname.split('/')[-1] %}
+{% set pkg_src = ('src/'+goname).replace("/",os.sep) %}
+
+{% set x4_plugin = name + '_v' + version + "_x4" + (".exe" if win else "")%}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - folder:  {{ pkg_src }}
+    url: https://{{ goname }}/archive/v{{ version }}.tar.gz
+    sha256: 65c31c8d51513dfabd25f1f37ecd22a38ab3bcdd5893bdf10f54941250e4f19d
+
+build:
+  number: 0
+  script:
+    - pushd {{ pkg_src }}
+    - go install -v -ldflags="-X main.version=v{{ version }}" ./cmd/dep
+
+requirements:
+  build:
+    - {{ compiler('go') }} >=1.11.3
+
+test:
+  requires:
+    - m2-coreutils  # [win]
+  commands:
+    - test -x ${PREFIX}/bin/dep
+    - dep version
+
+about:
+  home: https://golang.github.io/dep/
+  license: BSD-3-Clause
+  license_file: {{ pkg_src }}/LICENSE
+  summary: The Go dependency management tool
+  doc_url: https://golang.github.io/dep/docs/introduction.html
+  dev_url: https://{{ goname }}
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -11,8 +11,10 @@ package:
 
 source:
   - folder:  {{ pkg_src }}
-    url: https://{{ goname }}/archive/v{{ version }}.tar.gz
-    sha256: 65c31c8d51513dfabd25f1f37ecd22a38ab3bcdd5893bdf10f54941250e4f19d
+    url: https://{{ goname }}/archive/v{{ version }}.tar.gz  # [unix]
+    sha256: 65c31c8d51513dfabd25f1f37ecd22a38ab3bcdd5893bdf10f54941250e4f19d  # [unix]
+    url: https://{{ goname }}/archive/v{{ version }}.zip  # [win]
+    sha256: 3528435745f57a22e817b7878450dc5f8d8065ad617880d9192626f31a8efa85  # [win]
 
 build:
   number: 0

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -30,7 +30,8 @@ test:
   requires:         # [win]
     - m2-coreutils  # [win]
   commands:
-    - test -x ${PREFIX}/bin/dep
+    - test -x ${PREFIX}/bin/dep      # [unix]
+    - test -x ${PREFIX}/bin/dep.exe  # [win]
     - dep version
 
 about:

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.5.0" %}
 
 {% set name = goname.split('/')[-1] %}
-{% set pkg_src = ('src/'+goname).replace("/",os.sep) %}
+{% set pkg_src = ('src/'+goname).replace('/','\' if win else '/') %}
 
 package:
   name: go-{{ name|lower }}
@@ -29,8 +29,7 @@ test:
   requires:         # [win]
     - m2-coreutils  # [win]
   commands:
-    - test -x ${PREFIX}/bin/dep      # [unix]
-    - test -f %PREFIX%\bin\dep.exe  # [win]
+    - test -x {{target_gobin}}dep{{target_goexe}}
     - dep version
 
 about:

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -13,8 +13,8 @@ source:
   - folder:  {{ pkg_src }}
     url: https://{{ goname }}/archive/v{{ version }}.tar.gz  # [unix]
     sha256: 65c31c8d51513dfabd25f1f37ecd22a38ab3bcdd5893bdf10f54941250e4f19d  # [unix]
-    url: https://{{ goname }}/archive/v{{ version }}.zip  # [win]
-    sha256: 3528435745f57a22e817b7878450dc5f8d8065ad617880d9192626f31a8efa85  # [win]
+    git_url: https://{{ goname }}  # [win]
+    git_tag: v{{ version }}  # [win]
 
 build:
   number: 0

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "0.5.0" %}
 
 {% set name = goname.split('/')[-1] %}
-{% set pkg_src = ('src/'+goname).replace('/','\' if win else '/') %}
+{% set pkg_src = ('src/'+goname).replace("/", "\\" if win else "/") %}
 
 package:
   name: go-{{ name|lower }}
@@ -19,11 +19,11 @@ build:
   number: 0
   script:
     - pushd {{ pkg_src }}
-    - go install -v -ldflags="-X main.version=v{{ version }}" ./cmd/dep
+    - 'go install -v -ldflags="-X main.version=v{{ version }}" ./cmd/dep'
 
 requirements:
   build:
-    - {{ compiler('go') }} >=1.11.3
+    - {{ compiler("go") }} >=1.11.3
 
 test:
   requires:         # [win]

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -9,7 +9,7 @@ package:
   version: {{ version }}
 
 source:
-  - folder:  {{ pkg_src }}
+  - folder: {{ pkg_src }}
     url: https://{{ goname }}/archive/v{{ version }}.tar.gz  # [unix]
     sha256: 65c31c8d51513dfabd25f1f37ecd22a38ab3bcdd5893bdf10f54941250e4f19d  # [unix]
     git_url: https://{{ goname }}  # [win]

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -31,7 +31,7 @@ test:
     - m2-coreutils  # [win]
   commands:
     - test -x ${PREFIX}/bin/dep      # [unix]
-    - test -f ${PREFIX}/bin/dep.exe  # [win]
+    - test -f %PREFIX%\bin\dep.exe  # [win]
     - dep version
 
 about:

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -5,8 +5,6 @@
 {% set name = goname.split('/')[-1] %}
 {% set pkg_src = ('src/'+goname).replace("/",os.sep) %}
 
-{% set x4_plugin = name + '_v' + version + "_x4" + (".exe" if win else "")%}
-
 package:
   name: {{ name|lower }}
   version: {{ version }}

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -1,4 +1,3 @@
-{% set provider = "aws" %}
 {% set goname = "github.com/golang/dep" %}
 {% set version = "0.5.0" %}
 

--- a/recipes/go-dep/meta.yaml
+++ b/recipes/go-dep/meta.yaml
@@ -31,7 +31,7 @@ test:
     - m2-coreutils  # [win]
   commands:
     - test -x ${PREFIX}/bin/dep      # [unix]
-    - test -x ${PREFIX}/bin/dep.exe  # [win]
+    - test -f ${PREFIX}/bin/dep.exe  # [win]
     - dep version
 
 about:


### PR DESCRIPTION
This dependency is a build-requirement for 
conda-forge/singularity-feedstock#14 and other go packages. 

Without this conda-package, one has to build go-dep 
during the build process of their own go program, which 
is not very DRY-like, and risks creating clobbering issues 
with other packages.

At the moment, the linter will fail because I am still waiting for
PR conda-forge/conda-smithy#980 to be merged.

In the future, I would like to use this or a slightly simpler recipe
as a template for other go-programs to come.

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->