### PR TITLE
osc-lib: new recipe

### DIFF
--- a/recipes/osc-lib/meta.yaml
+++ b/recipes/osc-lib/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "osc-lib" %}
+{% set version = "1.14.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 3467a1edf62946f1b67724fa7f9c699b5e31d80b111ed9e4c7aec21633a3e30d
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pbr
+    - pip
+    - python
+    - setuptools
+  run:
+    - babel
+    - cliff
+    - keystoneauth1
+    - openstacksdk
+    - oslo.i18n
+    - oslo.utils
+    - pbr
+    - python
+    - setuptools
+    - simplejson
+    - six
+    - stevedore
+
+test:
+  imports:
+    - osc_lib
+
+about:
+  home: https://opendev.org/openstack/osc-lib
+  license: Apache Software
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "OpenStackClient Library"
+  doc_url: https://docs.openstack.org/osc-lib/latest/
+  dev_url: https://opendev.org/openstack/osc-lib
+
+extra:
+  recipe-maintainers:
+    - tschoonj


### PR DESCRIPTION
This is part of my effort to get python-openstackclient onto conda-forge...

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there