### PR TITLE
Add PyPSA 0.14.1

### DIFF
--- a/recipes/pypsa/meta.yaml
+++ b/recipes/pypsa/meta.yaml
@@ -13,6 +13,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+  noarch: python
 
 requirements:
   host:

--- a/recipes/pypsa/meta.yaml
+++ b/recipes/pypsa/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+  script: "{{ PYTHON }} -m pip install . -vvv "
   noarch: python
 
 requirements:

--- a/recipes/pypsa/meta.yaml
+++ b/recipes/pypsa/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pypsa" %}
-{% set version = "0.14.0" %}
-{% set sha256 = "86d97dee9942a5e3b4d638af0e0c6700e7c5736826d96f189141598898145479" %}
+{% set version = "0.14.1" %}
+{% set sha256 = "477716d83806a29e75bcb48c3e7c19b8f96ca1af68d7eaf6fd86202f3c79c913" %}
 
 package:
   name: "{{ name|lower }}"

--- a/recipes/pypsa/meta.yaml
+++ b/recipes/pypsa/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "pypsa" %}
+{% set version = "0.14.0" %}
+{% set sha256 = "86d97dee9942a5e3b4d638af0e0c6700e7c5736826d96f189141598898145479" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - cartopy >=0.16
+    - matplotlib
+    - networkx >=1.10
+    - numpy
+    - pandas >=0.19.0
+    - pyomo >=5.3
+    - python
+    - scipy
+    - six
+    - netcdf4
+    - pytables
+
+test:
+  imports:
+    - pypsa
+
+about:
+  home: https://pypsa.org/
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE.txt
+  summary: Python for Power Systems Analysis
+  description: |
+    PyPSA is a free software toolbox for simulating and optimising modern power
+    systems that include features such as conventional generators with unit
+    commitment, variable wind and solar generation, storage units, coupling to
+    other energy sectors, and mixed alternating and direct current networks.
+    PyPSA is designed to scale well with large networks and long time series.
+  doc_url: https://pypsa.org/doc/
+  dev_url: https://github.com/PyPSA/PyPSA
+
+extra:
+  recipe-maintainers:
+    - coroa
+    - nworbmot


### PR DESCRIPTION
@conda-forge/help-python

Include Python for Power System Analysis as a recipe based on its current version in PyPI. I'm one of the upstream maintainers for PyPSA.

I think the recipe is ready for review. Built fine locally with `conda-build`.

Checklist

- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages
- [X] Build number is 0
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
