### PR TITLE
add sbcl for linux [ROS]

### DIFF
--- a/recipes/sbcl/recipe/build.sh
+++ b/recipes/sbcl/recipe/build.sh
@@ -1,0 +1,19 @@
+export INSTALL_ROOT=$PREFIX
+
+sh install.sh
+
+mkdir -p $PREFIX/etc/conda/activate.d/
+mkdir -p $PREFIX/etc/conda/deactivate.d/
+
+cat >$PREFIX/etc/conda/activate.d/activate_sbcl.sh <<EOL
+#!/bin/sh
+export SBCL_HOME=\$CONDA_PREFIX/lib/sbcl
+EOL
+
+cat >$PREFIX/etc/conda/deactivate.d/deactivate_sbcl.sh <<EOL
+#!/bin/sh
+unset SBCL_HOME
+EOL
+
+chmod u+x $PREFIX/etc/conda/activate.d/activate_sbcl.sh
+chmod u+x $PREFIX/etc/conda/deactivate.d/deactivate_sbcl.sh

--- a/recipes/sbcl/recipe/meta.yaml
+++ b/recipes/sbcl/recipe/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "1.5.4" %}
+
+package:
+  name: sbcl
+  version: {{ version }}
+
+source:
+  url: http://prdownloads.sourceforge.net/sbcl/sbcl-{{ version }}-x86-64-linux-binary.tar.bz2  # [linux]
+  fn: sbcl-1.5.4.tar.gz
+  sha256: 9c6625cdb167e9450566f309686faa8a3fbf6b1a6de5697f3777836a4da0d100
+
+build:
+  number: 0
+  skip: true  # [win and osx]
+
+requirements:
+  build:
+  host:
+  run:
+
+test:
+  commands:
+    - sbcl --version
+    - sbcl --help
+    - sbcl --eval '(print "hello world")' --quit
+
+about:
+  home: http://www.sbcl.org
+  license: BSD
+  summary: Steel Bank Common Lisp (SBCL) is a high performance Common Lisp compiler
+  description: |
+    Steel Bank Common Lisp (SBCL) is a high performance Common Lisp compiler. 
+    It is open source / free software, with a permissive license. In addition to the 
+    compiler and runtime system for ANSI Common Lisp, it provides an interactive 
+    environment including a debugger, a statistical profiler, a code coverage tool,
+    and many other extensions.
+  doc_url: http://www.sbcl.org/manual/index.html
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

ROS has some light dependency on SBCL, the steel bank common lisp compiler. 

I couldn't find a package on conda/conda-forge. I believe this package works (for linux), however, it *does not* bootstrap the lisp compiler. It downloads a precompiled binary from the official website and installs it into the conda environment. 

Not sure if conda-forge is willing to accept this? 

Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
