### PR TITLE
Add compilers metapackage

### DIFF
--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,0 +1,49 @@
+package:
+  name: compilers-metapackages
+  version: 1.0.0
+
+build:
+  number: 0
+
+outputs:
+  - name: c-compiler
+    requirements:
+      run:
+        - {{ compiler('c') }}
+    test:
+      commands:
+        - $CC --help  # [not win]
+  - name: cxx-compiler
+    requirements:
+      run:
+        - {{ compiler('cxx') }}
+    test:
+      commands:
+        - $CXX --help  # [not win]
+  - name: fortran-compiler
+    requirements:
+      run:
+        - {{ compiler('fortran') }}
+    test:
+      commands:
+        - $FC --help  # [not win]
+  - name: compilers
+    requirements:
+      run:
+        - {{ pin_subpackage('c-compiler', exact=True) }}
+        - {{ pin_subpackage('cxx-compiler', exact=True) }}
+        - {{ pin_subpackage('fortran-compiler', exact=True) }}
+    test:
+      commands:
+        - $CC --help  # [not win]
+        - $CXX --help  # [not win]
+        - $FC --help  # [not win]
+
+about:
+  summary: Compiler metapackages
+  home: https://conda-forge.org
+  license: BSD
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,3 +1,7 @@
+{% set c_compiler = compiler('c').split('_')[0] %}
+{% set cxx_compiler = compiler('cxx').split('_')[0] %}
+{% set fortran_compiler = compiler('fortran').split('_')[0] %}
+
 {% set commands = {
   'binutils': {
     'linux': ['ar', 'as', 'ld', 'nm', 'size', 'strings', 'strip',
@@ -9,18 +13,23 @@
             'redo_prebinding', 'seg_addr_table', 'seg_hack', 'segedit'],
   },
   'c-compiler': {
-    'linux': ['cc', 'ct-ng.config', 'cpp', 'gcc', 'gcc-ar', 'gcc-nm',
+    'gcc': ['cc', 'ct-ng.config', 'cpp', 'gcc', 'gcc-ar', 'gcc-nm',
               'gcc-ranlib', 'gcov', 'gcov-dump', 'gcov-tool'],
-    'osx': ['clang'],
-  },
+    'clang': ['clang'],
+    'vs2008': [],
+    'vs2010': [],
+    'vs2015': [],
+  }[c_compiler],
   'cxx-compiler': {
-    'linux': ['g++', 'c++'],
-    'osx': ['clang++'],
-  },
+    'gxx': ['g++', 'c++'],
+    'clangxx': ['clang++'],
+    'vs2008': [],
+    'vs2010': [],
+    'vs2015': [],
+  }[cxx_compiler],
   'fortran-compiler': {
-    'linux': ['f95', 'gfortran', 'gfortran.bin'],
-    'osx': ['gfortran'],
-  },
+    'gfortran': ['gfortran'],
+  }[fortran_compiler],
 } %}
 
 
@@ -53,7 +62,8 @@ outputs:
         - {{ command }} --help > /dev/null  # [linux] Return code for --help is 1 on OSX
         - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [unix]
         - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [unix]
-{%- endfor %}  # [unix]
+{%- endfor %}  # [linux]
+{%- endfor %}  # [osx]
     about:
       home: https://conda-forge.org
       license: BSD
@@ -79,14 +89,16 @@ outputs:
     script: build-symlinks.sh
     test:
       commands:
-        - $CC --help  # [not win]
-{%- for command in commands['c-compiler']['linux'] %}  # [linux]
-{%- for command in commands['c-compiler']['osx'] %}  # [osx]
+        - $CC --help  # [unix]
+{%- for command in commands['c-compiler'] %}  # [unix]
         - {{ command }} --help > /dev/null  # [unix]
         - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [unix]
-        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [linux]
+  {%- if c_compiler == 'gcc' %}  # [unix]
+        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [unix]
+  {%- elif c_compiler == 'clang' %}  # [unix]
         # The prefixed compilers are a symlink on OSX - check they resolve to the same place
-        - "[ \"$(readlink \"$(which {{ command }})\")\" = \"$(readlink \"$(which ${BUILD}-{{ command }})\")\" ]"  # [osx]
+        - "[ \"$(readlink \"$(which {{ command }})\")\" = \"$(readlink \"$(which ${BUILD}-{{ command }})\")\" ]"  # [unix]
+  {%- endif %}  # [unix]
 {%- endfor %}  # [unix]
     about:
       home: https://conda-forge.org
@@ -114,14 +126,16 @@ outputs:
     script: build-symlinks.sh
     test:
       commands:
-        - $CXX --help  # [not win]
-{%- for command in commands['cxx-compiler']['linux'] %}  # [linux]
-{%- for command in commands['cxx-compiler']['osx'] %}  # [osx]
+        - $CXX --help  # [unix]
+{%- for command in commands['cxx-compiler'] %}  # [unix]
         - {{ command }} --help > /dev/null  # [unix]
         - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [unix]
-        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [linux]
+  {%- if cxx_compiler == 'gxx' %}  # [unix]
+        - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [unix]
+  {%- elif cxx_compiler == 'clangxx' %}  # [unix]
         # The prefixed compilers are a symlink on OSX - check they resolve to the same place
-        - "[ \"$(readlink \"$(which {{ command }})\")\" = \"$(readlink \"$(which ${BUILD}-{{ command }})\")\" ]"  # [osx]
+        - "[ \"$(readlink \"$(which {{ command }})\")\" = \"$(readlink \"$(which ${BUILD}-{{ command }})\")\" ]"  # [unix]
+  {%- endif %}  # [unix]
 {%- endfor %}  # [unix]
     about:
       home: https://conda-forge.org
@@ -148,9 +162,8 @@ outputs:
     script: build-symlinks.sh  # [linux] gfortran is already available on OSX
     test:
       commands:
-        - $FC --help  # [not win]
-{%- for command in commands['fortran-compiler']['linux'] %}  # [linux]
-{%- for command in commands['fortran-compiler']['osx'] %}  # [osx]
+        - $FC --help  # [unix]
+{%- for command in commands['fortran-compiler'] %}  # [unix]
         - {{ command }} --help > /dev/null  # [unix]
         - echo "Checking {{ command }} resolves to a path containing ${BUILD}"  # [linux]
         - readlink $(which {{ command }}) | grep -q "${BUILD}"  # [linux]
@@ -178,9 +191,9 @@ outputs:
         - {{ pin_subpackage('fortran-compiler', exact=True) }}
     test:
       commands:
-        - $CC --help  # [not win]
-        - $CXX --help  # [not win]
-        - $FC --help  # [not win]
+        - $CC --help  # [unix]
+        - $CXX --help  # [unix]
+        - $FC --help  # [unix]
 
 about:
   home: https://conda-forge.org

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: compilers-metapackages
+  name: compilers-metapackage
   version: 1.0.0
 
 build:
@@ -13,6 +13,20 @@ outputs:
     test:
       commands:
         - $CC --help  # [not win]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain a C compiler
+      description: |
+        This package is a generic way to obtain the C compiler for your system
+        that conda-forge used to compile its ecosystem.  This compiler is,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.  Use the Jinja template function compiler('c') instead.
+
   - name: cxx-compiler
     requirements:
       run:
@@ -20,6 +34,20 @@ outputs:
     test:
       commands:
         - $CXX --help  # [not win]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain a C++ compiler
+      description: |
+        This package is a generic way to obtain the C++ compiler for your system
+        that conda-forge used to compile its ecosystem.  This compiler is,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.  Use the Jinja template function compiler('cxx') instead.
+
   - name: fortran-compiler
     requirements:
       run:
@@ -27,6 +55,20 @@ outputs:
     test:
       commands:
         - $FC --help  # [not win]
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain a Fortran compiler
+      description: |
+        This package is a generic way to obtain the Fortran compiler for your
+        system that conda-forge used to compile its ecosystem.  This compiler
+        is, therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        This compiler metapackage is a convenience ONLY for users.
+        Do NOT use this package as a build or host dependency in other
+        recipes.  Use the Jinja template function compiler('fortran') instead.
+
   - name: compilers
     requirements:
       run:
@@ -39,11 +81,22 @@ outputs:
         - $CXX --help  # [not win]
         - $FC --help  # [not win]
 
-about:
-  summary: Compiler metapackages
-  home: https://conda-forge.org
-  license: BSD
+    about:
+      home: https://conda-forge.org
+      license: BSD
+      summary: A metapackage to obtain compilers
+      description: |
+        This package is a generic way to obtain the compilers for your system
+        that conda-forge used to compile its ecosystem. These compilers are,
+        therefore, guaranteed to be ABI compatible with the conda packages
+        you have installed.
+
+        These compiler metapackages are a convenience ONLY for users.
+        Do NOT use these packages as a build or host dependencies in other
+        recipes.  Use the compiler Jinja template function instead.
+        For C++ for example, use compiler('cxx') as usual.
 
 extra:
   recipe-maintainers:
     - duncanmmacleod
+    - scopatz

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -51,7 +51,7 @@ outputs:
         - binutils_linux-64  # [linux]
         - cctools  # [osx]
         - ld64  # [osx]
-    script: build-symlinks.sh
+    script: build-symlinks.sh  # [unix]
     build:
       skip: True  # [not unix]
     test:
@@ -86,7 +86,7 @@ outputs:
         - binutils  # [unix]
       run:
         - {{ compiler('c') }}
-    script: build-symlinks.sh
+    script: build-symlinks.sh  # [unix]
     test:
       commands:
         - $CC --help  # [unix]
@@ -123,7 +123,7 @@ outputs:
         - c-compiler  # [linux]
       run:
         - {{ compiler('cxx') }}
-    script: build-symlinks.sh
+    script: build-symlinks.sh  # [unix]
     test:
       commands:
         - $CXX --help  # [unix]

--- a/recipes/compilers/meta.yaml
+++ b/recipes/compilers/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: compilers-metapackage
+  name: compilers
   version: 1.0.0
 
 build:
@@ -81,20 +81,20 @@ outputs:
         - $CXX --help  # [not win]
         - $FC --help  # [not win]
 
-    about:
-      home: https://conda-forge.org
-      license: BSD
-      summary: A metapackage to obtain compilers
-      description: |
-        This package is a generic way to obtain the compilers for your system
-        that conda-forge used to compile its ecosystem. These compilers are,
-        therefore, guaranteed to be ABI compatible with the conda packages
-        you have installed.
+about:
+  home: https://conda-forge.org
+  license: BSD
+  summary: A metapackage to obtain compilers
+  description: |
+    This package is a generic way to obtain the compilers for your system
+    that conda-forge used to compile its ecosystem. These compilers are,
+    therefore, guaranteed to be ABI compatible with the conda packages
+    you have installed.
 
-        These compiler metapackages are a convenience ONLY for users.
-        Do NOT use these packages as a build or host dependencies in other
-        recipes.  Use the compiler Jinja template function instead.
-        For C++ for example, use compiler('cxx') as usual.
+    These compiler metapackages are a convenience ONLY for users.
+    Do NOT use these packages as a build or host dependencies in other
+    recipes.  Use the compiler Jinja template function instead.
+    For C++ for example, use compiler('cxx') as usual.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
@duncanmmacleod @scopatz This builds on #7739 to remove the assumption of which compiler is used on each platform when testing the symlinks. It also avoids the linter bug.

@duncanmmacleod I've invited you to my fork in case you want to make any changes.