### PR TITLE
Add compilers metapackage

### DIFF
--- a/recipes/compilers/build-symlinks.sh
+++ b/recipes/compilers/build-symlinks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu
+
+cd "${PREFIX}/bin"
+for fn in "${BUILD}-"*; do
+    new_fn=${fn//${BUILD}-/}
+    if [ ! -f "${new_fn}" ]; then
+        echo "Creating symlink from ${fn} to ${new_fn}"
+        ln -s "${fn}" "${new_fn}"
+    fi
+done

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,0 +1,49 @@
+package:
+  name: compilers-metapackages
+  version: 1.0.0
+
+build:
+  number: 0
+
+outputs:
+  - name: c-compiler
+    requirements:
+      run:
+        - {{ compiler('c') }}
+    test:
+      commands:
+        - $CC --help  # [not win]
+  - name: cxx-compiler
+    requirements:
+      run:
+        - {{ compiler('cxx') }}
+    test:
+      commands:
+        - $CXX --help  # [not win]
+  - name: fortran-compiler
+    requirements:
+      run:
+        - {{ compiler('fortran') }}
+    test:
+      commands:
+        - $FC --help  # [not win]
+  - name: compilers
+    requirements:
+      run:
+        - {{ pin_subpackage('c-compiler', exact=True) }}
+        - {{ pin_subpackage('cxx-compiler', exact=True) }}
+        - {{ pin_subpackage('fortran-compiler', exact=True) }}
+    test:
+      commands:
+        - $CC --help  # [not win]
+        - $CXX --help  # [not win]
+        - $FC --help  # [not win]
+
+about:
+  summary: Compiler metapackages
+  home: https://conda-forge.org
+  license: BSD
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: compilers-metapackages
+  name: compilers-metapackage
   version: 1.0.0
 
 build:
@@ -13,6 +13,20 @@ outputs:
     test:
       commands:
         - $CC --help  # [not win]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain a C compiler
+      description: |
+        This package is a generic way to obtain the C compiler for your system
+        that conda-forge used to compile its ecosystem.  This compiler is,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.  Use the Jinja template function compiler('c') instead.
+
   - name: cxx-compiler
     requirements:
       run:
@@ -20,6 +34,20 @@ outputs:
     test:
       commands:
         - $CXX --help  # [not win]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain a C++ compiler
+      description: |
+        This package is a generic way to obtain the C++ compiler for your system
+        that conda-forge used to compile its ecosystem.  This compiler is,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.  Use the Jinja template function compiler('cxx') instead.
+
   - name: fortran-compiler
     requirements:
       run:
@@ -27,6 +55,20 @@ outputs:
     test:
       commands:
         - $FC --help  # [not win]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain a Fortran compiler
+      description: |
+        This package is a generic way to obtain the Fortran compiler for your
+        system that conda-forge used to compile its ecosystem.  This compiler
+        is, therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.  Use the Jinja template function compiler('fortran') instead.
+
   - name: compilers
     requirements:
       run:
@@ -39,11 +81,22 @@ outputs:
         - $CXX --help  # [not win]
         - $FC --help  # [not win]
 
-about:
-  summary: Compiler metapackages
-  home: https://conda-forge.org
-  license: BSD
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain compilers
+      description: |
+        This package is a generic way to obtain the compilers for your system
+        that conda-forge used to compile its ecosystem. These compilers are,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        These compiler metapackages are a convenience ONLY for users.
+        Do NOT use these packages as a build or host dependencies in other
+        recipes.  Use the compiler Jinja template function instead.
+        For C++ for example, use compiler('cxx') as usual.
 
 extra:
   recipe-maintainers:
     - duncanmmacleod
+    - scopatz

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,3 +1,29 @@
+{% set commands = {
+  'binutils': {
+    'linux': ['ar', 'as', 'ld', 'nm', 'size', 'strings', 'strip',
+              'addr2line', 'c++filt', 'dwp', 'elfedit', 'gprof', 'ld.bfd',
+              'ld.gold', 'objcopy', 'objdump', 'ranlib', 'readelf'],
+    'osx': ['ar', 'as', 'ld', 'nm', 'size', 'strings', 'strip',
+            'checksyms', 'codesign_allocate', 'indr', 'install_name_tool',
+            'libtool', 'lipo', 'nmedit', 'otool', 'pagestuff', 'ranlib',
+            'redo_prebinding', 'seg_addr_table', 'seg_hack', 'segedit'],
+  },
+  'c-compiler': {
+    'linux': ['cc', 'ct-ng.config', 'cpp', 'gcc', 'gcc-ar', 'gcc-nm',
+              'gcc-ranlib', 'gcov', 'gcov-dump', 'gcov-tool'],
+    'osx': ['clang'],
+  },
+  'cxx-compiler': {
+    'linux': ['g++', 'c++'],
+    'osx': ['clang++'],
+  },
+  'fortran-compiler': {
+    'linux': ['f95', 'gfortran', 'gfortran.bin'],
+    'osx': ['gfortran'],
+  },
+} %}
+
+
 package:
   name: compilers
   version: 1.0.0
@@ -6,13 +32,62 @@ build:
   number: 0
 
 outputs:
+  - name: binutils
+    requirements:
+      host:
+        - binutils_linux-64  # [linux]
+        - cctools  # [osx]
+        - ld64  # [osx]
+      run:
+        - binutils_linux-64  # [linux]
+        - cctools  # [osx]
+        - ld64  # [osx]
+    script: build-symlinks.sh
+    build:
+      skip: True  # [not unix]
+    test:
+      commands:
+        - $LD --help  # [linux]
+{%- for command in commands['binutils']['linux'] %}  # [linux]
+{%- for command in commands['binutils']['osx'] %}  # [osx]
+        - {{ command }} --help > /dev/null  # [linux] Return code for --help is 1 on OSX
+        - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [unix]
+        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [unix]
+{%- endfor %}  # [unix]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain binutils
+      description: |
+        This package is a generic way to obtain binutils for your system
+        that conda-forge used to compile its ecosystem.  This compiler is,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.
+
   - name: c-compiler
     requirements:
+      host:
+        - {{ compiler('c') }}
+        # Depend on the other metapackages to prevent making duplicate symlinks
+        - binutils  # [unix]
       run:
         - {{ compiler('c') }}
+    script: build-symlinks.sh
     test:
       commands:
         - $CC --help  # [not win]
+{%- for command in commands['c-compiler']['linux'] %}  # [linux]
+{%- for command in commands['c-compiler']['osx'] %}  # [osx]
+        - {{ command }} --help > /dev/null  # [unix]
+        - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [unix]
+        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [linux]
+        # The prefixed compilers are a symlink on OSX - check they resolve to the same place
+        - "[ \"$(readlink \"$(which {{ command }})\")\" = \"$(readlink \"$(which ${BUILD}-{{ command }})\")\" ]"  # [osx]
+{%- endfor %}  # [unix]
     about:
       home: https://conda-forge.org
       license: BSD
@@ -29,11 +104,25 @@ outputs:
 
   - name: cxx-compiler
     requirements:
+      host:
+        - {{ compiler('cxx') }}
+        # Depend on the other metapackages to prevent making duplicate symlinks
+        - binutils  # [unix]
+        - c-compiler  # [linux]
       run:
         - {{ compiler('cxx') }}
+    script: build-symlinks.sh
     test:
       commands:
         - $CXX --help  # [not win]
+{%- for command in commands['cxx-compiler']['linux'] %}  # [linux]
+{%- for command in commands['cxx-compiler']['osx'] %}  # [osx]
+        - {{ command }} --help > /dev/null  # [unix]
+        - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [unix]
+        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [linux]
+        # The prefixed compilers are a symlink on OSX - check they resolve to the same place
+        - "[ \"$(readlink \"$(which {{ command }})\")\" = \"$(readlink \"$(which ${BUILD}-{{ command }})\")\" ]"  # [osx]
+{%- endfor %}  # [unix]
     about:
       home: https://conda-forge.org
       license: BSD
@@ -50,11 +139,22 @@ outputs:
 
   - name: fortran-compiler
     requirements:
+      host:
+        - {{ compiler('fortran') }}
+        # Depend on the other metapackages to prevent making duplicate symlinks
+        - binutils  # [unix]
       run:
         - {{ compiler('fortran') }}
+    script: build-symlinks.sh  # [linux] gfortran is already available on OSX
     test:
       commands:
         - $FC --help  # [not win]
+{%- for command in commands['fortran-compiler']['linux'] %}  # [linux]
+{%- for command in commands['fortran-compiler']['osx'] %}  # [osx]
+        - {{ command }} --help > /dev/null  # [unix]
+        - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [linux]
+        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [linux]
+{%- endfor %}  # [unix]
     about:
       home: https://conda-forge.org
       license: BSD
@@ -72,6 +172,7 @@ outputs:
   - name: compilers
     requirements:
       run:
+        - {{ pin_subpackage('binutils', exact=True) }}  # [unix]
         - {{ pin_subpackage('c-compiler', exact=True) }}
         - {{ pin_subpackage('cxx-compiler', exact=True) }}
         - {{ pin_subpackage('fortran-compiler', exact=True) }}
@@ -100,3 +201,4 @@ extra:
   recipe-maintainers:
     - duncanmmacleod
     - scopatz
+    - chrisburr

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: compilers-metapackage
+  name: compilers
   version: 1.0.0
 
 build:
@@ -81,20 +81,20 @@ outputs:
         - $CXX --help  # [not win]
         - $FC --help  # [not win]
 
-    about:
-      home: https://conda-forge.org
-      license: BSD
-      summary: A metapackage to obtain compilers
-      description: |
-        This package is a generic way to obtain the compilers for your system
-        that conda-forge used to compile its ecosystem. These compilers are,
-        therefore, guaranteed to be ABI compatible with the conda packages
-        you have installed.
+about:
+  home: https://conda-forge.org
+  license: BSD
+  summary: A metapackage to obtain compilers
+  description: |
+    This package is a generic way to obtain the compilers for your system
+    that conda-forge used to compile its ecosystem. These compilers are,
+    therefore, guaranteed to be ABI compatible with the conda packages
+    you have installed.
 
-        These compiler metapackages are a convenience ONLY for users.
-        Do NOT use these packages as a build or host dependencies in other
-        recipes.  Use the compiler Jinja template function instead.
-        For C++ for example, use compiler('cxx') as usual.
+    These compiler metapackages are a convenience ONLY for users.
+    Do NOT use these packages as a build or host dependencies in other
+    recipes.  Use the compiler Jinja template function instead.
+    For C++ for example, use compiler('cxx') as usual.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This adds a series of metapackages to bring in compilers for a given platform

- `c-compiler`
- `cxx-compiler`
- `fortran-compiler`
- `compilers` - all of the above

This is likely horribly incomplete, so I've made sure to allow edits from maintainers, who should feel encouraged to add themselves as maintainers under `extra/recipe-maintainers`, and to add tests for windows, etc. etc.

cc @scopatz, @chrisburr, ...

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
