### PR TITLE
MNT: Increase the azure build timeout to 6 hours

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -9,7 +9,7 @@ jobs:
         CONFIG: azure-linux-64-comp7
         CF_MAX_PY_VER: 37
         AZURE: True
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   steps:
   - script: |
       sudo pip install --upgrade pip

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,7 +8,7 @@ jobs:
       osx:
         CONFIG: azure-osx-64-comp7
         CF_MAX_PY_VER: 37
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   steps:
   # TODO: Fast finish on azure pipelines?
   - script: |

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,7 +8,7 @@ jobs:
       win:
         CONFIG: azure-win-64
         CF_MAX_PY_VER: 37
-  timeoutInMinutes: 240
+  timeoutInMinutes: 360
   steps:
     # TODO: Fast finish on azure pipelines?
     - script: |


### PR DESCRIPTION
In feedstock repos, `conda-smithy` configures the [azure build timeout][1] to be [6 hours][2].  This PR gives `staged-recipes` 6 hours, too.

cc @isuruf (who [requested this change][3])

[1]: https://github.com/conda-forge/conda-smithy/blob/68d59110e9a6a69c80c4cc7cb858a8f6100aa1ac/conda_smithy/templates/azure-pipelines-linux.yml.tmpl#L9
[2]: https://github.com/conda-forge/conda-smithy/blob/68d59110e9a6a69c80c4cc7cb858a8f6100aa1ac/conda_smithy/configure_feedstock.py#L1231
[3]: https://github.com/conda-forge/staged-recipes/pull/9209#issuecomment-524642117
