### PR TITLE
Add recipe for pymt_ecsimplesnow

### DIFF
--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - bmi-fortran=1.2
+    - bmi-fortran =1.2
     - ecsimplesnow
 
 test:

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "pymt_ecsimplesnow" %}
+{% set version = "0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/pymt-lab/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: e4a11a7afc4150634d974b4abd5b39cd2ba162366c955bfe062005bb19edd3b2
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+    - bmi-fortran=1.2
+  host:
+    - python
+    - pip
+    - cython
+    - numpy 1.11.*
+    - model_metadata
+    - bmi-fortran=1.2
+    - ecsimplesnow
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - pymt
+    - bmi-fortran=1.2
+    - ecsimplesnow
+
+test:
+  imports:
+    - pymt
+    - pymt_ecsimplesnow
+
+about:
+  home: https://github.com/pymt-lab/pymt_ecsimplesnow
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python package that wraps the ECSimpleSnow model.
+  dev_url: https://github.com/pymt-lab/pymt_ecsimplesnow
+
+extra:
+  recipe-maintainers:
+    - mdpiper

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - pip
     - cython
-    - numpy 1.11.*
+    - numpy
     - model_metadata
     - bmi-fortran=1.2
     - ecsimplesnow

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -30,13 +30,11 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - pymt
     - bmi-fortran=1.2
     - ecsimplesnow
 
 test:
   imports:
-    - pymt
     - pymt_ecsimplesnow
 
 about:

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pymt_ecsimplesnow" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pymt-lab/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: e058095431fa57e5666892803ad7edda28f15fd26d31f6966a623c3204dfdf8b
+  sha256: 8ee53a9981d9c208b8464cedd058ca302d2dd09afe14c9eba7b153bf6f0961c6
 
 build:
   number: 0

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pymt_ecsimplesnow" %}
-{% set version = "0.2" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/pymt-lab/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: e4a11a7afc4150634d974b4abd5b39cd2ba162366c955bfe062005bb19edd3b2
+  sha256: e058095431fa57e5666892803ad7edda28f15fd26d31f6966a623c3204dfdf8b
 
 build:
   number: 0

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
-    - bmi-fortran=1.2
   host:
     - python
     - pip

--- a/recipes/pymt_ecsimplesnow/meta.yaml
+++ b/recipes/pymt_ecsimplesnow/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cython
     - numpy
     - model_metadata
-    - bmi-fortran=1.2
+    - bmi-fortran =1.2
     - ecsimplesnow
   run:
     - python


### PR DESCRIPTION
This PR adds a conda recipe for the `pymt_ecsimplesnow` package, which brings the (Fortran) ECSimpleSnow model into Python as a plugin for the [PyMT modeling framework](https://pymt.readthedocs.io).

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
