### PR TITLE
Add recipe for XDesign

### DIFF
--- a/recipes/xdesign/meta.yaml
+++ b/recipes/xdesign/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
@@ -20,6 +20,7 @@ requirements:
     - python={{ python }}
     - setuptools
     - setuptools_scm
+    - setuptools_scm_git_archive
   run:
     - cached-property
     - matplotlib

--- a/recipes/xdesign/meta.yaml
+++ b/recipes/xdesign/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "xdesign" %}
+{% set version = "v0.5.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/tomography/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: cb5adc5cd4ee79913d975a74d9c3643adef43a4ed460de2a676287694b403449
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - pip
+    - python={{ python }}
+    - setuptools
+    - setuptools_scm
+  run:
+    - cached-property
+    - matplotlib
+    - numpy
+    - python={{ python }}
+    - scipy
+
+test:
+  imports:
+    - xdesign
+    - xdesign.geometry
+    - xdesign.metrics
+    - xdesign.phantom
+
+about:
+  home: http://xdesign.readthedocs.io
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Benchmarking and optimization tools for tomography.'
+  description: |
+    XDesign is an open-source Python package for creating x-ray imaging
+    phantoms, simulating data acquisition, and benchmarking x-ray
+    tomographic image reconstruction.
+  doc_url: https://xdesign.readthedocs.io
+  dev_url: https://github.com/tomography/xdesign
+
+extra:
+  recipe-maintainers:
+    - carterbox

--- a/recipes/xdesign/meta.yaml
+++ b/recipes/xdesign/meta.yaml
@@ -1,17 +1,17 @@
 {% set name = "xdesign" %}
-{% set version = "v0.5.1" %}
+{% set version = "0.5.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/tomography/{{ name }}/archive/{{ version }}.tar.gz
+  url: https://github.com/tomography/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: b0779b47c93f29d28b20f68355065c0bb7b470fa990898e62c6571078ad266d7
 
 build:
   noarch: python
-  number: 2
+  number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:

--- a/recipes/xdesign/meta.yaml
+++ b/recipes/xdesign/meta.yaml
@@ -11,13 +11,13 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
     - pip
-    - python={{ python }}
+    - python >=3
     - setuptools
     - setuptools_scm
     - setuptools_scm_git_archive
@@ -25,7 +25,7 @@ requirements:
     - cached-property
     - matplotlib
     - numpy
-    - python={{ python }}
+    - python >=3
     - scipy
 
 test:

--- a/recipes/xdesign/meta.yaml
+++ b/recipes/xdesign/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xdesign" %}
-{% set version = "v0.5.0" %}
+{% set version = "v0.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tomography/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: cb5adc5cd4ee79913d975a74d9c3643adef43a4ed460de2a676287694b403449
+  sha256: b0779b47c93f29d28b20f68355065c0bb7b470fa990898e62c6571078ad266d7
 
 build:
   noarch: python


### PR DESCRIPTION
Adds a build recipe for XDesign, a Python package for creating x-ray imaging phantoms, simulating data acquisition, and benchmarking x-ray tomographic image reconstruction.