### PR TITLE
py-mathjax

### DIFF
--- a/recipes/py-mathjax/conda.patch
+++ b/recipes/py-mathjax/conda.patch
@@ -1,19 +1,5 @@
-From 0cd205438388a4cd8d1a597c45b01bd3fadeaf92 Mon Sep 17 00:00:00 2001
-From: kiwi0fruit <peter.zagubisalo@gmail.com>
-Date: Sun, 10 Feb 2019 13:13:01 +0700
-Subject: [PATCH] com
-
----
- pymathjax/conda.py | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/pymathjax/conda.py b/pymathjax/conda.py
-index 12c26d2..985df44 100644
 --- a/pymathjax/conda.py
 +++ b/pymathjax/conda.py
 @@ -1 +1 @@
 -conda = False
 +conda = True
--- 
-2.16.1.windows.1
-

--- a/recipes/py-mathjax/conda.patch
+++ b/recipes/py-mathjax/conda.patch
@@ -1,3 +1,12 @@
+From 0cd205438388a4cd8d1a597c45b01bd3fadeaf92 Mon Sep 17 00:00:00 2001
+From: kiwi0fruit <peter.zagubisalo@gmail.com>
+Date: Sun, 10 Feb 2019 13:13:01 +0700
+Subject: [PATCH] com
+
+---
+ pymathjax/conda.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/pymathjax/conda.py b/pymathjax/conda.py
 index 12c26d2..985df44 100644
 --- a/pymathjax/conda.py
@@ -5,3 +14,6 @@ index 12c26d2..985df44 100644
 @@ -1 +1 @@
 -conda = False
 +conda = True
+-- 
+2.16.1.windows.1
+

--- a/recipes/py-mathjax/conda.patch
+++ b/recipes/py-mathjax/conda.patch
@@ -1,0 +1,7 @@
+diff --git a/pymathjax/conda.py b/pymathjax/conda.py
+index 12c26d2..985df44 100644
+--- a/pymathjax/conda.py
++++ b/pymathjax/conda.py
+@@ -1 +1 @@
+-conda = False
++conda = True

--- a/recipes/py-mathjax/meta.yaml
+++ b/recipes/py-mathjax/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "py-mathjax" %}
 {% set version = "2.7.5" %}
+{% set pypi_build = ".1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e4c2ad6adffa3a7abdc90f7899b1f97db6284aadc7729ed23c50be924147cf2b
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ pypi_build }}.tar.gz
+  sha256: a4ef8b5ee39b522ac4d27a7fa16f9a1d2e905f3f5221a082c35afc2bbebc2ae9
   patches:
     - conda.patch
 

--- a/recipes/py-mathjax/meta.yaml
+++ b/recipes/py-mathjax/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "py-mathjax" %}
+{% set version = "2.7.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e4c2ad6adffa3a7abdc90f7899b1f97db6284aadc7729ed23c50be924147cf2b
+  patches:
+    - conda.patch
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - py-mathjax-path = pymathjax.__main__:cli
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - mathjax ={{ version }}
+
+test:
+  imports:
+    - pymathjax
+  commands:
+    - py-mathjax-path
+    - py-mathjax-path --user
+
+about:
+  home: https://github.com/kiwi0fruit/py-mathjax
+  license: "Apache 2.0"
+  license_family: Apache
+  license_file: LICENSE
+  summary: "MathJax in pip and conda."
+  doc_url: https://github.com/kiwi0fruit/py-mathjax
+  dev_url: https://github.com/kiwi0fruit/py-mathjax
+
+extra:
+  recipe-maintainers:
+    - kiwi0fruit


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
`mathjax` should be pure conda package. But then pip in Anaconda is not aware of it.  
So `py-mathjax` is a wrapper around it that pip is aware of.