### PR TITLE
Add CuPy

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ jobs:
     matrix:
       linux:
         CONFIG: azure-linux-64-comp7
-        IMAGE_NAME: condaforge/linux-anvil-comp7
+        IMAGE_NAME: condaforge/linux-anvil-cuda:9.2
         CF_MAX_PY_VER: 37
         AZURE: True
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ jobs:
     matrix:
       linux:
         CONFIG: azure-linux-64-comp7
-        IMAGE_NAME: condaforge/linux-anvil-cuda:9.2
+        IMAGE_NAME: condaforge/linux-anvil-comp7
         CF_MAX_PY_VER: 37
         AZURE: True
   timeoutInMinutes: 360

--- a/recipes/cupy/meta.yaml
+++ b/recipes/cupy/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [not (linux64 and cuda_compiler_version != "None")]
+  skip: True  # [not (linux64 and cuda_compiler_version == "9.2")]
   script: "{{ PYTHON }} -m pip install . -vv"
   missing_dso_whitelist:
     - "*/libcuda.*"

--- a/recipes/cupy/meta.yaml
+++ b/recipes/cupy/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "cupy" %}
+{% set version = "6.4.0" %}
+{% set sha256 = "2a3cd1812f043ba9451b8ca4e5a4c31f9acc486c003f6970836e1a46c735c82e" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/cupy/cupy/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: True  # [not (linux64 and cuda_compiler_version != "None")]
+  script: "{{ PYTHON }} -m pip install . -vv"
+  missing_dso_whitelist:
+    - "*/libcuda.*"
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("cuda") }}
+
+  host:
+    - python
+    - pip
+    - setuptools
+    - cython >=0.24.0
+    - cudnn
+    - fastrlock >=0.3
+    - nccl
+
+  run:
+    - python
+    - setuptools
+    - cudnn
+    - fastrlock >=0.3
+    - numpy >=1.9.0
+    - six >=1.9.0
+
+test:
+  requires:
+    - pytest
+    - mock
+  source_files:
+    - tests
+
+about:
+  home: https://cupy.chainer.org/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: CuPy is an implementation of a NumPy-compatible multi-dimensional array on CUDA.
+
+extra:
+  recipe-maintainers:
+    - jakirkham

--- a/recipes/cupy/meta.yaml
+++ b/recipes/cupy/meta.yaml
@@ -57,3 +57,4 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - leofang

--- a/recipes/cupy/meta.yaml
+++ b/recipes/cupy/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [not (linux64 and cuda_compiler_version == "9.2")]
+  skip: True  # [not (linux64 and cuda_compiler_version != "None")]
   script: "{{ PYTHON }} -m pip install . -vv"
   missing_dso_whitelist:
     - "*/libcuda.*"

--- a/recipes/cupy/run_test.py
+++ b/recipes/cupy/run_test.py
@@ -1,0 +1,19 @@
+# Configure CuPy to use 1 GPU for testing
+import os
+os.environ["CUPY_TEST_GPU_LIMIT"] = "1"
+
+# Check for CuPy (without importing)
+import pkgutil
+pkgutil.find_loader("cupy")
+
+# Try to import CuPy
+import sys
+try:
+    import cupy
+except ImportError:
+    print("No GPU available. Exiting without running CuPy's tests.")
+    sys.exit(0)
+
+# Run CuPy's test suite
+import py
+py.test.cmdline.main(["tests/cupy_tests"])


### PR DESCRIPTION
Closes https://github.com/conda-forge/staged-recipes/pull/8638

Based off PR ( https://github.com/conda-forge/staged-recipes/pull/8638 ), this adds the `cupy` package. Tidied the PR a bit. Also dropped some changes to `staged-recipes` that are not needed.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
