### PR TITLE
Add recipes for docker-py and backports.ssl_match_hostname

### DIFF
--- a/recipes/backports.ssl_match_hostname/meta.yaml
+++ b/recipes/backports.ssl_match_hostname/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "backports.ssl_match_hostname" %}
+{% set version = "3.7.0.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bb82e60f9fbf4c080eabd957c39f0641f0fc247d9a16e31e26d594d8f42b9fd2
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - backports
+    - backports.ssl_match_hostname
+
+about:
+  home: http://bitbucket.org/brandon/backports.ssl_match_hostname
+  license: Python Software Foundation
+  license_family: OTHER
+  license_file: LICENSE.txt
+  summary: The ssl.match_hostname() function from Python 3.5
+
+extra:
+  recipe-maintainers:
+    - xhochy

--- a/recipes/docker-py/meta.yaml
+++ b/recipes/docker-py/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "docker-py" %}
+{% set pyname = "docker" %}
+{% set version = "3.7.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ pyname[0] }}/{{ pyname }}/{{ pyname }}-{{ version }}.tar.gz
+  sha256: c456ded5420af5860441219ff8e51cdec531d65f4a9e948ccd4133e063b72f50
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - docker-pycreds >=0.4.0
+    - pip
+    - python
+    - requests >=2.14.2
+    - six >=1.4.0
+    - websocket-client >=0.32.0
+  run:
+    - backports.ssl_match_hostname  # [py<3]
+    - docker-pycreds >=0.4.0
+    - requests >=2.14.2
+    - six >=1.4.0
+    - python
+    - websocket-client >=0.32.0
+
+test:
+  imports:
+    - docker
+    - docker.api
+    - docker.models
+    - docker.transport
+    - docker.types
+    - docker.utils
+  requires:
+    - coverage ==4.5.2
+    - flake8 ==3.6.0
+    - mock ==1.0.1
+    - pytest ==4.1.0
+    - pytest-cov ==2.6.1
+    - pytest-timeout ==1.3.3
+
+about:
+  home: https://github.com/docker/docker-py
+  license: Apache Software
+  license_family: APACHE
+  license_file: LICENSE
+  summary: A Python library for the Docker Engine API.
+  doc_url: https://docker-py.readthedocs.io/
+  dev_url: https://github.com/docker/docker-py
+
+extra:
+  recipe-maintainers:
+    - xhochy


### PR DESCRIPTION
cc @jaroslawk

Required for https://github.com/conda-forge/staged-recipes/pull/8072

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
