### PR TITLE
Add NotebookScripter to conda-forge

### DIFF
--- a/recipes/notebookscripter/LICENSE.txt
+++ b/recipes/notebookscripter/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 N. Ben Cohen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/notebookscripter/meta.yaml
+++ b/recipes/notebookscripter/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "NotebookScripter" %}
+{% set version = "5.1.0" %}
+{% set file_ext = "tar.gz" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "71ba29f31819a0e440f72881f49c065dce3d0fcd98b80b0325f27c4f42c9cae3" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  '{{ hash_type }}': '{{ hash_value }}'
+
+build:
+  noarch: python
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - ipython
+    - nbformat
+  run:
+    - python
+    - ipython
+    - nbformat
+
+test:
+  imports:
+    - NotebookScripter
+  requires:
+    - coverage
+    - matplotlib
+    - nose
+    - snapshottest
+
+about:
+  home: https://github.com/breathe/NotebookScripter
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Expose ipython jupyter notebooks as callable functions.  More info here https://github.com/breathe/NotebookScripter
+  description: "Expose ipython jupyter notebooks as callable functions.  More info here https://github.com/breathe/NotebookScripter\n\n\n"
+  doc_url: ''
+  dev_url: ''
+
+extra:
+  recipe-maintainers:
+    - breathe

--- a/recipes/notebookscripter/meta.yaml
+++ b/recipes/notebookscripter/meta.yaml
@@ -16,12 +16,12 @@ source:
 build:
   noarch: python
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
     - python
-    - setuptools
+    - pip
     - ipython
     - nbformat
   run:

--- a/recipes/notebookscripter/meta.yaml
+++ b/recipes/notebookscripter/meta.yaml
@@ -1,17 +1,13 @@
 {% set name = "NotebookScripter" %}
 {% set version = "5.1.0" %}
-{% set file_ext = "tar.gz" %}
-{% set hash_type = "sha256" %}
-{% set hash_value = "71ba29f31819a0e440f72881f49c065dce3d0fcd98b80b0325f27c4f42c9cae3" %}
 
 package:
   name: '{{ name|lower }}'
   version: '{{ version }}'
 
 source:
-  fn: '{{ name }}-{{ version }}.{{ file_ext }}'
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
-  '{{ hash_type }}': '{{ hash_value }}'
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 71ba29f31819a0e440f72881f49c065dce3d0fcd98b80b0325f27c4f42c9cae3
 
 build:
   noarch: python
@@ -22,8 +18,6 @@ requirements:
   host:
     - python
     - pip
-    - ipython
-    - nbformat
   run:
     - python
     - ipython
@@ -32,11 +26,6 @@ requirements:
 test:
   imports:
     - NotebookScripter
-  requires:
-    - coverage
-    - matplotlib
-    - nose
-    - snapshottest
 
 about:
   home: https://github.com/breathe/NotebookScripter
@@ -45,8 +34,8 @@ about:
   license_file: LICENSE.txt
   summary: Expose ipython jupyter notebooks as callable functions.  More info here https://github.com/breathe/NotebookScripter
   description: "Expose ipython jupyter notebooks as callable functions.  More info here https://github.com/breathe/NotebookScripter\n\n\n"
-  doc_url: ''
-  dev_url: ''
+  doc_url: https://github.com/breathe/NotebookScripter
+  dev_url: https://github.com/breathe/NotebookScripter
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Hi python `@conda-forge/help-python`

I'm wanting to add the package NotebookScripter to conda-forge.  Generated via conda skeleton pypi and then added python: noarch as this package has no dependencies on binary extensions.

Checklist

- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages
- [X] Build number is 0
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there


