### PR TITLE
Package libnova for conda-forge

### DIFF
--- a/recipes/libnova/build.sh
+++ b/recipes/libnova/build.sh
@@ -1,0 +1,4 @@
+autoreconf --force --install
+./configure --prefix=$PREFIX
+make
+make install

--- a/recipes/libnova/meta.yaml
+++ b/recipes/libnova/meta.yaml
@@ -28,6 +28,11 @@ requirements:
     - libtool
     - {{ compiler('c') }}
 
+test:
+  commands:
+    - test -f $PREFIX/lib/libnova$SHLIB_EXT  # [unix]
+    - test -d $PREFIX/include/libnova/  # [unix]
+
 about:
   home: http://libnova.sourceforge.net/
   license: LGPL-2.1
@@ -42,11 +47,6 @@ about:
     calculating positions of astronomical objects or celestial mechanics.
     libnova is the calculation engine used by the Nova project and most
     importantly, is free software.
-
-test:
-  commands:
-    - test -f $PREFIX/lib/libnova$SHLIB_EXT  # [unix]
-    - test -d $PREFIX/include/libnova/  # [unix]
 
 extra:
   recipe-maintainers:

--- a/recipes/libnova/meta.yaml
+++ b/recipes/libnova/meta.yaml
@@ -1,8 +1,3 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
-# Using the name variable with the URL in line 14 is convenient
-# when copying and pasting from another recipe, but not really needed.
 {% set name = "libnova" %}
 {% set version = "0.16" %}
 

--- a/recipes/libnova/meta.yaml
+++ b/recipes/libnova/meta.yaml
@@ -43,6 +43,11 @@ about:
     libnova is the calculation engine used by the Nova project and most
     importantly, is free software.
 
+test:
+  commands:
+    - test -f $PREFIX/lib/libnova$SHLIB_EXT  # [unix]
+    - test -d $PREFIX/include/libnova/  # [unix]
+
 extra:
   recipe-maintainers:
     - joseph-long

--- a/recipes/libnova/meta.yaml
+++ b/recipes/libnova/meta.yaml
@@ -1,0 +1,49 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+# Using the name variable with the URL in line 14 is convenient
+# when copying and pasting from another recipe, but not really needed.
+{% set name = "libnova" %}
+{% set version = "0.16" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # for reasons unknown, the maintainers never published the 0.16 release on their SourceForge
+  # however, distributions picked it up anyway. see https://packages.debian.org/buster/libnova-dev
+  url: http://deb.debian.org/debian/pool/main/libn/libnova/libnova_{{version}}.orig.tar.xz
+  sha256: 5dea5b29cba777ab8de4fd30cdfdbc1728fe1b3c573902270c1106bad55439a2
+
+build:
+  number: 0
+
+requirements:
+  build:
+    # If your project compiles code (such as a C extension) then add the required compilers as separate entries here.
+    # Compilers are named 'c', 'cxx' and 'fortran'.
+    - autoconf
+    - automake
+    - libtool
+    - {{ compiler('c') }}
+
+about:
+  home: http://libnova.sourceforge.net/
+  license: LGPL-2.1
+  license_file: COPYING
+  summary: 'Celestial Mechanics, Astrometry and Astrodynamics Library'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    libnova is a general purpose, double precision, Celestial Mechanics,
+    Astrometry and Astrodynamics library. The intended audience of libnova is
+    C / C++ programmers, astronomers and anyone else interested in
+    calculating positions of astronomical objects or celestial mechanics.
+    libnova is the calculation engine used by the Nova project and most
+    importantly, is free software.
+
+extra:
+  recipe-maintainers:
+    - joseph-long
+

--- a/recipes/libnova/meta.yaml
+++ b/recipes/libnova/meta.yaml
@@ -51,4 +51,3 @@ about:
 extra:
   recipe-maintainers:
     - joseph-long
-


### PR DESCRIPTION
    libnova is a general purpose, double precision, Celestial Mechanics,
    Astrometry and Astrodynamics library. The intended audience of libnova is
    C / C++ programmers, astronomers and anyone else interested in
    calculating positions of astronomical objects or celestial mechanics.
    libnova is the calculation engine used by the Nova project and most
    importantly, is free software.

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source **see comments in meta.yaml**
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
