### PR TITLE
py-pandoc

### DIFF
--- a/recipes/py-pandoc/conda.patch
+++ b/recipes/py-pandoc/conda.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index ed3d20c..2d1385e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -113,7 +113,6 @@ def excract_tar_and_move_files(url, hash, move, **kwargs):
+ setup(
+     name='py-pandoc',
+     version=version,
+-    cmdclass={'install': PostInstallCommand},
+     python_requires='>=3.6',
+     description='Pandoc in pip and conda',
+     url='https://github.com/kiwi0fruit/py-pandoc',

--- a/recipes/py-pandoc/conda.patch
+++ b/recipes/py-pandoc/conda.patch
@@ -1,10 +1,8 @@
 --- a/setup.py
 +++ b/setup.py
-@@ -113,7 +113,6 @@ def excract_tar_and_move_files(url, hash, move, **kwargs):
- setup(
-     name='py-pandoc',
-     version=version,
--    cmdclass={'install': PostInstallCommand},
-     python_requires='>=3.6',
-     description='Pandoc in pip and conda',
-     url='https://github.com/kiwi0fruit/py-pandoc',
+@@ -1,4 +1,4 @@
+-conda = False
++conda = True
+ # --------------------------
+ #
+ #

--- a/recipes/py-pandoc/conda.patch
+++ b/recipes/py-pandoc/conda.patch
@@ -1,3 +1,12 @@
+From 47bda7dd3010b80ab0b9a62ad237ac15e5565b8c Mon Sep 17 00:00:00 2001
+From: kiwi0fruit <peter.zagubisalo@gmail.com>
+Date: Sun, 10 Feb 2019 13:17:03 +0700
+Subject: [PATCH] c
+
+---
+ setup.py | 1 -
+ 1 file changed, 1 deletion(-)
+
 diff --git a/setup.py b/setup.py
 index ed3d20c..2d1385e 100644
 --- a/setup.py
@@ -10,3 +19,6 @@ index ed3d20c..2d1385e 100644
      python_requires='>=3.6',
      description='Pandoc in pip and conda',
      url='https://github.com/kiwi0fruit/py-pandoc',
+-- 
+2.16.1.windows.1
+

--- a/recipes/py-pandoc/conda.patch
+++ b/recipes/py-pandoc/conda.patch
@@ -1,14 +1,3 @@
-From 47bda7dd3010b80ab0b9a62ad237ac15e5565b8c Mon Sep 17 00:00:00 2001
-From: kiwi0fruit <peter.zagubisalo@gmail.com>
-Date: Sun, 10 Feb 2019 13:17:03 +0700
-Subject: [PATCH] c
-
----
- setup.py | 1 -
- 1 file changed, 1 deletion(-)
-
-diff --git a/setup.py b/setup.py
-index ed3d20c..2d1385e 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -113,7 +113,6 @@ def excract_tar_and_move_files(url, hash, move, **kwargs):
@@ -19,6 +8,3 @@ index ed3d20c..2d1385e 100644
      python_requires='>=3.6',
      description='Pandoc in pip and conda',
      url='https://github.com/kiwi0fruit/py-pandoc',
--- 
-2.16.1.windows.1
-

--- a/recipes/py-pandoc/conda_next.patch
+++ b/recipes/py-pandoc/conda_next.patch
@@ -1,5 +1,3 @@
-diff --git a/setup.py b/setup.py
-index a436bfc..b446fc2 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -1,4 +1,4 @@

--- a/recipes/py-pandoc/conda_next.patch
+++ b/recipes/py-pandoc/conda_next.patch
@@ -1,8 +1,0 @@
---- a/setup.py
-+++ b/setup.py
-@@ -1,4 +1,4 @@
--conda = False
-+conda = True
- # --------------------------
- #
- #

--- a/recipes/py-pandoc/conda_next.patch
+++ b/recipes/py-pandoc/conda_next.patch
@@ -1,0 +1,10 @@
+diff --git a/setup.py b/setup.py
+index a436bfc..b446fc2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -1,4 +1,4 @@
+-conda = False
++conda = True
+ # --------------------------
+ #
+ #

--- a/recipes/py-pandoc/meta.yaml
+++ b/recipes/py-pandoc/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "py-pandoc" %}
+{% set version = "2.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4ca469e6faf67ee0f6525d3e43606fb91017a94e32cb4c7ff4e4c9f9333c00d6
+  patches:
+    - conda.patch
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - pandoc ={{ version }}
+
+test:
+  commands:
+    - pandoc --version
+    - pandoc --help
+
+about:
+  home: https://github.com/kiwi0fruit/py-pandoc
+  license: "GPLv2+"
+  license_family: GPL
+  license_file: LICENSE
+  summary: "Pandoc in pip and conda."
+  doc_url: https://github.com/kiwi0fruit/py-pandoc
+  dev_url: https://github.com/kiwi0fruit/py-pandoc
+
+extra:
+  recipe-maintainers:
+    - kiwi0fruit

--- a/recipes/py-pandoc/meta.yaml
+++ b/recipes/py-pandoc/meta.yaml
@@ -1,13 +1,14 @@
 {% set name = "py-pandoc" %}
 {% set version = "2.5" %}
+{% set pypi_build = ".0.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4ca469e6faf67ee0f6525d3e43606fb91017a94e32cb4c7ff4e4c9f9333c00d6
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ pypi_build }}.tar.gz
+  sha256: ccf42c97fc0279bb14641ae75066579fce236eb15860a83855fe9001aae36796
   patches:
     - conda.patch
 

--- a/recipes/py-pandoc/meta.yaml
+++ b/recipes/py-pandoc/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "py-pandoc" %}
 {% set version = "2.5" %}
-{% set pypi_build = ".0.1" %}
+{% set pypi_build = ".0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ pypi_build }}.tar.gz
-  sha256: ccf42c97fc0279bb14641ae75066579fce236eb15860a83855fe9001aae36796
+  sha256: 0665f65580b48837ec3fdc0208624026bfcd30ceca720ee87c3574f76a650f7e
   patches:
     - conda.patch
 

--- a/recipes/py-pandoc/meta.yaml
+++ b/recipes/py-pandoc/meta.yaml
@@ -1,13 +1,12 @@
 {% set name = "py-pandoc" %}
-{% set version = "2.5" %}
-{% set pypi_build = ".0.2" %}
+{% set version = "2.5.0.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ pypi_build }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 0665f65580b48837ec3fdc0208624026bfcd30ceca720ee87c3574f76a650f7e
   patches:
     - conda.patch

--- a/recipes/py-pandoc/meta.yaml
+++ b/recipes/py-pandoc/meta.yaml
@@ -1,12 +1,13 @@
 {% set name = "py-pandoc" %}
-{% set version = "2.5.0.2" %}
+{% set version = "2.5" %}
+{% set pypi_build = ".0.2" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}
+  version: {{ version }}{{ pypi_build }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ pypi_build }}.tar.gz
   sha256: 0665f65580b48837ec3fdc0208624026bfcd30ceca720ee87c3574f76a650f7e
   patches:
     - conda.patch
@@ -22,7 +23,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - pandoc =2.5
+    - pandoc ={{ version }}
 
 test:
   commands:

--- a/recipes/py-pandoc/meta.yaml
+++ b/recipes/py-pandoc/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - pandoc ={{ version }}
+    - pandoc =2.5
 
 test:
   commands:


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
`pandoc` should be pure conda package. But then pip in Anaconda is not aware of it.  
So `py-pandoc` is a wrapper around it that pip is aware of.