### PR TITLE
Add osrf_pycommon and catkin_tools [ROS]

### DIFF
--- a/recipes/catkin_tools/recipe/meta.yaml
+++ b/recipes/catkin_tools/recipe/meta.yaml
@@ -26,8 +26,8 @@ requirements:
   run:
     - python
     - catkin_pkg >0.2.9
-    - setuptools
     - pyyaml
+    - psutil
     - osrf_pycommon >0.1.1
     - trollius  # [py < 34]
 

--- a/recipes/catkin_tools/recipe/meta.yaml
+++ b/recipes/catkin_tools/recipe/meta.yaml
@@ -41,6 +41,7 @@ test:
 about:
   home: https://catkin-tools.readthedocs.io/
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: 'This Python package provides command line tools for working with the catkin meta-buildsystem and catkin workspaces.'
   dev_url: https://github.com/catkin/catkin_tools

--- a/recipes/catkin_tools/recipe/meta.yaml
+++ b/recipes/catkin_tools/recipe/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "catkin_tools" %}
+{% set version = "0.4.5" %}
+{% set sha256 = "6a9a2512183824a8250979c7772dc9487e3d2830a956fbd52fd2d8d71fba6d58" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/catkin/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+  patches:
+    - remove_trollius.patch
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [win]
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - catkin_pkg >0.2.9
+    - setuptools
+    - pyyaml
+    - osrf_pycommon >0.1.1
+    - trollius  # [py < 34]
+
+test:
+  commands:
+    - catkin --help
+    - catkin init --help
+    - catkin build --help
+    - catkin list --help
+    - catkin env --help
+about:
+  home: https://catkin-tools.readthedocs.io/
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: 'This Python package provides command line tools for working with the catkin meta-buildsystem and catkin workspaces.'
+  dev_url: https://github.com/catkin/catkin_tools
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve

--- a/recipes/catkin_tools/recipe/remove_trollius.patch
+++ b/recipes/catkin_tools/recipe/remove_trollius.patch
@@ -1,0 +1,65 @@
+diff --git a/catkin_tools/common.py b/catkin_tools/common.py
+index b04b04e..d018d0e 100644
+--- a/catkin_tools/common.py
++++ b/catkin_tools/common.py
+@@ -20,7 +20,10 @@ import os
+ import re
+ import sys
+ 
+-import trollius as asyncio
++try:
++    import asyncio
++except ImportError:
++    import trollius as asyncio
+ 
+ from shlex import split as _cmd_split
+ try:
+diff --git a/catkin_tools/execution/executor.py b/catkin_tools/execution/executor.py
+index db04773..76b5568 100644
+--- a/catkin_tools/execution/executor.py
++++ b/catkin_tools/execution/executor.py
+@@ -18,7 +18,10 @@ import traceback
+ 
+ from itertools import tee
+ 
+-import trollius as asyncio
++try:
++    import asyncio
++except ImportError:
++    import trollius as asyncio
+ 
+ from concurrent.futures import ThreadPoolExecutor
+ from concurrent.futures import FIRST_COMPLETED
+diff --git a/catkin_tools/verbs/catkin_build/build.py b/catkin_tools/verbs/catkin_build/build.py
+index 5ed56ee..5dca706 100644
+--- a/catkin_tools/verbs/catkin_build/build.py
++++ b/catkin_tools/verbs/catkin_build/build.py
+@@ -22,7 +22,10 @@ import time
+ import traceback
+ import yaml
+ 
+-import trollius as asyncio
++try:
++    import asyncio
++except ImportError:
++    import trollius as asyncio
+ 
+ try:
+     # Python3
+diff --git a/setup.py b/setup.py
+index 03b728d..c566471 100644
+--- a/setup.py
++++ b/setup.py
+@@ -14,9 +14,10 @@ install_requires = [
+     'catkin-pkg > 0.2.9',
+     'setuptools',
+     'PyYAML',
+-    'osrf-pycommon > 0.1.1',
+-    'trollius'
++    'osrf-pycommon > 0.1.1'
+ ]
++if sys.version_info[0] == 3 and sys.version_info[1] <= 4:
++    install_requires.append('trollius')
+ if sys.version_info[0] == 2 and sys.version_info[1] <= 6:
+     install_requires.append('argparse')
+ 

--- a/recipes/osrf_pycommon/recipe/meta.yaml
+++ b/recipes/osrf_pycommon/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: https://github.com/osrf/osrf_pycommon
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: 'Commonly needed Python modules used by Python software developed at OSRF'
   dev_url: https://github.com/osrf/osrf_pycommon

--- a/recipes/osrf_pycommon/recipe/meta.yaml
+++ b/recipes/osrf_pycommon/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - setuptools
   run:
     - python
-    - setuptools
     - trollius  # [py < 34]
 
 test:

--- a/recipes/osrf_pycommon/recipe/meta.yaml
+++ b/recipes/osrf_pycommon/recipe/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "osrf_pycommon" %}
+{% set version = "0.1.7" %}
+{% set sha256 = "1d91f28c7416ddd856fad76ac0bf8c1810e52127d64ee030f49775564d2f24d2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://github.com/osrf//{{ name }}/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - setuptools
+    - trollius  # [py < 34]
+
+test:
+  imports:
+    - osrf_pycommon
+
+about:
+  home: https://github.com/osrf/osrf_pycommon
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: 'Commonly needed Python modules used by Python software developed at OSRF'
+  dev_url: https://github.com/osrf/osrf_pycommon
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve


### PR DESCRIPTION
I tried to make catkin_tools a noarch pacakge, however, it didn't work. The following multi-level nested `entry_points` seemed to have tripped up the conda-build command.
Does someone have experience with that? I tried to find other recipes but most seem to only use the implicit console_scripts?...

Cheers!


```
  noarch: python
  entry_points:
    console_scripts:
        - catkin = catkin_tools.commands.catkin:main
    catkin_tools.commands.catkin.verbs:
        - build = catkin_tools.verbs.catkin_build:description
        - clean = catkin_tools.verbs.catkin_clean:description
        - config = catkin_tools.verbs.catkin_config:description
        - create = catkin_tools.verbs.catkin_create:description
        - env = catkin_tools.verbs.catkin_env:description
        - init = catkin_tools.verbs.catkin_init:description
        - list = catkin_tools.verbs.catkin_list:description
        - locate = catkin_tools.verbs.catkin_locate:description
        - profile = catkin_tools.verbs.catkin_profile:description
    catkin_tools.jobs:
        - catkin = catkin_tools.jobs.catkin:description
        - cmake = catkin_tools.jobs.cmake:description
    catkin_tools.spaces:
        - build = catkin_tools.spaces.build:description
        - devel = catkin_tools.spaces.devel:description
        - install = catkin_tools.spaces.install:description
        - log = catkin_tools.spaces.log:description
        - source = catkin_tools.spaces.source:description
```