### PR TITLE
Add graphql-ws

### DIFF
--- a/recipes/graphql-ws/LICENSE
+++ b/recipes/graphql-ws/LICENSE
@@ -1,0 +1,11 @@
+
+MIT License
+
+Copyright (c) 2017, Syrus Akbary
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/recipes/graphql-ws/meta.yaml
+++ b/recipes/graphql-ws/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "graphql-ws" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b4e80b6bc50c29cfa27f3d63e8a289c91d3cffb49022a7dbe96dababcf763159
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - pytest-runner
+  run:
+    - python
+    - graphql-core >=2.0,<3
+
+test:
+  imports:
+    - graphql_ws
+
+about:
+  home: https://github.com/graphql-python/graphql-ws
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'GraphQL websockets'
+
+  description: |
+    GraphQL websockets. Websocket server for GraphQL subscriptions.
+  doc_url: https://github.com/graphql-python/graphql-ws
+  dev_url: https://github.com/graphql-python/graphql-ws
+
+extra:
+  recipe-maintainers:
+    - kinow


### PR DESCRIPTION
PR to add `graphql-ws` to Conda Forge.

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
