### PR TITLE
Add recipe for makedepf90

### DIFF
--- a/recipes/makedepf90/build.sh
+++ b/recipes/makedepf90/build.sh
@@ -1,0 +1,3 @@
+./configure --prefix="$PREFIX"
+make
+make install

--- a/recipes/makedepf90/meta.yaml
+++ b/recipes/makedepf90/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "makedepf90" %}
+{% set version = "2.8.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://archive.ubuntu.com/ubuntu/pool/universe/m/{{ name }}/{{ name }}_{{ version }}.orig.tar.gz
+  sha256: a5118aea198219f59bc04eab0a2099341cecac76a7029c2aef72141645e7596a
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+test:
+  commands:
+    - test -f $PREFIX/bin/makedepf90
+
+about:
+  home: https://linux.die.net/man/1/makedepf90
+  license: GPL-2.0
+  license_family: GPL
+  license_file: COPYING
+  summary: 'Creates Makefile dependency list for Fortran source files.'
+  doc_url: https://linux.die.net/man/1/makedepf90
+
+extra:
+  recipe-maintainers:
+    - kburns


### PR DESCRIPTION
[makedepf90](https://linux.die.net/man/1/makedepf90) is a tool for creating Makefile dependency list for Fortran source files.