### PR TITLE
Add selected fonts with ecosystem meta packages

### DIFF
--- a/recipes/font-ttf-dejavu-sans-mono-feedstock/build.sh
+++ b/recipes/font-ttf-dejavu-sans-mono-feedstock/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/fonts || true
+install -v -m644 ./ttf/DejaVuSans.ttf ${PREFIX}/fonts/DejaVuSans.ttf

--- a/recipes/font-ttf-dejavu-sans-mono-feedstock/meta.yaml
+++ b/recipes/font-ttf-dejavu-sans-mono-feedstock/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = '2.37' %}
+
+package:
+  name: font-ttf-dejavu-sans-mono
+  version: {{ version }}
+
+source:
+  url: https://sourceforge.net/projects/dejavu/files/dejavu/{{ version }}/dejavu-sans-ttf-{{ version }}.zip
+  sha256: 5c6e497a2f36552cb5ffb112c413a6af39c0f3c47653662b90b4fa6499822fd7
+
+build:
+  number: 0
+  noarch: generic
+
+# test:
+#   commands:
+#     - test -f ${PREFIX}/fonts/DejaVuSans.ttf  # [unix]
+
+about:
+  home: https://dejavu-fonts.github.io/
+  summary: Monospace font for pretty code listings with many mathematical and other symbols
+  description: |
+    DejaVu fonts are a font family based on the Vera Fonts. Its purpose is to provide a
+    wider range of characters while maintaining the original look and feel through the
+    process of collaborative development Monospace font for pretty code listings.
+    Next to that, DejaVu contains a lot of mathematical and other symbols, arrows, braille
+    patterns, etc
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - dbast

--- a/recipes/font-ttf-inconsolata-feedstock/build.sh
+++ b/recipes/font-ttf-inconsolata-feedstock/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/fonts || true
+install -v -m644 ./ofl/inconsolata/Inconsolata-Regular.ttf ${PREFIX}/fonts/Inconsolata-Regular.ttf
+install -v -m644 ./ofl/inconsolata/Inconsolata-Bold.ttf ${PREFIX}/fonts/Inconsolata-Bold.ttf

--- a/recipes/font-ttf-inconsolata-feedstock/meta.yaml
+++ b/recipes/font-ttf-inconsolata-feedstock/meta.yaml
@@ -1,0 +1,27 @@
+package:
+  name: font-ttf-inconsolata
+  version: 2.001
+
+source:
+  url: https://github.com/google/fonts/archive/e301650445524f7f80837ed04d8b9d3806e33d5e.zip
+  sha256: 9ef2f20e4fe8f062f365a98dde498f3fca06c9d5b1b7b29a63be8c9691ef116f
+
+build:
+  number: 0
+  noarch: generic
+
+# test:
+#   commands:
+#     - test -f ${PREFIX}/fonts/Inconsolata-Regular.ttf  # [unix]
+#     - test -f ${PREFIX}/fonts/Inconsolata-Bold.ttf     # [unix]
+
+about:
+  home: https://fonts.google.com/specimen/Inconsolata
+  summary: Monospace font for pretty code listings
+  license: OFL
+  license_file: ofl/inconsolata/OFL.txt
+  license_family: Other
+
+extra:
+  recipe-maintainers:
+    - dbast

--- a/recipes/font-ttf-source-code-pro-feedstock/build.sh
+++ b/recipes/font-ttf-source-code-pro-feedstock/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/fonts || true
+install -v -m644 ./TTF/*.ttf ${PREFIX}/fonts/

--- a/recipes/font-ttf-source-code-pro-feedstock/meta.yaml
+++ b/recipes/font-ttf-source-code-pro-feedstock/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: font-ttf-source-code-pro
+  version: 2.030
+
+source:
+  url: https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.tar.gz
+  sha256: a4e4dd59b8e0a436b934f0f612c2e91b5932910c6d1c3b7d1a5a9f389c86302b
+
+build:
+  number: 0
+  noarch: generic
+
+# test:
+#   commands:
+#     - test -f ${PREFIX}/fonts/SourceCodePro-Black.ttf         # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-BlackIt.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-Bold.ttf          # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-BoldIt.ttf        # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-ExtraLight.ttf    # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-ExtraLightIt.ttf  # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-It.ttf            # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-Light.ttf         # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-LightIt.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-Medium.ttf        # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-MediumIt.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-Regular.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-Semibold.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/SourceCodePro-SemiboldIt.ttf    # [unix]
+
+about:
+  home: https://adobe-fonts.github.io/source-code-pro/
+  summary: A set of fonts that have been designed to work well in UI environments
+  license: SIL Open Font Lic., Version 1.1
+  license_file: LICENSE.txt
+  license_family: Other
+
+extra:
+  recipe-maintainers:
+    - dbast

--- a/recipes/font-ttf-ubuntu-feedstock/bld.bat
+++ b/recipes/font-ttf-ubuntu-feedstock/bld.bat
@@ -1,0 +1,4 @@
+copy "%RECIPE_DIR%\build.sh" .
+set PREFIX=%PREFIX:\=/%
+bash -lc "./build.sh"
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/font-ttf-ubuntu-feedstock/build.sh
+++ b/recipes/font-ttf-ubuntu-feedstock/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/fonts || true
+# flatten by 1: automatic flattening does not always happen due to __MACOSX/* files
+mv ubuntu-font-family-${PKG_VERSION}/* . || true
+install -v -m644 *.ttf ${PREFIX}/fonts/

--- a/recipes/font-ttf-ubuntu-feedstock/meta.yaml
+++ b/recipes/font-ttf-ubuntu-feedstock/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = '0.83' %}
+
+package:
+  name: font-ttf-ubuntu
+  version: {{ version }}
+
+source:
+  url: https://assets.ubuntu.com/v1/0cef8205-ubuntu-font-family-{{ version }}.zip
+  sha256: 61a2b342526fd552f19fef438bb9211a8212de19ad96e32a1209c039f1d68ecf
+
+build:
+  number: 0
+  noarch: generic
+
+# test:
+#   commands:
+#     - test -f ${PREFIX}/fonts/Ubuntu-B.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-BI.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-C.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-L.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-LI.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-M.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-MI.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-R.ttf       # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-RI.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/Ubuntu-Th.ttf      # [unix]
+#     - test -f ${PREFIX}/fonts/UbuntuMono-B.ttf   # [unix]
+#     - test -f ${PREFIX}/fonts/UbuntuMono-BI.ttf  # [unix]
+#     - test -f ${PREFIX}/fonts/UbuntuMono-R.ttf   # [unix]
+#     - test -f ${PREFIX}/fonts/UbuntuMono-RI.ttf  # [unix]
+
+about:
+  home: https://design.ubuntu.com/font/
+  summary: The Ubuntu Font Family
+  description: |
+    A unique, custom designed font that has a very distinctive look and feel.
+  license: Ubuntu Font Licence Version 1.0
+  license_file: LICENCE.txt
+  license_family: Other
+
+extra:
+  recipe-maintainers:
+    - dbast

--- a/recipes/fonts-conda-ecosystem/LICENSE.txt
+++ b/recipes/fonts-conda-ecosystem/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2015-2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of staged-recipes nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/fonts-conda-ecosystem/meta.yaml
+++ b/recipes/fonts-conda-ecosystem/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: fonts-conda-ecosystem
+  version: 1
+
+build:
+  number: 0
+  noarch: generic
+
+requirements:
+  build:
+    - fonts-conda-forge
+  run:
+    - fonts-conda-forge
+
+# test:
+#   commands:
+#     - ls -alh ${PREFIX}/fonts/  # [unix]
+
+about:
+  home: https://conda.io
+  summary: Meta package pointing to the ecosystem specific font package
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - dbast

--- a/recipes/fonts-conda-forge-feedstock/LICENSE.txt
+++ b/recipes/fonts-conda-forge-feedstock/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2015-2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of staged-recipes nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/fonts-conda-forge-feedstock/meta.yaml
+++ b/recipes/fonts-conda-forge-feedstock/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: fonts-conda-forge
+  version: 1
+
+build:
+  number: 0
+  noarch: generic
+
+requirements:
+  build:
+    - font-ttf-ubuntu
+    - font-ttf-inconsolata
+    - font-ttf-dejavu-sans-mono
+    - font-ttf-source-code-pro
+  run:
+    - font-ttf-ubuntu
+    - font-ttf-inconsolata
+    - font-ttf-dejavu-sans-mono
+    - font-ttf-source-code-pro
+
+# test:
+#   commands:
+#     - ls -alh ${PREFIX}/fonts/  # [unix]
+
+about:
+  home: https://conda-forge.org/
+  summary: The curated conda-forge standard fonts
+  description: |
+    A curated set of different types of reasonable sized fonts to create high
+    quality plots in the conda-forge universe.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - dbast


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

This brings 4 fonts and 2 meta-packages:
* The fonts: `font-ttf-dejavu-sans-mono`, `font-ttf-inconsolata`, `font-ttf-source-code-pro`, `font-ttf-ubuntu` derived from https://github.com/AnacondaRecipes/aggregate/tree/master/$font-feedstock/recipe/meta.yaml
* The meta-package `fonts-conda-forge` intends to define the standard set of fonts for conda-forge, derived from https://github.com/AnacondaRecipes/aggregate/blob/master/fonts-anaconda-feedstock/recipe/meta.yaml
* The meta-package `fonts-conda-ecosystem` for indirection (the conda-forge version points to `fonts-conda-forge` and the anaconda version could point to `fonts-anaconda`). This is the package intended to be added (via various possible ways) as run-dependency to other packages.

Background of this PR can be found here:
* https://github.com/conda-forge/r-feedstock/pull/15
* https://github.com/conda-forge/r-base-feedstock/issues/91
* https://github.com/conda-forge/r-base-feedstock/pull/104

Open questions:
* Are those 4 fonts really the fonts conda-forge wants to define as kind of standard? @mingwandroid had some reasoning to do so for anaconda, is this written down somewhere?
* Do we maybe also want to add mscorefonts to `fonts-conda-forge`? (or maybe instead https://github.com/liberationfonts/liberation-1.7-fonts promoted as open/free mscorefonts alternative by e.g. debian)
* Anybody has ideas how to fix the tests? They fail with the same error as https://github.com/conda/conda-build/issues/3553
* Somebody willing to co-maintain those packages... @jdblischak, @bgruening ?
* Anything else to shape the font story?

After this, it still would remain an open question via which way to bring `fonts-conda-ecosystem` to its consumers, 1. adding to `run` dependency of individual consumer packages (e.g. `r-ggplot2`) or 2. also adding it to `run_exports` of `fontconfig`/`fontconfig-fonts` or 3. ... .

Pinging @conda-forge/core @conda-forge/r 