### PR TITLE
add pathspec 0.5.9

### DIFF
--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -30,7 +30,7 @@ test:
     - pytest --pyargs pathspec  # [unix]
     # skip symlink tests on windows
     # https://github.com/cpburnz/python-path-specification/commit/d268375a4c6aa
-    - pytest --pyargs pathspec -k "not test_2_1_check_realpath"  # [win]
+    - pytest --pyargs pathspec -k "not test_2_1_check_realpath and not test_2_4_recursive_links and not test_2_5_recursive_circular_links"  # [win]
 
 
 about:

--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -27,7 +27,11 @@ test:
   imports:
     - pathspec
   commands:
-    - pytest --pyargs pathspec
+    - pytest --pyargs pathspec  # [unix]
+    # skip symlink tests on windows
+    # https://github.com/cpburnz/python-path-specification/commit/d268375a4c6aa
+    - pytest --pyargs pathspec -k "not test_2_1_check_realpath" # [win]
+
 
 about:
   home: https://github.com/cpburnz/python-path-specification

--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -39,6 +39,7 @@ about:
     pathspec is a utility library for pattern matching of file paths. So far
     this only includes Git's wildmatch pattern matching which itself is derived
     from Rsync's wildmatch. Git uses wildmatch for its gitignore files.
+  doc_url: https://python-path-specification.readthedocs.io
 
 extra:
   recipe-maintainers:

--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -30,7 +30,7 @@ test:
     - pytest --pyargs pathspec  # [unix]
     # skip symlink tests on windows
     # https://github.com/cpburnz/python-path-specification/commit/d268375a4c6aa
-    - pytest --pyargs pathspec -k "not test_2_1_check_realpath" # [win]
+    - pytest --pyargs pathspec -k "not test_2_1_check_realpath"  # [win]
 
 
 about:

--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -45,3 +45,4 @@ about:
 extra:
   recipe-maintainers:
     - bollwyvl
+    - proinsias

--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -40,6 +40,7 @@ about:
     this only includes Git's wildmatch pattern matching which itself is derived
     from Rsync's wildmatch. Git uses wildmatch for its gitignore files.
   doc_url: https://python-path-specification.readthedocs.io
+  doc_source_url: https://github.com/cpburnz/python-path-specification/blob/master/doc/source/index.rst
 
 extra:
   recipe-maintainers:

--- a/recipes/pathspec/meta.yaml
+++ b/recipes/pathspec/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "pathspec" %}
+{% set version = "0.5.9" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 54a5eab895d89f342b52ba2bffe70930ef9f8d96e398cccf530d21fa0516a873
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  requires:
+    - pytest
+  imports:
+    - pathspec
+  commands:
+    - pytest --pyargs pathspec
+
+about:
+  home: https://github.com/cpburnz/python-path-specification
+  license: MPL-2.0
+  license_file: LICENSE
+  summary: 'Utility library for gitignore style pattern matching of file paths.'
+
+  description: |
+    pathspec is a utility library for pattern matching of file paths. So far
+    this only includes Git's wildmatch pattern matching which itself is derived
+    from Rsync's wildmatch. Git uses wildmatch for its gitignore files.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Adds [pathspec](https://github.com/cpburnz/python-path-specification) 0.5.9.

This is a missing dependency for https://github.com/conda-forge/yamllint-feedstock/issues/5

@proinsias interested in co-maintaining?