### PR TITLE
Added recipe for bqplot-image-gl

### DIFF
--- a/recipes/bqplot-image-gl/LICENSE
+++ b/recipes/bqplot-image-gl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Maarten Breddels
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/bqplot-image-gl/meta.yaml
+++ b/recipes/bqplot-image-gl/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bqplot-image-gl" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9b4ad1a5a34af035e327a547a9ad697ee74238c7da684eaf32eda0448d087329
+  sha256: c45ad7563987cbacacfd5bb42efc2dbbe6d90293587fc6b572c90da84feeca4f
 
 build:
   noarch: python

--- a/recipes/bqplot-image-gl/meta.yaml
+++ b/recipes/bqplot-image-gl/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "bqplot-image-gl" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9b4ad1a5a34af035e327a547a9ad697ee74238c7da684eaf32eda0448d087329
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    - bqplot
+
+test:
+  imports:
+    - bqplot_image_gl
+
+about:
+  home: http://github.com/glue-viz/bqplot-image-gl
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Jupyter widget for displaying images with WebGL in bqplot'
+  dev_url: https://github.com/glue-viz/bqplot-image-gl
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - maartenbreddels

--- a/recipes/bqplot-image-gl/run_test.py
+++ b/recipes/bqplot-image-gl/run_test.py
@@ -1,0 +1,8 @@
+import sys
+
+from notebook.nbextensions import validate_nbextension
+
+if validate_nbextension('bqplot-image-gl/extension') != []:
+    print("Issue detected with nbextension for bqplot-image-gl")
+    sys.exit(1)
+


### PR DESCRIPTION
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
