### PR TITLE
Add ldas-tools-diskcacheapi-swig

### DIFF
--- a/recipes/ldas-tools-diskcacheapi-swig/build.sh
+++ b/recipes/ldas-tools-diskcacheapi-swig/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+mkdir -p build
+pushd build
+
+# configure
+cmake .. \
+	-DCMAKE_INSTALL_PREFIX=${PREFIX} \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DENABLE_SWIG_PYTHON2=no \
+	-DENABLE_SWIG_PYTHON3=no
+
+# build
+cmake --build . -- -j ${CPU_COUNT}
+
+# check
+ctest -VV
+
+# install
+cmake --build . --target install

--- a/recipes/ldas-tools-diskcacheapi-swig/build.sh
+++ b/recipes/ldas-tools-diskcacheapi-swig/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 mkdir -p build
 pushd build

--- a/recipes/ldas-tools-diskcacheapi-swig/install-python.sh
+++ b/recipes/ldas-tools-diskcacheapi-swig/install-python.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+pushd ${SRC_DIR}/build
+
+# get python options
+if [ "${PY3K}" -eq 1 ]; then
+  PYTHON_BUILD_OPTS="-DENABLE_SWIG_PYTHON2=no -DENABLE_SWIG_PYTHON3=yes -DPYTHON3_EXECUTABLE=${PYTHON}"
+else
+  PYTHON_BUILD_OPTS="-DENABLE_SWIG_PYTHON3=no -DENABLE_SWIG_PYTHON2=yes -DPYTHON2_EXECUTABLE=${PYTHON}"
+fi
+
+# configure
+cmake .. \
+	-DCMAKE_INSTALL_PREFIX=${PREFIX} \
+	-DCMAKE_BUILD_TYPE=Release \
+	${PYTHON_BUILD_OPTS}
+
+# build
+cmake --build python -- -j ${CPU_COUNT}
+
+# check
+ctest -VV
+
+# install
+cmake --build python --target install

--- a/recipes/ldas-tools-diskcacheapi-swig/meta.yaml
+++ b/recipes/ldas-tools-diskcacheapi-swig/meta.yaml
@@ -1,0 +1,82 @@
+{% set name = "ldas-tools-diskcacheAPI-swig" %}
+{% set version = "2.6.6" %}
+
+# dependencies
+{% set ldas_tools_cmake_version = "1.0.4" %}
+{% set ldas_tools_diskcacheapi_version = "2.6.2" %}
+{% set ldas_tools_ldasgen_swig_version = "2.6.5" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz"
+  sha256: b5d2f444d1ef621d93253aa20ed29c4cb71531e34c6afaca4d1041f09cf83de2
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake >=3.6
+    - pkg-config  # [not win]
+    - make  # [not win]
+    - swig 3
+  host:
+    - ldas-tools-cmake >={{ ldas_tools_cmake_version }}
+    - ldas-tools-diskcacheapi >={{ ldas_tools_diskcacheapi_version }}
+  run:
+    - ldas-tools-diskcacheapi >={{ ldas_tools_diskcacheapi_version }}
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/diskcacheAPI/diskCache.i  # [not win]
+
+outputs:
+  - name: ldas-tools-diskcacheapi-swig
+
+  - name: python-ldas-tools-diskcacheapi
+    script: install-python.sh
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - cmake >=3.6
+        - pkg-config  # [not win]
+        - make  # [not win]
+        - swig 3
+      host:
+        - ldas-tools-cmake >={{ ldas_tools_cmake_version }}
+        - ldas-tools-diskcacheapi >={{ ldas_tools_diskcacheapi_version }}
+        - {{ pin_subpackage('ldas-tools-diskcacheapi-swig', exact=True) }}
+        - python
+      run:
+        - python
+        - python-ldas-tools-al
+        - ldas-tools-diskcacheapi >={{ ldas_tools_diskcacheapi_version }}
+        - {{ pin_subpackage('ldas-tools-diskcacheapi-swig', exact=True) }}
+    test:
+      imports:
+        - LDAStools.diskCache
+    about:
+      home: https://wiki.ligo.org/Computing/LDASTools
+      dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+      license: GPL-3.0-or-later
+      license_family: GPL
+      license_file: COPYING
+      summary: Python bindings for the LDAS Tools disk cache library
+
+about:
+  home: https://wiki.ligo.org/Computing/LDASTools
+  dev_url: https://git.ligo.org/ldastools/LDAS_Tools
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: COPYING
+  summary: SWIG interface for the LDAS Tools disk cache library
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros


### PR DESCRIPTION
This PR adds a recipe for ldas-tools-diskcacheAPI-swig, the bindings package for [ldas-tools-diskcacheapi](https://github.com/conda-forge/ldas-tools-diskcacheapi-feedstock/) (already forged).

@emaros, can you post a comment to indicate you are ok being named as co-maintainer.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x]  Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
