### PR TITLE
Pin conda to 4.6.14

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -17,8 +17,10 @@ export PYTHONUNBUFFERED=1
 # Install Miniconda.
 echo ""
 echo "Installing a fresh version of Miniconda."
-curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > ~/miniconda.sh
+curl -L https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh > ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
+touch ~/miniconda/conda-meta/pinned
+cat "conda 4.6.14" >> ~/miniconda/conda-meta/pinned
 (
     source ~/miniconda/bin/activate root
 


### PR DESCRIPTION
AFAICT things last worked at staged-recipes when we were using conda 4.6.14. This pins staged recipes to 4.6.14 in the hope that fixes issues we have been seeing in conversion.

cc @conda-forge/core

xref: https://github.com/conda-forge/staged-recipes/issues/8628

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there