### PR TITLE
Add omcompiler

### DIFF
--- a/recipes/omcompiler/build.sh
+++ b/recipes/omcompiler/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+git submodule -q sync
+git submodule -q update --init --recursive
+
+# netstream does not build with conda-forge's default c++1z
+export CXXFLAGS="${CXXFLAGS} -std=c++14"
+
+# error: expected '=', ',', ';', 'asm' or '__attribute__' before 'void'
+cd 3rdParty/FMIL && curl -L https://raw.githubusercontent.com/conda-forge/fmilib-feedstock/master/recipe/undef_gnu_source.patch | patch -p1 && cd -
+
+# help sundials find lapack
+sed -i "s|DLAPACK_ENABLE:Bool=ON|DLAPACK_ENABLE:Bool=ON -DCMAKE_PREFIX_PATH=${PREFIX}|g" Makefile.common
+
+# help find conda dependencies in prefix
+sed -i "s|\-lOpenModelicaCompiler|\-L${PREFIX}/lib \-lOpenModelicaCompiler|g" common/m4/omhome.m4
+sed -i "s|RT_LDFLAGS_SHARED=\"\-Wl,\-rpath\-link,|RT_LDFLAGS_SHARED=\"\-Wl,\-rpath\-link,${PREFIX}/lib \-Wl,\-rpath\-link,|g" configure.ac
+
+autoconf
+./configure --prefix=${PREFIX}
+make -j${CPU_COUNT}
+make install
+

--- a/recipes/omcompiler/meta.yaml
+++ b/recipes/omcompiler/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "1.13.2" %}
+
+package:
+  name: omcompiler
+  version: {{ version }}
+
+source:
+  # use git because no tarball including submodules is available
+  git_url: https://github.com/OpenModelica/OMCompiler.git
+  git_tag: v{{ version }}
+
+build:
+  number: 0
+  skip: true  # [not linux]
+
+requirements:
+  build:
+    - cmake
+    - autoconf
+    - automake
+    - libtool
+    - pkg-config
+    - {{ compiler('fortran') }}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - bdw-gc
+    - expat
+    - lp_solve
+    - openjdk
+    - openblas
+  run:
+    - bdw-gc
+    - expat
+    - lp_solve
+    - openjdk
+    - openblas
+
+test:
+  commands:
+    - omc --version
+
+about:
+   home: https://openmodelica.org/
+   license: OSMC-PL
+   license_family: GPL
+   license_file: OSMC-License.txt
+   summary: The Open Source Modelica Suite - OpenModelica Compiler
+
+extra:
+  recipe-maintainers:
+    - jschueller


### PR DESCRIPTION
The openmodelica compiler: https://github.com/OpenModelica/OMCompiler
Having a package in conda-forge would allow to export fmu files compatible with the user's host (for use with PyFMI etc).