### PR TITLE
Add tensorflow-probability 0.5.0 to conda-forge

### DIFF
--- a/recipes/tensorflow-probability/0001-always-build-release.patch
+++ b/recipes/tensorflow-probability/0001-always-build-release.patch
@@ -1,13 +1,15 @@
 diff --git a/setup.py b/setup.py
-index 5a43400..6243dc0 100644
+index 5a43400..2208279 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -33,7 +33,7 @@ REQUIRED_PACKAGES = [
+@@ -33,9 +33,8 @@ REQUIRED_PACKAGES = [
      'numpy >= 1.13.3',
  ]
  
 -if '--release' in sys.argv:
 +if True:
    release = True
-   sys.argv.remove('--release')
+-  sys.argv.remove('--release')
  else:
+   # Build a nightly package by default.
+   release = False

--- a/recipes/tensorflow-probability/0001-always-build-release.patch
+++ b/recipes/tensorflow-probability/0001-always-build-release.patch
@@ -1,0 +1,13 @@
+diff --git a/setup.py b/setup.py
+index 5a43400..6243dc0 100644
+--- a/setup.py
++++ b/setup.py
+@@ -33,7 +33,7 @@ REQUIRED_PACKAGES = [
+     'numpy >= 1.13.3',
+ ]
+ 
+-if '--release' in sys.argv:
++if True:
+   release = True
+   sys.argv.remove('--release')
+ else:

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -12,11 +12,11 @@ source:
     - 0001-always-build-release.patch
 
 build:
-  noarch: python
   number: 0
   script: 
     - rm -f BUILD
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: True  # [win or osx or py37]
 
 requirements:
   host:

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "tensorflow-probability" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/tensorflow/probability/archive/v{{ version }}.tar.gz
+  sha256: 6e0e21b40555cbc1725f2fde96fa7705c160d856ae67f84107ad889896314694
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - tensorflow >=1.11.0
+
+test:
+  imports:
+    - tensorflow_probability
+
+about:
+  home: https://www.tensorflow.org/probability/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'TensorFlow Probability is a library for probabilistic reasoning and statistical analysis in TensorFlow'
+
+  # The remaining entries in this section are optional, but recommended
+  description: |
+    TensorFlow Probability is a library for probabilistic reasoning 
+    and statistical analysis in TensorFlow. As part of the TensorFlow
+    ecosystem, TensorFlow Probability provides integration of
+    probabilistic methods with deep networks, gradient-based inference
+    via automatic differentiation, and scalability to large datasets
+    and models via hardware acceleration (e.g., GPUs) and distributed
+    computation.
+  doc_url: https://www.tensorflow.org/probability/overview
+  dev_url: https://github.com/tensorflow/probability
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -12,9 +12,11 @@ source:
     - 0001-always-build-release.patch
 
 build:
+  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: True  # [not linux]
+  script: 
+    - rm -f BUILD
+    - "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -16,8 +16,6 @@ build:
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
     - python
     - pip

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv --install-option=\"--release\""
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   build:

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -39,7 +39,6 @@ about:
   license_file: LICENSE
   summary: 'TensorFlow Probability is a library for probabilistic reasoning and statistical analysis in TensorFlow'
 
-  # The remaining entries in this section are optional, but recommended
   description: |
     TensorFlow Probability is a library for probabilistic reasoning 
     and statistical analysis in TensorFlow. As part of the TensorFlow

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: True  # [not linux]
 
 requirements:
   host:

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -8,18 +8,23 @@ package:
 source:
   url: https://github.com/tensorflow/probability/archive/v{{ version }}.tar.gz
   sha256: 6e0e21b40555cbc1725f2fde96fa7705c160d856ae67f84107ad889896314694
+  patches:
+    - 0001-always-build-release.patch
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv --install-option=\"--release\""
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python
     - pip
   run:
     - python
+    - numpy >=1.13.3
+    - six >=1.10.0
     - tensorflow >=1.11.0
 
 test:

--- a/recipes/tensorflow-probability/meta.yaml
+++ b/recipes/tensorflow-probability/meta.yaml
@@ -16,7 +16,7 @@ build:
   script: 
     - rm -f BUILD
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: True  # [win or osx or py37]
+  skip: True  # [win or osx or py>36]
 
 requirements:
   host:


### PR DESCRIPTION
A noarch recipe for `tensorflow-probability`.
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->