### PR TITLE
Add formulas (and schedula)

### DIFF
--- a/recipes/formulas/0001-bs4-canonical.patch
+++ b/recipes/formulas/0001-bs4-canonical.patch
@@ -1,0 +1,11 @@
+--- setup.py	2019-05-04 14:11:20.409186851 -0400
++++ setup.py	2019-05-04 21:53:34.400244170 -0400
+@@ -81,7 +81,7 @@
+
+     extras = {
+         'excel': ['openpyxl', 'networkx'],
+-        'plot': ['graphviz', 'regex', 'flask', 'Pygments', 'lxml', 'bs4',
++        'plot': ['graphviz', 'regex', 'flask', 'Pygments', 'lxml', 'beautifulsoup4',
+                  'jinja2', 'docutils']  # ['schedula[plot]>=0.2.0']
+     }
+     extras['all'] = sorted(functools.reduce(set.union, extras.values(), set()))

--- a/recipes/formulas/meta.yaml
+++ b/recipes/formulas/meta.yaml
@@ -68,7 +68,7 @@ test:
     - pip
     - pygments
     - python
-    - python-graphviz
+    - python-graphviz <0.10.1
     - regex
     - requests
     - schedula >=0.3.1

--- a/recipes/formulas/meta.yaml
+++ b/recipes/formulas/meta.yaml
@@ -8,13 +8,13 @@ package:
 source:
   url: https://github.com/vinci1it2000/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: ee9bebe86f37239eeba24c92a16f725c22a409d0215d12246f4e934080f9e54c
+  patches:
+    - 0001-bs4-canonical.patch
 
 build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  patches:
-    - 0001-bs4-canonical.patch
 
 requirements:
   host:

--- a/recipes/formulas/meta.yaml
+++ b/recipes/formulas/meta.yaml
@@ -1,0 +1,93 @@
+{% set name = "formulas" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/vinci1it2000/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: ee9bebe86f37239eeba24c92a16f725c22a409d0215d12246f4e934080f9e54c
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  patches:
+    - 0001-bs4-canonical.patch
+
+requirements:
+  host:
+    - beautifulsoup4
+    - ddt
+    - docutils
+    - flask
+    - jinja2
+    - lxml
+    - multiprocess
+    - nose
+    - numpy >=1.15
+    - openpyxl
+    - pip
+    - pygments
+    - python
+    - python-graphviz
+    - regex
+    - requests
+    - schedula >=0.3.1
+    - sphinx
+    - sphinx_rtd_theme
+    - sphinxcontrib-restbuilder
+  run:
+    - numpy >=1.15
+    - python
+    - regex
+    - schedula >=0.3.1
+
+test:
+  source_files:
+    - setup.cfg
+    - test/test_files
+    - test/test_cell.py
+    - test/test_excel.py
+    - test/test_import.py
+    - test/test_parser.py
+    - test/test_ranges.py
+    - test/test_tokens.py
+  requires:
+    - beautifulsoup4
+    - ddt
+    - docutils
+    - flask
+    - jinja2
+    - lxml
+    - multiprocess
+    - nose
+    - numpy >=1.15
+    - openpyxl
+    - pip
+    - pygments
+    - python
+    - python-graphviz
+    - regex
+    - requests
+    - schedula >=0.3.1
+    - sphinx
+    - sphinx_rtd_theme
+    - sphinxcontrib-restbuilder
+  imports:
+    - formulas
+  commands:
+    - nosetests
+
+about:
+  home: https://github.com/vinci1it2000/formulas
+  license: EUPL-1.1
+  license_family: OTHER
+  license_file: LICENSE.txt
+  summary: 'Parse and compile Excel formulas and workbooks in python code.'
+  doc_url: https://formulas.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/formulas/meta.yaml
+++ b/recipes/formulas/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - openpyxl
     - pip
     - pygments
-    - python
+    - python >=3
     - python-graphviz
     - regex
     - requests
@@ -40,7 +40,7 @@ requirements:
     - sphinxcontrib-restbuilder
   run:
     - numpy >=1.15
-    - python
+    - python >=3
     - regex
     - schedula >=0.3.1
 

--- a/recipes/schedula/0001-bs4-canonical.patch
+++ b/recipes/schedula/0001-bs4-canonical.patch
@@ -1,0 +1,11 @@
+--- setup.py	2019-05-04 16:21:33.815260676 -0400
++++ setup.py	2019-05-04 16:23:52.613052860 -0400
+@@ -81,7 +81,7 @@
+
+     extras = {
+         'web': ['regex', 'flask'],
+-        'plot': ['graphviz', 'regex', 'flask', 'Pygments', 'lxml', 'bs4',
++        'plot': ['graphviz', 'regex', 'flask', 'Pygments', 'lxml', 'beautifulsoup4',
+                  'jinja2', 'docutils'],
+         'parallel': ['multiprocess'],
+     }

--- a/recipes/schedula/meta.yaml
+++ b/recipes/schedula/meta.yaml
@@ -1,0 +1,81 @@
+{% set name = "schedula" %}
+{% set version = "0.3.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/vinci1it2000/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 3bf4929ebeae8cc8c6fb13e602c04cd1658be8812905654851e27fc54064c013
+  patches:
+    - 0001-bs4-canonical.patch
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - beautifulsoup4
+    - dill
+    - docutils
+    - flask
+    - jinja2
+    - lxml
+    - multiprocess
+    - networkx >=2.0.0
+    - nose
+    - pip
+    - pygments
+    - python
+    - python-graphviz
+    - regex
+    - requests
+    - sphinx
+    - sphinx_rtd_theme
+    - sphinxcontrib-restbuilder
+  run:
+    - dill
+    - networkx >=2.0.0
+    - python
+
+test:
+  source_files:
+    - test/test_dispatcher.py
+    - test/utils
+    - setup.cfg
+  requires:
+    - nose
+    - docutils
+    - beautifulsoup4
+    - dill
+    - flask
+    - jinja2
+    - lxml
+    - multiprocess
+    - networkx >=2.0.0
+    - nose
+    - pip
+    - pygments
+    - python
+    - python-graphviz
+    - regex
+    - requests
+  imports:
+    - schedula
+  commands:
+    - nosetests
+
+about:
+  home: https://github.com/vinci1it2000/schedula
+  license: EUPL-1.1
+  license_family: OTHER
+  license_file: LICENSE.txt
+  summary: 'An intelligent function scheduler, which selects and executes functions.'
+  doc_url: https://schedula.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/schedula/meta.yaml
+++ b/recipes/schedula/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - nose
     - pip
     - pygments
-    - python
+    - python >=3
     - python-graphviz
     - regex
     - requests
@@ -59,7 +59,7 @@ test:
     - nose
     - pip
     - pygments
-    - python
+    - python >=3
     - python-graphviz
     - regex
     - requests

--- a/recipes/schedula/meta.yaml
+++ b/recipes/schedula/meta.yaml
@@ -60,7 +60,7 @@ test:
     - pip
     - pygments
     - python >=3
-    - python-graphviz
+    - python-graphviz <0.10.1
     - regex
     - requests
   imports:


### PR DESCRIPTION
Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
  - > the pypi source doesn't contain enough stuff, due to install-time use of sphinx, etc.
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Adds [formulas](https://github.com/vinci1it2000/formulas) and its primary dependency [schedula](https://github.com/vinci1it2000/schedula).

These both have a large number of optional dependencies... i'm tempted to add `openpyxl` to formulas, but i suppose there is a reason you'd want to do something with excel AST that wasn't coming from an _actual_ excel file... 