### PR TITLE
Add ftd2xx.

### DIFF
--- a/recipes/ftd2xx/20-avoid_unrecoverable_errors.patch
+++ b/recipes/ftd2xx/20-avoid_unrecoverable_errors.patch
@@ -1,0 +1,25 @@
+From 618a4fdae339bf2a28207e38409caed70494af7f Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Tue, 27 Aug 2019 17:59:37 -0400
+Subject: [PATCH] Avoid unrecoverable failure if the dll can't be found.
+
+---
+ ftd2xx/_ftd2xx.py | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/ftd2xx/_ftd2xx.py b/ftd2xx/_ftd2xx.py
+index 8c3bf94..b6897f0 100644
+--- a/ftd2xx/_ftd2xx.py
++++ b/ftd2xx/_ftd2xx.py
+@@ -42,8 +42,9 @@
+             _libraries['ftd2xx.dll'] = WinDLL('ftd2xx.dll')
+         except OSError as e:
+             if e.winerror == 126:
+-                sys.stderr.write('Unable to find D2XX DLL. Please make sure ftd2xx.dll or ftd2xx64.dll is in the path\n')
+-                sys.exit(1)
++                error_message = e.args[1] + 'Unable to find D2XX DLL. Please make sure ftd2xx.dll or ftd2xx64.dll is in the path.'
++                e.args = (e.args(0), error_message) + e.args[2:]
++                raise e
+             else:
+                 raise
+ else:

--- a/recipes/ftd2xx/20-avoid_unrecoverable_errors.patch
+++ b/recipes/ftd2xx/20-avoid_unrecoverable_errors.patch
@@ -1,14 +1,5 @@
-From 618a4fdae339bf2a28207e38409caed70494af7f Mon Sep 17 00:00:00 2001
-From: Mark Harfouche <mark.harfouche@gmail.com>
-Date: Tue, 27 Aug 2019 17:59:37 -0400
-Subject: [PATCH] Avoid unrecoverable failure if the dll can't be found.
-
----
- ftd2xx/_ftd2xx.py | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
-
 diff --git a/ftd2xx/_ftd2xx.py b/ftd2xx/_ftd2xx.py
-index 8c3bf94..b6897f0 100644
+index 8c3bf94..56fd6b8 100644
 --- a/ftd2xx/_ftd2xx.py
 +++ b/ftd2xx/_ftd2xx.py
 @@ -42,8 +42,9 @@
@@ -18,7 +9,7 @@ index 8c3bf94..b6897f0 100644
 -                sys.stderr.write('Unable to find D2XX DLL. Please make sure ftd2xx.dll or ftd2xx64.dll is in the path\n')
 -                sys.exit(1)
 +                error_message = e.args[1] + 'Unable to find D2XX DLL. Please make sure ftd2xx.dll or ftd2xx64.dll is in the path.'
-+                e.args = (e.args(0), error_message) + e.args[2:]
++                e.args = (e.args[0], error_message) + e.args[2:]
 +                raise e
              else:
                  raise

--- a/recipes/ftd2xx/LICENSE
+++ b/recipes/ftd2xx/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 90df60c2468e7dd9c870fcfe6dff8da6b477334f912e5028c3ccf54a78466f3a
+  patches:
+    - 20-avoid_unrecoverable_errors.patch
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
@@ -23,8 +25,9 @@ requirements:
     - pywin32  # [win]
 
 test:
-  imports:
-    - ftd2xx
+  commands:
+    # tests are in the run_test.py section
+    - echo hi
 
 about:
   home: https://github.com/snmishra/ftd2xx/blob/master/LICENSE

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 90df60c2468e7dd9c870fcfe6dff8da6b477334f912e5028c3ccf54a78466f3a
   patches:
-    - 20-avoid_unrecoverable_errors.patch
+    - 20-avoid_unrecoverable_errors.patch  # [not py27]
 
 build:
   number: 1

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -16,6 +16,8 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
+  build:
+    - m2-patch  # [win]
   host:
     - python
     - pip

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 20-avoid_unrecoverable_errors.patch  # [not py27]
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -35,7 +35,6 @@ about:
   license_file: LICENSE
   summary: 'ftd2xx is a simple python wrapper around the D2XX DLL from FTDI using ctypes.'
 
-  # The remaining entries in this section are optional, but recommended.
   description: |
     The API based on Pablo Bleyer Kocik’s d2xx extension.
 

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -26,10 +26,7 @@ requirements:
     - future
     - pywin32  # [win]
 
-test:
-  commands:
-    # tests are in the run_test.py section
-    - echo hi
+# Tests done in run_test.py
 
 about:
   home: https://github.com/snmishra/ftd2xx/blob/master/LICENSE

--- a/recipes/ftd2xx/meta.yaml
+++ b/recipes/ftd2xx/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "ftd2xx" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 90df60c2468e7dd9c870fcfe6dff8da6b477334f912e5028c3ccf54a78466f3a
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - future
+    - pywin32  # [win]
+
+test:
+  imports:
+    - ftd2xx
+
+about:
+  home: https://github.com/snmishra/ftd2xx/blob/master/LICENSE
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'ftd2xx is a simple python wrapper around the D2XX DLL from FTDI using ctypes.'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    The API based on Pablo Bleyer Kocik’s d2xx extension.
+
+    Version 1.1.0 is compatible with Python 3. Please ensure you have FTDI
+    drivers installed or available where the linker looks for shared libraries
+    (e.g., PATH on windows, LD_LIBRARY_PATH or standard library directories
+    on Linux)
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/ftd2xx/run_test.py
+++ b/recipes/ftd2xx/run_test.py
@@ -1,0 +1,6 @@
+try:
+    # This is going to fail with an OSError complaining that the necessary
+    # library isn't installed
+    import ftd2xx
+except OSError as e:
+    pass

--- a/recipes/ftd2xx/run_test.py
+++ b/recipes/ftd2xx/run_test.py
@@ -1,3 +1,10 @@
+import sys
+import os
+# On windows and python 2, the tests fail miserably due to a forced exit
+# when the dll cannot be loaded.
+if sys.version[0] == '2' and os.name == 'nt':
+    exit(0)
+
 try:
     # This is going to fail with an OSError complaining that the necessary
     # library isn't installed


### PR DESCRIPTION
This likely won't work as it needs some proprietary dlls from 
https://www.ftdichip.com/Support/Documents/ProgramGuides.htm

that likely aren't installed on the system. I could just skip the tests, or check for the existance of a module.


Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
