### PR TITLE
Add conda recipe for bmi-fortran

### DIFF
--- a/recipes/bmi-fortran/build.sh
+++ b/recipes/bmi-fortran/build.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+
+mkdir _build && cd _build
+
+cmake .. \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_BUILD_TYPE=Release
+
+make
+make install

--- a/recipes/bmi-fortran/build.sh
+++ b/recipes/bmi-fortran/build.sh
@@ -6,5 +6,5 @@ cmake .. \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DCMAKE_BUILD_TYPE=Release
 
-make
+make -j${CPU_COUNT}
 make install

--- a/recipes/bmi-fortran/meta.yaml
+++ b/recipes/bmi-fortran/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "bmi-fortran" %}
+{% set version = "1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/csdms/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 2ade92d7bfa494d379fa6fea4d03734cfd640d46840b944ce013a34a933c5ef5
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('fortran') }}
+
+test:
+  commands:
+    - test -f $PREFIX/include/bmif_{{ version|replace(".","_") }}.mod
+    - test -h $PREFIX/lib/libbmif$SHLIB_EXT
+
+about:
+  home: https://bmi.readthedocs.io
+  license: MIT
+  license_file: LICENSE
+  summary: 'Fortran specification for the Basic Model Interface'
+  description: |
+    Bindings, developed with Fortran 2003, for the CSDMS Basic Model
+    Interface (BMI). This package defines a module that includes an
+    interface intended to be overriden by a model developer when they
+    add a BMI to their model.
+  doc_url: https://bmi.readthedocs.io
+  dev_url: https://github.com/csdms/bmi-fortran
+
+extra:
+  recipe-maintainers:
+    - mdpiper

--- a/recipes/bmi-fortran/meta.yaml
+++ b/recipes/bmi-fortran/meta.yaml
@@ -27,6 +27,7 @@ test:
 about:
   home: https://bmi.readthedocs.io
   license: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: 'Fortran specification for the Basic Model Interface'
   description: |

--- a/recipes/bmi-fortran/meta.yaml
+++ b/recipes/bmi-fortran/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - cmake
     - {{ compiler('fortran') }}
+    - make
 
 test:
   commands:


### PR DESCRIPTION
This PR adds a conda recipe for the `bmi-fortran` package, which defines the Fortran 2003 bindings for the [Basic Model Interface](https://bmi.readthedocs.io).

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
