### PR TITLE
separate suitesparse components: graphBLAS, Mongoose

### DIFF
--- a/recipes/graphblas/build.sh
+++ b/recipes/graphblas/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# make sure CMake install goes in the right place
+export INSTALL="${PREFIX}"
+export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
+
+# make SuiteSparse
+make library static VERBOSE=1
+make install VERBOSE=1

--- a/recipes/graphblas/meta.yaml
+++ b/recipes/graphblas/meta.yaml
@@ -22,9 +22,11 @@ requirements:
     - make
     - m4
   host:
-    - openmp
+    - openmp  # [linux]
+    - llvm-openmp  # [osx]
   run:
-    - openmp
+    - openmp  # [linux]
+    - llvm-openmp  # [osx]
 
 test:
   commands:

--- a/recipes/graphblas/meta.yaml
+++ b/recipes/graphblas/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "3.1.0" %}
+
+package:
+  name: graphblas
+  version: {{ version }}
+
+source:
+  url: http://faculty.cse.tamu.edu/davis/GraphBLAS/GraphBLAS-{{ version }}.tar.gz
+  sha256: 7e7c9042dc037f2355825d6cf2b57b4a03be61414874b38419a574587f66a0b8
+
+build:
+  skip: true  # [win]
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("graphblas") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+    - m4
+  host:
+    - openmp
+  run:
+    - openmp
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/GraphBLAS.h
+    - test -f ${PREFIX}/lib/libgraphblas${SHLIB_EXT}
+    - test -f ${PREFIX}/lib/libgraphblas.a
+
+about:
+  home: http://faculty.cse.tamu.edu/davis/GraphBLAS.html
+  license: Apache 2.0
+  license_family: Apache
+  license_file: Doc/License.txt
+  summary: SuiteSparse:GraphBLAS is a full implementation of the GraphBLAS standard
+
+extra:
+  recipe-maintainers:
+    - grlee77
+    - jakirkham
+    - basnijholt
+    - minrk
+    - jayfurmanek

--- a/recipes/mongoose/build.sh
+++ b/recipes/mongoose/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+export INSTALL="${PREFIX}"
+# make sure CMake install goes in the right place
+export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
+
+# make mongoose
+make library static VERBOSE=1
+make install VERBOSE=1

--- a/recipes/mongoose/disable-coverage-clang.patch
+++ b/recipes/mongoose/disable-coverage-clang.patch
@@ -1,0 +1,30 @@
+From 35305d55ca723b1f13db437e694cc006971c3508 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Thu, 3 Oct 2019 13:20:53 +0200
+Subject: [PATCH] disable --coverage flag
+
+seems to fail with conda clang
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 64c09272..322a273c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -323,9 +323,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" ST
+     # using Clang
+     SET(CMAKE_CXX_FLAGS "-O3 -fwrapv")
+     # Debug flags for Clang
+-    SET(CMAKE_CXX_FLAGS_DEBUG "--coverage -g -fwrapv")
+-    SET(CMAKE_C_FLAGS_DEBUG "--coverage -g")
+-    SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "--coverage -g")
++    SET(CMAKE_CXX_FLAGS_DEBUG "-g -fwrapv")
++    SET(CMAKE_C_FLAGS_DEBUG "-g")
++    SET(CMAKE_EXE_LINKER_FLAGS_DEBUG "-g")
+ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+     # using GCC
+     SET(CMAKE_CXX_FLAGS "-O3 -fwrapv")
+-- 
+2.23.0
+

--- a/recipes/mongoose/meta.yaml
+++ b/recipes/mongoose/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "2.0.4" %}
+
+package:
+  name: mongoose
+  version: {{ version }}
+
+source:
+  url: https://github.com/ScottKolo/Mongoose/archive/v{{ version }}.tar.gz
+  sha256: 746ded2b8c2ab1b4c9ba94622bd89ecb8bcdb58957c18ee3795f5a3696face0c
+  patches:
+    - disable-coverage-clang.patch
+
+build:
+  skip: true  # [win]
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("mongoose") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+    - m4
+
+test:
+  source_files:
+    - Matrix
+  commands:
+    - test -f ${PREFIX}/bin/mongoose
+    - test -f ${PREFIX}/include/Mongoose.hpp
+    - test -f ${PREFIX}/lib/libmongoose${SHLIB_EXT}
+    - test -f ${PREFIX}/lib/libmongoose.a
+    # make sure the bundled libsuitesparse doesn't get installed
+    - test ! -f ${PREFIX}/lib/libsuitesparsconfig${SHLIB_EXT}
+    - test ! -f ${PREFIX}/lib/libsuitesparsconfig.a
+    # test that mongoose runs
+    - mongoose Matrix/Pd.mtx
+
+about:
+  home: http://faculty.cse.tamu.edu/davis/suitesparse.html
+  license: GPLv3
+  license_family: GPL
+  license_file: Doc/License.txt
+  summary: Mongoose is a graph partitioning library, distributed as part of SuiteSparse
+
+extra:
+  recipe-maintainers:
+    - grlee77
+    - jakirkham
+    - basnijholt
+    - minrk
+    - jayfurmanek


### PR DESCRIPTION
these are shipped with suitesparse 5.4, but unlike umfpack and friends, are independently versioned and distributed as well.

see https://github.com/conda-forge/suitesparse-feedstock/issues/55

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vend other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

I've initialized maintainers of the suitesparse recipe as maintainers of these as well:

- @grlee77
- @jakirkham
- @basnijholt
- @jayfurmanek

pleas confirm if this is okay. If not, I'll remove you.