### PR TITLE
Adds CoreUI Dash Components

### DIFF
--- a/recipes/dash-coreui-components/meta.yaml
+++ b/recipes/dash-coreui-components/meta.yaml
@@ -31,7 +31,7 @@ about:
   home: https://github.com/MolSSI/dash-coreui-components
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE.txt
+  license_file: LICENSE
   summary: 'CoreUI components for Plotly Dash'
 
   description: |

--- a/recipes/dash-coreui-components/meta.yaml
+++ b/recipes/dash-coreui-components/meta.yaml
@@ -35,7 +35,7 @@ about:
   summary: 'CoreUI components for Plotly Dash'
 
   description: |
-    CoreUI components have been brough to Plotly Dash allowing quick
+    CoreUI components have been brough to Plotly Dash allowing
     construction of beautiful dashboards quickly and easily.
   dev_url: https://github.com/MolSSI/dash-coreui-components
 

--- a/recipes/dash-coreui-components/meta.yaml
+++ b/recipes/dash-coreui-components/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace("-", "_") }}-{{ version }}.tar.gz
   sha256: 9d01969c0a3eb8db8071fdb075edbabd494a440fa3e50f5dea6124198ed39a51
 
 build:

--- a/recipes/dash-coreui-components/meta.yaml
+++ b/recipes/dash-coreui-components/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 9d01969c0a3eb8db8071fdb075edbabd494a440fa3e50f5dea6124198ed39a51
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipes/dash-coreui-components/meta.yaml
+++ b/recipes/dash-coreui-components/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "dash-coreui-components" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9d01969c0a3eb8db8071fdb075edbabd494a440fa3e50f5dea6124198ed39a51
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - dash >=1.0.0
+    - dash-bootstrap-components >=0.7.2
+
+test:
+  imports:
+    - dash_coreui_components
+
+about:
+  home: https://github.com/MolSSI/dash-coreui-components
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'CoreUI components for Plotly Dash'
+
+  description: |
+    CoreUI components have been brough to Plotly Dash allowing quick
+    construction of beautiful dashboards quickly and easily.
+  dev_url: https://github.com/MolSSI/dash-coreui-components
+
+extra:
+  recipe-maintainers:
+    - dgasmith
+    - lnaden


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

This is a bit of an odd package as [Dash](https://plot.ly/dash/) stores the JavaScript required inside the package itself. In some ways this could be viewed as vendoring another package as the full [`CoreUI`](https://github.com/coreui/coreui) JS is distributed. That file of course has its full license MIT license retained in the file. I don't think this is an issue, but wanted to bring it up out of an abundance of caution.

This is analogous to the `dash-bootstrap-components` package.

@lnaden Can you be a co-maintainer on this package as well with your MolSSI hat on so that we have two.

@conda-forge/help-python