### PR TITLE
dask-memusage recipe

### DIFF
--- a/recipes/dask-memusage/meta.yaml
+++ b/recipes/dask-memusage/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "dask-memusage" %}
+{% set version = "1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dask_memusage-{{ version }}.tar.gz
+  sha256: 44f05a009a256f5fe1af323970b212f024bad9150a649e595776185c3611bf47
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m flit --debug install --deps none"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+    - flit
+  run:
+    - python >=3.5
+    - distributed
+    - click
+
+test:
+  imports:
+    - dask_memusage
+
+about:
+  home: https://github.com/itamarst/dask-memusage
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Runtime memory usage tracking for Dask Distributed'
+  description: |
+    Statistical profiler for Dask Distributed that records min and max memory
+    usage for each job.
+  doc_url: https://github.com/itamarst/dask-memusage
+  dev_url: https://github.com/itamarst/dask-memusage
+
+extra:
+  recipe-maintainers:
+    - itamarst

--- a/recipes/dask-memusage/meta.yaml
+++ b/recipes/dask-memusage/meta.yaml
@@ -33,7 +33,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: 'Runtime memory usage tracking for Dask Distributed'
+  summary: 'Runtime statistical memory profiler for Dask Distributed'
   description: |
     Statistical profiler for Dask Distributed that records min and max memory
     usage for each job.


### PR DESCRIPTION
@conda-forge/help-python any idea what's up with Windows build? Both `distributed` and `click` have Windows packages. and it doesn't tell m _what_ the missing dependency is :crying_cat_face: 