### PR TITLE
Add ruamel namespace package

### DIFF
--- a/recipes/ruamel/LICENSE.txt
+++ b/recipes/ruamel/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of staged-recipes nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/ruamel/meta.yaml
+++ b/recipes/ruamel/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: ruamel
+  version: 1.0
+
+build:
+  number: 0
+  script:
+    - cd {{ SP_DIR if SP_DIR is defined else '' }}
+    - mkdir ruamel && cd ruamel
+    - python -c "open('__init__.py', 'w').close()"
+    - cd {{ SRC_DIR if SRC_DIR is defined else '' }}
+    - python -c "import ruamel"
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - ruamel
+
+about:
+  home: http://github.com/conda-forge/ruamel-feedstock
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: {{ RECIPE_DIR if RECIPE_DIR is defined else '' }}/LICENSE.txt
+  summary: A package to ensure the `ruamel` namespace is available.
+
+extra:
+  recipe-maintainers:
+    - jakirkham


### PR DESCRIPTION
This essentially copies the [`backports`]( https://github.com/conda-forge/backports-feedstock ) recipe. Have intentionally not made this `noarch` because it will become a dependency of `conda`.

cc @jjhelmus @mariusvniekerk