### PR TITLE
Add recipe for QtSerialPort

### DIFF
--- a/recipes/qtserialport/bld.bat
+++ b/recipes/qtserialport/bld.bat
@@ -1,0 +1,13 @@
+@echo on
+
+mkdir build
+cd build
+
+qmake ..\qtserialport.pro
+if errorlevel 1 exit 1
+
+nmake
+if errorlevel 1 exit 1
+:: No "make check" available
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/qtserialport/build.sh
+++ b/recipes/qtserialport/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+[[ -d build ]] || mkdir build
+cd build/
+
+# Need to specify these QMAKE variables because of build environment residue
+# in qt mkspecs referencing "qt_1548879054661"
+# Report: https://github.com/conda-forge/qtlocation-feedstock/pull/3#issuecomment-466278804
+# Fix PR: https://github.com/conda-forge/qt-feedstock/pull/97
+qmake \
+    QMAKE_CC=${CC} \
+    QMAKE_CXX=${CXX} \
+    QMAKE_LINK=${CXX} \
+    QMAKE_RANLIB=${RANLIB} \
+    QMAKE_OBJDUMP=${OBJDUMP} \
+    QMAKE_STRIP=${STRIP} \
+    QMAKE_AR="${AR} cqs" \
+    ..
+
+make -j$CPU_COUNT
+make check
+make install

--- a/recipes/qtserialport/meta.yaml
+++ b/recipes/qtserialport/meta.yaml
@@ -31,8 +31,7 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/libQt5SerialPort.{{ version }}.dylib  # [osx]
-    - test -f ${PREFIX}/lib/libQt5SerialPort.so.5  # [linux]
+    - test -f ${PREFIX}/lib/libQt5SerialPort${SHLIB_EXT}  # [unix]
 
 about:
   home: https://github.com/qt/qtserialport

--- a/recipes/qtserialport/meta.yaml
+++ b/recipes/qtserialport/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "qtserialport" %}
+{% set version = "5.6.2" %}
+{% set ver = '.'.join(version.split('.')[:2]) %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://download.qt.io/official_releases/qt/{{ ver }}/{{ version }}/submodules/qtserialport-opensource-src-{{ version }}.tar.xz
+  sha256: af76281bad2c2bd283189635316b46091f6712134b845ae1b9e3016eec94f376
+
+build:
+  # QtSerialPort already comes with Windows Qt builds but the included bld.bat
+  # should work (just doesn't package anything because files already exist)
+  skip: true  # [win]
+  number: 0
+
+requirements:
+  build:
+    # if your project compiles code (such as a C extension) then add the required compilers as separate entries here.
+    # compilers are named 'c', 'cxx' and 'fortran'.
+    - perl
+    - cmake
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - qt
+  run:
+    - qt
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libQt5SerialPort.{{ version }}.dylib  # [osx]
+    - test -f ${PREFIX}/lib/libQt5SerialPort.so.5  # [linux]
+
+about:
+  home: https://github.com/qt/qtserialport
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE.GPLv3
+  summary: 'The QtSerialPort module is an add-on module for the Qt5 library, providing a single interface for both hardware and virtual serial ports.'
+  description: |
+    The QtSerialPort module is an add-on module for the Qt5 library, providing a single
+    interface for both hardware and virtual serial ports. Serial interfaces, due to
+    their simplicity and reliability, are still popular in some industries like the
+    development of embedded systems, robotics, etc. Using the QtSerialPort module,
+    developers can significantly reduce the time needed to implement Qt applications
+    that require access to a serial interface.
+  doc_url: http://doc.qt.io/qt-5/qtserialport-index.html
+  dev_url: https://github.com/qt/qtserialport
+
+extra:
+  recipe-maintainers:
+    - ceholden


### PR DESCRIPTION
This is a recipe to add a component of Qt that is not built by the conda-forge recipes (like `qtlocation` and a few other feedstocks), and is needed to update QGIS recipe to the latest long term release (3.4.5). Few bits worth mentioning about the recipe:

1. The `build.sh` has a temporary workaround for an issue with `qmake`. There is a [PR](https://github.com/conda-forge/qt-feedstock/pull/97) to fix it with more information
2. This recipe skips the Windows build because the Qt recipe [Windows build](https://github.com/conda-forge/qt-feedstock/blob/78a5467531dc7c6047d28624e83d6af187ab577e/recipe/bld.bat#L136) already includes it, while the [Linux/Mac builds](https://github.com/conda-forge/qt-feedstock/blob/78a5467531dc7c6047d28624e83d6af187ab577e/recipe/build.sh#L105) skip it. We could try rebuilding the Mac/Linux Qt builds without skipping `qtserialport`, which would be more consistent and avoid another feedstock, but Qt is really difficult and already takes a long time to compile. Seems worth it to be separate, but I could see either way.
3. The build script for Windows included here does work, but nothing gets packaged because no new files are created (because Qt already has them...)