### PR TITLE
Add ligo-raven

### DIFF
--- a/recipes/ligo-raven/meta.yaml
+++ b/recipes/ligo-raven/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "ligo-raven" %}
+{% set version = "1.8" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  # ligo-raven-1.8 on pypi only provides wheels, not a tarball,
+  # so we build from the relevant git commit in the upstream repo.
+  # Reported as: https://git.ligo.org/lscsoft/raven/issues/5
+  git_url: https://git.ligo.org/lscsoft/raven.git
+  git_tag: 6d62f0b9f022ce644b995c379a86d153d5d051f4
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools
+  run:
+    - python >=3.6
+    - h5py
+    - healpy !=1.12.0
+    - lalsuite
+    - ligo-common
+    - ligo-gracedb >=2.0.0
+    - ligo-segments
+    - ligo.skymap
+    - lscsoft-glue
+    - lxml
+    - numpy >=1.14.5
+    - scipy >=0.7.2
+    - voeventlib >=1.2
+
+test:
+  imports:
+    - ligo.raven
+    - ligo.raven.gracedb_events
+    - ligo.raven.search
+  commands:
+    - raven_coinc_search_gracedb --help
+    - raven_fetch_external_triggers --help
+    - raven_file_cache_monitor --help
+    - raven_gcn_web_scraper --help
+
+about:
+  home: https://git.ligo.org/lscsoft/raven/
+  dev_url: https://git.ligo.org/lscsoft/raven/
+  license: GPLv3+
+  license_family: GPL
+  license_file: COPYING
+  summary: Low-latency coincidence search between external triggers and GW candidates
+  description: |
+    Low-latency coincidence search between external triggers and GW candidates
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This adds a recipe for ligo-raven.

Similarly to #7589, this package is labelled as `noarch: python` despite technically being unix-only because of dependencies. I'm waiting on confirmation that this is ok.

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
