### PR TITLE
Add tesserocr-feedstock

### DIFF
--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "tesserocr" %}
 {% set version = "2.4.1" %}
-{% set sha256 = "8becfe0542a1a118fe92f9b2c1fc0ded9c90ce12a8374b3de33a9e20179fa546" %}
 
 package:
   name: "{{ name|lower }}"
@@ -9,11 +8,11 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 8becfe0542a1a118fe92f9b2c1fc0ded9c90ce12a8374b3de33a9e20179fa546
 
 build:
   number: 0
-  script: 'python -m pip install . --no-deps --ignore-installed -vvv'
+  script: "{{ PYTHON }} -m pip install . -vv"
   skip: true  # [win and py==27]
 
 requirements:

--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - autoconf
     - pkg-config
     - libtool
+    - pip
   host:
     - libpng
     - tesseract =4.1.0
@@ -36,6 +37,7 @@ requirements:
     - giflib
     - cython
     - python
+    - pip
   run:
     - python
     - pillow
@@ -49,10 +51,10 @@ about:
   home: https://github.com/sirfz/tesserocr
   license: MIT
   license_family: MIT
-  license_file:
+  license_file: LICENSE
   summary: A simple, Pillow-friendly, Python wrapper around tesseract-ocr API using Cython
-  doc_url:
-  dev_url:
+  doc_url: https://github.com/sirfz/tesserocr
+  dev_url: https://github.com/sirfz/tesserocr
 
 extra:
   recipe-maintainers:

--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "tesserocr" %}
+{% set version = "2.4.1" %}
+{% set sha256 = "8becfe0542a1a118fe92f9b2c1fc0ded9c90ce12a8374b3de33a9e20179fa546" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: 'python -m pip install . --no-deps --ignore-installed -vvv'
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - automake
+    - autoconf
+    - pkg-config
+    - libtool
+  host:
+    - libpng
+    - tesseract =4.1.0
+    - jpeg
+    - libtiff
+    - zlib
+    - leptonica
+    - libwebp
+    - xz
+    - openjpeg
+    - giflib
+    - cython
+    - python
+  run:
+    - python
+    - pillow
+    - tesseract =4.1.0
+
+test:
+    imports:
+        - tesserocr
+
+about:
+  home: https://github.com/sirfz/tesserocr
+  license: MIT
+  license_family: MIT
+  license_file:
+  summary: A simple, Pillow-friendly, Python wrapper around tesseract-ocr API using Cython
+  doc_url:
+  dev_url:
+
+extra:
+  recipe-maintainers:
+    - Chilipp
+    - sirfz

--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -19,11 +19,11 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - automake
-    - autoconf
-    - pkg-config
-    - libtool
-    - pip
+    - autoconf  # [not win]
+    - automake  # [not win]
+    - libtool  # [not win]
+    - pkg-config  # [not win]
+    - cmake  # [win]
   host:
     - libpng
     - tesseract =4.1.0
@@ -40,8 +40,8 @@ requirements:
     - pip
   run:
     - python
+    - {{ pin_compatible('tesseract') }}
     - pillow
-    - tesseract =4.1.0
 
 test:
     imports:

--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -19,22 +19,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - autoconf  # [not win]
-    - automake  # [not win]
-    - libtool  # [not win]
-    - pkg-config  # [not win]
-    - cmake  # [win]
   host:
-    - libpng
-    - tesseract =4.1.0
-    - jpeg
-    - libtiff
-    - zlib
-    - leptonica
-    - libwebp
-    - xz
-    - openjpeg
-    - giflib
+    - tesseract
     - cython
     - python
     - pip

--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -27,7 +27,8 @@ requirements:
     - pip
   run:
     - python
-    - {{ pin_compatible('tesseract') }}
+    - {{ pin_compatible('tesseract', max_pin='x.x.x') }}
+    - leptonica  # [not win]
     - pillow
 
 test:

--- a/recipes/tesserocr/meta.yaml
+++ b/recipes/tesserocr/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pip
   run:
     - python
-    - {{ pin_compatible('tesseract', max_pin='x.x.x') }}
+    - {{ pin_compatible('tesseract', max_pin='x.x') }}
     - leptonica  # [not win]
     - pillow
 


### PR DESCRIPTION
Closes https://github.com/sirfz/tesserocr/issues/196

This PR adds a new recipe for the tesserocr package (https://github.com/sirfz/tesserocr), a Python wrapper for the tesseract-ocr API.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->



Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

- [x] @sirfz: Please ping any other Github user that should be included as maintainer in the recipe,  here in this thread
- [x] Skipping build for Windows and Python 2.7 - Approved by @sirfz
