### PR TITLE
Drop `openssl` install hacks

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -35,8 +35,7 @@ bash ~/miniconda.sh -b -p ~/miniconda
 )
 source ~/miniconda/bin/activate root
 
-conda install --yes --quiet openssl=1.1.1a
-conda install --yes --quiet conda-forge-ci-setup=2.* conda-smithy=3.* conda-forge-pinning git=2.12.2 conda-build>=3.16 openssl=1.1.1a
+conda install --yes --quiet conda-forge-ci-setup=2.* conda-smithy=3.* conda-forge-pinning git=2.12.2 conda-build>=3.16
 
 conda info
 conda config --get


### PR DESCRIPTION
These don't seem to work as expected either despite getting the seemingly required version of `openssl` installed. So just go ahead and drop them.

Reverts ( https://github.com/conda-forge/staged-recipes/pull/8626 )
Reverts ( https://github.com/conda-forge/staged-recipes/pull/8625 )

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there