### PR TITLE
Add build from tarballs not repos in the github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,4 +30,10 @@ Checklist
 - [ ] Source is from official source
 - [ ] Package does not vendor other packages
 - [ ] Build number is 0
+- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
+      recipe (see
+      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
+      for more details)
+- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
+
 - [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,5 +35,3 @@ Checklist
       [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
       for more details)
 - [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
-
-- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there


### PR DESCRIPTION
This is something I was not aware of when I opened my PR and it seems it belongs in the PR template checklist.