### PR TITLE
Rename matplotlib2tikz to tikzplotlib

### DIFF
--- a/recipes/tikzplotlib/LICENSE
+++ b/recipes/tikzplotlib/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2010-2019 Nico Schlömer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/tikzplotlib/meta.yaml
+++ b/recipes/tikzplotlib/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "tikzplotlib" %}
+{% set version = "0.8.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0ff9a0f79c80749873c4f54018c61726fb4d4aff656c2904205fc04f7d65516d
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+    - matplotlib >=1.4.0
+    - numpy
+    - pillow
+
+test:
+  imports:
+    - tikzplotlib
+    - tikzplotlib.axes
+    - tikzplotlib.color
+    - tikzplotlib.files
+    - tikzplotlib.image
+    - tikzplotlib.legend
+    - tikzplotlib.line2d
+    - tikzplotlib.patch
+    - tikzplotlib.path
+    - tikzplotlib.quadmesh
+    - tikzplotlib.save
+    - tikzplotlib.text
+    - tikzplotlib.util
+
+about:
+  home: https://github.com/nschloe/tikzplotlib
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Convert matplotlib figures into TikZ/PGFPlots'
+  dev_url: https://github.com/nschloe/tikzplotlib
+
+extra:
+  recipe-maintainers:
+    - m-rossi
+

--- a/recipes/tikzplotlib/meta.yaml
+++ b/recipes/tikzplotlib/meta.yaml
@@ -51,4 +51,3 @@ about:
 extra:
   recipe-maintainers:
     - m-rossi
-


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

The package `matplotlib2tikz` got renamed to `tikzplotlib`. I followed the instructions at https://conda-forge.org/docs/orga/guidelines.html#renaming-packages and created a new recipe. As listed in the checklist below the feedstock needs to be removed after merging this PR.

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [ ] Remove old feedstock: https://github.com/conda-forge/matplotlib2tikz-feedstock