### PR TITLE
Temporarily revert to conda-smithy 3.2.x for feedstock conversion

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -35,7 +35,9 @@ bash ~/miniconda.sh -b -p ~/miniconda
 )
 source ~/miniconda/bin/activate root
 
-conda install --yes --quiet conda-forge-ci-setup=2.* conda-smithy=3.* conda-forge-pinning git=2.12.2 conda-build>=3.16
+# FIXME: Pin to conda-smithy=3.* when it is fixed
+conda install --yes --quiet conda-forge-ci-setup=2.* conda-smithy=3.2.* conda-forge-pinning git=2.12.2 conda-build>=3.16
+# conda install --yes --quiet conda-forge-ci-setup=2.* conda-smithy=3.* conda-forge-pinning git=2.12.2 conda-build>=3.16
 
 conda info
 conda config --get


### PR DESCRIPTION
It seems https://github.com/conda-forge/conda-smithy/pull/1051 wasn't enough and feedstock conversion is still broken. This pull request downgrades to `conda-smithy=3.2.x` until it's fixed.

@conda-forge/core Thoughts?