### PR TITLE
Run `setup_conda_rc` as part of all builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ skip_commits:
 environment:
 
   CONDA_INSTALL_LOCN: "C:\\Miniconda36-x64"
+  CONFIG: azure-win-64
 
   matrix:
     - PLATFORM: "64"
@@ -40,7 +41,7 @@ install:
 
 
     - cmd: appveyor-retry conda.exe install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-pinning conda-forge-ci-setup=2.* networkx "conda-build>=3.16"
-
+    - cmd: setup_conda_rc .\ .\recipes .\.ci_support\%CONFIG%.yaml
     - cmd: appveyor-retry run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -62,6 +62,8 @@ jobs:
     - script: conda.exe config --add channels conda-forge
       displayName: configure conda channels
 
+    # Configure the VM
+    - script: setup_conda_rc .\ .\recipes .\.ci_support\%CONFIG%.yaml
 
     # Configure the VM.
     - script: call run_conda_forge_build_setup

--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -44,6 +44,8 @@ conda index /home/conda/staged-recipes/build_artifacts
 
 conda install --yes --quiet "conda!=4.6.1,<4.7.11a0" conda-forge-ci-setup=2.* conda-forge-pinning networkx "conda-build>=3.16"
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/staged-recipes}"
+export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
+setup_conda_rc "${FEEDSTOCK_ROOT}" "${FEEDSTOCK_ROOT}/recipes" "${CI_SUPPORT}/${CONFIG}.yaml"
 source run_conda_forge_build_setup
 
 # yum installs anything from a "yum_requirements.txt" file that isn't a blank line or comment.

--- a/.circleci/run_docker_build.sh
+++ b/.circleci/run_docker_build.sh
@@ -35,6 +35,7 @@ docker run ${DOCKER_RUN_ARGS} \
            -v ${REPO_ROOT}:/home/conda/staged-recipes \
            -e HOST_USER_ID=${HOST_USER_ID} \
            -e AZURE=${AZURE} \
+           -e CONFIG \
            -e CI \
            $IMAGE_NAME \
            bash \


### PR DESCRIPTION
This was already being handled for macOS (see below). Here we handle the rest of the platforms.

https://github.com/conda-forge/staged-recipes/blob/1a5216f73723c2318566e96c3cca61fa78e37543/.azure-pipelines/azure-pipelines-osx.yml#L42