### PR TITLE
Add word2number 1.1

### DIFF
--- a/recipes/word2number/meta.yaml
+++ b/recipes/word2number/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "word2number" %}
+{% set version = "1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: 70e27a5d387f67b04c71fbb7621c05930b19bfd26efd6851e6e0f9969dcde7d0
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - {{ name }}
+
+about:
+  home: https://github.com/akshaynagpal/w2n
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'Convert number words eg. three hundred and forty two to numbers (342).'
+  description: |
+    This is a Python module to convert number words (eg. twenty one) to numeric
+    digits (21). It works for positive numbers upto the range of 999,999,999,999
+    (i.e. billions)
+  doc_url: https://w2n.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Adds [word2number](https://github.com/akshaynagpal/w2n), a dependency of https://github.com/conda-forge/allennlp-feedstock/pull/5

@CurtLH @sodre

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
