### PR TITLE
Psfex recipe

### DIFF
--- a/recipes/psfex/0001-Search-lapacke-library.patch
+++ b/recipes/psfex/0001-Search-lapacke-library.patch
@@ -1,0 +1,22 @@
+diff --git a/m4/acx_openblas.m4 b/m4/acx_openblas.m4
+index 5421eec..fe43f65 100644
+--- a/m4/acx_openblas.m4
++++ b/m4/acx_openblas.m4
+@@ -100,7 +100,7 @@ dnl ----------------------------
+ 		[Define if you have the OpenBLAS parallel library and header files.]),
+       unset ac_cv_search_LAPACKE_dpotrf
+       [AC_SEARCH_LIBS(
+-        [LAPACKE_dpotrf], ["openblas"$acx_openblas_suffix],
++        [LAPACKE_dpotrf], ["openblas"$acx_openblas_suffix "lapacke"$acx_openblas_suffix],
+ 	[OPENBLAS_WARN="parallel OpenBLAS"$acx_openblas_suffix" not found, reverting to scalar OpenBLAS"$acx_openblas_suffix"!"],
+         [OPENBLAS_ERROR="OpenBLAS"$acx_openblas_suffix" library file not found!"],
+         $acx_openblas_libopt
+@@ -109,7 +109,7 @@ dnl ----------------------------
+     )
+   else
+     AC_SEARCH_LIBS(
+-      [LAPACKE_dpotrf], ["openblas"$acx_openblas_suffix],,
++      [LAPACKE_dpotrf], ["openblas"$acx_openblas_suffix "lapacke"$acx_openblas_suffix],,
+       [OPENBLAS_ERROR="OpenBLAS"$acx_openblas_suffix" library file not found!"],
+       $acx_openblas_libopt
+     )

--- a/recipes/psfex/build.sh
+++ b/recipes/psfex/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+sh autogen.sh
+./configure --prefix=${PREFIX} \
+    --enable-openblas \
+    --with-openblas-incdir=${PREFIX}/include \
+    --with-openblas-libdir=${PREFIX}/lib \
+    --enable-plplot=no
+make
+make install

--- a/recipes/psfex/meta.yaml
+++ b/recipes/psfex/meta.yaml
@@ -25,8 +25,7 @@ requirements:
     - openblas
   run:
     - fftw
-    - libopenblas  # [osx]
-    - openblas  # [linux]
+    - openblas
 
 test:
   commands:

--- a/recipes/psfex/meta.yaml
+++ b/recipes/psfex/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "3.21.1" %}
 
 package:
-  name: {{ name }}
+  name: astromatic-{{ name }}
   version: {{ version }}
 
 source:

--- a/recipes/psfex/meta.yaml
+++ b/recipes/psfex/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/astromatic/{{ name }}/archive/{{ version }}.tar.gz
   sha256: a670f7a7273419a8686c3210b93b184e19649c70f420adc1a0b0c01467b5fe8d
+  patches:
+    - 0001-Search-lapacke-library.patch
 
 build:
   skip: true  # [win]
@@ -22,10 +24,9 @@ requirements:
     - make
   host:
     - fftw
-    - openblas
+    - liblapacke
   run:
     - fftw
-    - openblas
 
 test:
   commands:

--- a/recipes/psfex/meta.yaml
+++ b/recipes/psfex/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "psfex" %}
+{% set version = "3.21.1" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/astromatic/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: a670f7a7273419a8686c3210b93b184e19649c70f420adc1a0b0c01467b5fe8d
+
+build:
+  skip: true  # [win]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - autoconf
+    - automake
+    - libtool
+    - make
+  host:
+    - fftw
+    - openblas
+  run:
+    - fftw
+    - libopenblas
+
+test:
+  commands:
+    - psfex -d
+
+about:
+  home: http://www.astromatic.net/software/psfex
+  licence: GPL3
+  license_file: LICENSE
+  summary: a utility that makes PSF models for use with the SExtractor program.
+  description: |
+    PSFEx (PSF Extractor) is a computer program that extracts precise models
+    of the Point Spread Functions (PSFs) from images processed by SExtractor
+    and measures the quality of images. The generated PSF models can be used
+    for model-fitting photometry or morphological analyses.
+  doc_url: https://psfex.readthedocs.io/
+  dev_url: https://github.com/astromatic/psfex
+
+extra:
+  recipe-maintainers:
+    - teake

--- a/recipes/psfex/meta.yaml
+++ b/recipes/psfex/meta.yaml
@@ -34,7 +34,7 @@ test:
 
 about:
   home: http://www.astromatic.net/software/psfex
-  licence: GPL3
+  licence: GPL-3.0
   license_file: LICENSE
   summary: a utility that makes PSF models for use with the SExtractor program.
   description: |

--- a/recipes/psfex/meta.yaml
+++ b/recipes/psfex/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - openblas
   run:
     - fftw
-    - libopenblas
+    - libopenblas  # [osx]
+    - openblas  # [linux]
 
 test:
   commands:


### PR DESCRIPTION
@conda-forge/help-c-cpp

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

__Note__: this package's name clashes with that of https://github.com/conda-forge/psfex-feedstock. I'm not sure what the best way to proceed is. The existing psfex conda forge package looks like a misnomer, [as it appears to be a utility to reconstruct images from psfex models](https://github.com/esheldon/psfex#psfex) (i.e. from files generated by the program in this PR, [psfex](https://psfex.readthedocs.io/en/latest/Introduction.html)).

If the existing conda forge package would have had zero downloads I'd vote to rename it (to `psfex-rec`, like its cli tool). But since that is not the case, I'm not sure how to proceed. I could rename the package name in the PR to `astromatic-psfex`, since it is part of the so-called [AstrOmatic software suite](https://www.astromatic.net/software). But I have more recipes for AstrOmatic utilities lined up, and this is the only one with a name clash. So I'm a bit hesitant to prefix all of them with `astromatic-`.

CC'ing the existing psf-feedstock maintainer @beckermr and the author of the underlying code @esheldon for input.