### PR TITLE
Add recipe for GNU which

### DIFF
--- a/recipes/which/build.sh
+++ b/recipes/which/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+./configure --prefix=${PREFIX}
+make
+make check
+make install

--- a/recipes/which/meta.yaml
+++ b/recipes/which/meta.yaml
@@ -25,7 +25,7 @@ test:
 
 about:
   home: https://carlowood.github.io/which/
-  license: GPL3
+  license: GPL-3.0
   license_file: COPYING
   summary: 'Shows the full path of (shell) commands'
   description: |

--- a/recipes/which/meta.yaml
+++ b/recipes/which/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "which" %}
+{% set version = "2.21" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://carlowood.github.io/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+test:
+  commands:
+    - which --version
+    - which which | grep ${CONDA_PREFIX}/bin/which
+
+about:
+  home: https://carlowood.github.io/which/
+  license: GPL3
+  license_file: COPYING
+  summary: 'Shows the full path of (shell) commands'
+  description: |
+    Which takes one or more arguments. For each of its arguments it prints
+    to stdout the full path of the executables that would have been exe-
+    cuted when this argument had been entered at the shell prompt. It does
+    this by searching for an executable or script in the directories listed
+    in the environment variable PATH using the same algorithm as bash(1).
+
+extra:
+  recipe-maintainers:
+    - teake


### PR DESCRIPTION
@conda-forge/staged-recipes

While `which` is available on most *nix OSes, it is not present on
all (e.g. minimal containers).

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there