### PR TITLE
Scapy

### DIFF
--- a/recipes/scapy/meta.yaml
+++ b/recipes/scapy/meta.yaml
@@ -15,7 +15,7 @@ build:
   entry_points:
     - scapy = scapy.main:interact
     - UTscapy = scapy.tools.UTscapy:main
-  script: "{{ PYTHON }} -m pip install .[all] --ignore-installed "
+  script: "{{ PYTHON }} -m pip install . --ignore-installed -vv "
 
 requirements:
   host:
@@ -23,6 +23,9 @@ requirements:
     - python
   run:
     - python
+    - ipython
+    - cryptography
+    - matplotlib
 
 test:
   imports:

--- a/recipes/scapy/meta.yaml
+++ b/recipes/scapy/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "scapy" %}
+{% set version = "2.4.3rc2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "193da281a73d368b9f4b9b6b712bd3fee7ee40e07d69dfbe2763ecd409a064e6"
+
+build:
+  number: 0
+  entry_points:
+    - scapy = scapy.main:interact
+    - UTscapy = scapy.tools.UTscapy:main
+  script: "{{ PYTHON }} -m pip install .[all] --ignore-installed "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - scapy
+    - scapy.arch
+    - scapy.asn1
+    - scapy.contrib
+    - scapy.contrib.automotive
+    - scapy.contrib.automotive.bmw
+    - scapy.contrib.automotive.gm
+    - scapy.contrib.automotive.obd
+    - scapy.contrib.automotive.obd.iid
+    - scapy.contrib.automotive.obd.mid
+    - scapy.contrib.automotive.obd.pid
+    - scapy.contrib.automotive.obd.tid
+    - scapy.contrib.scada
+    - scapy.contrib.scada.iec104
+    - scapy.layers
+    - scapy.layers.tls
+    - scapy.layers.tls.crypto
+    - scapy.modules
+    - scapy.tools
+  commands:
+    - scapy -h
+    - UTscapy -h
+
+about:
+  home: "https://scapy.net"
+  license: "GNU General Public v2 (GPLv2)"
+  license_family: "GPL2"
+  license_file: "LICENSE"
+  summary: "Scapy: interactive packet manipulation tool"
+  doc_url: "https://scapy.readthedocs.io"
+  dev_url: "https://github.com/secdev/scapy"
+
+extra:
+  recipe-maintainers:
+    - gpotter2

--- a/recipes/scapy/meta.yaml
+++ b/recipes/scapy/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - scapy = scapy.main:interact
     - UTscapy = scapy.tools.UTscapy:main


### PR DESCRIPTION
We're on verge of [releasing 2.4.3](https://github.com/secdev/scapy/issues/1866), and I thought it could be a good idea to also have it packed in conda-forge.

### Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

### Questions to the team

- I'm not sure yet if it would be better for me (gpotter2) or [secdev](https://github.com/secdev) (the organization that hosts the scapy repo) to be the maintainer :/
- We have several `extras_require` bundles available: `[none]`, `basic` (+ipython), `all` (+ipython, pyx, cryptography, matplotlib). The latter are mostly used for graphical features, plotting & other fancy things. What would be best for conda ? (for now I've setup `all`)

In fact, we made it to require no dependency by default, but some are optionals.

Any advice would be greatly appreciated