### PR TITLE
h3-python bindings

### DIFF
--- a/recipes/h3-py/meta.yaml
+++ b/recipes/h3-py/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "h3-py" %}
+{% set version = "3.4.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/h/h3/h3-{{ version }}.tar.gz
+  sha256: a292a5a63bcf535f0137141019f3defd21ad2fbd258dc8de587f921cf2c5b41d
+
+build:
+  number: 0
+  skip: True  # [win]
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - h3 # TODO: how can I overwrite https://github.com/uber/h3-py/blob/master/setup.py to use the conda provided H3 https://github.com/conda-forge/h3-feedstock
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - h3
+
+about:
+  home: https://github.com/uber/h3-py
+  license: Apache 2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Python bindings for H3, a hierarchical hexagonal geospatial indexing system'
+  doc_url: https://uber.github.io/h3/
+  dev_url: https://github.com/uber/h3-py
+
+extra:
+  recipe-maintainers:
+    - geoHeil

--- a/recipes/h3-py/meta.yaml
+++ b/recipes/h3-py/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/h/h3/h3-{{ version }}.tar.gz
   sha256: a292a5a63bcf535f0137141019f3defd21ad2fbd258dc8de587f921cf2c5b41d
+  patches:
+    - setup.py
 
 build:
   number: 0

--- a/recipes/h3-py/meta.yaml
+++ b/recipes/h3-py/meta.yaml
@@ -15,11 +15,10 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
-  build:
-    - h3 # TODO: how can I overwrite https://github.com/uber/h3-py/blob/master/setup.py to use the conda provided H3 https://github.com/conda-forge/h3-feedstock
   host:
     - python
     - pip
+    - h3
   run:
     - python
 

--- a/recipes/h3-py/setup.py
+++ b/recipes/h3-py/setup.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import platform
+from setuptools import setup, find_packages
+from setuptools.dist import Distribution
+
+from h3_version import h3_version
+from binding_version import binding_version
+
+# Tested with wheel v0.29.0
+class BinaryDistribution(Distribution):
+    def __init__(self, attrs=None):
+        Distribution.__init__(self, attrs)
+        # The values used for the name and sources in the Extension below are
+        # not important, because we override the build_ext command above.
+        # The normal C extension building logic is never invoked, and is
+        # replaced with our own custom logic. However, ext_modules cannot be
+        # empty, because this signals to other parts of distutils that our
+        # package contains C extensions and thus needs to be built for
+        # different platforms separately.
+        self.ext_modules = [Extension('h3c', [])]
+
+long_description = open('README.rst').read()
+
+setup(
+    name='h3',
+    version=binding_version,
+    description=
+    'Python bindings for H3, a hierarchical hexagonal geospatial indexing system developed by Uber Technologies',
+    long_description=long_description,
+    author='Uber Technologies',
+    author_email='Niel Hu <hu.niel92@gmail.com>',
+    url='https://github.com/uber/h3-py.git',
+    packages=find_packages(exclude=['tests', 'tests.*']),
+    install_requires=[],
+    cmdclass={
+        'build_ext': CustomBuildExtCommand,
+    },
+    package_data={
+        'h-py':
+        ['out/*.dylib' if platform.system() == 'Darwin' else (
+            'out/*.dll' if platform.system() == 'Windows' else
+            'out/*.so.*')]
+    },
+    license='Apache License 2.0',
+    distclass=BinaryDistribution)

--- a/recipes/h3-py/setup.py
+++ b/recipes/h3-py/setup.py
@@ -20,7 +20,8 @@ class BinaryDistribution(Distribution):
         # different platforms separately.
         self.ext_modules = [Extension('h3c', [])]
 
-long_description = open('README.rst').read()
+with open("README.rst", "r") as fh:
+    long_description = fh.read()
 
 setup(
     name='h3',


### PR DESCRIPTION
Add python bindings from https://github.com/uber/h3-py to https://github.com/conda-forge/h3-feedstock.

How can I overwrite https://github.com/uber/h3-py/blob/master/setup.py to use the conda provided H3 https://github.com/conda-forge/h3-feedstock

@conda-forge/help-python-c looking forward to your feedback.
