### PR TITLE
add proj datumgrids

### DIFF
--- a/recipes/proj_datum/install.bat
+++ b/recipes/proj_datum/install.bat
@@ -1,0 +1,4 @@
+set DATADIR="%LIBRARY_PREFIX%\\share\\proj"
+if not exist %DATADIR% mkdir %DATADIR%
+
+xcopy %PKG_NAME%\*  %DATADIR% /s /e || exit 1

--- a/recipes/proj_datum/install.sh
+++ b/recipes/proj_datum/install.sh
@@ -1,0 +1,4 @@
+export DATADIR="${PREFIX}/share/proj"
+mkdir -p ${DATADIR}
+
+cp -r ${PKG_NAME}/* ${DATADIR}

--- a/recipes/proj_datum/meta.yaml
+++ b/recipes/proj_datum/meta.yaml
@@ -1,0 +1,68 @@
+{% set europe_ver = "1.3" %}
+{% set north_america_ver = "1.2" %}
+{% set oceania_ver = "1.0" %}
+{% set world_ver = "1.0" %}
+
+package:
+  name: datumgrid
+
+source:
+  - url: http://download.osgeo.org/proj/proj-datumgrid-europe-{{ europe_ver }}.tar.gz
+    sha256: a6345a4a10c656ba436515c5890a67c7cc8a861a572cb562d03f3a228345a78f
+    folder: proj-datumgrid-europe
+
+  - url: http://download.osgeo.org/proj/proj-datumgrid-north-america-{{ north_america_ver }}.tar.gz
+    sha256: 00b51e15165e52f4ded7fd915ca41cdafa8a0d8e7fd12a65ba6a0ebe807f7ec0
+    folder: proj-datumgrid-north-america
+
+  - url: http://download.osgeo.org/proj/proj-datumgrid-oceania-{{ oceania_ver }}.tar.gz
+    sha256: 7cf0c3ca6221485317f1c752e592e9cb8b10eb9caf761e3847148fa3e4629a66
+    folder: proj-datumgrid-oceania
+
+  - url: http://download.osgeo.org/proj/proj-datumgrid-world-{{ world_ver }}.tar.gz
+    sha256: a488a5a69d1af6ec2ee83a2c64c52adac52e6dbfafe883f0341340009a9f40ba
+    folder: proj-datumgrid-world
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - proj4
+
+test:
+  commands:
+    # TODO: we need real tests for each datumgrid.
+    - echo -105 40 | cs2cs +init=epsg:4326 +to +init=epsg:2975
+
+outputs:
+  - name: proj-datumgrid-europe
+    version: {{ europe_ver }}
+    script: install.sh  # [not win]
+    script: install.bat  # [win]
+
+  - name: proj-datumgrid-north-america
+    version: {{ north_america_ver }}
+    script: install.sh  # [not win]
+    script: install.bat  # [win]
+
+  - name: proj-datumgrid-oceania
+    version: {{ oceania_ver }}
+    script: install.sh  # [not win]
+    script: install_bat  # [win]
+
+  - name: proj-datumgrid-world
+    version: {{ world_ver }}
+    script: install.sh  # [not win]
+    script: install.bat  # [win]
+
+about:
+  home: https://github.com/OSGeo/proj-datumgrid
+  license: Public domain | X/MIT | BSD-2/3/4-Clause | CC0 | CC-BY (v3.0 or later) | CC-BY-SA (v3.0 or later)
+  # Each package has a README file with the license info, that is copied with the datum files.
+  # license_file: README.<name>
+  summary: 'Cartographic Projections and Coordinate Transformations Library'
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/proj_datum/meta.yaml
+++ b/recipes/proj_datum/meta.yaml
@@ -49,7 +49,7 @@ outputs:
   - name: proj-datumgrid-oceania
     version: {{ oceania_ver }}
     script: install.sh  # [not win]
-    script: install_bat  # [win]
+    script: install.bat  # [win]
 
   - name: proj-datumgrid-world
     version: {{ world_ver }}


### PR DESCRIPTION
@hobu do you mind taking a quick look at this package?
It should produce an output package for each one of the 4 regional datumgrids.

I did not create a separate package for `proj-datumgrid-1.8.tar.gz` b/c that one is bundled in the `proj.4` recipe as the default datumgrid.