### PR TITLE
Add clang's python bindings

### DIFF
--- a/recipes/clang-bindings-python/meta.yaml
+++ b/recipes/clang-bindings-python/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "5.0.0" %}
+
+package:
+  name: clang-bindings-python
+  version: {{ version }}
+
+source:
+  url: http://llvm.org/releases/{{ version }}/cfe-{{ version }}.src.tar.xz
+  sha256: 019f23c2192df793ac746595e94a403908749f8e0c484b403476d2611dd20970
+
+build:
+  number: 0
+  noarch: python
+  script:
+    - mkdir -p "${SP_DIR}"
+    - cp -r bindings/python/clang "${SP_DIR}"
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+    - clangdev =={{ version }}
+
+test:
+  requires:
+    - nose
+  source_files:
+    - bindings/python/tests
+    - bindings/python/examples/cindex
+  imports:
+    - clang
+    - clang.cindex
+  commands:
+    - cd bindings/python
+    - cp tests/cindex/util.py tests
+    - nosetests -v
+
+about:
+  home: http://llvm.org/
+  license: NCSA
+  license_file: LICENSE.TXT
+  summary: Python bindings for clang
+
+extra:
+  recipe-maintainers:
+    - chrisburr

--- a/recipes/python-clang/meta.yaml
+++ b/recipes/python-clang/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "5.0.0" %}
 
 package:
-  name: clang-bindings-python
+  name: python-clang
   version: {{ version }}
 
 source:


### PR DESCRIPTION
<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Adds clang's python bindings as a separate package. Once this is merged I'll add it for the other versions of `clangdev` that are supported by conda-forge.