### PR TITLE
Packages jupyter-server-proxy and simpervisor

### DIFF
--- a/recipes/jupyter-server-proxy/LICENSE
+++ b/recipes/jupyter-server-proxy/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Data Science 8
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/jupyter-server-proxy/meta.yaml
+++ b/recipes/jupyter-server-proxy/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "jupyter-server-proxy" %}
+{% set version = "1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5a7d5bd044e43b40ca04df4040dd92efa66f7a98406e7b7b4c985fd86b18cbdd
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3
+    - pip
+    - setuptools
+  run:
+    - python >=3
+    - notebook
+    - simpervisor >=0.2
+    - aiohttp
+
+test:
+  imports:
+    - jupyter_server_proxy
+
+about:
+  home: https://github.com/jupyterhub/jupyter-server-proxy
+  license: BSD-3-Clause
+  # Vendoring the license file until the packages include it.
+  # xref: https://github.com/jupyterhub/jupyter-server-proxy/pull/105
+  license_file: LICENSE
+  summary: Jupyter server extension to supervise and proxy web services
+  description: |
+    Jupyter Server Proxy lets you run arbitrary external processes (such as
+    RStudio, Shiny Server, syncthing, PostgreSQL, etc) alongside your notebook,
+    and provide authenticated web access to them.
+  doc_url: https://jupyter-server-proxy.readthedocs.io
+  dev_url: https://github.com/jupyterhub/jupyter-server-proxy
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - lsetiawan
+    - minrk
+    - ocefpaf

--- a/recipes/simpervisor/LICENSE
+++ b/recipes/simpervisor/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, Yuvi Panda
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/simpervisor/meta.yaml
+++ b/recipes/simpervisor/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "simpervisor" %}
+{% set version = "0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d82e4527ae326747551e4bdfa632ff4ebef275ce721f80886c747adfdbf41c2e
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3
+    - pip
+    - setuptools
+  run:
+    - python >=3
+
+test:
+  imports:
+    - simpervisor
+
+about:
+  home: https://github.com/yuvipanda/simpervisor
+  license: BSD-3-Clause
+  # Vendoring the license file until the packages include it.
+  # xref: https://github.com/yuvipanda/simpervisor/pull/5
+  license_file: LICENSE
+  summary: Jupyter server extension to supervise and proxy web services
+  description: |
+    Jupyter Server Proxy lets you run arbitrary external processes (such as
+    RStudio, Shiny Server, syncthing, PostgreSQL, etc) alongside your notebook,
+    and provide authenticated web access to them.
+  doc_url: https://simpervisor.readthedocs.io
+  dev_url: https://github.com/yuvipanda/simpervisor
+
+extra:
+  recipe-maintainers:
+    - jakirkham
+    - lsetiawan
+    - minrk
+    - ocefpaf


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/7810

Adds Conda recipes for `jupyter-server-proxy` and `simpervisor` (one of its dependencies). This replaces `nbserverproxy`. Have gone ahead and added myself and all of the maintainers from @conda-forge/nbserverproxy.

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
