### PR TITLE
add conda-package-handling

### DIFF
--- a/recipes/conda-package-handling/meta.yaml
+++ b/recipes/conda-package-handling/meta.yaml
@@ -1,20 +1,21 @@
 {% set name = "conda-package-handling" %}
-{% set version = "1.0.2" %}
-{% set sha256 = "a24d700305f148447c0a0b99a19294315bf573a4278119e9fa29dfd9231ab9d7" %}
+{% set version = "1.0.4" %}
+{% set sha256 = "00c7ac4cd55775eac3a0251804991eddbca41b56a86f71ac9e848b13337d129d" %}
 
 package:
-  name: conda_package_handling
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: conda-package-handling-{{ version }}.tar.gz
+  fn: {{ name }}-{{ version }}.tar.gz
   url: https://github.com/conda/{{ name }}/releases/download/{{ version }}/{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  noarch: python
+  # ideally this would work, but this is a conda dep, so we need to be careful.
+  # noarch: python
   entry_points:
     - cph = conda_package_handling.cli:main
 
@@ -23,8 +24,10 @@ requirements:
     - python
     - pip
   run:
+    - libarchive >=3.3.3
     - python
     - python-libarchive-c
+    - six
     - tqdm
 
 test:

--- a/recipes/conda-package-handling/meta.yaml
+++ b/recipes/conda-package-handling/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "conda-package-handling" %}
+{% set version = "1.0.2" %}
+{% set sha256 = "a24d700305f148447c0a0b99a19294315bf573a4278119e9fa29dfd9231ab9d7" %}
+
+package:
+  name: conda_package_handling
+  version: {{ version }}
+
+source:
+  fn: conda-package-handling-{{ version }}.tar.gz
+  url: https://github.com/conda/{{ name }}/releases/download/{{ version }}/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  noarch: python
+  entry_points:
+    - cph = conda_package_handling.cli:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - python-libarchive-c
+    - tqdm
+
+test:
+  source_files:
+    - tests
+  requires:
+    - pytest
+    - pytest-cov
+  commands:
+    - pytest tests
+
+about:
+  home: https://github.com/conda/conda-package-handling
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: Create and extract conda packages of various formats
+
+extra:
+  recipe-maintainers:
+    - msarahan


### PR DESCRIPTION
This is a new library that breaks out package extraction and creation from conda and conda-build.  It will be a prereq of future versions of conda and conda-build.