### PR TITLE
Add ECMWF cfgrib: open GRIB files with xarray

### DIFF
--- a/recipes/cfgrib/meta.yaml
+++ b/recipes/cfgrib/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "cfgrib" %}
+{% set version = "0.9.5.6" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b218992379415ca26d6ac6ddd3f0363b40505c5ef1ad53d8b504635326e0e353
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - cfgrib=cfgrib.__main__:cfgrib_cli
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - attrs
+    - cffi
+    - click
+    - eccodes 2.12.0
+    - future
+    - numpy
+    - pip
+    - pytest-runner
+    - python
+    - typing
+    - xarray
+  run:
+    - attrs
+    - cffi
+    - click
+    - eccodes >=2.12.0
+    - future
+    - numpy
+    - python
+    - typing
+    - xarray >=0.11.0
+
+test:
+  imports:
+    - cf2cdm
+    - cfgrib
+  commands:
+    - cfgrib --help
+
+about:
+  home: https://github.com/ecmwf/cfgrib
+  license: Apache Software
+  license_family: APACHE
+  license_file: LICENSE
+  summary: Maps GRIB files to the NetCDF Common Data Model with CF Convention using ecCodes
+  doc_url: https://github.com/ecmwf/cfgrib
+  dev_url: https://github.com/ecmwf/cfgrib
+
+extra:
+  recipe-maintainers:
+    - alexamici
+    - StephanSiemen

--- a/recipes/cfgrib/meta.yaml
+++ b/recipes/cfgrib/meta.yaml
@@ -49,7 +49,7 @@ test:
 
 about:
   home: https://github.com/ecmwf/cfgrib
-  license: Apache Software
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
   summary: Maps GRIB files to the NetCDF Common Data Model with CF Convention using ecCodes

--- a/recipes/cfgrib/meta.yaml
+++ b/recipes/cfgrib/meta.yaml
@@ -50,7 +50,7 @@ test:
 about:
   home: https://github.com/ecmwf/cfgrib
   license: Apache-2.0
-  license_family: APACHE
+  license_family: Apache
   license_file: LICENSE
   summary: Maps GRIB files to the NetCDF Common Data Model with CF Convention using ecCodes
   doc_url: https://github.com/ecmwf/cfgrib

--- a/recipes/cfgrib/meta.yaml
+++ b/recipes/cfgrib/meta.yaml
@@ -18,17 +18,9 @@ build:
 
 requirements:
   host:
-    - attrs
-    - cffi
-    - click
-    - eccodes 2.12.0
-    - future
-    - numpy
     - pip
     - pytest-runner
     - python
-    - typing
-    - xarray
   run:
     - attrs
     - cffi


### PR DESCRIPTION
Hi, this recipe adds the ability to work with the very popular GRIB file format in `xarray` on Linux, MacOS and Windows (with the next release).

The need for a conda package is due to the `eccodes` dependency.