### PR TITLE
Initialize django rest swagger recipe

### DIFF
--- a/recipes/django-rest-swagger/meta.yaml
+++ b/recipes/django-rest-swagger/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - python
   run:
-    - coreapi >=2.3.0
+    - python-coreapi
     - djangorestframework >=3.5.4
     - openapi-codec >=1.3.1
     - python

--- a/recipes/django-rest-swagger/meta.yaml
+++ b/recipes/django-rest-swagger/meta.yaml
@@ -1,4 +1,3 @@
-{% set name = "django-rest-swagger" %}
 {% set version = "2.2.0" %}
 
 package:
@@ -19,7 +18,7 @@ requirements:
     - pip
     - python
   run:
-    - python-coreapi
+    - python-coreapi >=2.3.0
     - djangorestframework >=3.5.4
     - openapi-codec >=1.3.1
     - python

--- a/recipes/django-rest-swagger/meta.yaml
+++ b/recipes/django-rest-swagger/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:

--- a/recipes/django-rest-swagger/meta.yaml
+++ b/recipes/django-rest-swagger/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "django-rest-swagger" %}
+{% set version = "2.2.0" %}
+
+package:
+  name: django-rest-swagger
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/d/django-rest-swagger/django-rest-swagger-{{ version }}.tar.gz
+  sha256: 48f6aded9937e90ae7cbe9e6c932b9744b8af80cc4e010088b3278c700e0685b
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - coreapi >=2.3.0
+    - djangorestframework >=3.5.4
+    - openapi-codec >=1.3.1
+    - python
+    - simplejson
+
+test:
+  imports:
+    - rest_framework_swagger
+
+about:
+  home: https://github.com/marcgibbons/django-rest-swagger
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Swagger UI for Django REST Framework 3.5+
+  doc_url: https://django-rest-swagger.readthedocs.io/en/latest/
+  dev_url: https://github.com/marcgibbons/django-rest-swagger
+
+extra:
+  recipe-maintainers:
+    - lsetiawan


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->

## Overview

This PR adds `django-rest-swagger` package to conda-forge. 
> An API documentation generator for Swagger UI and Django REST Framework.

This is the latest version `2.2.0` compared to #5143, that never got merged.



@conda-forge/staged-recipes Please review and merge this recipe, if everything looks good. Thank you very much! 
