### PR TITLE
Rename existing pre_commit to pre-commit

### DIFF
--- a/recipes/pre-commit/meta.yaml
+++ b/recipes/pre-commit/meta.yaml
@@ -37,7 +37,8 @@ requirements:
     - pyyaml
     - six
     - toml
-    - virtualenv
+    - virtualenv >=15.2
+    - futures  # [py2k]
 
 test:
   imports:

--- a/recipes/pre-commit/meta.yaml
+++ b/recipes/pre-commit/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "pre-commit" %}
+{% set version = "1.12.0" %}
+{% set hash_type = "sha256" %}
+{% set hash = "81fe7b1b0cba93e7d7aa3cfbfd55f5280d3639e4fcb14bf9d1b95ab35f41cf0d" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-v{{ version }}.tar.gz
+  url: https://github.com/pre-commit/pre-commit/archive/v{{ version }}.tar.gz
+  {{ hash_type }}: {{ hash }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  entry_points:
+    - pre-commit = pre_commit.main:main
+    - pre-commit-validate-config = pre_commit.clientlib:validate_config_main
+    - pre-commit-validate-manifest = pre_commit.clientlib:validate_manifest_main
+
+requirements:
+  host:
+    - pip
+    - python
+
+  run:
+    - aspy.yaml
+    - cached-property
+    - cfgv >=1.0.0
+    - identify >=1.0.0
+    - importlib_metadata
+    - importlib_resources  # [py<37]
+    - nodeenv >=0.11.1
+    - python
+    - pyyaml
+    - six
+    - toml
+    - virtualenv
+
+test:
+  imports:
+    - pre_commit
+    - pre_commit.commands
+    - pre_commit.languages
+  commands:
+    - pre-commit --help
+    - pre-commit-validate-config --help
+    - pre-commit-validate-manifest --help
+
+about:
+  home: http://pre-commit.com/
+  license: MIT
+  license_file: LICENSE
+  summary: 'A framework for managing and maintaining multi-language pre-commit hooks.'
+  license_family: MIT
+  dev_url: https://github.com/pre-commit/pre-commit
+  doc_url: https://github.com/pre-commit/pre-commit
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
Rename existing pre_commit to pre-commit

Copied almost verbatim from conda-forge/pre_commit, only changing:

* package name
* build number
* pip install command

See conda-forge/pre_commit-feedstock#35