### PR TITLE
Add gst-orc

### DIFF
--- a/recipes/gst-orc/build.sh
+++ b/recipes/gst-orc/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# conda-forge/conda-forge.github.io#621
+find ${PREFIX} -name "*.la" -delete
+
+# configure using PYTHON=pythonX.Y to get correct includes path
+./configure \
+	PYTHON=${PYTHON}${PY_VER} \
+	--prefix=${PREFIX}
+
+# make and install
+make -j${CPU_COUNT} ${VERBOSE_AT}
+make install

--- a/recipes/gst-orc/meta.yaml
+++ b/recipes/gst-orc/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "orc" %}
+{% set version = "0.4.28" %}
+{% set sha256 = "bfcd7c6563b05672386c4eedfc4c0d4a0a12b4b4775b74ec6deb88fc2bcd83ce" %}
+
+package:
+  # apache orc is already registered as 'orc', so we call this gst-orc
+  name: gst-{{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://gstreamer.freedesktop.org/src/{{ name }}/{{ name }}-{{ version }}.tar.xz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+
+test:
+  commands:
+    - orcc --help
+    - orc-bugreport --help
+    - test -f ${PREFIX}/lib/pkgconfig/orc-0.4.pc  # [unix]
+    - conda inspect linkages -p ${PREFIX} ${PKG_NAME}  # [not win]
+    - conda inspect objects -p ${PREFIX} ${PKG_NAME}  # [osx]
+
+about:
+  home: http://gstreamer.freedesktop.org/modules/orc.html
+  dev_url: https://gitlab.freedesktop.org/gstreamer/orc
+  doc_url: http://gstreamer.freedesktop.org/data/doc/orc/
+  license: BSD
+  license_family: BSD
+  license_file: COPYING
+  summary: Optimized Inner Loop Runtime Compiler
+  description: |
+    Orc is a library and set of tools for compiling and executing
+    very simple programs that operate on arrays of data.  The "language"
+    is a generic assembly language that represents many of the features
+    available in SIMD architectures, including saturated addition and
+    subtraction, and many arithmetic operations.
+
+    At this point, developers interested in using Orc should look at the
+    examples and try out a few Orc programs in an experimental branch
+    of their own projects.  And provide feedback on how it works.  There
+    will likely be some major changes in ease of use from a developer's
+    perspective over the next few releases.
+
+    The 0.4 series of Orc releases will be API and ABI compatible, and
+    will be incompatible with the 0.5 series when it comes out.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This adds a recipe for [`orc`](http://gstreamer.freedesktop.org/modules/orc.html) - Apache ORC is already available from `defaults` as `orc`, so this package will be called `gst-orc`.
I have no idea how to use this software, I just know something else I want to package uses it...

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
