### PR TITLE
Drop Windows 32-bit and 64-bit variants

### DIFF
--- a/.ci_support/win32.yaml
+++ b/.ci_support/win32.yaml
@@ -1,2 +1,0 @@
-target_platform:
-- win-32

--- a/.ci_support/win64.yaml
+++ b/.ci_support/win64.yaml
@@ -1,2 +1,0 @@
-target_platform:
-- win-64


### PR DESCRIPTION
We already set the Windows 64-bit variant in conda-forge-pinning. So this makes the 64-bit variant redundant. Plus we don't build or support Windows 32-bit any more. So that can be dropped as well.

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
