### PR TITLE
Add recipe for httpcore

### DIFF
--- a/recipes/httpcore/meta.yaml
+++ b/recipes/httpcore/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "httpcore" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "96f910b528d47b683242ec207050c7bbaa99cd1b9a07f78ea80cf61e55556b58"
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv "
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+  run:
+    - certifi
+    - chardet ==3.*
+    - h11 ==0.8.*
+    - h2 ==3.*
+    - idna ==2.*
+    - python >=3.6
+    - rfc3986 ==1.*
+
+test:
+  imports:
+    - httpcore
+    - httpcore.dispatch
+
+about:
+  home: https://github.com/encode/httpcore
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: The next generation HTTP client.
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
This is a little confusing, because the package is now named http3,
but older versions were released as httpcore.

httpcore is a dependency to build request-async 0.5:

https://github.com/conda-forge/requests-async-feedstock/pull/2#issuecomment-504492293

And I need request-async 0.5 to build sanic:

https://github.com/conda-forge/sanic-feedstock/pull/10

😓 
