### PR TITLE
add recipe for fury package

### DIFF
--- a/recipes/fury/LICENSE.txt
+++ b/recipes/fury/LICENSE.txt
@@ -1,0 +1,33 @@
+Unless otherwise specified by LICENSE.txt files in individual
+directories, or within individual files or functions, all code is:
+
+Copyright (c) 2008-2019, fury developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the fury developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/fury/meta.yaml
+++ b/recipes/fury/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "fury" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ad0eff6921823b8e261c5e4c7339c549b12f9bc6cc05ab4a51aae899ac067ca6
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+
+  run:
+    - python
+    - numpy
+    - scipy
+    - vtk
+    - matplotlib
+    - six
+
+test:
+  imports:
+    - fury
+
+about:
+  home: http://github.com/fury-gl/fury
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Free Unified Rendering for Python - Scientific Visualization'
+  description: |
+    Free Unified Rendering for Python (FURY) is a library that offers
+    a collection of new widgets, functionnality to vtk. It works under
+    Python 2.7 and Python 3.4+
+  doc_url: http://fury.gl/
+  dev_url: https://github.com/fury-gl/fury
+
+extra:
+  recipe-maintainers:
+    - skoudoro
+    - garyfallidis


### PR DESCRIPTION
This PR adds the [fury package](https://pypi.org/project/fury/)

checklist:
----------

- [x] License file is packaged (see here for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (url) rather than a repo (e.g. git_url) is used in your recipe 
- [x]   GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there