### PR TITLE
Add graphene-tornado

### DIFF
--- a/recipes/graphene-tornado/LICENSE
+++ b/recipes/graphene-tornado/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016-Present Syrus Akbary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/graphene-tornado/meta.yaml
+++ b/recipes/graphene-tornado/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "graphene-tornado" %}
+{% set version = "2.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d95bd6a6018aa922dcf56c9ac8effe24b57a4363ba950b092ea7b017ea32fa1e
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - pytest
+  run:
+    - python
+    - graphene >=2.1,<3
+    - jinja2 >=2.10.1
+    - six >=1.10.0
+    - tornado >=5.1.0
+    - werkzeug ==0.12.2
+
+test:
+  imports:
+    - graphene_tornado
+
+about:
+  home: https://github.com/graphql-python/graphene-tornado
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A project for running Graphene on top of Tornado in Python 2 and 3.'
+
+  description: |
+    A project for running Graphene on top of Tornado in Python 2 and 3.
+    The codebase is a port of graphene-django.
+  doc_url: https://github.com/graphql-python/graphene-tornado
+  dev_url: https://github.com/graphql-python/graphene-tornado
+
+extra:
+  recipe-maintainers:
+    - kinow


### PR DESCRIPTION
Pull request for [graphene-tornado](https://github.com/graphql-python/graphene-tornado). 

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
