### PR TITLE
Add psfgen

### DIFF
--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -7,7 +7,6 @@ package:
     version: {{ version }}
 
 source:
-    fn: {{ name }} -v{{ version }}.tar.gz
     url: https://github.com/Eigenstate/{{ name }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 1
+    number: 2
     skip: true  # [win]
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "psfgen" %}
-{% set version = "0.0.1" %}
+{% set version = "1.0.0" %}
 {% set sha256 = "6bd766ec837f0cd7c42cd110ae81acb5405134bb534bbc38cc10030c5613ab88" %}
 
 package:

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 2
+    number: 0
     skip: true  # [win]
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -29,7 +29,7 @@ requirements:
 test:
     imports:
         - pytest
-        - vmd-python
+        - psfgen
     requires:
         - pytest
         - vmd-python >=3.0.0

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
     build:
         - {{ compiler('c') }}
+        - setuptools
     host:
         - python
         - pip

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "psfgen" %}
+{% set version = "0.0.1" %}
+{% set sha256 = "6bd766ec837f0cd7c42cd110ae81acb5405134bb534bbc38cc10030c5613ab88" %}
+
+package:
+    name: {{ name|lower }}
+    version: {{ version }}
+
+source:
+    fn: {{ name }} -v{{ version }}.tar.gz
+    url: https://github.com/Eigenstate/{{ name }}/archive/v{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+
+build:
+    number: 0
+    skip: true  # [win]
+    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+    build:
+        - {{ compiler('c') }}
+    host:
+        - python
+        - pip
+    run:
+        - python
+
+test:
+    imports:
+        - pytest
+        - vmd-python
+    requires:
+        - pytest
+        - vmd-python >=3.0.0
+    commands:
+        - py.test --pyargs psfgen
+        - conda inspect linkages -p $PREFIX {{ name|lower }}  # [not win]
+        - conda inspect objects -p $PREFIX {{ name|lower }}  # [osx]
+
+about:
+    home: https://github.com/Eigenstate/psfgen
+    license: VMD
+    license_file: LICENSE
+    summary: "Protein Structure builder, with Python bindings"
+    description: |
+        PSFGen is a structure building tool distributed with VMD
+        used to prepare systems for simulation with the CHARMM
+        forcefield.
+    doc_url: https://psfgen.robinbetz.com
+    dev_url: https://github.com/Eigenstate/psfgen
+
+extra:
+    recipe-maintainers:
+        - Eigenstate

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "psfgen" %}
-{% set version = "1.0.0" %}
-{% set sha256 = "6bd766ec837f0cd7c42cd110ae81acb5405134bb534bbc38cc10030c5613ab88" %}
+{% set version = "1.0.1" %}
+{% set sha256 = "ecf5a23805e5fb4841c352203225bd7715e28e9251be2684d1e4c977953b5cbd"
 
 package:
     name: {{ name|lower }}
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 1
+    number: 0
     skip: true  # [win]
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -34,7 +34,7 @@ test:
         - pytest
         - vmd-python >=3.0.0
     commands:
-        - python setup.py test
+        - py.test --pyargs psfgen
         - conda inspect linkages -p $PREFIX {{ name|lower }}  # [not win]
         - conda inspect objects -p $PREFIX {{ name|lower }}  # [osx]
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "psfgen" %}
 {% set version = "1.0.1" %}
-{% set sha256 = "ecf5a23805e5fb4841c352203225bd7715e28e9251be2684d1e4c977953b5cbd"
+{% set sha256 = "ecf5a23805e5fb4841c352203225bd7715e28e9251be2684d1e4c977953b5cbd" %}
 
 package:
     name: {{ name|lower }}

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -34,7 +34,7 @@ test:
         - pytest
         - vmd-python >=3.0.0
     commands:
-        - py.test --pyargs psfgen
+        - {{ PYTHON }} setup.py test
         - conda inspect linkages -p $PREFIX {{ name|lower }}  # [not win]
         - conda inspect objects -p $PREFIX {{ name|lower }}  # [osx]
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -34,7 +34,7 @@ test:
         - pytest
         - vmd-python >=3.0.0
     commands:
-        - {{ PYTHON }} setup.py test
+        - python setup.py test
         - conda inspect linkages -p $PREFIX {{ name|lower }}  # [not win]
         - conda inspect objects -p $PREFIX {{ name|lower }}  # [osx]
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -35,8 +35,6 @@ test:
         - vmd-python >=3.0.0
     commands:
         - py.test --pyargs psfgen
-        - conda inspect linkages -p $PREFIX {{ name|lower }}  # [not win]
-        - conda inspect objects -p $PREFIX {{ name|lower }}  # [osx]
 
 about:
     home: https://github.com/Eigenstate/psfgen

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -19,10 +19,10 @@ build:
 requirements:
     build:
         - {{ compiler('c') }}
-        - setuptools
     host:
         - python
         - pip
+        - setuptools
     run:
         - python
 

--- a/recipes/psfgen/meta.yaml
+++ b/recipes/psfgen/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-    number: 0
+    number: 1
     skip: true  # [win]
     script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 


### PR DESCRIPTION
Initial attempt at adding the Python interface to PSFGen, which prepares proteins and other molecules for molecular dynamics simulation. It's a simple C extension with some Python bindings. The test cases pass with Python 2.7 and 3.6 on my Linux machine.