### PR TITLE
Add uproot and it's dependencies

### DIFF
--- a/recipes/awkward/meta.yaml
+++ b/recipes/awkward/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "awkward" %}
+{% set version = "0.7.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0111190b3d8fa5f3143b90279a5aad09bbb652b25cbfcf8f48aaf323b450a63c
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  noarch: python
+
+requirements:
+  build:
+  host:
+    - python
+    - pip
+    - numpy >=1.13.1
+    - pytest-runner
+  run:
+    - python
+    - numpy >=1.13.1
+
+test:
+  imports:
+    - awkward
+
+about:
+  home: https://github.com/scikit-hep/{{ name }}
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Manipulate arrays of complex data structures as easily as Numpy.'
+  dev_url: https://github.com/scikit-hep/{{ name }}
+
+extra:
+  recipe-maintainers:
+    - chrisburr

--- a/recipes/awkward/meta.yaml
+++ b/recipes/awkward/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   host:
     - python
     - pip
-    - numpy >=1.13.1
     - pytest-runner
   run:
     - python

--- a/recipes/uproot-methods/meta.yaml
+++ b/recipes/uproot-methods/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "uproot-methods" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d2a03460973b825e07b4e5069d30dca02931f277bc8e969ff1d46f711e660235
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy >=1.13.1
+    - awkward >=0.7.0
+  run:
+    - python
+    - numpy >=1.13.1
+    - awkward >=0.7.0
+
+test:
+  imports:
+    - uproot_methods
+
+about:
+  home: https://github.com/scikit-hep/{{ name }}
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Pythonic behaviors for non-I/O related ROOT classes.'
+  dev_url: https://github.com/scikit-hep/{{ name }}
+
+extra:
+  recipe-maintainers:
+    - chrisburr

--- a/recipes/uproot-methods/meta.yaml
+++ b/recipes/uproot-methods/meta.yaml
@@ -18,8 +18,6 @@ requirements:
   host:
     - python
     - pip
-    - numpy >=1.13.1
-    - awkward >=0.7.0
   run:
     - python
     - numpy >=1.13.1

--- a/recipes/uproot/meta.yaml
+++ b/recipes/uproot/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "uproot" %}
+{% set version = "3.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: acc15883ae8632fcd9e4d94f9e9a3618a2108710d6ab16765cb6dc01da13a7ab
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy >=1.13.1
+    - awkward >=0.7.0
+    - uproot-methods >=0.3.0
+    - cachetools
+    - backports.lzma  # [py27]
+    - lz4
+    # - xrootd
+    - pytest-runner
+  run:
+    - python
+    - numpy >=1.13.1
+    - awkward >=0.7.0
+    - uproot-methods >=0.3.0
+    - cachetools
+    - backports.lzma  # [py27]
+    - lz4
+    # - xrootd
+
+test:
+  imports:
+    - uproot_methods
+
+about:
+  home: https://github.com/scikit-hep/{{ name }}
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'ROOT I/O in pure Python and Numpy.'
+  description: |
+    uproot (originally μproot, for “micro-Python ROOT”) is a reader and a writer
+    of the ROOT file format using only Python and Numpy. Unlike the standard C++
+    ROOT implementation, uproot is only an I/O library, primarily intended to
+    stream data into machine learning libraries in Python. Unlike PyROOT and
+    root_numpy, uproot does not depend on C++ ROOT. Instead, it uses Numpy calls
+    to rapidly cast data blocks in the ROOT file as Numpy arrays.
+  dev_url: https://github.com/scikit-hep/{{ name }}
+  doc_url: https://{{ name }}.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - chrisburr

--- a/recipes/uproot/meta.yaml
+++ b/recipes/uproot/meta.yaml
@@ -17,13 +17,6 @@ requirements:
   host:
     - python
     - pip
-    - numpy >=1.13.1
-    - awkward >=0.7.0
-    - uproot-methods >=0.3.0
-    - cachetools
-    - backports.lzma  # [py27]
-    - lz4
-    # - xrootd
     - pytest-runner
   run:
     - python

--- a/recipes/uproot/meta.yaml
+++ b/recipes/uproot/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - cachetools
     - backports.lzma  # [py27]
     - lz4
-    # - xrootd
+    - xrootd  # [unix]
 
 test:
   imports:


### PR DESCRIPTION
Adds recipes for `uproot` and two of it's dependencies (`awkward` and `uproot-methods`).
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
