### PR TITLE
Added recipe for pytest-astropy-header

### DIFF
--- a/recipes/pytest-astropy-header/LICENSE.rst
+++ b/recipes/pytest-astropy-header/LICENSE.rst
@@ -1,0 +1,26 @@
+Copyright (c) 2019, Astropy Developers
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of the Astropy Team nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/pytest-astropy-header/meta.yaml
+++ b/recipes/pytest-astropy-header/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "pytest-astropy-header" %}
+{% set version = "0.1.1" %}
+{% set git_url = "https://github.com/astropy/pytest-astropy-header" %}
+{% set sha256 = "928547645e53586ff57c9e00ed050b876d4dd53dce95f7e6b0130851a4f71aec" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  build:
+    - python
+    - pip
+    - pytest >=3.0
+  run:
+    - python
+    - pytest >=3.0
+
+test:
+  imports:
+    - pytest_astropy_header
+    - pytest_astropy_header.display
+
+about:
+  home: {{ git_url }}
+  license_family: BSD
+  license: BSD 3-Clause
+  license_file: LICENSE.rst
+  summary: 'Pytest plugin to add diagnostic information to the header of the test output'
+  doc_url: {{ git_url }}
+  dev_url: {{ git_url }}
+
+extra:
+  recipe-maintainers:
+    - astrofrog-conda-forge
+    - bsipocz

--- a/recipes/pytest-astropy-header/meta.yaml
+++ b/recipes/pytest-astropy-header/meta.yaml
@@ -15,7 +15,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   build:


### PR DESCRIPTION
Checklist

* [x] License file is packaged (see here for an example)
* [x] Source is from official source
* [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
* [ ] <s>If static libraries are linked in, the license of the static library is packaged.</s>
* [x] Build number is 0
* [x] A tarball (url) rather than a repo (e.g. git_url) is used in your recipe (see here for more details)
* [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there