### PR TITLE
Add ldas-tools-frameapi

### DIFF
--- a/recipes/ldas-tools-frameapi/build.sh
+++ b/recipes/ldas-tools-frameapi/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+./configure \
+  --prefix=${PREFIX} \
+  --with-optimization=high \
+  --disable-tcl \
+  --disable-python \
+  --without-doxygen \
+  --without-dot
+
+# build
+make -j ${CPU_COUNT}
+
+# test
+make -j ${CPU_COUNT} check
+
+# install
+make -j ${CPU_COUNT} install

--- a/recipes/ldas-tools-frameapi/meta.yaml
+++ b/recipes/ldas-tools-frameapi/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "ldas-tools-frameAPI" %}
+{% set version = "2.6.3" %}
+{% set sha256 = "910c3b94e78bdf097b30cdce9f9544b275d076bc1c0d1d69c37364a14da8e336" %}
+
+# upstream dependency versions
+{% set ldas_tools_framecpp_version = "2.6.4" %}
+{% set ldas_tools_filters_version = "2.6.3" %}
+{% set ldas_tools_ldasgen_version = "2.6.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config  # [not win]
+    - make  # [not win]
+  host:
+    - ldas-tools-framecpp >={{ ldas_tools_framecpp_version }}
+    - ldas-tools-filters >={{ ldas_tools_filters_version }}
+    - ldas-tools-ldasgen >={{ ldas_tools_ldasgen_version }}
+    - openssl
+    - zlib
+  run:
+    - ldas-tools-framecpp >={{ ldas_tools_framecpp_version }}
+    - ldas-tools-filters >={{ ldas_tools_filters_version }}
+    - ldas-tools-ldasgen >={{ ldas_tools_ldasgen_version }}
+
+test:
+  commands:
+    - test -d ${PREFIX}/include/frameAPI  # [not win]
+    - test -f ${PREFIX}/lib/libldasframe${SHLIB_EXT}  # [not win]
+    - conda inspect linkages -p ${PREFIX} ${PKG_NAME}  # [not win]
+    - conda inspect objects -p ${PREFIX} ${PKG_NAME}  # [osx]
+
+about:
+  home: https://wiki.ligo.org/Computing/DASWG/LDASTools
+  dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+  license: GPLv2
+  license_family: GPL
+  license_file: COPYING
+  summary: LDAS tools frameAPI library
+  description: This provides the runtime libraries for the frameAPI library.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros


### PR DESCRIPTION
This adds a recipe for `ldas-tools-frameapi`, a component of LDAS Tools used in GW astronomy.

cc @emaros as co-maintainer

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
