### PR TITLE
Remove `--no-deps` from example build string in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ to manage, and we strive to get all dependencies built in conda-forge.
 
 ### 7. **When or why do I need to use `{{ PYTHON }} -m pip install . -vv`?**
 
-This should be the default install line for most Python packages. This is preferable to `python setup.py` because it handles metadata in a `conda`-friendlier way. We also want to make sure dependencies are handled through `conda`, and `--no-deps` means most Python dependencies are needed only at `run` time, not `build`.
+This should be the default install line for most Python packages. This is preferable to `python setup.py` because it handles metadata in a `conda`-friendlier way.
 
 ### 8. **Do I need `bld.bat` and/or `build.sh`?**
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Short answer: yes. Long answer: In principle, as long as your dependencies are i
 your user's conda channels they will be able to install your package. In practice, that is difficult
 to manage, and we strive to get all dependencies built in conda-forge.
 
-### 7. **When or why do I need to use `{{ PYTHON }} -m pip install --no-deps . -vv`?**
+### 7. **When or why do I need to use `{{ PYTHON }} -m pip install . -vv`?**
 
 This should be the default install line for most Python packages. This is preferable to `python setup.py` because it handles metadata in a `conda`-friendlier way. We also want to make sure dependencies are handled through `conda`, and `--no-deps` means most Python dependencies are needed only at `run` time, not `build`.
 


### PR DESCRIPTION
This makes the FAQ in the README compatible with the example meta.yaml. The `--no-deps` flag was there as a work-around but was removed in PR #7142.

This is what I've inferred has happened from the outside but perhaps @chrisburr can confirm this is the right thing to do?

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->
