### PR TITLE
Add 4ti2

### DIFF
--- a/recipes/4ti2/build.sh
+++ b/recipes/4ti2/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./configure
+make
+make install

--- a/recipes/4ti2/build.sh
+++ b/recipes/4ti2/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-./configure
+./configure --prefix=$PREFIX
 make -j${CPU_COUNT}
 make install

--- a/recipes/4ti2/build.sh
+++ b/recipes/4ti2/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 ./configure
-make
+make -j${CPU_COUNT}
 make install

--- a/recipes/4ti2/build.sh
+++ b/recipes/4ti2/build.sh
@@ -2,4 +2,5 @@
 
 ./configure --prefix=$PREFIX
 make -j${CPU_COUNT}
+make check -j${CPU_COUNT}
 make install

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -12,9 +12,7 @@ source:
 build:
   number: 0
   skip: True  # [win]
-  run_exports:
-    - {{ pin_subpackage("4ti2") }}
-
+  
 requirements:
   build:
     - automake

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   skip: True  # [win]
+  run_exports:
+    - {{ pin_subpackage("4ti2") }}
 
 requirements:
   build:

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/4ti2/4ti2/releases/download/Release_{{ version.replace(".", "_") }}/4ti2-{{ version }}.tar.gz
-  sha256: d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
+  sha256: 3053e7467b5585ad852f6a56e78e28352653943e7249ad5e5174d4744d174966
 
 build:
   number: 0

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -22,6 +22,9 @@ requirements:
   host:
     - gmp
     - glpk
+  run:
+    # We link against glpk which does not specify a run_exports so we need to add it explicitly here.
+    - glpk
 
 test:
   commands:

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/4ti2/{{ name }}/archive/{{ version }}.tar.gz
+  url: https://github.com/4ti2/4ti2/releases/download/Release_{{ version.replace(".", "_") }}/4ti2-{{ version }}.tar.gz
   sha256: d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
 
 build:

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - gmp
     - glpk
   run:
-    # We link against glpk which does not specify a run_exports so we need to add it explicitly here.
+    # We link against glpk which does not specify a run_exports so we need to add it explicitly here, see https://github.com/conda-forge/glpk-feedstock/pull/32
     - glpk
 
 test:

--- a/recipes/4ti2/meta.yaml
+++ b/recipes/4ti2/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "4ti2" %}
+{% set version = "1.6.9" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/4ti2/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - automake
+    - libtool
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - gmp
+    - glpk
+
+test:
+  commands:
+    - gensymm --version
+
+about:
+  home: https://4ti2.github.io/
+  license: GPLv2+
+  license_file: COPYING
+  summary: 'A software package for algebraic, geometric and combinatorial problems on linear spaces'
+  doc_url: https://4ti2.github.io/
+  dev_url: https://github.com/4ti2/4ti2
+
+extra:
+  recipe-maintainers:
+    - saraedum


### PR DESCRIPTION
an optional dependency of SageMath, see https://github.com/conda-forge/sage-feedstock/issues/42. For me it's a prerequisite to package sage-flatsurf.