### PR TITLE
Add Pypubsub recipe

### DIFF
--- a/recipes/pypubsub/meta.yaml
+++ b/recipes/pypubsub/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = "v4.0.0" %}
+{% set checksum = "e4391c98b747c5168277ca8f37508a3f7ef65cc83bdef698316ba2e87fdb5389" %}
+
+package:
+    name: pypubsub
+    version: {{ version }}
+
+source:
+    url: https://github.com/schollii/pypubsub/archive/{{ version }}.tar.gz
+    sha256: {{ checksum }}
+
+build:
+    number: 0
+    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+    noarch: python
+
+requirements:
+    host:
+        - python >=3.3
+        - pip
+
+    run:
+        - python >=3.3
+
+test:
+    imports:
+        - pubsub
+
+about:
+    license: Simplified BSD License
+    license_file: src/pubsub/LICENSE_BSD_Simple.txt
+    license_family: BSD
+    summary: A python publish-subscribe library
+    home: https://github.com/schollii/pypubsub
+
+extra:
+    recipe-maintainers:
+        - constantinpape
+        - schollii

--- a/recipes/pypubsub/meta.yaml
+++ b/recipes/pypubsub/meta.yaml
@@ -27,7 +27,7 @@ test:
         - pubsub
 
 about:
-    license: Simplified BSD License
+    license: Simplified BSD
     license_file: src/pubsub/LICENSE_BSD_Simple.txt
     license_family: BSD
     summary: A python publish-subscribe library


### PR DESCRIPTION
Add a recipe for pypubsub:
https://github.com/schollii/pypubsub
This package is not on conda-forge, but is required by wxpython (which is on conda-forge),
which seems to cause this issue:
https://github.com/conda-forge/wxpython-feedstock/issues/25 

@schollii
I have added you to the maintainers here, please confirm if you want to be added.
Also, please review the license information I have added and confirm that there are no 
dependencies besides python and pip.

@conda-forge/help-python
This is a python noarch package with only python and pip dependency (I think).