### PR TITLE
adding _r-mutex recipe

### DIFF
--- a/recipes/_r-mutex/LICENSE.txt
+++ b/recipes/_r-mutex/LICENSE.txt
@@ -1,0 +1,14 @@
+BSD 3-clause license
+Copyright (c) 2015, Anaconda, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/recipes/_r-mutex/meta.yaml
+++ b/recipes/_r-mutex/meta.yaml
@@ -1,0 +1,22 @@
+package:
+  name: _r-mutex
+  version: 1.0.0
+
+build:
+  string: anacondar_1
+  number: 1
+
+test:
+  commands:
+    - conda list | grep '_r-mutex'
+
+about:
+  home: https://anaconda.org/r/_r-mutex
+  license: BSD
+  license_file: LICENSE.txt
+  summary: A mutex package to ensure environment exclusivity between Anaconda R and MRO.
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - fhoehle


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [ ] ~Build number is 0~ `r-base` is requiring 1.* anacondar_1
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Dear All,

to make conda-forge more self-contained I want to the _r-mutex R package which is necessary for installing r-base from conda-forge.
I'm open to discuss if tests are needed because this package resembles a mutex.

This PR resolves the issue https://github.com/conda-forge/r-base-feedstock/issues/83 by mirroring https://github.com/AnacondaRecipes/aggregateR/tree/master/_r-mutex-feedstock