### PR TITLE
Add go-glide to conda-forge.

### DIFF
--- a/recipes/go-glide/conda_build_config.yaml
+++ b/recipes/go-glide/conda_build_config.yaml
@@ -1,0 +1,17 @@
+go_compiler:
+  - go-nocgo
+cgo_compiler:
+  - go-cgo
+target_goos:
+  - linux                      # [linux]
+  - darwin                     # [osx]
+  - windows                    # [win]
+target_goarch:
+  - 386                        # [x86]
+  - amd64                      # [x86_64]
+target_goexe:
+  -                            # [unix]
+  - .exe                       # [win]
+target_gobin:
+  - '${PREFIX}/bin/'           # [unix]
+  - '%PREFIX%\bin\'            # [win]

--- a/recipes/go-glide/meta.yaml
+++ b/recipes/go-glide/meta.yaml
@@ -10,8 +10,11 @@ package:
 
 source:
   - folder: {{ pkg_src }}
-    url: https://{{ goname }}/archive/v{{ version }}.tar.gz
-    sha256: 0886851af2437b161d47b279a32bef426577e7bec3f5acdadebe34549aae8270
+    url: https://{{ goname }}/archive/v{{ version }}.tar.gz  # [unix]
+    sha256: 0886851af2437b161d47b279a32bef426577e7bec3f5acdadebe34549aae8270  # [unix]
+
+    git_url: https://{{ goname }}  # [win]
+    git_tag: v{{ version }}  # [win]
 
 build:
   number: 0

--- a/recipes/go-glide/meta.yaml
+++ b/recipes/go-glide/meta.yaml
@@ -10,8 +10,7 @@ package:
 
 source:
   - folder: {{ pkg_src }}
-    git_url: https://{{ goname }}
-    git_tag: v{{ version }}
+    url: https://{{ goname }}/archive/v{{ version }}.tar.gz
 
 build:
   number: 0

--- a/recipes/go-glide/meta.yaml
+++ b/recipes/go-glide/meta.yaml
@@ -11,6 +11,7 @@ package:
 source:
   - folder: {{ pkg_src }}
     url: https://{{ goname }}/archive/v{{ version }}.tar.gz
+    sha256: 0886851af2437b161d47b279a32bef426577e7bec3f5acdadebe34549aae8270
 
 build:
   number: 0

--- a/recipes/go-glide/meta.yaml
+++ b/recipes/go-glide/meta.yaml
@@ -1,0 +1,50 @@
+{% set goname = "github.com/Masterminds/glide" %}
+{% set version = "0.13.2" %}
+
+{% set name = goname.split('/')[-1] %}
+{% set pkg_src = ('src/'+goname).replace("/", "\\" if win else "/") %}
+
+package:
+  name: go-{{ name|lower }}
+  version: {{ version }}
+
+source:
+  - folder: {{ pkg_src }}
+    git_url: https://{{ goname }}
+    git_tag: v{{ version }}
+
+build:
+  number: 0
+  script:
+    - pushd {{ pkg_src }}
+    - go install -v -ldflags "-X main.version={{ version }}" .
+
+requirements:
+  build:
+    - {{ compiler('go') }}
+
+test:
+  commands:
+    - test -x {{ target_gobin }}glide{{ target_goexe }}
+    - glide --version
+    - glide --help
+
+about:
+  home: https://glide.sh
+  license: MIT
+  license_file: {{pkg_src}}/LICENSE
+  summary: 'Package Management for Golang'
+
+  description: |
+      Manage your vendor and vendored packages with ease. Glide is a tool
+      for managing the vendor directory within a Go package. This feature,
+      first introduced in Go 1.5, allows each package to have a vendor
+      directory containing dependent packages for the project. These vendor
+      packages can be installed by a tool (e.g. glide), similar to go get
+      or they can be vendored and distributed with the package.
+  dev_url: https://{{ goname }}
+  doc_url: http://glide.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
This is a build-time dependency for building kubernetes-helm.