### PR TITLE
add tlsh

### DIFF
--- a/recipes/tlsh/build.sh
+++ b/recipes/tlsh/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+sh make.sh
+cd build/release
+make install
+cp ../../bin/* ${PREFIX}/bin

--- a/recipes/tlsh/build.sh
+++ b/recipes/tlsh/build.sh
@@ -1,5 +1,2 @@
 #!/usr/bin/env bash
 sh make.sh
-cd build/release
-make install
-cp ../../bin/* ${PREFIX}/bin

--- a/recipes/tlsh/install-libtlsh.sh
+++ b/recipes/tlsh/install-libtlsh.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+cd "${SRC_DIR}/build/release"
+make install

--- a/recipes/tlsh/install-python-tlsh.sh
+++ b/recipes/tlsh/install-python-tlsh.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eux
+export LIBRARY_PATH="${PREFIX}/lib"
+export LD_LIBRARY_PATH="${PREFIX}/lib"
+cd "${SRC_DIR}/py_ext"
+python setup.py install --prefix=$PREFIX

--- a/recipes/tlsh/install-tlsh-tools.sh
+++ b/recipes/tlsh/install-tlsh-tools.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -eux
+mkdir -p "${PREFIX}/bin"
+cp ${SRC_DIR}/bin/tlsh* ${PREFIX}/bin

--- a/recipes/tlsh/make.patch
+++ b/recipes/tlsh/make.patch
@@ -1,0 +1,16 @@
+--- make.sh	2019-04-28 14:01:04.261862274 -0400
++++ make.sh.new	2019-04-28 14:02:39.494599400 -0400
+@@ -20,7 +20,12 @@
+ else
+   mkdir -p build/release
+   cd build/release
+-  cmake ../..
++  cmake ../.. \
++		-DCMAKE_BUILD_TYPE=Release \
++		-DCMAKE_PREFIX_PATH=${PREFIX} \
++		-DCMAKE_INSTALL_PREFIX=${PREFIX} \
++		-DCMAKE_INSTALL_RPATH=${PREFIX}/lib \
++		-DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib"
+ fi
+ makecversion=0
+ if [ $# -eq 1 -a "$1" = "-c" ]; then

--- a/recipes/tlsh/meta.yaml
+++ b/recipes/tlsh/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "tlsh" %}
+{% set version = "3.11.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/trendmicro/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 09e116130d98d6ed180624ff9f7da22b669ccd6f24e316f59019bf56436ee444
+  patches:
+    - make.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+
+test:
+  commands:
+    - tlsh --help
+
+about:
+  home: https://github.com/trendmicro/tlsh
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'TLSH is a fuzzy matching library.'
+  description: |
+     Given a byte stream with a minimum length of 50 bytes TLSH generates a
+     hash value which can be used for similarity comparisons. Similar objects
+     will have similar hash values which allows for the detection of similar
+     objects by comparing their hash values. Note that the byte stream should
+     have a sufficient amount of complexity. For example, a byte stream of
+     identical bytes will not generate a hash value.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/tlsh/meta.yaml
+++ b/recipes/tlsh/meta.yaml
@@ -13,16 +13,81 @@ source:
 
 build:
   number: 0
+  skip: true  # [win]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
+    - make
+  host:
+    - python
+    - pip
+  run:
+    - python
 
 test:
   commands:
-    - tlsh --help
+    - echo tlsh metapackage has no tests
+
+outputs:
+  - name: libtlsh
+    script: install-libtlsh.sh
+    build:
+      run_exports:
+        - {{ pin_subpackage('libtlsh', max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - make
+    test:
+      commands:
+        - echo libtlsh tested are during build
+  - name: python-tlsh
+    script: install-python-tlsh.sh
+    build:
+      run_exports:
+        - {{ pin_subpackage('python-tlsh', max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - make
+      host:
+        - {{ pin_subpackage('libtlsh', exact=True) }}
+        - python
+        - pip
+      run:
+        - {{ pin_subpackage('libtlsh', exact=True) }}
+        - python
+    test:
+      source_files:
+        - Testing
+        - py_ext
+      imports:
+        - tlsh
+      commands:
+        - cd Testing && sh python_test.sh
+  - name: tlsh-tools
+    script: install-tlsh-tools.sh
+    build:
+      run_exports:
+        - {{ pin_subpackage('libtlsh', max_pin='x.x') }}
+    test:
+      commands:
+        - tlsh --help
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - make
+      run:
+        - {{ pin_subpackage('libtlsh', max_pin='x.x') }}
 
 about:
   home: https://github.com/trendmicro/tlsh

--- a/recipes/tlsh/meta.yaml
+++ b/recipes/tlsh/meta.yaml
@@ -29,7 +29,7 @@ requirements:
 
 test:
   commands:
-    - echo tlsh metapackage has no tests
+    - test -f ${CONDA_PREFIX}/lib/libtlsh.${SHLIB_EXT}
 
 outputs:
   - name: libtlsh
@@ -80,14 +80,17 @@ outputs:
     test:
       commands:
         - tlsh --help
+        - tlsh_unittest --help
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake
         - make
+      host:
+        - {{ pin_subpackage('libtlsh', exact=True) }}
       run:
-        - {{ pin_subpackage('libtlsh', max_pin='x.x') }}
+        - {{ pin_subpackage('libtlsh', exact=True) }}
 
 about:
   home: https://github.com/trendmicro/tlsh


### PR DESCRIPTION
Adds [`tlsh`](https://github.com/trendmicro/tlsh), following the [debian pattern](https://packages.debian.org/sid/libtlsh0) of splitting into `libtlsh`, `tlsh-tools` and `python-tlsh`.

I'm mainly interested in the interplay with `python-tlsh` and [`diffoscope`](https://github.com/conda-forge/diffoscope-feedstock/pull/30). It _claims_ to be a "recommended" dependency, but now appears to be a [test-time dependency](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=31379&view=logs&jobId=1bf226d3-0e2f-52d8-fa93-7d9e633347b3&taskId=c09a5a47-eec3-5700-9284-6f1bd7b23501&lineStart=1206&lineEnd=1207&colStart=1&colEnd=1), and will always generate warnings, apparently, so would consider adding the runtime dependency.
 
Windows build [is documented](https://github.com/trendmicro/tlsh#windows-visual-studio), but I am again limited to how robustly I can test that, and would wait until somebody volunteers to help out. Will see if it builds for py2k, but would not be against skipping that as well.

## Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
