### PR TITLE
Add intern

### DIFF
--- a/recipes/intern/meta.yaml
+++ b/recipes/intern/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.0.4" %}
+
+package:
+  name: intern
+  version: {{ version }}
+
+source:
+  url: https://github.com/jhuapl-boss/intern/archive/v{{ version }}.tar.gz
+  sha256: 6967488decde6bf817d97550ceabf13e8a4ed6dfcddf3ed6e488b11c06bf0732
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - requests >=2.11.1
+    - python-blosc >=1.4.4
+    - six
+
+test:
+
+# We can't run the full test suite without boss credentials,
+# so we don't bother with these for now
+#  requires:
+#    - mock
+#    - nose2
+
+  imports:
+    - intern
+    - intern.remote.boss.remote
+    - intern.resource.boss.resource
+    - intern.service.boss.service
+    - intern.utils.parallel
+
+about:
+  home: https://github.com/jhuapl-boss/intern
+  license: Apache 2.0
+  license_file: license
+  summary: 'Python 2/3 SDK for interacting with the Boss REST API '
+
+extra:
+  recipe-maintainers:
+    - jtpdowns
+    - stuarteberg


### PR DESCRIPTION
This adds a recipe for `intern` (Integrated Toolkit for Extensible and Reproducible Neuroscience).  It's a python package for accessing the [Boss storage service from JHU-APL][1].

The `intern` package is pure-python, so this recipe is straightforward.

[1]: https://docs.theboss.io

<!-- 
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with 
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
