### PR TITLE
astrometry.net recipe added

### DIFF
--- a/recipes/astrometry.net/bld.bat
+++ b/recipes/astrometry.net/bld.bat
@@ -1,0 +1,3 @@
+
+echo Not supported.
+exit 1

--- a/recipes/astrometry.net/build.sh
+++ b/recipes/astrometry.net/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# remove ncurses tic.h that conficts with astrometry tic.h
+rm -f $CONDA_PREFIX/include/tic.h
+
+export CFLAGS="$CFLAGS -I$PREFIX/include -L$PREFIX/lib -I$CONDA_PREFIX/include -L$CONDA_PREFIX/lib"
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib -L$CONDA_PREFIX/lib"
+export CFITS_INC="-I$CONDA_PREFIX/include"
+export CFITS_LIB="-L$CONDA_PREFIX/lib -lcfitsio -lm"
+export NETPBM_INC="-I$CONDA_PREFIX/include"
+export NETPBM_LIB="-L$CONDA_PREFIX/lib -lnetpbm"
+export CAIRO_INC="-I$CONDA_PREFIX/include -I$CONDA_PREFIX/include/cairo"
+export CAIRO_LIB="-L$CONDA_PREFIX/lib -lcairo"
+export PNG_INC="-I$CONDA_PREFIX/include"
+export PNG_LIB="-L$CONDA_PREFIX/lib -lpng16"
+export JPEG_INC="-I$CONDA_PREFIX/include"
+export JPEG_LIB="-L$CONDA_PREFIX/lib -ljpeg"
+export ZLIB_INC="-I$CONDA_PREFIX/include"
+export ZLIB_LIB="-L$CONDA_PREFIX/lib -lz"
+
+make
+make extra
+make install INSTALL_DIR="$PREFIX"

--- a/recipes/astrometry.net/meta.yaml
+++ b/recipes/astrometry.net/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 85480b9636757c89ef5ccc7aac557409ac2ab377eb6c6eca862b16cdd4faefd9
 
 build:
-    number: 1
+    number: 0
     skip: True # [osx]
     skip: True # [win]
 

--- a/recipes/astrometry.net/meta.yaml
+++ b/recipes/astrometry.net/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "astrometry.net" %}
+{% set version = "0.78" %}
+
+package:
+    name: {{ name|lower}}
+    version: {{ version }}
+
+source:
+    fn: {{name}}-{{ version }}.zip
+    url: https://github.com/dstndstn/astrometry.net/archive/{{ version }}.zip
+    sha256: 85480b9636757c89ef5ccc7aac557409ac2ab377eb6c6eca862b16cdd4faefd9
+
+build:
+    number: 1
+    skip: True # [osx]
+    skip: True # [win]
+
+requirements:
+    build:
+        - swig
+        - {{ compiler('c') }}
+        - git
+        - make
+        - {{ cdt('libx11-devel') }}          # [linux]
+        - {{ cdt('libxau-devel') }}          # [linux]
+        - {{ cdt('libxext-devel') }}         # [linux]
+        - {{ cdt('libxrender-devel') }}      # [linux]
+        - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
+        - zlib
+        - jpeg
+        - netpbm
+        - libpng
+        - cfitsio
+        - astropy
+        - numpy
+        - bzip2
+        - cairo
+        - gsl
+    run:
+        - zlib
+        - jpeg
+        - netpbm
+        - libpng
+        - cfitsio
+        - astropy
+        - numpy
+        - bzip2
+        - cairo
+        - gsl
+
+about:
+    home: http://astrometry.net/
+    license: BSD-like
+    summary: Automatic recognition of astronomical images; or standards-compliant astrometric metadata from data.
+    description: |
+         If you have astronomical imaging of the sky with celestial coordinates you do not know—or do not
+         trust—then Astrometry.net is for you. Input an image and we'll give you back astrometric
+         calibration meta-data, plus lists of known objects falling inside the field of view
+    doc_url: http://astrometry.net/doc/readme.html
+    dev_url: https://github.com/dstndstn/astrometry.net/
+
+extra:
+    recipe-maintainers:
+        - juliotux

--- a/recipes/astrometry.net/meta.yaml
+++ b/recipes/astrometry.net/meta.yaml
@@ -50,7 +50,7 @@ requirements:
 
 about:
     home: http://astrometry.net/
-    license: BSD-like
+    license: BSD
     summary: Automatic recognition of astronomical images; or standards-compliant astrometric metadata from data.
     description: |
          If you have astronomical imaging of the sky with celestial coordinates you do not know—or do not


### PR DESCRIPTION
Description

Astrometry.net is a very known software used for astrometric calibration of astronomical images, used a lot in astronomical data pipelines. As it is not packed for conda by default, adding it to Conda-Forge would be a good addition.

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
