### PR TITLE
Add flask-smorest

### DIFF
--- a/recipes/flask-smorest/meta.yaml
+++ b/recipes/flask-smorest/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "flask-smorest" %}
+{% set version = "0.18.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5d3d80aeaf790516661c853c6b5c5a516a4613fb20fd9b5a3058eed057a4e984
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - apispec
+    - flask
+    - marshmallow
+    - python >=3
+    - webargs
+    - werkzeug
+
+test:
+  imports:
+    - flask_smorest
+
+about:
+  home: https://github.com/marshmallow-code/flask-smorest
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'DB agnostic framework to build auto-documented REST APIs with Flask and marshmallow'
+  doc_url: https://flask-smorest.readthedocs.io/
+  dev_url: https://github.com/marshmallow-code/flask-smorest
+
+extra:
+  recipe-maintainers:
+    - mcs07


### PR DESCRIPTION
I'm submitting this to staged-recipes due to **flask-rest-api** being renamed to **flask-smorest**.

I believe that once this is merged, the old [flask-rest-api-feedstock](https://github.com/conda-forge/flask-rest-api-feedstock) should be archived.

- flask-smorest PR where project was renamed: https://github.com/marshmallow-code/flask-smorest/pull/100
- flask-rest-api-feedstock issue: https://github.com/conda-forge/flask-rest-api-feedstock/issues/7

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
