### PR TITLE
Add latest javabridge recipe

### DIFF
--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -16,16 +16,18 @@ source:
 build:
   noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt && find ./ -type f -name "*.dll"
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - openjdk
   host:
     - python
     - cython
     - setuptools
     - numpy
+    - openjdk
   run:
     - python
     - setuptools

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -14,26 +14,28 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt && export LIBRARY_PATH="${PREFIX}/lib" && export LD_LIBRARY_PATH="${PREFIX}/lib"
+  script: python -m pip install --no-deps --ignore-installed .
+  #script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - openjdk
+    #- openjdk
   host:
     - python
+    - pip
     - cython
-    - setuptools
     - numpy
     - openjdk
+    #- setuptools
   run:
     - python
-    - setuptools
+    - cython
     - numpy
     - openjdk
-
+    #- setuptools
+    
 test:
   imports:
     - javabridge

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -29,6 +29,7 @@ requirements:
   run:
     - python
     - numpy
+    - openjdk
     
 test:
   imports:
@@ -36,6 +37,7 @@ test:
     - javabridge.tests
   requires:
     - nose
+    - openjdk
 
 about:
   home: http://github.com/CellProfiler/python-javabridge/

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -16,15 +16,16 @@ source:
 build:
   noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: python setup.py install --single-version-externally-managed --record=record.txt && find ./ -type f -name "*.dll"
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python
     - cython
     - setuptools
     - numpy
-    - openjdk
   run:
     - python
     - setuptools

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -18,6 +18,8 @@ build:
   script: python -m pip install --no-deps --ignore-installed .
   
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python
     - pip

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -12,7 +12,8 @@ source:
   fn: '{{ name }}-{{ version }}.{{ file_ext }}'
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
   '{{ hash_type }}': '{{ hash_value }}'
-  patches: setup.py.patch # [osx]
+  patches: 
+    - setup.py.patch # [osx]
 
 build:
   number: 0

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "javabridge" %}
+{% set version = "1.0.18" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "d6d27dad4331fd1f4cc4a82aedd168bbc3d57641def8f055e137ae3cad521737" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  noarch: python
+  number: 0
+  script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - numpy
+  run:
+    - python
+    - setuptools
+    - numpy
+
+test:
+  imports:
+    - javabridge
+    - javabridge.tests
+  requires:
+    - nose
+
+about:
+  home: http://github.com/CellProfiler/python-javabridge/
+  license: BSD License
+  license_family: BSD
+  summary: Python wrapper for the Java Native Interface
+  description: "The python-javabridge package makes it easy to start a Java virtual\nmachine (JVM) from Python and interact with it. Python code can\ninteract with the JVM using a low-level API or a more\
+    \ convenient\nhigh-level API. Python-javabridge was developed for and is used by the\ncell image analysis software CellProfiler (cellprofiler.org)."
+  doc_url: 'https://pythonhosted.org/javabridge/'
+  dev_url: 'http://github.com/CellProfiler/python-javabridge/'

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -13,7 +13,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
   '{{ hash_type }}': '{{ hash_value }}'
   patches: 
-    - setup.py.patch # [osx]
+    - setup.py.patch  # [osx]
 
 build:
   number: 0

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -21,10 +21,12 @@ build:
 requirements:
   host:
     - python
+    - cython
     - setuptools
     - numpy
   run:
     - python
+    - cython
     - setuptools
     - numpy
 

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: $PYTHON setup.py install --single-version-externally-managed --record=record.txt
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   host:

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -26,7 +26,6 @@ requirements:
     - numpy
   run:
     - python
-    - cython
     - setuptools
     - numpy
 

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -35,6 +35,7 @@ test:
     - javabridge.tests
   requires:
     - nose
+    - openjdk
 
 about:
   home: http://github.com/CellProfiler/python-javabridge/

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - pip
     - numpy
+    - cython
     - openjdk
   run:
     - python

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -16,25 +16,15 @@ source:
 build:
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
-  #script: python setup.py install --single-version-externally-managed --record=record.txt
-
+  
 requirements:
-  build:
-    - {{ compiler('c') }}
-    #- openjdk
   host:
     - python
     - pip
-    - cython
     - numpy
-    - openjdk
-    #- setuptools
   run:
     - python
-    - cython
     - numpy
-    - openjdk
-    #- setuptools
     
 test:
   imports:
@@ -42,7 +32,6 @@ test:
     - javabridge.tests
   requires:
     - nose
-    - openjdk
 
 about:
   home: http://github.com/CellProfiler/python-javabridge/

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -24,10 +24,12 @@ requirements:
     - cython
     - setuptools
     - numpy
+    - openjdk
   run:
     - python
     - setuptools
     - numpy
+    - openjdk
 
 test:
   imports:

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -12,11 +12,12 @@ source:
   fn: '{{ name }}-{{ version }}.{{ file_ext }}'
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
   '{{ hash_type }}': '{{ hash_value }}'
+  patches: setup.py.patch # [osx]
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
-  
+  script: python -m pip install --no-deps --ignore-installed . 
+
 requirements:
   build:
     - {{ compiler('c') }}

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -37,10 +37,14 @@ test:
 
 about:
   home: http://github.com/CellProfiler/python-javabridge/
-  license: BSD License
+  license: BSD
   license_family: BSD
   summary: Python wrapper for the Java Native Interface
   description: "The python-javabridge package makes it easy to start a Java virtual\nmachine (JVM) from Python and interact with it. Python code can\ninteract with the JVM using a low-level API or a more\
     \ convenient\nhigh-level API. Python-javabridge was developed for and is used by the\ncell image analysis software CellProfiler (cellprofiler.org)."
   doc_url: 'https://pythonhosted.org/javabridge/'
   dev_url: 'http://github.com/CellProfiler/python-javabridge/'
+
+extra:
+  recipe-maintainers:
+    - drpatelh

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: python setup.py install --single-version-externally-managed --record=record.txt && export LIBRARY_PATH="${PREFIX}/lib" && export LD_LIBRARY_PATH="${PREFIX}/lib"
 
 requirements:
   build:

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
     - pip
     - numpy
+    - openjdk
   run:
     - python
     - numpy

--- a/recipes/javabridge/setup.py.patch
+++ b/recipes/javabridge/setup.py.patch
@@ -1,13 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 10f8908..30e59b9 100644
+index 605d486..680b8d2 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -268,7 +268,7 @@ class build_ext(_build_ext):
-             library_dirs=library_dirs,
-            libraries=libraries,
-             export_symbols=export_symbols,
--            extra_postargs=extra_postargs)
-+            extra_postargs=extra_postargs+['-framework', 'CoreFoundation'])
-         if needs_manifest:
-             temp_dir = os.path.dirname(objects[0])
-             manifest_name = lib_name +".manifest"
+@@ -257,6 +257,8 @@ class build_ext(_build_ext):
+         needs_manifest = sys.platform == 'win32' and ver.major == 2 and not is_mingw
+         extra_postargs = ["/MANIFEST"] if needs_manifest else None
+         libraries = ["python{}{}".format(ver.major, ver.minor)] if is_mingw else None
++        if sys.platform == "darwin":
++            extra_postargs = ["-framework", "CoreFoundation"]
+         self.compiler.link(
+             CCompiler.SHARED_OBJECT,
+             objects, lib_name,

--- a/recipes/javabridge/setup.py.patch
+++ b/recipes/javabridge/setup.py.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 10f8908..30e59b9 100644
+--- a/setup.py
++++ b/setup.py
+@@ -268,7 +268,7 @@ class build_ext(_build_ext):
+             library_dirs=library_dirs,
+            libraries=libraries,
+             export_symbols=export_symbols,
+-            extra_postargs=extra_postargs)
++            extra_postargs=extra_postargs+['-framework', 'CoreFoundation'])
+         if needs_manifest:
+             temp_dir = os.path.dirname(objects[0])
+             manifest_name = lib_name +".manifest"


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->

Adding the latest version of `javabridge` due to incompatibility issues with `openjdk`. See
https://github.com/bioconda/bioconda-recipes/pull/13430

The recipe was generated with:
```
conda skeleton pypi javabridge
```


