### PR TITLE
Add pyparallel

### DIFF
--- a/recipes/pyparallel/LICENSE
+++ b/recipes/pyparallel/LICENSE
@@ -1,0 +1,39 @@
+Copyright (c) 2001-2015 Chris Liechti <cliechti@gmx.net>
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+  * Neither the name of the copyright holder nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------------------------------------------------------------
+Note:
+Individual files contain the following tag instead of the full license text.
+
+    SPDX-License-Identifier:    BSD-3-Clause
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -15,7 +15,6 @@ build:
   # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
   # Once resolved, it should be removed.
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: true  # [not linux]
 
 requirements:
   host:

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "pyparallel" %}
+{% set version = "0.2.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b5550293af42a42d7b2e1ada1224d3c3ce2f09b80e85421820e068655908c611
+
+build:
+  number: 0
+  # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
+  # Once resolved, it should be removed.
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - parallel
+
+about:
+  home: https://github.com/pyserial/pyparallel
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python parallel port access library'
+  description: |
+    This module encapsulates the access for the parallel port. It
+    provides backends for Python running on Windows and Linux.
+    Other platforms are possible too but not yet integrated.
+  doc_url: http://simplejson.readthedocs.io/
+  dev_url: https://github.com/simplejson/simplejson
+
+extra:
+  recipe-maintainers:
+    - hoechenberger
+    - kastman

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/pyserial/pyparallel/archive/{{ commit_sha }}.zip
-
+  sha256: 6235c0d3af9ad4fcca84693f206113144686d9eeb12811748e3935b3400dc5aa
 
 build:
   number: 0

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "pyparallel" %}
 {% set version = "0.2.2" %}
+{% set commit_sha = "c79718e4fe700286dd27cfe5f756f9b37dcf48e8" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b5550293af42a42d7b2e1ada1224d3c3ce2f09b80e85421820e068655908c611
+  url: https://github.com/pyserial/pyparallel/archive/{{ commit_sha }}.zip
+
 
 build:
   number: 0
@@ -31,7 +32,7 @@ about:
   home: https://github.com/pyserial/pyparallel
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENSE.txt
   summary: 'Python parallel port access library'
   description: |
     This module encapsulates the access for the parallel port.

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -36,8 +36,7 @@ about:
     This module encapsulates the access for the parallel port. It
     provides backends for Python running on Windows and Linux.
     Other platforms are possible too but not yet integrated.
-  doc_url: http://simplejson.readthedocs.io/
-  dev_url: https://github.com/simplejson/simplejson
+  dev_url: https://github.com/pyserial/pyparallel
 
 extra:
   recipe-maintainers:

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -14,6 +14,7 @@ build:
   # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
   # Once resolved, it should be removed.
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: true  # [win]
 
 requirements:
   host:

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   host:
     - python
     - pip
+    - flake8
   run:
     - python
 

--- a/recipes/pyparallel/meta.yaml
+++ b/recipes/pyparallel/meta.yaml
@@ -14,7 +14,7 @@ build:
   # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
   # Once resolved, it should be removed.
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: true  # [win]
+  skip: true  # [not linux]
 
 requirements:
   host:
@@ -34,9 +34,7 @@ about:
   license_file: LICENSE
   summary: 'Python parallel port access library'
   description: |
-    This module encapsulates the access for the parallel port. It
-    provides backends for Python running on Windows and Linux.
-    Other platforms are possible too but not yet integrated.
+    This module encapsulates the access for the parallel port.
   dev_url: https://github.com/pyserial/pyparallel
 
 extra:


### PR DESCRIPTION
Currently shipping with a copy of the license file. I opened a [PR to include a license file upstream](https://github.com/pyserial/pyparallel/pull/11), too.