### PR TITLE
Conda ecosystem user package isolation 

### DIFF
--- a/recipes/conda-ecosystem-user-package-isolation/activate-user-package-isolation.sh
+++ b/recipes/conda-ecosystem-user-package-isolation/activate-user-package-isolation.sh
@@ -1,0 +1,11 @@
+if [[ "$CONDA_USER_PACKAGE_ISOLATION" -eq "0" ]]; then
+	# Ignore python packages installed into the user's home directory
+	export CONDA_PYTHONNOUSERSITE_BAK="$PYTHONNOUSERSITE"
+	export PYTHONNOUSERSITE=1
+	# Ignore R packages installed into the user's home directory
+	export CONDA_RLIBSUSER_BAK="$R_LIBS_USER"
+	export R_LIBS_USER="-"
+fi
+
+# Update activation counter
+export CONDA_USER_PACKAGE_ISOLATION=$[$CONDA_USER_PACKAGE_ISOLATION+1]

--- a/recipes/conda-ecosystem-user-package-isolation/build.sh
+++ b/recipes/conda-ecosystem-user-package-isolation/build.sh
@@ -1,0 +1,4 @@
+mkdir -p $PREFIX/etc/conda/activate.d
+mkdir -p $PREFIX/etc/conda/deactivate.d
+cp $RECIPE_DIR/activate-user-package-isolation.sh $PREFIX/etc/conda/activate.d/user-package-isolation.sh
+cp $RECIPE_DIR/deactivate-user-package-isolation.sh $PREFIX/etc/conda/deactivate.d/user-package-isolation.sh

--- a/recipes/conda-ecosystem-user-package-isolation/deactivate-user-package-isolation.sh
+++ b/recipes/conda-ecosystem-user-package-isolation/deactivate-user-package-isolation.sh
@@ -1,0 +1,25 @@
+# Decrement activation counter
+if [[ "$CONDA_USER_PACKAGE_ISOLATION" -gt "0" ]]; then
+	export CONDA_USER_PACKAGE_ISOLATION=$[$CONDA_USER_PACKAGE_ISOLATION-1]
+fi
+
+if [[ "$CONDA_USER_PACKAGE_ISOLATION" -eq "0" ]]; then
+	# Reset PYTHONNOUSERSITE
+	if [[ -z "$CONDA_PYTHONNOUSERSITE_BAK" ]]; then
+		unset PYTHONNOUSERSITE
+	else
+		PYTHONNOUSERSITE="$CONDA_PYTHONNOUSERSITE_BAK"
+	fi
+	unset CONDA_PYTHONNOUSERSITE_BAK
+
+	# Reset R_LIBS_USER
+	if [[ -z "$CONDA_RLIBSUSER_BAK" ]]; then
+		unset R_LIBS_USER
+	else
+		R_LIBS_USER="$CONDA_RLIBSUSER_BAK"
+	fi
+	unset CONDA_RLIBSUSER_BAK
+
+	# Finally get rid of counter
+	unset CONDA_USER_PACKAGE_ISOLATION
+fi

--- a/recipes/conda-ecosystem-user-package-isolation/meta.yaml
+++ b/recipes/conda-ecosystem-user-package-isolation/meta.yaml
@@ -1,0 +1,15 @@
+package:
+  name: conda-ecosystem-user-package-isolation
+  version: 1.0
+
+build:
+  number: 0
+
+about:
+  home: http://conda.io
+  license: BSD
+  summary: 'Prevent python and R from searching for packages in the user's home'
+
+extra:
+  recipe-maintainers:
+    - fgp

--- a/recipes/conda-ecosystem-user-package-isolation/meta.yaml
+++ b/recipes/conda-ecosystem-user-package-isolation/meta.yaml
@@ -6,8 +6,13 @@ build:
   number: 0
   skip: true  # [win]
 
+test:
+  commands:
+    - '[[ "$PYTHONNOUSERSITE" == "1" ]] || exit 1'
+    - '[[ "$R_LIBS_USER" == "-" ]] || exit 1'
+
 about:
-  home: http://conda.io
+  home: http://conda-forge.org/
   license: BSD
   summary: 'Prevent python and R from searching for packages outside of the current environment'
 

--- a/recipes/conda-ecosystem-user-package-isolation/meta.yaml
+++ b/recipes/conda-ecosystem-user-package-isolation/meta.yaml
@@ -4,6 +4,7 @@ package:
 
 build:
   number: 0
+  skip: true  # [win]
 
 about:
   home: http://conda.io

--- a/recipes/conda-ecosystem-user-package-isolation/meta.yaml
+++ b/recipes/conda-ecosystem-user-package-isolation/meta.yaml
@@ -8,8 +8,8 @@ build:
 
 test:
   commands:
-    - '[[ "$PYTHONNOUSERSITE" == "1" ]] || exit 1'
-    - '[[ "$R_LIBS_USER" == "-" ]] || exit 1'
+    - test "$PYTHONNOUSERSITE" == "1"
+    - test "$R_LIBS_USER" == "-"
 
 about:
   home: http://conda-forge.org/

--- a/recipes/conda-ecosystem-user-package-isolation/meta.yaml
+++ b/recipes/conda-ecosystem-user-package-isolation/meta.yaml
@@ -9,7 +9,7 @@ build:
 about:
   home: http://conda.io
   license: BSD
-  summary: 'Prevent python and R from searching for packages in the user's home'
+  summary: 'Prevent python and R from searching for packages outside of the current environment'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This package adds scripts to `etc/conda/activate.d/` and `/etc/conda/deactivate.d/` that set `PYTHONNOUSERSITE=1` and `R_LIBS_USER=-` to prevent python and R from searching for packages installed into the user's home directory.

See also [conda issue 7707](https://github.com/conda/conda/issues/7707)

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
