### PR TITLE
Fixes syntax error in urbansim_templates recipe

### DIFF
--- a/recipes/urbansim_templates/meta.yaml
+++ b/recipes/urbansim_templates/meta.yaml
@@ -21,14 +21,14 @@ requirements:
     - python
     - pip
   run:
-    - choicemodels >= 0.2
-    - numpy >= 1.14
-    - orca >= 1.4
-    - pandas >= 0.22
-    - patsy >= 0.4
+    - choicemodels >=0.2
+    - numpy >=1.14
+    - orca >=1.4
+    - pandas >=0.22
+    - patsy >=0.4
     - python
-    - statsmodels >= 0.8
-    - urbansim >= 3.1
+    - statsmodels >=0.8
+    - urbansim >=3.1
 
 test:
   imports:


### PR DESCRIPTION
This PR fixes a syntax error in the urbansim_templates recipe that was preventing it from converting. See discussion in PR #7723, thanks @jakirkham for pointing this out!

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->