### PR TITLE
Add QCPortal to Conda-Forge

### DIFF
--- a/recipes/qcportal/meta.yaml
+++ b/recipes/qcportal/meta.yaml
@@ -25,16 +25,15 @@ requirements:
     - numpy
     - pandas
     - requests
-    - pydantic
+    - pydantic >=0.20
     - qcelemental >=0.2.6
 
 test:
   requires:
     - pytest
-    - pytest-cov
-    - codecov
   imports:
     - qcportal
+    - pytest --pyargs qcportal
 
 about:
   home: https://github.com/MolSSI/QCPortal

--- a/recipes/qcportal/meta.yaml
+++ b/recipes/qcportal/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "qcportal" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "eb44ec03590116ffdfe7c9efea1987d8bcea9cb61b58dcc6d47ed2225dca3766" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+
+  run:
+    - python >=3.6
+    - numpy
+    - pandas
+    - requests
+    - pydantic
+    - qcelemental >=0.2.6
+
+test:
+  requires:
+    - pytest
+    - pytest-cov
+    - codecov
+  imports:
+    - qcportal
+
+about:
+  home: https://github.com/MolSSI/QCPortal
+  dev_url: https://github.com/MolSSI/QCPortal
+  doc_url: https://qcfractal.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/MolSSI/QCFractal/blob/master/docs/source/portal-client.rst
+  license: BSD-3-Clause
+  license_url: https://opensource.org/licenses/BSD-3-Clause
+  license_file: LICENSE
+  license_family: BSD
+  summary: A client interface to the QC Archive Project
+
+extra:
+    recipe-maintainers:
+        - dgasmith
+        - lnaden

--- a/recipes/qcportal/meta.yaml
+++ b/recipes/qcportal/meta.yaml
@@ -33,6 +33,7 @@ test:
     - pytest
   imports:
     - qcportal
+  run:
     - pytest --pyargs qcportal
 
 about:

--- a/recipes/qcportal/meta.yaml
+++ b/recipes/qcportal/meta.yaml
@@ -33,7 +33,7 @@ test:
     - pytest
   imports:
     - qcportal
-  run:
+  commands:
     - pytest --pyargs qcportal
 
 about:

--- a/recipes/qcportal/meta.yaml
+++ b/recipes/qcportal/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qcportal" %}
-{% set version = "0.5.0" %}
-{% set sha256 = "eb44ec03590116ffdfe7c9efea1987d8bcea9cb61b58dcc6d47ed2225dca3766" %}
+{% set version = "0.5.0.post1" %}
+{% set sha256 = "5e493e11e1f306adba1640c852515d5b6397f2feb76eda6bd759ae6178876784" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/qcportal/meta.yaml
+++ b/recipes/qcportal/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "qcportal" %}
-{% set version = "0.5.0.post1" %}
-{% set sha256 = "5e493e11e1f306adba1640c852515d5b6397f2feb76eda6bd759ae6178876784" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "21fc87bb84ed37b77a54c763d7b43857af080502593285d55045a28aee92a648" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->

This PR adds the QCPortal interface to Conda-forge. This package serves as a client-side interface to [QC Archive Ecosystem](https://github.com/MolSSI/QCFractal) maintained through the [QCFractal Feedstock](https://github.com/conda-forge/qcfractal-feedstock)

cc @dgasmith who will need to approve himself being a maintainer.