### PR TITLE
[R4R] Add github-webhook to conda-forge

### DIFF
--- a/recipes/github-webhook/meta.yaml
+++ b/recipes/github-webhook/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "github-webhook" %}
+{% set version = "1.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 5b13f43f1b764f688426f166c69d0dcdc4a1d88fa87a9017d127ed5752714d12
+  - url: https://raw.githubusercontent.com/bloomberg/python-github-webhook/master/LICENSE
+    sha256: c7da80d92a14d353b0f4ebbe917e155b4051f280ae665035ab5d4a4b9613a506
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - flask
+    - six
+
+test:
+  imports:
+    - github_webhook
+
+about:
+  home: https://bloomberg.github.io/python-github-webhook/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Very simple, but powerful, microframework for writing Github webhooks in Python.'
+
+  description: |
+    python-github-webhook is a very simple, but powerful, 
+    microframework for writing GitHub webhooks in Python. It can be used
+    to write webhooks for individual repositories or whole organisations,
+    and can be used for GitHub.com or GitHub Enterprise installations.
+  doc_url: https://bloomberg.github.io/python-github-webhook
+  dev_url: https://github.com/bloomberg/python-github-webhook
+
+extra:
+  recipe-maintainers:
+    - sodre
+

--- a/recipes/github-webhook/meta.yaml
+++ b/recipes/github-webhook/meta.yaml
@@ -47,4 +47,3 @@ about:
 extra:
   recipe-maintainers:
     - sodre
-


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there