### PR TITLE
Add recipe for google-cloud-bigquery-storage package.

### DIFF
--- a/recipes/google-cloud-bigquery-storage/meta.yaml
+++ b/recipes/google-cloud-bigquery-storage/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "google-cloud-bigquery-storage" %}
+{% set version = "0.2.0" %}
+{% set sha256 = "b0972b77ce24533758ec4a75c0d93072201fc3ccfb40519e98dbcac20150e08c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
+  # Once resolved, it should be removed.
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - google-api-core >=1.6.0,<2.0.0dev
+    - grpcio >= 1.8.2
+    # Backport of enum for Python < 3.4
+    - enum34  # [py2k]
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - google.api_core
+    - google.cloud.bigquery_storage_v1beta1
+
+about:
+  home: https://googleapis.github.io/google-cloud-python/latest/bigquery_storage/index.html
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Fast access to BigQuery managed storage'
+  description: |
+    The BigQuery Storage API provides fast access to BigQuery managed storage
+    by using an rpc-based protocol.
+  doc_url: https://googleapis.github.io/google-cloud-python/latest/bigquery_storage/index.html
+  dev_url: https://github.com/googleapis/google-cloud-python
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming
+    # maintainers of the recipe. (There will be spam!)
+    - tswast


### PR DESCRIPTION
The BigQuery Storage API provides fast access to BigQuery managed
storage.

API docs: https://cloud.google.com/bigquery/docs/reference/storage/
Python docs: https://googleapis.github.io/google-cloud-python/latest/bigquery_storage/index.html

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those catagories please contact 
the full review team `@conda-forge/staged-recipes`.
-->
