### PR TITLE
Add recipes for pickleDB and reprexpy

### DIFF
--- a/recipes/pickleDB/LICENSE
+++ b/recipes/pickleDB/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2019 The pickleDB developers
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/pickleDB/meta.yaml
+++ b/recipes/pickleDB/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:

--- a/recipes/pickleDB/meta.yaml
+++ b/recipes/pickleDB/meta.yaml
@@ -29,8 +29,8 @@ about:
   home: http://github.com/patx/pickledb
   license: BSD 3-clause
   license_family: BSD
-  # There is currently no license file, see https://github.com/patx/pickledb/issues/52
-  # license_file:
+  # See https://github.com/patx/pickledb/issues/52
+  license_file: LICENSE
   summary: A lightweight and simple database using json.
 
 extra:

--- a/recipes/pickleDB/meta.yaml
+++ b/recipes/pickleDB/meta.yaml
@@ -20,12 +20,16 @@ requirements:
   run:
     - python
 
+test:
+  imports:
+    - pickledb
+
 about:
   home: http://github.com/patx/pickledb
   license: BSD 3-clause
   license_family: BSD
   # There is currently no license file, see https://github.com/patx/pickledb/issues/52
-  # license_file: 
+  # license_file:
   summary: A lightweight and simple database using json.
 
 extra:

--- a/recipes/pickleDB/meta.yaml
+++ b/recipes/pickleDB/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "pickleDB" %}
+{% set version = "0.9.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ec6973e65d7d112849e78ce522840aa908efb2523470bb8ce5c7942310192240
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+about:
+  home: http://github.com/patx/pickledb
+  license: BSD 3-clause
+  license_family: BSD
+  # There is currently no license file, see https://github.com/patx/pickledb/issues/52
+  # license_file: 
+  summary: A lightweight and simple database using json.
+
+extra:
+  recipe-maintainers:
+    - xhochy

--- a/recipes/reprexpy/meta.yaml
+++ b/recipes/reprexpy/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "reprexpy" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 847dd3a6584b26c8f02f5a61f23b3d548d745a56da4ad6788c1e3129a8a0d6ca
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python
+    # This currently a hard dependency on installation.
+    # Can be removed once https://github.com/crew102/reprexpy/pull/3 is merged
+    - pytest-runner
+  run:
+    - asttokens
+    - ipykernel
+    - ipython
+    - matplotlib
+    - nbconvert
+    - nbformat
+    - pyimgur
+    - pyperclip
+    - python
+    - setuptools
+    - stdlib-list
+    - tornado <=5.1.1
+
+test:
+  imports:
+    - reprexpy
+  requires:
+    - pickledb
+    - pytest
+    - pyzmq
+
+about:
+  home: https://reprexpy.readthedocs.io/en/latest
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Render reproducible examples of Python code (port of R package `reprex`)
+  dev_url: https://github.com/crew102/reprexpy
+
+extra:
+  recipe-maintainers:
+    - xhochy


### PR DESCRIPTION
`pickleDB` doesn't provide a LICENSE file. I have made an upstream issue about this https://github.com/patx/pickledb/issues/52 Is that enough to get this merged?

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
