### PR TITLE
Add recipe for git_root

### DIFF
--- a/recipes/git_root/meta.yaml
+++ b/recipes/git_root/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "git_root" %}
+{% set version = "0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jtilly/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 34d7edee2413d8c80700b2273ea75bb58162e65343e07e5b974742be5681003a
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - git_root
+
+about:
+  home: https://github.com/jtilly/git_root
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Find the root of a git repo'
+  description: 'Find the root of a git repo'
+  dev_url: https://github.com/jtilly/git_root
+
+extra:
+  recipe-maintainers:
+    - jtilly


### PR DESCRIPTION
This is a trivial pure python package that only contains a single function.