### PR TITLE
certipy

### DIFF
--- a/recipes/certipy/LICENSE
+++ b/recipes/certipy/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, Lawrence Livermore National Security, LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/certipy/meta.yaml
+++ b/recipes/certipy/meta.yaml
@@ -22,12 +22,9 @@ requirements:
     - pip
   run:
     - python >=3.3
-    - setuptools
     - pyopenssl
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - certipy
   commands:
@@ -38,7 +35,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   # LICENSE file is missing from sdist, but present in repo
-  # license_file: LICENSE
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
   summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
 
   description: |

--- a/recipes/certipy/meta.yaml
+++ b/recipes/certipy/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "certipy" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 695704b7716b033375c9a1324d0d30f27110a28895c40151a90ec07ff1032859
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.3
+    - pip
+  run:
+    - python >=3.3
+    - setuptools
+    - pyopenssl
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - certipy
+  commands:
+    - certipy test
+
+about:
+  home: https://github.com/LLNL/certipy
+  license: BSD-3-Clause
+  license_family: BSD
+  # LICENSE file is missing from sdist, but present in repo
+  # license_file: LICENSE
+  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+  description: |
+    A simple python tool for creating certificate authorities
+    and certificates on the fly.
+  dev_url: https://github.com/LLNL/certipy
+
+extra:
+  recipe-maintainers:
+    - minrk

--- a/recipes/certipy/meta.yaml
+++ b/recipes/certipy/meta.yaml
@@ -13,6 +13,8 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  entry_points:
+    - certipy = certipy.command_line:main
 
 requirements:
   host:


### PR DESCRIPTION
required by jupyterhub 1.0

https://github.com/conda-forge/jupyterhub-feedstock/pull/24

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there