### PR TITLE
ILAMB 2.3.1 recipe

### DIFF
--- a/recipes/ilamb/LICENSE
+++ b/recipes/ilamb/LICENSE
@@ -1,0 +1,29 @@
+Copyright (c) 2019 UT-BATTELLE, LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/recipes/ilamb/meta.yaml
+++ b/recipes/ilamb/meta.yaml
@@ -44,8 +44,9 @@ test:
 
 about:
   home: https://bitbucket.org/ncollier/ilamb
-  license: NONE
-  license_family: NONE
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
   summary: The International Land Model Benchmarking Package
   description: |
     The International Land Model Benchmarking (ILAMB) project is a model-data

--- a/recipes/ilamb/meta.yaml
+++ b/recipes/ilamb/meta.yaml
@@ -17,18 +17,16 @@ build:
 requirements:
   host:
     - pip
-    - python =2
+    - python
     - setuptools
   run:
-    - python =2
-    - cython
+    - python
     - basemap >=1.0.7
     - cf-units >=2.0.0
     - matplotlib >=1.4.3
     - mpi4py >=1.3.1
     - netCDF4 >=1.1.4
     - numpy >=1.11.0
-    - proj4
     - scipy >=0.9.0
     - sympy >=0.7.6
 

--- a/recipes/ilamb/meta.yaml
+++ b/recipes/ilamb/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = "ILAMB" %}
+{% set version = "2.3.1" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 15c2e0da0139d406df5883dad428ab8692aeebbb55368db0ed3b93466f9d19db
+
+build:
+  number: 0
+  skip: True  # [py3k]
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - pip
+    - python =2
+    - setuptools
+  run:
+    - python =2
+    - cython
+    - basemap >=1.0.7
+    - cf-units >=2.0.0
+    - matplotlib >=1.4.3
+    - mpi4py >=1.3.1
+    - netCDF4 >=1.1.4
+    - numpy >=1.11.0
+    - proj4
+    - scipy >=0.9.0
+    - sympy >=0.7.6
+
+test:
+  imports:
+    - ILAMB
+  commands:
+    - ilamb-doctor -h
+    - ilamb-fetch -h
+    - ilamb-run -h
+    - ilamb-mean -h
+    - ilamb-table -h
+
+about:
+  home: https://bitbucket.org/ncollier/ilamb
+  license: NONE
+  license_family: NONE
+  summary: The International Land Model Benchmarking Package
+  description: |
+    The International Land Model Benchmarking (ILAMB) project is a model-data
+    intercomparison and integration project designed to improve the performance
+    of land models and, in parallel, improve the design of new measurement
+    campaigns to reduce uncertainties associated with key land surface processes.
+    Building upon past model evaluation studies, the goals of ILAMB are to:
+
+    * develop internationally accepted benchmarks for land model performance,
+      promote the use of these benchmarks by the international community for
+      model intercomparison,
+
+    * strengthen linkages between experimental, remote sensing, and climate
+      modeling communities in the design of new model tests and new measurement
+      programs, and
+
+    * support the design and development of a new, open source, benchmarking
+      software system for use by the international community.
+
+    It is the last of these goals to which this repository is concerned. We have
+    developed a python-based generic benchmarking system, initially focused on
+    assessing land model performance.
+  doc_url: 'https://www.ilamb.org/doc'
+  dev_url: 'https://bitbucket.org/ncollier/ilamb'
+
+extra:
+  recipe-maintainers:
+    - jhkennedy
+    - nocollier

--- a/recipes/ilamb/meta.yaml
+++ b/recipes/ilamb/meta.yaml
@@ -34,11 +34,11 @@ test:
   imports:
     - ILAMB
   commands:
-    - ilamb-doctor -h
-    - ilamb-fetch -h
-    - ilamb-run -h
-    - ilamb-mean -h
-    - ilamb-table -h
+    - ilamb-doctor -h  # [not win]
+    - ilamb-fetch -h  # [not win]
+    - ilamb-run -h  # [not win]
+    - ilamb-mean -h  # [not win]
+    - ilamb-table -h  # [not win]
 
 about:
   home: https://bitbucket.org/ncollier/ilamb


### PR DESCRIPTION
@conda-forge/help-python FIY: this is for the python 2 only version of ILAMB, which is still being used at many of DOE's computing centers. Once this recipe is accepted and a feedstock created, I'll bump it to the latest ILAMB 2.4 version there, which is python 3 only. Thanks! 