### PR TITLE
Add R package ggnewscale

### DIFF
--- a/recipes/r-ggnewscale/bld.bat
+++ b/recipes/r-ggnewscale/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-ggnewscale/build.sh
+++ b/recipes/r-ggnewscale/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  mv DESCRIPTION DESCRIPTION.old
+  grep -v '^Priority: ' DESCRIPTION.old > DESCRIPTION
+  $R CMD INSTALL --build .
+else
+  mkdir -p $PREFIX/lib/R/library/ggnewscale
+  mv * $PREFIX/lib/R/library/ggnewscale
+fi

--- a/recipes/r-ggnewscale/meta.yaml
+++ b/recipes/r-ggnewscale/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = '0.1.0' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggnewscale
+  version: {{ version|replace("-", "_") }}
+
+source:
+
+  git_url: https://github.com/eliocamp/ggnewscale
+  git_tag: v0.1.0
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}filesystem        # [win]
+    - {{posix}}git
+    - {{posix}}zip               # [win]
+
+  host:
+    - r-base
+    - r-ggplot2 >=3.0.0
+    - r-stringi
+
+  run:
+    - r-base
+    - r-ggplot2 >=3.0.0
+    - r-stringi
+
+test:
+  commands:
+    - $R -e "library('ggnewscale')"           # [not win]
+    - "\"%R%\" -e \"library('ggnewscale')\""  # [win]
+
+about:
+  home: https://github.com/eliocamp/ggnewscale
+  license: GPL-3
+  summary: Use multiple fill and color scales in `ggplot2`.
+  license_family: GPL3
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - ryanraaum
+
+# The original CRAN metadata for this package was:
+
+# Package: ggnewscale
+# Title: Multiple Fill and Color Scales in `ggplot2`
+# Version: 0.1.0
+# Authors@R: person(given = "Elio", family = "Campitelli", role = c("cre", "aut"), email = "elio.campitelli@cima.fcen.uba.ar", comment = c(ORCID = "0000-0002-7742-9230"))
+# Description: Use multiple fill and color scales in `ggplot2`.
+# DOI: 10.5281/zenodo.2543762
+# Date: 2019-01-18
+# License: GPL-3
+# Encoding: UTF-8
+# LazyData: true
+# Imports: ggplot2 (>= 3.0.0), stringi
+# RoxygenNote: 6.1.1


### PR DESCRIPTION
Add new R package ggnewscale. Created using `conda skeleton cran <url>` from GitHub (package is not in CRAN). Cleaned out excess comments in the `meta.yaml` file and added myself as a recipe maintainer. Also added `noarch: generic` in the build section as this is a pure-R package.