### PR TITLE
Add voeventlib

### DIFF
--- a/recipes/voeventlib/meta.yaml
+++ b/recipes/voeventlib/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "voeventlib" %}
+{% set version = "1.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  # voeventlib-1.2 on pypi only provides wheels, not a tarball,
+  # so we build from the relevant git commit in the upstream repo.
+  # Reported as: https://git.ligo.org/emfollow/VOEventLib/issues/2
+  git_url: https://git.ligo.org/emfollow/VOEventLib
+  git_tag: 2452c5b81d6d6051b210f62355824ec7885669c1
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+    - setuptools
+  run:
+    - python >=3.5
+    - lxml
+
+test:
+  imports:
+    - VOEventLib
+    - VOEventLib.VOEvent
+    - VOEventLib.Vutil
+
+about:
+  home: https://git.ligo.org/emfollow/VOEventLib
+  dev_url: https://git.ligo.org/emfollow/VOEventLib
+  license: GPLv3+
+  license_family: GPL
+  license_file: LICENSE.md
+  summary: Python library to read, modify, and create VOEvents
+  description: Python library to read, modify, and create VOEvents
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds a recipe for [`voeventlib`](https://pypi.org/project/voeventlib). This builds directly from the git repo because the pypi upload only includes a wheel, this has been reported as https://git.ligo.org/emfollow/VOEventLib/issues/2.

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
