### PR TITLE
libusb-compat

### DIFF
--- a/recipes/libusb-0/meta.yaml
+++ b/recipes/libusb-0/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = "0.1.12" %}
+
+package:
+  name: libusb-0
+  version: {{ version }}
+
+source:
+  url: https://ayera.dl.sourceforge.net/project/libusb/libusb-0.1%20%28LEGACY%29/{{ version }}/libusb-{{ version }}.tar.gz
+  sha256: 37f6f7d9de74196eb5fc0bbe0aea9b5c939de7f500acba3af6fd643f3b538b44
+
+build:
+  number: 0
+  # For now, start with linux builds ony
+  skip: True  # [not linux]
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  script:
+    - export CFLAGS="$CFLAGS -Wno-error=format-truncation"
+    - export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
+    - export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
+    - ./configure --disable-build-docs --prefix={{ PREFIX }} --verbose
+    - make
+    - make install
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - libtool  # [unix]
+  host:
+  run:
+
+
+test:
+  commands:
+    - echo hi
+
+about:
+  home: http://github.com/simplejson/simplejson
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
+  license_family: MIT
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
+  license_file: LICENSE.txt
+  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    simplejson is a simple, fast, complete, correct and extensible
+    JSON <http://json.org> encoder and decoder for Python 2.5+ and
+    Python 3.3+. It is pure Python code with no dependencies, but includes
+    an optional C extension for a serious speed boost.
+  doc_url: http://simplejson.readthedocs.io/
+  dev_url: https://github.com/simplejson/simplejson
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - LisaSimpson
+    - LandoCalrissian
+

--- a/recipes/libusb-compat/build.sh
+++ b/recipes/libusb-compat/build.sh
@@ -5,3 +5,4 @@ export CFLAGS="$CFLAGS -Wno-error=format-truncation"
 ./configure --disable-build-docs --prefix=${PREFIX} --verbose
 make
 make install
+make check

--- a/recipes/libusb-compat/build.sh
+++ b/recipes/libusb-compat/build.sh
@@ -2,8 +2,8 @@
 
 # http://www.linuxfromscratch.org/blfs/view/6.3/general/libusb.html
 export CFLAGS="$CFLAGS -Wno-error=format-truncation"
-export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
-export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
+# export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
+# export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
 ./configure --disable-build-docs --prefix=${PREFIX} --verbose
 make
 make install

--- a/recipes/libusb-compat/build.sh
+++ b/recipes/libusb-compat/build.sh
@@ -2,8 +2,6 @@
 
 # http://www.linuxfromscratch.org/blfs/view/6.3/general/libusb.html
 export CFLAGS="$CFLAGS -Wno-error=format-truncation"
-# export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
-# export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
 ./configure --disable-build-docs --prefix=${PREFIX} --verbose
 make
 make install

--- a/recipes/libusb-compat/build.sh
+++ b/recipes/libusb-compat/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# http://www.linuxfromscratch.org/blfs/view/6.3/general/libusb.html
+export CFLAGS="$CFLAGS -Wno-error=format-truncation"
+export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
+export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
+./configure --disable-build-docs --prefix=${PREFIX} --verbose
+make
+make install

--- a/recipes/libusb-compat/build.sh
+++ b/recipes/libusb-compat/build.sh
@@ -5,4 +5,5 @@ export CFLAGS="$CFLAGS -Wno-error=format-truncation"
 ./configure --disable-build-docs --prefix=${PREFIX} --verbose
 make
 make install
-make check
+# make check seems to fail with known issues that will not be resolved since this library is deprecated
+# make check

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - libtool  # [unix]
     - pkg-config  # [unix]
     - make  # [unix]
-  host:
 
 test:
   commands:

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -10,6 +10,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - {{ pin_subpackage('libusb-compat') }}
   # For now, start with linux builds ony
   skip: True  # [not linux]
   script:

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "0.1.12" %}
 
 package:
-  name: libusb-0
+  name: libusb-compat
   version: {{ version }}
 
 source:

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -5,17 +5,15 @@ package:
   version: {{ version }}
 
 source:
-  url: https://ayera.dl.sourceforge.net/project/libusb/libusb-0.1%20%28LEGACY%29/{{ version }}/libusb-{{ version }}.tar.gz
+  url: http://downloads.sourceforge.net/libusb/libusb-0.1.12.tar.gz
   sha256: 37f6f7d9de74196eb5fc0bbe0aea9b5c939de7f500acba3af6fd643f3b538b44
 
 build:
   number: 0
   # For now, start with linux builds ony
   skip: True  # [not linux]
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   script:
+    # http://www.linuxfromscratch.org/blfs/view/6.3/general/libusb.html
     - export CFLAGS="$CFLAGS -Wno-error=format-truncation"
     - export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
     - export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
@@ -28,41 +26,24 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - libtool  # [unix]
+    - pkg-config  # [unix]
   host:
   run:
 
 
 test:
   commands:
+    # It never gets to the testing section....
     - echo hi
 
 about:
-  home: http://github.com/simplejson/simplejson
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
-  license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
-  license_family: MIT
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See http://conda.pydata.org/docs/building/meta-yaml.html#license-file
-  license_file: LICENSE.txt
-  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+  home: https://sourceforge.net/projects/libusb/files/libusb-0.1%20%28LEGACY%29/
+  license: LGPL-2.1
+  license_family: LGPL
+  license_file: LICENSE
+  summary: '(Legacy) A cross-platform library that gives apps easy access to USB devices'
 
-  # The remaining entries in this section are optional, but recommended.
-  description: |
-    simplejson is a simple, fast, complete, correct and extensible
-    JSON <http://json.org> encoder and decoder for Python 2.5+ and
-    Python 3.3+. It is pure Python code with no dependencies, but includes
-    an optional C extension for a serious speed boost.
-  doc_url: http://simplejson.readthedocs.io/
-  dev_url: https://github.com/simplejson/simplejson
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
-    - LisaSimpson
-    - LandoCalrissian
-
+    - hmaarrfk

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://downloads.sourceforge.net/libusb/libusb-0.1.12.tar.gz
+  url: http://downloads.sourceforge.net/libusb/libusb-{{ version }}.tar.gz
   sha256: 37f6f7d9de74196eb5fc0bbe0aea9b5c939de7f500acba3af6fd643f3b538b44
 
 build:

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - pkg-config  # [unix]
   host:
 
-
 test:
   commands:
     - test -f $PREFIX/include/usb.h

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - {{ compiler('cxx') }}
     - libtool  # [unix]
     - pkg-config  # [unix]
+    - make  # [unix]
   host:
 
 test:

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -41,7 +41,6 @@ about:
   license_file: LICENSE
   summary: '(Legacy) A cross-platform library that gives apps easy access to USB devices'
 
-
 extra:
   recipe-maintainers:
     - hmaarrfk

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -28,13 +28,15 @@ requirements:
     - libtool  # [unix]
     - pkg-config  # [unix]
   host:
-  run:
 
 
 test:
   commands:
-    # It never gets to the testing section....
-    - echo hi
+    - test -f $PREFIX/include/usb.h
+    - test -f $PREFIX/include/usbpp.h
+    - test -f $PREFIX/bin/libusb-config
+    - test -f $PREFIX/lib/libusb.so
+    - test -f $PREFIX/lib/libusb-0.1.so.4
 
 about:
   home: https://sourceforge.net/projects/libusb/files/libusb-0.1%20%28LEGACY%29/

--- a/recipes/libusb-compat/meta.yaml
+++ b/recipes/libusb-compat/meta.yaml
@@ -11,17 +11,11 @@ source:
 build:
   number: 0
   run_exports:
+    # This package is very unlikely to change in the near future as it is
+    # legacy code
     - {{ pin_subpackage('libusb-compat') }}
   # For now, start with linux builds ony
   skip: True  # [not linux]
-  script:
-    # http://www.linuxfromscratch.org/blfs/view/6.3/general/libusb.html
-    - export CFLAGS="$CFLAGS -Wno-error=format-truncation"
-    - export CXXFLAGS="$CXXFLAGS -Wno-error=format-truncation"
-    - export CPPFLAGS="$CPPFLAGS -Wno-error=format-truncation"
-    - ./configure --disable-build-docs --prefix={{ PREFIX }} --verbose
-    - make
-    - make install
 
 requirements:
   build:


### PR DESCRIPTION
I want this for some old executable that hasn't updated to libusb1. 

I don't think code that old on windows and macosx used libusb0. 

Checklist

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vend other packages
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
