### PR TITLE
Add spacy-lookups-data recipe

### DIFF
--- a/recipes/spacy-lookups-data/LICENSE
+++ b/recipes/spacy-lookups-data/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 ExplosionAI GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ spacy_lookups_data }}-{{ version }}.tar.gz
   sha256: 7831260fa75d9a61b3dc16c0853662285e8403ba714042435611277ea9b94ca5
 
 build:
@@ -25,7 +25,7 @@ test:
   imports:
     - spacy_lookups_data
   commands:
-    - python -m pytest --tb=native --pyargs {{ name }}
+    - python -m pytest --tb=native --pyargs spacy_lookups_data
 
 about:
   home: https://github.com/explosion/spacy-lookups-data

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ spacy_lookups_data }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/spacy_lookups_data-{{ version }}.tar.gz
   sha256: 7831260fa75d9a61b3dc16c0853662285e8403ba714042435611277ea9b94ca5
 
 build:
@@ -22,10 +22,11 @@ requirements:
     - python
 
 test:
-  imports:
+  requires:
+    - pytest
     - spacy_lookups_data
   commands:
-    - python -m pytest --tb=native --pyargs spacy-lookups-data
+    - python -m pytest --tb=native --pyargs spacy_lookups_data
 
 about:
   home: https://github.com/explosion/spacy-lookups-data

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -20,6 +20,9 @@ requirements:
     - pip
   run:
     - python
+    - setuptools
+    - srsly>=0.1.0,<1.1.0
+    - pathlib==1.0.1; python_version < "3.4"
 
 test:
   imports:

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "spacy-lookups-data" %}
+{% set version = "0.0.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7831260fa75d9a61b3dc16c0853662285e8403ba714042435611277ea9b94ca5
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - spacy_lookups_data
+  commands:
+    - python -m pytest --tb=native --pyargs {{ name }}
+
+about:
+  home: https://github.com/explosion/spacy-lookups-data
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Additional lookup tables and data resources for spaCy'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    This package contains additional data files to be used with spaCy v2.2+.
+    When it's installed in the same environment as spaCy, this package makes
+    the resources for each language available as an entry point, which spaCy
+    checks when setting up the Vocab and Lookups.
+  doc_url: https://spacy.io/
+  dev_url: https://github.com/explosion/spacy-lookups-data
+
+extra:
+  recipe-maintainers:
+    - honnibal
+    - ines

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -24,7 +24,6 @@ requirements:
 test:
   requires:
     - pytest
-    - spacy-lookups-data
   commands:
     - python -m pytest --tb=native --pyargs spacy_lookups_data
 

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -25,7 +25,7 @@ test:
   imports:
     - spacy_lookups_data
   commands:
-    - python -m pytest --tb=native --pyargs spacy_lookups_data
+    - python -m pytest --tb=native --pyargs spacy-lookups-data
 
 about:
   home: https://github.com/explosion/spacy-lookups-data

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -21,8 +21,6 @@ requirements:
   run:
     - python
     - setuptools
-    - srsly >=0.1.0,<1.1.0
-    - pathlib ==1.0.1  # [py27]
 
 test:
   imports:

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -22,10 +22,8 @@ requirements:
     - python
 
 test:
-  requires:
-    - pytest
-  commands:
-    - python -m pytest --tb=native --pyargs spacy_lookups_data
+  imports:
+    - spacy_lookups_data
 
 about:
   home: https://github.com/explosion/spacy-lookups-data

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python
     - setuptools
     - srsly >=0.1.0,<1.1.0
-    - pathlib ==1.0.1; python_version < "3.4"
+    - pathlib ==1.0.1  # [py27]
 
 test:
   imports:

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -24,7 +24,7 @@ requirements:
 test:
   requires:
     - pytest
-    - spacy_lookups_data
+    - spacy-lookups-data
   commands:
     - python -m pytest --tb=native --pyargs spacy_lookups_data
 

--- a/recipes/spacy-lookups-data/meta.yaml
+++ b/recipes/spacy-lookups-data/meta.yaml
@@ -21,8 +21,8 @@ requirements:
   run:
     - python
     - setuptools
-    - srsly>=0.1.0,<1.1.0
-    - pathlib==1.0.1; python_version < "3.4"
+    - srsly >=0.1.0,<1.1.0
+    - pathlib ==1.0.1; python_version < "3.4"
 
 test:
   imports:


### PR DESCRIPTION
spaCy v2.2 splits some data files into a new package. This adds a conda recipe for it.

cc @ines: Please comment to confirm you agree to maintain.

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
