### PR TITLE
[R4R] Add github-ssh-auth to conda-forge

### DIFF
--- a/recipes/github-auth-ssh/meta.yaml
+++ b/recipes/github-auth-ssh/meta.yaml
@@ -15,6 +15,10 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+      - github-ssh = github_ssh_auth.cli:cli
+      - github-ssh-update = github_ssh_auth.cli:update
+      - github-ssh-auth = github_ssh_auth.cli:auth
 
 requirements:
   host:
@@ -31,6 +35,8 @@ test:
     - github_ssh_auth
   commands:
     - github-ssh --help
+    - github-ssh-update --help
+    - github-ssh-auth --help
 
 about:
   home: https://github.com/oorabona/github-ssh-auth

--- a/recipes/github-auth-ssh/meta.yaml
+++ b/recipes/github-auth-ssh/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "github-ssh-auth" %}
+{% set version = "0.9.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 57269a316e168822f9dd0856d85a3242192eefb06a3087a00b1a79dd7e019516
+  - url: https://raw.githubusercontent.com/oorabona/github-ssh-auth/master/LICENSE
+    sha256: 3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - click >=7.0
+    - pygithub >=1.2.0
+    - configparser
+
+test:
+  imports:
+    - github_ssh_auth
+  commands:
+    - github-ssh --help
+
+about:
+  home: https://github.com/oorabona/github-ssh-auth
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: Use your GitHub organization user's keys as a SSH authentication method.
+
+  description: |
+      This project aims to provide a way for SSHd to authenticate users on shell boxes 
+      using GitHub API v3 SSH keys of users in your organization.
+  dev_url: https://github.com/oorabona/github-ssh-auth
+
+extra:
+  recipe-maintainers:
+    - sodre
+

--- a/recipes/github-ssh-auth/meta.yaml
+++ b/recipes/github-ssh-auth/meta.yaml
@@ -53,4 +53,3 @@ about:
 extra:
   recipe-maintainers:
     - sodre
-


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there