### PR TITLE
Avoid conda-4.6.1 in staged-recipes builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - cmd: appveyor-retry conda.exe update --yes --quiet conda
 
 
-    - cmd: appveyor-retry conda.exe install --yes --quiet conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build>=3.16
+    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1" conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build>=3.16
 
     - cmd: appveyor-retry run_conda_forge_build_setup
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - cmd: appveyor-retry conda.exe update --yes --quiet conda
 
 
-    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1" conda-forge-pinning conda-forge-ci-setup=1.* networkx conda-build>=3.16
+    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1" conda-forge-pinning conda-forge-ci-setup=2.* networkx conda-build>=3.16
 
     - cmd: appveyor-retry run_conda_forge_build_setup
 

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -37,7 +37,7 @@ export CONDA_NPY='19'
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1" conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -37,7 +37,7 @@ export CONDA_NPY='19'
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet "conda!=4.6.1" conda-forge-ci-setup=1.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -26,7 +26,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.


### PR DESCRIPTION
This PR hacks the build scripts for all three CI providers so avoid `conda-4.6.1`, see https://github.com/conda/conda/issues/8150.

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
