### PR TITLE
add catkin [ROS]

### DIFF
--- a/recipes/catkin/001_remove_rt.patch
+++ b/recipes/catkin/001_remove_rt.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake/templates/pkgConfig.cmake.in b/cmake/templates/pkgConfig.cmake.in
+index 9c0e46d..65b228c 100644
+--- a/cmake/templates/pkgConfig.cmake.in
++++ b/cmake/templates/pkgConfig.cmake.in
+@@ -119,7 +119,7 @@ endif()
+ set(libraries "@PKG_CONFIG_LIBRARIES@")
+ foreach(library ${libraries})
+   # keep build configuration keywords, target names and absolute libraries as-is
+-  if("${library}" MATCHES "^(debug|optimized|general)$")
++  if("${library}" MATCHES "^(debug|optimized|general|rt|pthread|dl)$")
+     list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
+   elseif(${library} MATCHES "^-l")
+     list(APPEND @PROJECT_NAME@_LIBRARIES ${library})
+diff --git a/cmake/tools/rt.cmake b/cmake/tools/rt.cmake
+index 3e5b708..d6141ee 100644
+--- a/cmake/tools/rt.cmake
++++ b/cmake/tools/rt.cmake
+@@ -38,8 +38,8 @@ if(NOT (APPLE OR WIN32 OR MINGW OR ANDROID))
+     # depend on the linker to find it for us.
+     set(RT_LIBRARY rt CACHE FILEPATH "Hacked find of rt for cmake < 2.8.4")
+   else()
+-    find_library(RT_LIBRARY rt)
+-    assert_file_exists(${RT_LIBRARY} "RT Library")
++    set(RT_LIBRARY rt)
++    # assert_file_exists(${RT_LIBRARY} "RT Library")
+   endif()
+   #message(STATUS "RT_LIBRARY: ${RT_LIBRARY}")
+ endif()

--- a/recipes/catkin/002_no_hardcoded_python.patch
+++ b/recipes/catkin/002_no_hardcoded_python.patch
@@ -1,0 +1,10 @@
+diff --git a/cmake/templates/_setup_util.py.in b/cmake/templates/_setup_util.py.in
+index d03cd81..00e86d3 100755
+--- a/cmake/templates/_setup_util.py.in
++++ b/cmake/templates/_setup_util.py.in
+@@ -1,4 +1,4 @@
+-#!@PYTHON_EXECUTABLE@
++#!/usr/bin/env python
+ # -*- coding: utf-8 -*-
+ 
+ # Software License Agreement (BSD License)

--- a/recipes/catkin/003_ros_setup.patch
+++ b/recipes/catkin/003_ros_setup.patch
@@ -1,0 +1,24 @@
+diff --git a/setup.sh b/setup.sh
+index 6246eef..5784020 100644
+--- a/setup.sh
++++ b/setup.sh
+@@ -11,8 +11,17 @@
+ 
+ # since this file is sourced either use the provided _CATKIN_SETUP_DIR
+ # or fall back to the destination set at configure time
+-: ${_CATKIN_SETUP_DIR:=ABCABCPLACEHOLDERABCABC}
+-_SETUP_UTIL="$_CATKIN_SETUP_DIR/_setup_util.py"
++
++if [ -n "`$SHELL -c 'echo $ZSH_VERSION'`" ]; then
++  CATKIN_SHELL=zsh
++elif [ -n "`$SHELL -c 'echo $BASH_VERSION'`" ]; then
++  CATKIN_SHELL=bash
++else
++  echo "could not detect your shell"
++fi
++
++: ${_CATKIN_SETUP_DIR:=$CONDA_PREFIX/etc/conda/activate.d/}
++_SETUP_UTIL="$_CATKIN_SETUP_DIR/ros_setup_util.py"
+ unset _CATKIN_SETUP_DIR
+ 
+ if [ ! -f "$_SETUP_UTIL" ]; then

--- a/recipes/catkin/004_setup_util.patch
+++ b/recipes/catkin/004_setup_util.patch
@@ -1,0 +1,24 @@
+diff --git a/_setup_util.py b/_setup_util.py
+index 3c23425..df04ed0 100755
+--- a/_setup_util.py
++++ b/_setup_util.py
+@@ -269,14 +269,14 @@ if __name__ == '__main__':
+             # don't consider any other prefix path than this one
+             CMAKE_PREFIX_PATH = []
+         # prepend current workspace if not already part of CPP
+-        base_path = os.path.dirname(__file__)
++        # base_path = os.path.dirname(__file__)
+         # CMAKE_PREFIX_PATH uses forward slash on all platforms, but __file__ is platform dependent
+         # base_path on Windows contains backward slashes, need to be converted to forward slashes before comparison
+-        if os.path.sep != '/':
+-            base_path = base_path.replace(os.path.sep, '/')
++        # if os.path.sep != '/':
++        #     base_path = base_path.replace(os.path.sep, '/')
+ 
+-        if base_path not in CMAKE_PREFIX_PATH:
+-            CMAKE_PREFIX_PATH.insert(0, base_path)
++        # if base_path not in CMAKE_PREFIX_PATH:
++        #    CMAKE_PREFIX_PATH.insert(0, base_path)
+         CMAKE_PREFIX_PATH = os.pathsep.join(CMAKE_PREFIX_PATH)
+ 
+         environ = dict(os.environ)

--- a/recipes/catkin/build.sh
+++ b/recipes/catkin/build.sh
@@ -1,0 +1,45 @@
+# if [ -f "$PREFIX/setup.sh" ]; then source $PREFIX/setup.sh; fi
+
+mkdir build
+cd build
+
+# turn this into a catkin workspace by adding the catkin token if it doesn't
+# exist already
+if [ ! -f $PREFIX/.catkin ]; then
+    touch $PREFIX/.catkin
+fi
+
+# NOTE: there might be undefined references occurring
+# in the Boost.system library, depending on the C++ versions
+# used to compile Boost and/or the piranha examples. We
+# can avoid them by forcing the use of the header-only
+# version of the library.
+export CXXFLAGS="$CXXFLAGS -DBOOST_ERROR_CODE_HEADER_ONLY"
+
+cmake .. -DCMAKE_INSTALL_PREFIX=$PREFIX \
+         -DCMAKE_PREFIX_PATH=$PREFIX \
+         -DCMAKE_INSTALL_LIBDIR=lib \
+         -DCMAKE_BUILD_TYPE=Release \
+         -DSETUPTOOLS_DEB_LAYOUT=OFF
+         # remove the following line for catkin so `setup.sh` scripts are installed!
+         # -DCATKIN_BUILD_BINARY_PACKAGE="1" \
+
+make VERBOSE=1 -j${CPU_COUNT}
+make install
+mkdir -p $PREFIX/etc/conda/activate.d/
+
+cd ..
+# remove prefix from setup sh so that patch works
+sed -i".bak" -e "s#_CATKIN_SETUP_DIR:=$PREFIX#_CATKIN_SETUP_DIR:=ABCABCPLACEHOLDERABCABC#g" $PREFIX/setup.sh
+sed -i'.bak' -e 's/setup.sh/etc\/conda\/activate.d\/setup.sh/g' $PREFIX/.rosinstall
+
+patch $PREFIX/setup.sh < ${RECIPE_DIR}/003_ros_setup.patch
+patch $PREFIX/_setup_util.py < ${RECIPE_DIR}/004_setup_util.patch
+
+mv $PREFIX/setup.sh $PREFIX/etc/conda/activate.d/ros_setup.sh
+mv $PREFIX/_setup_util.py $PREFIX/etc/conda/activate.d/ros_setup_util.py
+
+# handled by conda activate
+rm $PREFIX/setup.*
+rm $PREFIX/local_setup.*
+rm $PREFIX/env.sh

--- a/recipes/catkin/meta.yaml
+++ b/recipes/catkin/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - empy
     - cmake
   run:
-    - ros-conda-mutex * melodic
     - ros-conda-base
     - gtest
     - nose

--- a/recipes/catkin/meta.yaml
+++ b/recipes/catkin/meta.yaml
@@ -26,9 +26,9 @@ requirements:
     - python
     - catkin_pkg
     - empy
-    - cmake
   run:
     - ros-conda-base
+    - cmake
     - gtest
     - nose
     - empy

--- a/recipes/catkin/meta.yaml
+++ b/recipes/catkin/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: ros-catkin
+  version: 0.7.17
+
+source:
+  - url: https://github.com/ros-gbp/catkin-release/archive/release/melodic/catkin/0.7.17-0.tar.gz
+    sha256: 316178707bc3f0edcb86a77ec2ec174b98b4d2ccf41306162cefe6588b3a9d41
+    patches:
+      - 001_remove_rt.patch
+      - 002_no_hardcoded_python.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - cmake
+    - make
+    - sed
+  host:
+    - ros-conda-mutex * melodic
+    - ros-conda-base
+    - python
+    - catkin_pkg
+    - empy
+    - cmake
+  run:
+    - ros-conda-mutex * melodic
+    - ros-conda-base
+    - gtest
+    - nose
+    - empy
+    - gmock
+
+test:
+  requires:
+    - rospkg
+  commands:
+    - catkin_find
+    - catkin_find --help
+    - catkin_make --help
+    - export ROS_ROOT=$PREFIX && python -c "import rospkg;s = rospkg.RosPack();ret = s.get_path('catkin');print(ret)"
+
+about:
+  home: http://www.ros.org/wiki/catkin
+  summary: Low-level build system macros and infrastructure for ROS.
+  description: |
+    Low-level build system macros and infrastructure for ROS.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve
+    - SylvainCorlay

--- a/recipes/ros-conda-base/LICENSE.txt
+++ b/recipes/ros-conda-base/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) Wolf Vollprecht, QuantStack
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/ros-conda-base/meta.yaml
+++ b/recipes/ros-conda-base/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: ros-conda-base
+  version: 0.0.1
+
+build:
+  number: 0
+  noarch: generic
+
+requirements:
+  run:
+    - ros-conda-mutex * melodic
+  run_constrained:
+    - boost 1.68.*
+    - cmake >=3.7.2
+    - gazebo >=9.0
+    - ogre3d >=3.2
+    - opencv >=3.2
+    - pcl >=1.8.1
+    - pyqt >=5.7
+    - qt >=5.7
+
+test:
+  commands:
+    - exit 0
+
+about:
+  home: https://www.ros.org/
+  summary: Run constraints for the ROS infrastructure on conda.
+  description: |
+    Run constraints for the ROS infrastructure on conda.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve
+    - SylvainCorlay

--- a/recipes/ros-conda-mutex/LICENSE.txt
+++ b/recipes/ros-conda-mutex/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) Wolf Vollprecht, QuantStack
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/ros-conda-mutex/meta.yaml
+++ b/recipes/ros-conda-mutex/meta.yaml
@@ -1,0 +1,32 @@
+{% set ros_version = 'melodic' %}
+
+package:
+  name: ros-conda-mutex
+  version: 1.0
+
+build:
+  number: 0
+  # need to put this in conda_build_config.yml when more versions of ROS land.
+  string: {{ ros_version }}
+  noarch: generic
+  run_exports:
+    - ros-conda-mutex * {{ ros_version }}
+
+test:
+  commands:
+    - exit 0
+
+about:
+  home: https://www.ros.org/
+  description: |
+    Mutex package for the ROS infrastructure on conda.
+  summary: Mutex package for the ROS infrastructure on conda.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - lesteve
+    - SylvainCorlay

--- a/recipes/ros-conda-mutex/meta.yaml
+++ b/recipes/ros-conda-mutex/meta.yaml
@@ -14,8 +14,8 @@ build:
 
 requirements:
   build:
-    # a fake dep to make tests go through
-    - make  # [unix]
+    # a couple of fake dep to make tests go through
+    - make
 
 test:
   commands:

--- a/recipes/ros-conda-mutex/meta.yaml
+++ b/recipes/ros-conda-mutex/meta.yaml
@@ -12,6 +12,11 @@ build:
   run_exports:
     - ros-conda-mutex * {{ ros_version }}
 
+requirements:
+  build:
+    # a fake dep to make tests go through
+    - make  # [unix]
+
 test:
   commands:
     - exit 0


### PR DESCRIPTION
This is the first of the "auto"-generated recipes, and at the same time the most important one. 
ROS also knows environments, so called "catkin workspaces". 
The catkin installer adds a "setup.sh" file to the `conda/activate.d` which is mostly identical with the default setup.sh that ROS uses. It sets a bunch of ROS specific environment variables, and, most importantly a `CMAKE_PREFIX_PATH` that is the root ROS workspace. The root ROS workspace for the conda packages is identical with the conda environment which hopefully means 100% interoperability :)

Also, since we add the setup.sh to the conda activation script, ROS environment activation is magical and automatic. 

`conda create -n my_ros_env catkin` will create a new ros environment with the name and
`conda activate my_ros_env` will then "source" the setup.sh of that ROS environment.

There are some open questions though: 

- This package is from the ROS melodic distribution. Should I add a `melodic` tag as build string?
- should we namespace ROS packages with `ros-...`? There is already one name conflict in conda forge (ROS knows a package named `genpy` to generate Python files from message definitions, but another `genpy` package exists in conda-forge).
- I can auto-generate the recipes, but I don't know what to do for run_exports or tests ...
