### PR TITLE
Add tinyxml recipe

### DIFF
--- a/recipes/tinyxml/CMakeLists.txt
+++ b/recipes/tinyxml/CMakeLists.txt
@@ -8,9 +8,7 @@ add_library(tinyxml SHARED tinyxml.cpp tinyxmlerror.cpp tinyxmlparser.cpp)
 set_target_properties(tinyxml PROPERTIES
                       INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 
-install(TARGETS tinyxml
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION lib)
+install(TARGETS tinyxml)
+
 install(FILES tinyxml.h
         DESTINATION include)

--- a/recipes/tinyxml/CMakeLists.txt
+++ b/recipes/tinyxml/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 2.4.6)
+add_definitions(-DTIXML_USE_STL)
+add_library(tinyxml SHARED tinyxml.cpp tinyxmlerror.cpp tinyxmlparser.cpp)
+set_target_properties(tinyxml PROPERTIES
+                      INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+
+install(TARGETS tinyxml
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        RUNTIME DESTINATION lib)
+install(FILES tinyxml.h
+        DESTINATION include)

--- a/recipes/tinyxml/CMakeLists.txt
+++ b/recipes/tinyxml/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Taken from https://gist.githubusercontent.com/scpeters/6325123/raw/cfb079be67997cb19a1aee60449714a1dedefed5/tinyxml_CMakeLists.patch
+# This CMakeLists.txt file builds a shared library and provide an install
+# target for tinyxml. This was submitted upstream as
+# https://sourceforge.net/p/tinyxml/patches/66/
 cmake_minimum_required(VERSION 2.4.6)
 add_definitions(-DTIXML_USE_STL)
 add_library(tinyxml SHARED tinyxml.cpp tinyxmlerror.cpp tinyxmlparser.cpp)

--- a/recipes/tinyxml/LICENSE
+++ b/recipes/tinyxml/LICENSE
@@ -1,0 +1,21 @@
+www.sourceforge.net/projects/tinyxml
+Original code by Lee Thomason (www.grinninglizard.com)
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software. If you use this
+software in a product, an acknowledgment in the product documentation
+would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source
+distribution.

--- a/recipes/tinyxml/build.sh
+++ b/recipes/tinyxml/build.sh
@@ -5,7 +5,9 @@ cd build
 
 cmake .. \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib
 
 make
 make install

--- a/recipes/tinyxml/build.sh
+++ b/recipes/tinyxml/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX
+
+make
+make install

--- a/recipes/tinyxml/enforce-use-stl.patch
+++ b/recipes/tinyxml/enforce-use-stl.patch
@@ -1,0 +1,18 @@
+Description: TinyXml is built with TIXML_USE_STL, so we have to
+ enforce it when the library is used.
+Author: Felix Geyer <debfx-pkg@fobos.de>
+
+diff -Nur tinyxml-2.5.3/tinyxml.h tinyxml-2.5.3.patch/tinyxml.h
+--- tinyxml-2.5.3/tinyxml.h	2007-05-07 00:41:23.000000000 +0200
++++ tinyxml-2.5.3.patch/tinyxml.h	2009-07-08 22:32:03.000000000 +0200
+@@ -26,6 +26,10 @@
+ #ifndef TINYXML_INCLUDED
+ #define TINYXML_INCLUDED
+ 
++#ifndef TIXML_USE_STL
++	#define TIXML_USE_STL
++#endif
++
+ #ifdef _MSC_VER
+ #pragma warning( push )
+ #pragma warning( disable : 4530 )

--- a/recipes/tinyxml/entity-encoding.patch
+++ b/recipes/tinyxml/entity-encoding.patch
@@ -1,0 +1,58 @@
+Description: TinyXML incorrectly encodes text element containing an ampersand followed by either x or #.
+Origin: http://sourceforge.net/tracker/index.php?func=detail&aid=3031828&group_id=13559&atid=313559
+
+diff -u -r1.105 tinyxml.cpp
+--- a/tinyxml.cpp
++++ b/tinyxml.cpp
+@@ -57,30 +57,7 @@
+ 	{
+ 		unsigned char c = (unsigned char) str[i];
+ 
+-		if (    c == '&' 
+-		     && i < ( (int)str.length() - 2 )
+-			 && str[i+1] == '#'
+-			 && str[i+2] == 'x' )
+-		{
+-			// Hexadecimal character reference.
+-			// Pass through unchanged.
+-			// &#xA9;	-- copyright symbol, for example.
+-			//
+-			// The -1 is a bug fix from Rob Laveaux. It keeps
+-			// an overflow from happening if there is no ';'.
+-			// There are actually 2 ways to exit this loop -
+-			// while fails (error case) and break (semicolon found).
+-			// However, there is no mechanism (currently) for
+-			// this function to return an error.
+-			while ( i<(int)str.length()-1 )
+-			{
+-				outString->append( str.c_str() + i, 1 );
+-				++i;
+-				if ( str[i] == ';' )
+-					break;
+-			}
+-		}
+-		else if ( c == '&' )
++		if ( c == '&' )
+ 		{
+ 			outString->append( entity[0].str, entity[0].strLength );
+ 			++i;
+diff -u -r1.89 xmltest.cpp
+--- a/xmltest.cpp
++++ b/xmltest.cpp
+@@ -1340,6 +1340,16 @@
+ 		}*/
+ 	}
+ 
++	#ifdef TIXML_USE_STL
++	{
++		TiXmlDocument xml;
++		xml.Parse("<foo>foo&amp;#xa+bar</foo>");
++		std::string str;
++		str << xml;
++		XmlTest( "Entity escaping", "<foo>foo&amp;#xa+bar</foo>", str.c_str() );
++	}
++	#endif
++
+ 	/*  1417717 experiment
+ 	{
+ 		TiXmlDocument xml;

--- a/recipes/tinyxml/meta.yaml
+++ b/recipes/tinyxml/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "tinyxml" %}
+{% set version = "2.6.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz
+    sha256: 15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593
+    patches:
+      # These two patches are taken from the debian packaging of tinyxml.
+      #   The first patch enforces use of stl strings, rather than a custom string type.
+      #   The second patch is a fix for incorrect encoding of elements with special characters
+      #   originally posted at https://sourceforge.net/p/tinyxml/patches/51/
+      - enforce-use-stl.patch
+      - entity-encoding.patch
+  # This adds a CMakeLists.txt file to build a shared library and provide an install target
+  # submitted upstream as https://sourceforge.net/p/tinyxml/patches/66/
+  - path: CMakeLists.txt
+  
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+
+test:
+  commands:
+    - ls $PREFIX/lib/*{{ name }}*
+
+about:
+  home: http://www.grinninglizard.com/tinyxml
+  license: zlib
+  license_file: LICENSE
+  summary: 'A simple, small, C++ XML parser that can be easily integrated into other programs'
+  dev_url: https://www.sourceforge.net/projects/tinyxml
+
+extra:
+  recipe-maintainers:
+    - jcarpent
+    - lesteve

--- a/recipes/tinyxml/meta.yaml
+++ b/recipes/tinyxml/meta.yaml
@@ -18,11 +18,13 @@ source:
   # This adds a CMakeLists.txt file to build a shared library and provide an install target
   # submitted upstream as https://sourceforge.net/p/tinyxml/patches/66/
   - path: CMakeLists.txt
-  
+
 
 build:
   number: 0
   skip: true  # [win]
+  run_exports:
+    - tinyxml
 
 requirements:
   build:

--- a/recipes/tinyxml/meta.yaml
+++ b/recipes/tinyxml/meta.yaml
@@ -32,7 +32,7 @@ requirements:
 
 test:
   commands:
-    - ls $PREFIX/lib/*{{ name }}*
+    - test -f $PREFIX/lib/lib{{ name }}$SHLIB_EXT
 
 about:
   home: http://www.grinninglizard.com/tinyxml

--- a/recipes/tinyxml/meta.yaml
+++ b/recipes/tinyxml/meta.yaml
@@ -44,4 +44,5 @@ about:
 extra:
   recipe-maintainers:
     - jcarpent
+    - wolfv
     - lesteve


### PR DESCRIPTION
Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Some comments:
- I followed very closely the [homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/tinyxml.rb). The only minor difference is that I included the `CMakeLists.txt` as a source file rather than a patch because it does not seem like conda-build can patch non-existent files.
- `tinyxml` is deprecated and the project has continued as `tinyxml2` (`tinyxml2` is already in conda-forge). However `tinyxml` is still a dependency for some ROS (Robot Operating Systems) projects. There has been some discussion of migrating from `tinyxml` to `tinyxml2`,  for example https://github.com/ros/urdfdom/pull/99 but from what I gather this is unlikely to happen in the next few months. Having `tinyxml` packaged in conda-forge would be a very convenient interim solution.

