### PR TITLE
add keops

### DIFF
--- a/recipes/gputil/LICENSE.txt
+++ b/recipes/gputil/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 anderskm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/gputil/meta.yaml
+++ b/recipes/gputil/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "GPUtil" %}
+{% set version = "1.4.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 099e52c65e512cdfa8c8763fca67f5a5c2afb63469602d5dcb4d296b3661efb9
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - GPUtil
+
+about:
+  home: https://github.com/anderskm/gputil
+  license: MIT
+  license_family: MIT
+  # license in feedstock; https://github.com/anderskm/gputil/pull/28
+  license_file: LICENSE.txt
+  summary: 'A Python module for getting the GPU status from NVIDA GPUs using nvidia-smi programmically in Python'
+  description: |
+    GPUtil is a Python module for getting the GPU status from NVIDA GPUs
+    using nvidia-smi. GPUtil locates all GPUs on the computer, determines
+    their availablity and returns a ordered list of available GPUs.
+    Availablity is based upon the current memory consumption and load of
+    each GPU. The module is written with GPU selection for Deep Learning in
+    mind, but it is not task/library specific and it can be applied to any
+    task, where it may be useful to identify available GPUs.
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland
+

--- a/recipes/gputil/meta.yaml
+++ b/recipes/gputil/meta.yaml
@@ -44,4 +44,3 @@ about:
 extra:
   recipe-maintainers:
     - dougalsutherland
-

--- a/recipes/pykeops/cache-name.patch
+++ b/recipes/pykeops/cache-name.patch
@@ -1,0 +1,50 @@
+From cd7274c16b6c5f2d75e5e77048df9f95dedee276 Mon Sep 17 00:00:00 2001
+From: "Dougal J. Sutherland" <dougal@gmail.com>
+Date: Thu, 1 Aug 2019 15:17:22 +0100
+Subject: [PATCH] set_path: include python version in cache dir name
+
+---
+ pykeops/common/set_path.py | 18 ++++++++++++------
+ 1 file changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/pykeops/common/set_path.py b/pykeops/common/set_path.py
+index d0a6306..6e5f589 100644
+--- a/pykeops/common/set_path.py
++++ b/pykeops/common/set_path.py
+@@ -1,6 +1,9 @@
+ import os.path
++import sys
++
+ import pykeops
+ 
++
+ ###########################################################
+ #             Set build_folder
+ ###########################################################
+@@ -10,17 +13,20 @@ def set_build_folder():
+     This function set a default build folder that contains the python module compiled
+     by pykeops.
+     """
+-    bf_source = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + '..' + os.path.sep + 'build' + os.path.sep
++    bf_source = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'build')
+     bf_home = os.path.expanduser('~')
++    name = 'pykeops-{}-{}'.format(pykeops.__version__, sys.implementation.cache_tag)
+ 
+     if os.path.isdir(bf_source): # assume we are loading from source
+-        build_folder  = bf_source
+-    elif os.path.isdir(bf_home): # assume we are ussing wheel and home is accessible
+-       build_folder = bf_home + os.path.sep + '.cache' + os.path.sep + 'pykeops-' + pykeops.__version__ + os.path.sep 
++        build_folder = bf_source
++    elif os.path.isdir(bf_home): # assume we are using wheel and home is accessible
++        build_folder = os.path.join(bf_home, '.cache', name)
+     else: 
+         import tempfile
+-        build_folder = tempfile.mkdtemp(prefix='pykeops-' + pykeops.__version__) + os.path.sep
+-        
++        build_folder = tempfile.mkdtemp(prefix=name)
++    
++    if not build_folder.endswith(os.path.sep):
++        build_folder += os.path.sep
+     os.makedirs(build_folder, exist_ok=True)
+ 
+     return build_folder

--- a/recipes/pykeops/licence.txt
+++ b/recipes/pykeops/licence.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2018 B. Charlier, J. Feydy, J. Glaunès
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pykeops/meta.yaml
+++ b/recipes/pykeops/meta.yaml
@@ -10,22 +10,20 @@ source:
   sha256: c5876c6a3e4764154dbbdf7294d3fc8900a5f9ed48891c0e08b28c3818bf229b
 
 build:
-  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [py2k]
+  # Could be noarch: python except for the {{ compiler }} dependencies, I think
 
 requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
   host:
-    - python >=3
+    - python
     - pip
   run:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.10
-    - python >=3
+    - python
     - gputil
     - numpy
 

--- a/recipes/pykeops/meta.yaml
+++ b/recipes/pykeops/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: true  # [py2k]
+  skip: true  # [py2k or win]
   # Could be noarch: python except for the {{ compiler }} dependencies, I think
 
 requirements:

--- a/recipes/pykeops/meta.yaml
+++ b/recipes/pykeops/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "pykeops" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c5876c6a3e4764154dbbdf7294d3fc8900a5f9ed48891c0e08b28c3818bf229b
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python >=3
+    - pip
+  run:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=3.10
+    - python >=3
+    - gputil
+    - numpy
+
+test:
+  # there's also a run_test.py
+  imports:
+    - pykeops
+
+about:
+  home: https://www.kernel-operations.io
+  license: MIT
+  license_family: MIT
+  # license in the feedstock; https://github.com/getkeops/keops/pull/15
+  license_file: licence.txt
+  summary: 'KErnel OPerationS, on CPUs and GPUs, with autodiff and without memory overflows'
+  description: |
+    The KeOps library lets you compute generic reductions of very large arrays
+    whose entries are given by a mathematical formula. It combines a tiled
+    reduction scheme with an automatic differentiation engine, and can be
+    used through Matlab, NumPy or PyTorch backends. It is perfectly suited
+    to the computation of Kernel dot products and the associated gradients,
+    even when the full kernel matrix does not fit into the GPU memory.
+  doc_url: https://www.kernel-operations.io/keops/python/
+  dev_url: https://github.com/getkeops/keops
+
+extra:
+  recipe-maintainers:
+    - dougalsutherland
+

--- a/recipes/pykeops/meta.yaml
+++ b/recipes/pykeops/meta.yaml
@@ -54,4 +54,3 @@ about:
 extra:
   recipe-maintainers:
     - dougalsutherland
-

--- a/recipes/pykeops/meta.yaml
+++ b/recipes/pykeops/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: c5876c6a3e4764154dbbdf7294d3fc8900a5f9ed48891c0e08b28c3818bf229b
+  patches:
+    # https://github.com/getkeops/keops/pull/17
+    - cache-name.patch
 
 build:
   number: 0

--- a/recipes/pykeops/run_test.py
+++ b/recipes/pykeops/run_test.py
@@ -1,0 +1,10 @@
+# from the docs, except use CPU backend
+import numpy as np
+import pykeops.numpy as pknp
+
+x = np.arange(1, 10).reshape(-1, 3).astype('float32')
+y = np.arange(3, 9).reshape(-1, 3).astype('float32')
+
+my_conv = pknp.Genred('SqNorm2(x - y)', ['x = Vi(3)', 'y = Vj(3)'])
+res = my_conv(x, y, backend='CPU')
+assert res.shape == (2, 1)


### PR DESCRIPTION
Add `pykeops` and its dependency `GPUtil`.

Going with the name `pykeops` because that's what gets used in `pip install` as well. keops is kind of like Theano in that it compiles things itself, so there are `run` dependencies on compilers (as well as `cmake`). Ideally, users would have `nvcc` installed and configured appropriately to work with the Anaconda compilers, but that's a matter for #8229 and isn't *strictly* necessary since you can run things on the CPU too.

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
