### PR TITLE
Add recipe for pymt_gipl

### DIFF
--- a/recipes/pymt_gipl/meta.yaml
+++ b/recipes/pymt_gipl/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "pymt_gipl" %}
+{% set version = "0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/pymt-lab/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: bf96a2c99d6a0b0fb577570bb192cbe9b98a686a9ae79590b031a483e41d1953
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+  host:
+    - python
+    - pip
+    - cython
+    - numpy
+    - model_metadata
+    - bmi-fortran =1.2
+    - gipl
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - bmi-fortran =1.2
+    - gipl
+
+test:
+  imports:
+    - pymt_gipl
+
+about:
+  home: https://github.com/pymt-lab/pymt_gipl
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Python package that wraps the GIPL model.
+  dev_url: https://github.com/pymt-lab/pymt_gipl
+
+extra:
+  recipe-maintainers:
+    - mdpiper

--- a/recipes/pymt_gipl/meta.yaml
+++ b/recipes/pymt_gipl/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - cython
     - numpy
     - model_metadata
-    - bmi-fortran =1.2
+    - bmi-fortran 1.2
     - gipl
   run:
     - python

--- a/recipes/pymt_gipl/meta.yaml
+++ b/recipes/pymt_gipl/meta.yaml
@@ -29,7 +29,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - bmi-fortran =1.2
+    - bmi-fortran 1.2
     - gipl
 
 test:

--- a/recipes/pymt_gipl/meta.yaml
+++ b/recipes/pymt_gipl/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . -vv"
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
This PR adds a recipe for *pymt_gipl*, a Python wrapper around the [Geophysical Institute Permafrost Laboratory (GIPL) model](https://github.com/conda-forge/gipl-feedstock). 

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
