### PR TITLE
Add ldas-tools-diskcacheapi

### DIFF
--- a/recipes/ldas-tools-diskcacheapi/build.sh
+++ b/recipes/ldas-tools-diskcacheapi/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./configure \
+  --prefix=${PREFIX} \
+  --disable-warnings-as-errors \
+  --with-optimization=high \
+  --without-doxygen \
+  --without-dot
+
+# build
+make -j ${CPU_COUNT}
+
+# install
+make -j ${CPU_COUNT} install

--- a/recipes/ldas-tools-diskcacheapi/meta.yaml
+++ b/recipes/ldas-tools-diskcacheapi/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "ldas-tools-diskcacheAPI" %}
+{% set version = "2.6.3" %}
+{% set sha256 = "7dca15fbb47d915fb40c75ca990c72ffe622042fa2b625caacb0888115b1f8c7" %}
+
+{% set ldas_tools_al_version = "2.6.2" %}
+{% set ldas_tools_ldasgen_version = "2.6.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config  # [not win]
+    - make  # [not win]
+  host:
+    - boost-cpp
+    - ldas-tools-al >={{ ldas_tools_al_version }}
+    - ldas-tools-ldasgen >={{ ldas_tools_ldasgen_version }}
+  run:
+    - ldas-tools-al >={{ ldas_tools_al_version }}
+    - ldas-tools-ldasgen >={{ ldas_tools_ldasgen_version }}
+
+test:
+  commands:
+    # check executables
+    - diskcache --help
+    # check libraries
+    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
+    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
+
+about:
+  home: https://wiki.ligo.org/Computing/DASWG/LDASTools
+  doc_url: https://ldastools.docs.ligo.org/LDAS_Tools/Beta/doc/ldas-tools-diskcacheAPI/diskcache/html/
+  dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+  license: GPLv2
+  license_family: GPL
+  license_file: COPYING
+  summary: LDAS tools diskcacheAPI library
+  description: |
+    LDAS tools diskcacheAPI library. This package provides the runtime
+    libraries and executables but does not provide the systemd
+    infrastructure to run diskcache as a service.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros


### PR DESCRIPTION
This adds a recipe for `ldas-tools-diskcacheAPI`, part of the LDAS Tools suite.

cc: @emaros as co-maintainer

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
