### PR TITLE
Re-add PyEVTK to try to fix errors after switch to noarch

### DIFF
--- a/recipes/pyevtk/meta.yaml
+++ b/recipes/pyevtk/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = "1.1.2" %}
+
+package:
+    name: pyevtk
+    version: {{ version }}
+
+source:
+  url: https://github.com/pyscience-projects/pyevtk/archive/v{{version}}.tar.gz
+  sha256: ce6cedc5d9fcfa971752d355530adda899ad9dbf3355bc484e2e48c2e0691016
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - pip
+    - numpy
+    - pytest-runner
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  requires:
+    - pytest
+  source_files:
+    - examples/*.py
+    - tests/*.py
+  commands:
+    - pytest tests/dummy.py
+about:
+  home: https://github.com/pyscience-projects/pyevtk
+  license: BSD 2-clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: |
+    EVTK (Export VTK) package allows exporting data to binary VTK files for
+    visualization and data analysis with any of the visualization packages that
+    support VTK files, e.g. Paraview, VisIt and Mayavi. EVTK does not depend on
+    any external library (e.g. VTK), so it is easy to install in different
+    systems.
+  dev_url: https://github.com/paulo-herrera/PyEVTK
+
+extra:
+  recipe-maintainers:
+    - renefritze
+    - xylar

--- a/recipes/pyevtk/meta.yaml
+++ b/recipes/pyevtk/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: ce6cedc5d9fcfa971752d355530adda899ad9dbf3355bc484e2e48c2e0691016
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv"
   noarch: python
 


### PR DESCRIPTION
@jakirkham suggested readding this recipe after the switch to `noarch` to try to make sure we iron out some glitches we saw, specifically that AppVeyor was running when it shouldn't.

See https://github.com/conda-forge/conda-forge.github.io/issues/736#issuecomment-475076605