### PR TITLE
Add pyWinhook

### DIFF
--- a/recipes/pyWinhook/meta.yaml
+++ b/recipes/pyWinhook/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "pyWinhook" %}
+{% set version = "1.5.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 39bc4fd0477bc2d51d07ad4a9d4923654b417a4f4adc487c67966afa1780daee
+
+build:
+  number: 0
+  # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
+  # Once resolved, it should be removed.
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: True  # [not win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - swig
+  host:
+    - python <3
+    - pip
+  run:
+    - python <3
+
+test:
+  imports:
+    - pyWinhook
+
+about:
+  home: https://github.com/Tungsteno74/pyWinhook
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'A fork of pyHook from Peter P. with some updates'
+  description: |
+    A pyHook fork with some updates for support latest Visual Studio
+    compilers.
+
+extra:
+  recipe-maintainers:
+    - hoechenberger

--- a/recipes/pyWinhook/meta.yaml
+++ b/recipes/pyWinhook/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 39bc4fd0477bc2d51d07ad4a9d4923654b417a4f4adc487c67966afa1780daee
+  patches:
+    - support-python-3.patch
 
 build:
   number: 0

--- a/recipes/pyWinhook/meta.yaml
+++ b/recipes/pyWinhook/meta.yaml
@@ -45,3 +45,4 @@ about:
 extra:
   recipe-maintainers:
     - hoechenberger
+    - kastman

--- a/recipes/pyWinhook/meta.yaml
+++ b/recipes/pyWinhook/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
   sha256: 39bc4fd0477bc2d51d07ad4a9d4923654b417a4f4adc487c67966afa1780daee
   patches:
     - support-python-3.patch
@@ -23,10 +23,10 @@ requirements:
     - {{ compiler('c') }}
     - swig
   host:
-    - python <3
+    - python
     - pip
   run:
-    - python <3
+    - python
 
 test:
   imports:

--- a/recipes/pyWinhook/support-python-3.patch
+++ b/recipes/pyWinhook/support-python-3.patch
@@ -1,0 +1,169 @@
+Index: pyWinhook/HookManager.py
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- pyWinhook/HookManager.py	(revision 3f892f77b9c9674fff1e9a86514d7730f275f7a1)
++++ pyWinhook/HookManager.py	(revision a7681d0d993dd9a39eda947b722e9239403e4428)
+@@ -1,4 +1,4 @@
+-import cpyHook
++from . import cpyHook
+
+ def GetKeyState(key_id):
+   return cpyHook.cGetKeyState(key_id)
+Index: pyWinhook/__init__.py
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- pyWinhook/__init__.py	(revision 3f892f77b9c9674fff1e9a86514d7730f275f7a1)
++++ pyWinhook/__init__.py	(revision a7681d0d993dd9a39eda947b722e9239403e4428)
+@@ -1,1 +1,1 @@
+-from HookManager import *
+\ No newline at end of file
++from .HookManager import *
+\ No newline at end of file
+Index: pyWinhook/aa hook.py
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- pyWinhook/aa hook.py	(revision 3f892f77b9c9674fff1e9a86514d7730f275f7a1)
++++ pyWinhook/aa hook.py	(revision a7681d0d993dd9a39eda947b722e9239403e4428)
+@@ -1,3 +1,4 @@
++from __future__ import print_function
+ import wx
+ import pyWinhook as pyHook
+ from pyAA import *
+@@ -21,44 +22,44 @@
+     elif event.Type == 'mouse':
+       ao = AccessibleObjectFromPoint(event.Position)
+
+-    print
+-    print '---------------------------'
+-    print 'Event:'
+-    print ' ',event.MessageName
+-    print '  Window:', event.WindowName
++    print('')
++    print('---------------------------')
++    print('Event:')
++    print(' %s' % event.MessageName)
++    print('  Window: %s' % event.WindowName)
+     if event.Type == 'keyboard':
+-      print '  Key:',event.Key
+-    print
+-    print 'Object:'
++      print('  Key: %s' % event.Key)
++    print('')
++    print('Object:')
+     try:
+-      print '  Name:', ao.Name
++      print('  Name: %s' % ao.Name)
+     except:
+-      print
++      print()
+
+     try:
+-      print '  Value:', ao.Value
++      print('  Value: %s' % ao.Value)
+     except:
+-      print
++      print()
+
+     try:
+-      print '  Role:', ao.RoleText
++      print('  Role: %s' % ao.RoleText)
+     except:
+-      print
++      print()
+
+     try:
+-      print '  Description:', ao.Description
++      print('  Description: %s' %ao.Description)
+     except:
+-      print
++      print()
+
+     try:
+-      print '  State:', ao.StateText
++      print('  State: %s' % ao.StateText)
+     except:
+-      print
++      print()
+
+     try:
+-      print '  Shortcut:', ao.KeyboardShortcut
++      print('  Shortcut: %s' % ao.KeyboardShortcut)
+     except:
+-      print
++      print()
+
+   def OnMouseEvent(self, event):
+     event.Type = 'mouse'
+Index: pyWinhook/example.py
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- pyWinhook/example.py	(revision 3f892f77b9c9674fff1e9a86514d7730f275f7a1)
++++ pyWinhook/example.py	(revision 8083b6177ec22931af9b8946aec3d8399f77cb97)
+@@ -1,35 +1,36 @@
++from __future__ import print_function
+ import pyWinhook as pyHook
+
+ def OnMouseEvent(event):
+-  print 'MessageName:',event.MessageName
+-  print 'Message:',event.Message
+-  print 'Time:',event.Time
+-  print 'Window:',event.Window
+-  print 'WindowName:',event.WindowName
+-  print 'Position:',event.Position
+-  print 'Wheel:',event.Wheel
+-  print 'Injected:',event.Injected
+-  print '---'
++  print('MessageName: %s' % event.MessageName)
++  print('Message: %s' % event.Message)
++  print('Time: %s' % event.Time)
++  print('Window: %s' % event.Window)
++  print('WindowName: %s' % event.WindowName)
++  print('Position: (%d, %d)' % event.Position)
++  print('Wheel: %s' % event.Wheel)
++  print('Injected: %s' % event.Injected)
++  print('---')
+
+   # return True to pass the event to other handlers
+   # return False to stop the event from propagating
+   return True
+
+ def OnKeyboardEvent(event):
+-  print 'MessageName:',event.MessageName
+-  print 'Message:',event.Message
+-  print 'Time:',event.Time
+-  print 'Window:',event.Window
+-  print 'WindowName:',event.WindowName
+-  print 'Ascii:', event.Ascii, chr(event.Ascii)
+-  print 'Key:', event.Key
+-  print 'KeyID:', event.KeyID
+-  print 'ScanCode:', event.ScanCode
+-  print 'Extended:', event.Extended
+-  print 'Injected:', event.Injected
+-  print 'Alt', event.Alt
+-  print 'Transition', event.Transition
+-  print '---'
++  print('MessageName: %s' % event.MessageName)
++  print('Message: %s' % event.Message)
++  print('Time: %s' % event.Time)
++  print('Window: %s' % event.Window)
++  print('WindowName: %s' % event.WindowName)
++  print('Ascii: %s' %  event.Ascii, chr(event.Ascii))
++  print('Key: %s' %  event.Key)
++  print('KeyID: %s' %  event.KeyID)
++  print('ScanCode: %s' %  event.ScanCode)
++  print('Extended: %s' %  event.Extended)
++  print('Injected: %s' %  event.Injected)
++  print('Alt %s' %  event.Alt)
++  print('Transition %s' %  event.Transition)
++  print('---')
+
+   # return True to pass the event to other handlers
+   # return False to stop the event from propagating


### PR DESCRIPTION
This PR adds a recipe for `pyWinhook`, which is a fork of `pyHook` that works with modern versions of the VS Compilers.

The latest release does not support Python 3; therefore, I created a patch to add Py3 support. There is also a [PR upstream to integrate this](https://github.com/Tungsteno74/pyWinhook/pull/2) (in fact, the patch is the diff of that PR). Note, however, that the project has been inactive for about 2 years now, so I doubt this change will get merged into upstream and released anytime soon, if ever. That's why I created the patch for the `conda-forge` recipe.