### PR TITLE
Add recipe for gn

### DIFF
--- a/recipes/gn/add-lrt.patch
+++ b/recipes/gn/add-lrt.patch
@@ -1,0 +1,12 @@
+diff --git a/build/gen.py b/build/gen.py
+index 99de57e..da2564f 100755
+--- a/build/gen.py
++++ b/build/gen.py
+@@ -330,6 +330,7 @@ def WriteGNNinja(path, platform, host, options):
+       ])
+       # This is needed by libc++.
+       libs.append('-ldl')
++      libs.append('-lrt')
+     elif platform.is_darwin():
+       min_mac_version_flag = '-mmacosx-version-min=10.9'
+       cflags.append(min_mac_version_flag)

--- a/recipes/gn/build.sh
+++ b/recipes/gn/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+python build/gen.py
+ninja -C out
+mkdir -p $PREFIX/bin
+cp out/gn $PREFIX/bin/gn

--- a/recipes/gn/meta.yaml
+++ b/recipes/gn/meta.yaml
@@ -36,7 +36,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'GN is a meta-build system that generates build files for Ninja.<Paste>'
+  summary: 'GN is a meta-build system that generates build files for Ninja.'
 
 extra:
   recipe-maintainers:

--- a/recipes/gn/meta.yaml
+++ b/recipes/gn/meta.yaml
@@ -16,6 +16,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win]
 
 requirements:
   build:
@@ -40,4 +41,3 @@ about:
 extra:
   recipe-maintainers:
     - xhochy
-

--- a/recipes/gn/meta.yaml
+++ b/recipes/gn/meta.yaml
@@ -1,0 +1,43 @@
+# As there are no releases in GN, we build the latest tag from time to time.
+# The version is the time of the latest master commit in YYYYMMDDHHMMSS
+# notation.
+
+{% set name = "gn" %}
+{% set version = "0.0.20190712172645" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # We have to use git as the source as the provided tarballs are not stable.
+  git_url: https://gn.googlesource.com/gn
+  git_rev: 579b5b394094db3a07c46c3ee459860bd5619224
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - python
+    - ninja
+  host:
+  run:
+
+test:
+  commands:
+    - test -f $PREFIX/bin/gn
+
+about:
+  home: https://gn.googlesource.com/gn/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'GN is a meta-build system that generates build files for Ninja.<Paste>'
+
+extra:
+  recipe-maintainers:
+    - xhochy
+

--- a/recipes/gn/meta.yaml
+++ b/recipes/gn/meta.yaml
@@ -13,6 +13,8 @@ source:
   # We have to use git as the source as the provided tarballs are not stable.
   git_url: https://gn.googlesource.com/gn
   git_rev: 579b5b394094db3a07c46c3ee459860bd5619224
+  patches:
+    - add-lrt.patch  # [linux]
 
 build:
   number: 0


### PR DESCRIPTION
`gn` is used by many Google provided tools, e.g. V8 but is sadly in a head-only development mode and thus doesn't do releases by itself. Neither do they provide stable tarballs.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
