### PR TITLE
Add gwsurrogate

### DIFF
--- a/recipes/gwsurrogate/meta.yaml
+++ b/recipes/gwsurrogate/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "gwsurrogate" %}
+{% set version = "0.9.9" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: cfee861487c53eeb1f71ba6370dae368c493348643d90bb36d7382b2753a91a7
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - gsl
+    - numpy
+    - pip
+    - python
+    - setuptools
+  run:
+    - gsl
+    - gwtools
+    - h5py
+    - {{ pin_compatible('numpy') }}
+    - python
+    - scikit-learn
+
+test:
+  imports:
+    - gwsurrogate
+
+about:
+  home: "https://pypi.org/project/gwsurrogate/"
+  license: "MIT"
+  license_family: "MIT"
+  license_file: "LICENSE"
+  summary: "An easy to use interface to gravitational wave surrogate models"
+  description: |
+    GWSurrogate is an easy to use interface to gravitational wave surrogate
+    models.
+
+    Surrogates provide a fast and accurate evaluation mechanism for
+    gravitational waveforms which would otherwise be found through solving
+    differential equations. These equations must be solved in the 'building'
+    phase, which was performed using other codes.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - sfield17
+    - vijayvarma392


### PR DESCRIPTION
This commit adds recipes for `gwtools` and `gwsurrogate`.

@sfield17, @vijayvarma392, can you please post messages stating that you are ok being named as co-maintainers of these recipes? thanks.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
      recipe (see
      [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)
      for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
