### PR TITLE
Add pytest-bdd

### DIFF
--- a/recipes/pytest-bdd/LICENSE.txt
+++ b/recipes/pytest-bdd/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright (C) 2013-2014 Oleg Pidsadnyi, Anatoly Bubenkov and others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/pytest-bdd/meta.yaml
+++ b/recipes/pytest-bdd/meta.yaml
@@ -52,9 +52,9 @@ test:
 
 about:
   home: https://github.com/pytest-dev/pytest-bdd
-  license: MIT License
+  license: MIT
   license_family: MIT
-  license_file: ''
+  license_file: LICENSE.txt
   summary: BDD for pytest
   description: ""
   doc_url: ''

--- a/recipes/pytest-bdd/meta.yaml
+++ b/recipes/pytest-bdd/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "pytest-bdd" %}
+{% set version = "3.1.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "17dfc2b65c275641a4e76fa1f913ab737604815c275dc2afe7133956c6ab6743" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - pytest-bdd = pytest_bdd.scripts:main
+  script: "{{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt"
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - glob2
+    - mako
+    - parse
+    - parse_type
+    - py
+    - pytest >=3.0.0
+    - six >=1.9.0
+  run:
+    - python
+    - setuptools
+    - glob2
+    - mako
+    - parse
+    - parse_type
+    - py
+    - pytest >=3.0.0
+    - six >=1.9.0
+
+test:
+  imports:
+    - pytest_bdd
+  commands:
+    - pytest-bdd --help
+  requires:
+    - tox
+
+about:
+  home: https://github.com/pytest-dev/pytest-bdd
+  license: MIT License
+  license_family: MIT
+  license_file: ''
+  summary: BDD for pytest
+  description: ""
+  doc_url: ''
+  dev_url: ''
+
+extra:
+  recipe-maintainers: 
+    - breathe

--- a/recipes/pytest-bdd/meta.yaml
+++ b/recipes/pytest-bdd/meta.yaml
@@ -1,39 +1,28 @@
 {% set name = "pytest-bdd" %}
 {% set version = "3.1.0" %}
-{% set file_ext = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash_value = "17dfc2b65c275641a4e76fa1f913ab737604815c275dc2afe7133956c6ab6743" %}
 
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'
 
 source:
-  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
-  '{{ hash_type }}': '{{ hash_value }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 17dfc2b65c275641a4e76fa1f913ab737604815c275dc2afe7133956c6ab6743
 
 build:
   noarch: python
   number: 0
   entry_points:
     - pytest-bdd = pytest_bdd.scripts:main
-  script: "{{ PYTHON }} setup.py install --single-version-externally-managed --record=record.txt"
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
-  build:
+  host:
     - python
-    - setuptools
-    - glob2
-    - mako
-    - parse
-    - parse_type
-    - py
-    - pytest >=3.0.0
-    - six >=1.9.0
+    - pip
   run:
     - python
-    - setuptools
+    - pip
     - glob2
     - mako
     - parse
@@ -47,8 +36,6 @@ test:
     - pytest_bdd
   commands:
     - pytest-bdd --help
-  requires:
-    - tox
 
 about:
   home: https://github.com/pytest-dev/pytest-bdd
@@ -56,9 +43,9 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: BDD for pytest
-  description: ""
-  doc_url: ''
-  dev_url: ''
+  description: "pytest-bdd implements a subset of the Gherkin language to enable automating project requirements testing and to facilitate behavioral driven development."
+  dev_url: 'https://github.com/pytest-dev/pytest-bdd'
+  doc_url: 'https://github.com/pytest-dev/pytest-bdd'
 
 extra:
   recipe-maintainers: 


### PR DESCRIPTION
Hi python review team: `@conda-forge/help-python`

Would like to get this pytest extension into conda-forge.  meta.yaml is adapted from `conda skeleton pypi` -- I added 

```
build:
    noarch: python 
```

As I believe the package does not have any native extension dependencies.

Checklist

- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages
- [X] Build number is 0
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there (@breathe is me and I am willing)