### PR TITLE
Create terrainbento-feedstock

### DIFF
--- a/recipes/terrainbento/meta.yaml
+++ b/recipes/terrainbento/meta.yaml
@@ -1,5 +1,5 @@
 
-{% set version = "0.9.1" %}
+{% set version = "0.9.2" %}
 
 package:
   name: terrainbento
@@ -7,10 +7,11 @@ package:
 
 source:
   url: https://github.com/TerrainBento/terrainbento/archive/v{{ version }}.tar.gz
-  sha256: 8f82a7d805179cfd61bdeb42f681c985116597ba8cadd75561e9d4950e51d389
+  sha256: 0c4e72fa9b6d5a3e508d5d569719daa29fc0da9145c7ea2a5407da97754a618b
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:

--- a/recipes/terrainbento/meta.yaml
+++ b/recipes/terrainbento/meta.yaml
@@ -38,6 +38,11 @@ test:
   imports:
     - terrainbento
 
+  commands:
+      - pytest --pyargs terrainbento --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
+  source_files:
+      - tests/data/*
+
 about:
   home: https://terrainbento.github.io
   license: MIT

--- a/recipes/terrainbento/meta.yaml
+++ b/recipes/terrainbento/meta.yaml
@@ -1,0 +1,54 @@
+
+{% set version = "0.9.1" %}
+
+package:
+  name: terrainbento
+  version: {{ version }}
+
+source:
+  url: https://github.com/TerrainBento/terrainbento/archive/v{{ version }}.tar.gz
+  sha256: 8f82a7d805179cfd61bdeb42f681c985116597ba8cadd75561e9d4950e51d389
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+
+  run:
+    - python
+    - numpy
+    - six
+    - pyyaml
+    - scipy
+    - xarray
+    - dask
+    - landlab >=1.7
+
+test:
+  requires:
+    - pytest
+    - pytest-cov
+    - pytest-runner
+
+  imports:
+    - terrainbento
+
+about:
+  home: https://terrainbento.github.io
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Multi-model package for earth surface processes'
+  description: |
+    A modular landscape evolution modeling package for mulit-model analysis built on top of the Landlab Toolkit.
+  doc_url: https://terrainbento.readthedocs.io/
+  dev_url: https://github.com/TerrainBento/terrainbento
+
+extra:
+  recipe-maintainers:
+    - kbarnhart

--- a/recipes/terrainbento/meta.yaml
+++ b/recipes/terrainbento/meta.yaml
@@ -40,7 +40,7 @@ test:
     - terrainbento
 
   commands:
-      - pytest --pyargs terrainbento --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
+      - pytest --pyargs terrainbento tests --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
   source_files:
       - tests/data/*
 


### PR DESCRIPTION
This pull request is to create a feedstock for [terrainbento](https://github.com/TerrainBento/terrainbento). I previously distributed this through Anaconda cloud, but want to migrate distribution to conda-forge. 

Thanks!