### PR TITLE
Aarch64 cdts

### DIFF
--- a/recipes/expat-cos7-aarch64/meta.yaml
+++ b/recipes/expat-cos7-aarch64/meta.yaml
@@ -30,6 +30,9 @@ build:
 
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/bin/xmlwf"
 
@@ -51,7 +54,10 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
-      commands:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
+      cemmands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libexpat.so"
 
 

--- a/recipes/expat-cos7-aarch64/meta.yaml
+++ b/recipes/expat-cos7-aarch64/meta.yaml
@@ -1,0 +1,41 @@
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: expat-{{ cos }}-{{ arch }}
+  version: 2.0.1
+
+source:
+  - url: {{ url_base }}expat-2.1.0-10.el7_3.aarch64.rpm
+    sha256: f5313d176b7ea683b1abdf3152d6bee22903628b99e9d07372377985a1d25edb
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+  script:
+    - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+    - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+    - cp -Rf {{ SRC_DIR }}/binary/* .
+
+test:
+  commands:
+    - test -f "${PREFIX}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/bin/xmlwf"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MIT
+  license_family: MIT
+  license_file: binary/usr/share/doc/expat-2.1.0/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/expat-cos7-aarch64/meta.yaml
+++ b/recipes/expat-cos7-aarch64/meta.yaml
@@ -1,39 +1,65 @@
+# A few variables that make this a tiny bit more portable
+{% set name = "expat" %}
+{% set version = '2.1.0' %}
+{% set centos_build = '10' %}
+{% set el = 'el7_3' %}
 {% set arch = "aarch64" %}
 {% set cos = "cos7" %}
 {% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
 
 package:
-  name: expat-{{ cos }}-{{ arch }}
-  version: 2.0.1
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
 
 source:
-  - url: {{ url_base }}expat-2.1.0-10.el7_3.aarch64.rpm
+  - url: {{ url_base }}{{ name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
     sha256: f5313d176b7ea683b1abdf3152d6bee22903628b99e9d07372377985a1d25edb
     # conda seems to remove folders if they are the only ones there
     # we need to keep the structure of the RPM
     # https://github.com/conda/conda-build/issues/3595
     folder: binary/usr
+  - url: {{ url_base }}{{ name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 3feb40b3e54a9313750494730125931de854569e42e7a9bd72d77d52b1569469
+    folder: devel/usr
 
 build:
   number: 0
   noarch: generic
   missing_dso_whitelist:
     - '*'
-  script:
-    - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
-    - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
-    - cp -Rf {{ SRC_DIR }}/binary/* .
+
 
 test:
   commands:
-    - test -f "${PREFIX}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/bin/xmlwf"
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/bin/xmlwf"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libexpat.so"
 
 
 about:
   home: http://www.libexpat.org/
   license: MIT
   license_family: MIT
-  license_file: binary/usr/share/doc/expat-2.1.0/COPYING
+  license_file: binary/usr/share/doc/{{ name }}-{{ version }}/COPYING
   summary: "(CDT) An XML parser library"
 
 extra:

--- a/recipes/libdrm-cos7-aarch64/meta.yaml
+++ b/recipes/libdrm-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libdrm-cos7-aarch64/meta.yaml
+++ b/recipes/libdrm-cos7-aarch64/meta.yaml
@@ -1,0 +1,72 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libdrm" %}
+{% set name = centos_name |lower %}
+{% set version = '2.4.91' %}
+{% set centos_build = '3' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '2' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 89486bec2726191923af975933d147cc4aaac98e32d71f50f29d613cfd4c4d3c
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 7400b959f014f7a1021b273f0a9868dacfcce343d9ec0672a1863563b4048402
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+about:
+  home: http://dri.sourceforge.net
+  license: MIT
+  license_family: MIT
+  summary: "(CDT) Direct Rendering Manager runtime library"
+  description: Direct Rendering Manager runtime library
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libdrm-cos7-aarch64/meta.yaml
+++ b/recipes/libdrm-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,8 +46,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -61,7 +57,7 @@ outputs:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 
 about:
-  home: http://dri.sourceforge.net
+  home: https://dri.sourceforge.net
   license: MIT
   license_family: MIT
   summary: "(CDT) Direct Rendering Manager runtime library"

--- a/recipes/libselinux-cos7-aarch64/LICENSE
+++ b/recipes/libselinux-cos7-aarch64/LICENSE
@@ -1,0 +1,21 @@
+This library (libselinux) is public domain software, i.e. not copyrighted.
+
+Warranty Exclusion
+------------------
+You agree that this software is a
+non-commercially developed program that may contain "bugs" (as that
+term is used in the industry) and that it may not function as intended.
+The software is licensed "as is". NSA makes no, and hereby expressly
+disclaims all, warranties, express, implied, statutory, or otherwise
+with respect to the software, including noninfringement and the implied
+warranties of merchantability and fitness for a particular purpose.
+
+Limitation of Liability
+-----------------------
+In no event will NSA be liable for any damages, including loss of data,
+lost profits, cost of cover, or other special, incidental,
+consequential, direct or indirect damages arising from the software or
+the use thereof, however caused and on any theory of liability. This
+limitation will apply even if NSA has been advised of the possibility
+of such damage. You acknowledge that this is a reasonable allocation of
+risk.

--- a/recipes/libselinux-cos7-aarch64/meta.yaml
+++ b/recipes/libselinux-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libselinux-cos7-aarch64/meta.yaml
+++ b/recipes/libselinux-cos7-aarch64/meta.yaml
@@ -1,0 +1,73 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libselinux" %}
+{% set name = centos_name |lower %}
+{% set version = '2.5' %}
+{% set centos_build = '14.1' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '1' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: a4c3bbb0a88b8a779b69f552d798981dab95142ee615da2f67558ca6a4c9fae2
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 5c948506977fe1fb879ddd86218f85f3a63262c5b812bc461ca87f596dcce520
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  summary: (CDT) SELinux library and simple utilities
+  home: https://github.com/SELinuxProject/selinux/wiki
+  license: Public-Domain
+  license_family: Public-Domain
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libselinux-cos7-aarch64/meta.yaml
+++ b/recipes/libselinux-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,8 +46,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1

--- a/recipes/libxau-cos7-aarch64/meta.yaml
+++ b/recipes/libxau-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libxau-cos7-aarch64/meta.yaml
+++ b/recipes/libxau-cos7-aarch64/meta.yaml
@@ -62,11 +62,11 @@ outputs:
 
 
 about:
-  home: http://www.libexpat.org/
-  license: MOZILLA
-  license_family: MOZILLA
+  summary: (CDT) Sample Authorization Protocol for X
+  license: X11
+  license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
-  summary: "(CDT) An XML parser library"
+
 
 extra:
   recipe-maintainers:

--- a/recipes/libxau-cos7-aarch64/meta.yaml
+++ b/recipes/libxau-cos7-aarch64/meta.yaml
@@ -1,0 +1,73 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libXau" %}
+{% set name = centos_name |lower %}
+{% set version = '1.0.8' %}
+{% set centos_build = '2.1' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '6' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: a8cd3649457f0166dabae26350f387b43bc6f9ac52f49766d8dee1a9cc60742a
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 0003ff9339ca18cbab3dd6c0899d7d8ec8ea703351da9c9ccd16dfdd211fc57b
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MOZILLA
+  license_family: MOZILLA
+  license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libxau-cos7-aarch64/meta.yaml
+++ b/recipes/libxau-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,8 +46,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -63,6 +59,7 @@ outputs:
 
 about:
   summary: (CDT) Sample Authorization Protocol for X
+  home: https://x.org/
   license: X11
   license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING

--- a/recipes/libxdamage-cos7-aarch64/meta.yaml
+++ b/recipes/libxdamage-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libxdamage-cos7-aarch64/meta.yaml
+++ b/recipes/libxdamage-cos7-aarch64/meta.yaml
@@ -1,0 +1,73 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libXdamage" %}
+{% set name = centos_name |lower %}
+{% set version = '1.1.4' %}
+{% set centos_build = '4.1' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '1' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 92f25a6874106bb3637e8d4d763cce4df09f1eecd959101774337c3170c7108c
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: c70eeac31841ba08349db03ee50c92a61ddc48f7f927a603d11e118fc16f7327
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MOZILLA
+  license_family: MOZILLA
+  license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libxdamage-cos7-aarch64/meta.yaml
+++ b/recipes/libxdamage-cos7-aarch64/meta.yaml
@@ -62,11 +62,12 @@ outputs:
 
 
 about:
-  home: http://www.libexpat.org/
-  license: MOZILLA
-  license_family: MOZILLA
+  home: http://www.x.org
+  license: MIT
+  license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
-  summary: "(CDT) An XML parser library"
+  summary: (CDT) X Damage extension library
+
 
 extra:
   recipe-maintainers:

--- a/recipes/libxdamage-cos7-aarch64/meta.yaml
+++ b/recipes/libxdamage-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,8 +46,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -62,7 +58,7 @@ outputs:
 
 
 about:
-  home: http://www.x.org
+  home: https://www.x.org
   license: MIT
   license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING

--- a/recipes/libxext-cos7-aarch64/meta.yaml
+++ b/recipes/libxext-cos7-aarch64/meta.yaml
@@ -1,0 +1,72 @@
+# A few variables that make this a tiny bit more portable
+{% set name = "libxext" %}
+{% set centos_name = "libXext" %}
+{% set version = '1.3.3' %}
+{% set centos_build = '3' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 00ed1512384e41e06a822984152a5a42a46dc963f5ca16f0e7007274cc1d54f3
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 16da1ccb6de8f6618ff8aed0c6dea27ecaa4c698fec36ae717c5f5ce35f086cb
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.6"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MOZILLA
+  license_family: MOZILLA
+  license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libxext-cos7-aarch64/meta.yaml
+++ b/recipes/libxext-cos7-aarch64/meta.yaml
@@ -59,13 +59,12 @@ outputs:
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 
-
 about:
-  home: http://www.libexpat.org/
-  license: MOZILLA
-  license_family: MOZILLA
+  home: http://www.x.org
+  license: MIT
+  license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
-  summary: "(CDT) An XML parser library"
+  summary: (CDT) X.Org X11 libXext runtime library
 
 extra:
   recipe-maintainers:

--- a/recipes/libxext-cos7-aarch64/meta.yaml
+++ b/recipes/libxext-cos7-aarch64/meta.yaml
@@ -37,8 +37,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -47,8 +45,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -60,7 +56,7 @@ outputs:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 
 about:
-  home: http://www.x.org
+  home: https://x.org/
   license: MIT
   license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING

--- a/recipes/libxext-cos7-aarch64/meta.yaml
+++ b/recipes/libxext-cos7-aarch64/meta.yaml
@@ -31,6 +31,9 @@ build:
 
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.6"
 
@@ -52,6 +55,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libxfixes-cos7-aarch64/meta.yaml
+++ b/recipes/libxfixes-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libxfixes-cos7-aarch64/meta.yaml
+++ b/recipes/libxfixes-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,22 +46,19 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
         - cp -Rf {{ SRC_DIR }}/devel/* .
     requirements:
-      run:
-        - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 
 
 about:
-  home: http://www.x.org
+  home: https://www.x.org
   license: MIT
   license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING

--- a/recipes/libxfixes-cos7-aarch64/meta.yaml
+++ b/recipes/libxfixes-cos7-aarch64/meta.yaml
@@ -1,0 +1,73 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libXfixes" %}
+{% set name = centos_name |lower %}
+{% set version = '5.0.3' %}
+{% set centos_build = '1' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '3' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: e20b03ef865873f1cc6903e1e78c898d593e114df4e3436caaf20b49f2c994c8
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: b8eb45abf6e6f4cb9b149821aedb6fedbe0b307d609c46773063701baa62420a
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MOZILLA
+  license_family: MOZILLA
+  license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libxfixes-cos7-aarch64/meta.yaml
+++ b/recipes/libxfixes-cos7-aarch64/meta.yaml
@@ -55,18 +55,19 @@ outputs:
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
         - cp -Rf {{ SRC_DIR }}/devel/* .
     requirements:
-      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+      run:
+        - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 
 
 about:
-  home: http://www.libexpat.org/
-  license: MOZILLA
-  license_family: MOZILLA
+  home: http://www.x.org
+  license: MIT
+  license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
-  summary: "(CDT) An XML parser library"
+  summary: (CDT) X Fixes library
 
 extra:
   recipe-maintainers:

--- a/recipes/libxrender-cos7-aarch64/meta.yaml
+++ b/recipes/libxrender-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libxrender-cos7-aarch64/meta.yaml
+++ b/recipes/libxrender-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,8 +46,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -62,11 +58,11 @@ outputs:
 
 
 about:
-  home: http://www.libexpat.org/
-  license: MOZILLA
-  license_family: MOZILLA
+  home: https://www.x.org/
+  license: MIT
+  license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
-  summary: "(CDT) An XML parser library"
+  summary: (CDT) X.Org X11 libXrender runtime library
 
 extra:
   recipe-maintainers:

--- a/recipes/libxrender-cos7-aarch64/meta.yaml
+++ b/recipes/libxrender-cos7-aarch64/meta.yaml
@@ -1,0 +1,73 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libXrender" %}
+{% set name = centos_name |lower %}
+{% set version = '0.9.10' %}
+{% set centos_build = '1' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '1' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 9fe491041a1bbcd7bae323a953b6526164eedd37fa707f1d15e95151f067c7eb
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: f6d9da30d0aee0a97cf77aa48186612a8d0f7f10e4eefe0d299a0e3bc460c72f
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MOZILLA
+  license_family: MOZILLA
+  license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libxxf86vm-cos7-aarch64/meta.yaml
+++ b/recipes/libxxf86vm-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
 
@@ -53,6 +56,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
 

--- a/recipes/libxxf86vm-cos7-aarch64/meta.yaml
+++ b/recipes/libxxf86vm-cos7-aarch64/meta.yaml
@@ -38,8 +38,6 @@ test:
 outputs:
   - name: {{ name }}-{{ cos }}-{{ arch }}
     build:
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -48,8 +46,6 @@ outputs:
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
       noarch: generic
-      missing_dso_whitelist:
-        - '*'
       script:
         - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
@@ -62,11 +58,12 @@ outputs:
 
 
 about:
-  home: http://www.libexpat.org/
-  license: MOZILLA
-  license_family: MOZILLA
+  home: https://x.org
+  license: MIT
+  license_family: MIT
   license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
-  summary: "(CDT) An XML parser library"
+  summary: (CDT) X.org libXxf86vm library.
+
 
 extra:
   recipe-maintainers:

--- a/recipes/libxxf86vm-cos7-aarch64/meta.yaml
+++ b/recipes/libxxf86vm-cos7-aarch64/meta.yaml
@@ -1,0 +1,73 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "libXxf86vm" %}
+{% set name = centos_name |lower %}
+{% set version = '1.1.4' %}
+{% set centos_build = '1' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '1' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 66fafbf534a52b2c9b4446136505e06fc1bc38e786f7834255bdb03a5bb6a990
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 44be5b49b06848119cc67c198fed8d61f8e6d7ac833bf51225a157b2a6108e6e
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      missing_dso_whitelist:
+        - '*'
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/{{ centos_name }}.so"
+
+
+about:
+  home: http://www.libexpat.org/
+  license: MOZILLA
+  license_family: MOZILLA
+  license_file: binary/usr/share/doc/{{ centos_name }}-{{ version }}/COPYING
+  summary: "(CDT) An XML parser library"
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/mesa-dri-drivers-cos7-aarch64/LICENSE
+++ b/recipes/mesa-dri-drivers-cos7-aarch64/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/mesa-dri-drivers-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-dri-drivers-cos7-aarch64/meta.yaml
@@ -25,6 +25,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/dri/msm_dri.so"
 

--- a/recipes/mesa-dri-drivers-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-dri-drivers-cos7-aarch64/meta.yaml
@@ -1,0 +1,51 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "mesa-dri-drivers" %}
+{% set name = centos_name |lower %}
+{% set version = '18.0.5' %}
+{% set centos_build = '3' %}
+# No good way to get this other than to fail once, I think???
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: c98fd4a044666348cd3ccced16fa597e888d91f532deedd5028b5cf59f9a6587
+    folder: binary
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/dri/msm_dri.so"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+about:
+  description: 'Mesa-based DRI drivers.'
+  home: http://www.mesa3d.org
+  # The license is kinda complicated for this. Seems like it is a mix of code
+  # from different people
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: (CDT) Mesa-based DRI drivers
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/mesa-libgl-cos7-aarch64/LICENSE
+++ b/recipes/mesa-libgl-cos7-aarch64/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/mesa-libgl-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-libgl-cos7-aarch64/meta.yaml
@@ -32,6 +32,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libGLX_mesa.so.{{ so_version }}"
 
@@ -58,6 +61,9 @@ outputs:
     requirements:
       - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
+      # dummy requirement to workaround a bug with the CDT tests
+      requires:
+        - zlib
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libglapi.so"
 

--- a/recipes/mesa-libgl-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-libgl-cos7-aarch64/meta.yaml
@@ -1,0 +1,86 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "mesa-libGL" %}
+{% set name = centos_name |lower %}
+{% set version = '18.0.5' %}
+{% set centos_build = '3' %}
+# No good way to get this other than to fail once, I think???
+{% set so_version = '0' %}
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: db4020062635fddff4e3f8ed19bde4d615d07172a36b8759110aca621c4cb6cd
+    # conda seems to remove folders if they are the only ones there
+    # we need to keep the structure of the RPM
+    # https://github.com/conda/conda-build/issues/3595
+    folder: binary/usr
+  - url: {{ url_base }}{{ centos_name }}-devel-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 62f2fbcf330222a5246d81f7d18cd4f722fce845daa9b24932c0a7bfc6338b59
+    folder: devel/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libGLX_mesa.so.{{ so_version }}"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+        # Not sure where libGL system is supposed to point. Do we need it????
+        - rm usr/lib64/libGLX_system.so.0
+    requirements:
+      build:
+        - mesa-libglapi-{{ cos }}-{{ arch }}
+        - libdrm-{{ cos }}-{{ arch }}
+      run:
+        - mesa-libglapi-{{ cos }}-{{ arch }}
+        - libdrm-{{ cos }}-{{ arch }}
+
+  - name: {{ name }}-devel-{{ cos }}-{{ arch }}
+    build:
+      noarch: generic
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/devel/* .
+    requirements:
+      build:
+        - mesa-libglapi-{{ cos }}-{{ arch }}
+        - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+      run:
+        - mesa-libglapi-{{ cos }}-{{ arch }}
+        - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+    test:
+      commands:
+        - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libglapi.so"
+
+
+about:
+  description: Mesa libGL runtime library.
+  home: http://www.mesa3d.org
+  # The license is kinda complicated for this. Seems like it is a mix of code
+  # from different people
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: (CDT) Mesa libGL runtime libraries and DRI drivers<Paste>
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/mesa-libgl-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-libgl-cos7-aarch64/meta.yaml
@@ -45,12 +45,8 @@ outputs:
         # Not sure where libGL system is supposed to point. Do we need it????
         - rm usr/lib64/libGLX_system.so.0
     requirements:
-      build:
-        - mesa-libglapi-{{ cos }}-{{ arch }}
-        - libdrm-{{ cos }}-{{ arch }}
-      run:
-        - mesa-libglapi-{{ cos }}-{{ arch }}
-        - libdrm-{{ cos }}-{{ arch }}
+      - mesa-libglapi-{{ cos }}-{{ arch }}
+      - libdrm-{{ cos }}-{{ arch }}
 
   - name: {{ name }}-devel-{{ cos }}-{{ arch }}
     build:
@@ -60,12 +56,7 @@ outputs:
         - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
         - cp -Rf {{ SRC_DIR }}/devel/* .
     requirements:
-      build:
-        - mesa-libglapi-{{ cos }}-{{ arch }}
-        - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
-      run:
-        - mesa-libglapi-{{ cos }}-{{ arch }}
-        - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
+      - {{ pin_subpackage(name + '-' + cos + '-' + arch, exact=True) }}
     test:
       commands:
         - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libglapi.so"

--- a/recipes/mesa-libglapi-cos7-aarch64/LICENSE
+++ b/recipes/mesa-libglapi-cos7-aarch64/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 1999-2007  Brian Paul   All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/mesa-libglapi-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-libglapi-cos7-aarch64/meta.yaml
@@ -1,0 +1,49 @@
+# A few variables that make this a tiny bit more portable
+{% set centos_name = "mesa-libglapi" %}
+{% set name = centos_name |lower %}
+{% set version = '18.0.5' %}
+{% set centos_build = '3' %}
+# No good way to get this other than to fail once, I think???
+{% set el = 'el7' %}
+{% set arch = "aarch64" %}
+{% set cos = "cos7" %}
+{% set url_base = "http://mirror.centos.org/altarch/7/os/aarch64/Packages/" %}
+
+package:
+  name: {{ name }}-{{ cos }}-{{ arch }}
+  version: {{ version }}
+
+source:
+  - url: {{ url_base }}{{ centos_name }}-{{ version }}-{{ centos_build }}.{{ el }}.{{ arch }}.rpm
+    sha256: 8765d2f47966a1e9b044dc6febf0c0f556da07ecac10cc21088a40c7c08ec1ef
+    folder: binary/usr
+
+build:
+  number: 0
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+test:
+  commands:
+    - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libglapi.so.0"
+
+outputs:
+  - name: {{ name }}-{{ cos }}-{{ arch }}
+    build:
+      script:
+        - mkdir -p {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot
+        - pushd {{ PREFIX }}/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot > /dev/null 2>&1
+        - cp -Rf {{ SRC_DIR }}/binary/* .
+
+about:
+  description: Mesa shared glapi
+  home: http://www.mesa3d.org
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: (CDT) Mesa shared glapi
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/mesa-libglapi-cos7-aarch64/meta.yaml
+++ b/recipes/mesa-libglapi-cos7-aarch64/meta.yaml
@@ -25,6 +25,9 @@ build:
     - '*'
 
 test:
+  # dummy requirement to workaround a bug with the CDT tests
+  requires:
+    - zlib
   commands:
     - test -f "$PREFIX/{{ arch }}-conda_{{ cos }}-linux-gnu/sysroot/usr/lib64/libglapi.so.0"
 


### PR DESCRIPTION
Quite a few aarch cdts
The requirements shorthand seems to compile to both a `host` and a `run` requirement.

cc: @conda-forge/arm-arch @jjhelmus @jakirkham 
xref: https://github.com/conda-forge/gstreamer-feedstock/pull/27

Sorry for the heavy handed jinja, it really helped create the xorg cdts.



Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
