### PR TITLE
fastdiff 0.1.4

### DIFF
--- a/recipes/fastdiff/meta.yaml
+++ b/recipes/fastdiff/meta.yaml
@@ -28,7 +28,7 @@ test:
   requires:
     - pytest <4
     - pytest-benchmark
-    - ptest-cov
+    - pytest-cov
   imports:
     - fastdiff
   commands:

--- a/recipes/fastdiff/meta.yaml
+++ b/recipes/fastdiff/meta.yaml
@@ -46,4 +46,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - bollywvl
+    - bollwyvl

--- a/recipes/fastdiff/meta.yaml
+++ b/recipes/fastdiff/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "fastdiff" %}
+{% set version = "0.1.4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 8f9510b9c7d0d3482cea602af161f02eb813303138284893704f5f3e9ef189fb
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - pytest-runner
+    - python
+  run:
+    - python
+
+test:
+  source_files:
+    - tests
+  requires:
+    - pytest <4
+    - pytest-benchmark
+    - ptest-cov
+  imports:
+    - fastdiff
+  commands:
+    - pytest --cov fastdiff
+
+about:
+  home: https://github.com/syrusakbary/fastdiff
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A fast native implementation of diff algorithm with a pure Python fallback
+  description: |
+    fastdiff is a re-implementation of difflib in pure Rust compiled to
+    WebAssembly to speedup different language integrations:
+
+extra:
+  recipe-maintainers:
+    - bollywvl


### PR DESCRIPTION
Adds https://github.com/syrusakbary/fastdiff

Needed as a dependency for snapshottest 0.5.1 (https://github.com/conda-forge/snapshottest-feedstock/pull/1).

This is only allows use of the python implementation. The WASM-based approach is reportedly:

> When comparing strings with 300 lines, the WebAssembly based approach is about 75 times faster than the pure Python approach.

...powered by [https://pypi.org/project/wasmer](wasmer) which looks like a pretty heavy-duty (though very interesting) feedstock project (#8817). Even if wasmer was available, this would probably _still_ be a `noarch: python`, which seems like a very useful template for shipping high-performing things, built easily.

### Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
