### PR TITLE
BUG pin conda to <4.7.11a0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - cmd: appveyor-retry conda.exe update --yes --quiet conda
 
 
-    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1" conda-forge-pinning conda-forge-ci-setup=2.* networkx conda-build>=3.16
+    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-pinning conda-forge-ci-setup=2.* networkx conda-build>=3.16
 
     - cmd: appveyor-retry run_conda_forge_build_setup
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -39,7 +39,7 @@ install:
     - cmd: appveyor-retry conda.exe update --yes --quiet conda
 
 
-    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-pinning conda-forge-ci-setup=2.* networkx conda-build>=3.16
+    - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-pinning conda-forge-ci-setup=2.* networkx "conda-build>=3.16"
 
     - cmd: appveyor-retry run_conda_forge_build_setup
 

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -13,7 +13,7 @@ jobs:
   # TODO: Fast finish on azure pipelines?
   - script: |
       echo "Fast Finish"
-  
+
   - script: |
       echo "Removing homebrew from Azure to avoid conflicts."
       curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
@@ -31,7 +31,7 @@ jobs:
   - script: |
       set -x -e
       source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build shyaml networkx conda-forge-pinning
+      conda install -n base -c conda-forge --quiet --yes "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2 conda-build shyaml networkx conda-forge-pinning
     displayName: 'Add conda-forge-ci-setup=2'
 
   - script: |
@@ -42,7 +42,6 @@ jobs:
       setup_conda_rc ./ ./recipes ./.ci_support/${CONFIG}.yaml
 
       source run_conda_forge_build_setup
-      conda update --yes --quiet --all
     env: {
       OSX_FORCE_SDK_DOWNLOAD: "1"
     }

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -44,7 +44,7 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2 networkx  conda-forge-pinning' # Optional
+        packageSpecs: 'python=3.6 conda-build conda!=4.6.1,<4.7.11a0 conda-forge::conda-forge-ci-setup=2 networkx  conda-forge-pinning' # Optional
         installOptions: "-c conda-forge"
         updateConda: false
       displayName: Install conda-build and activate environment
@@ -58,15 +58,15 @@ jobs:
       displayName: configure conda channels
     - script: conda.exe config --add channels defaults
       displayName: configure conda channels
-    
+
     - script: conda.exe config --add channels conda-forge
       displayName: configure conda channels
-    
+
 
     # Configure the VM.
     - script: call run_conda_forge_build_setup
       displayName: conda-forge build setup
-        
+
     # Find the recipes from master in this PR and remove them.
     - script: |
         git fetch --force origin master:master
@@ -82,5 +82,3 @@ jobs:
       env: {
         VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",
       }
-
-    

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -42,7 +42,7 @@ export CONDA_NPY='19'
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet "conda!=4.6.1" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -42,7 +42,7 @@ export CONDA_NPY='19'
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx "conda-build>=3.16"
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -26,7 +26,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx "conda-build>=3.16"
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -26,7 +26,7 @@ echo ""
 echo "Configuring conda."
 conda config --add channels conda-forge
 conda config --set show_channel_urls true
-conda install --yes --quiet "conda!=4.6.1" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
+conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx conda-build>=3.16
 source run_conda_forge_build_setup
 
 # Find the recipes from master in this PR and remove them.


### PR DESCRIPTION
This PR pins conda to `<4.7.11a0` in order to avoid the bug reported here https://github.com/conda/conda-build/issues/3735.

This is preferred over pulling the buggy versions per discussion here https://github.com/conda-forge/conda-feedstock/issues/106.