### PR TITLE
Add volk

### DIFF
--- a/recipes/volk/bld.bat
+++ b/recipes/volk/bld.bat
@@ -1,0 +1,31 @@
+setlocal EnableDelayedExpansion
+
+:: Make a build folder and change to it
+mkdir build
+cd build
+
+:: configure
+cmake -G "NMake Makefiles JOM" ^
+      -DBoost_NO_BOOST_CMAKE=ON ^
+      -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+      -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+      -DPYTHON_EXECUTABLE:PATH="%PYTHON%" ^
+      -DVOLK_PYTHON_DIR:PATH="%PREFIX%"\Lib\site-packages ^
+      -DCMAKE_BUILD_TYPE:STRING=Release ^
+      -DENABLE_ORC:BOOL=OFF ^
+      -DENABLE_PROFILING:BOOL=OFF ^
+      -DENABLE_TESTING:BOOL=ON ^
+      ..
+if errorlevel 1 exit 1
+
+:: build
+cmake --build . -- -j%CPU_COUNT%
+if errorlevel 1 exit 1
+
+:: test
+ctest --output-on-failure
+::if errorlevel 1 exit 1
+
+:: install
+cmake --build . --target install
+if errorlevel 1 exit 1

--- a/recipes/volk/build.sh
+++ b/recipes/volk/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mkdir build
+cd build
+cmake \
+    -DBoost_NO_BOOST_CMAKE=ON \
+    -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DPYTHON_EXECUTABLE=$PYTHON \
+    -DLIB_SUFFIX="" \
+    -DENABLE_PROFILING=OFF \
+    -DENABLE_TESTING=ON \
+    ..
+cmake --build . -- -j${CPU_COUNT}
+ctest --output-on-failure || true
+cmake --build . --target install

--- a/recipes/volk/meta.yaml
+++ b/recipes/volk/meta.yaml
@@ -1,0 +1,90 @@
+{% set version = "2.0.0" %}
+{% set sha256 = "d4274c4cb07d634f4d5f94f4845fb54156ad45ee03f4cd045496b91967b21c30" %}
+{% set build_number = "0" %}
+
+package:
+  name: volk
+  version: {{ version }}
+
+source:
+  url: https://github.com/gnuradio/volk/releases/download/v{{ version }}/volk-v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: {{ build_number }}
+  run_exports:
+    - {{ pin_subpackage('volk', max_pin='x') }}
+  # windows requires vs2015+ to build and therefore can't build against py2k
+  skip: True  # [win and py2k]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=2.8.12
+    - jom  # [win]
+    - pkg-config  # [not win]
+
+  host:
+    - boost-cpp
+    - mako >=0.4.2
+    - python
+    - six
+
+  run:
+    - boost-cpp
+    - python
+    - six
+
+test:
+  commands:
+    # verify CLI tools
+    {% set volk_cmds = [
+        "volk-config-info",
+        "volk_profile",
+    ] %}
+    {% set volk_python_cmds = ["volk_modtool"] %}  # [unix]
+    {% set volk_python_cmds = ["volk_modtool.py"] %}  # [win]
+    {% for each_cmd in volk_cmds + volk_python_cmds %}
+    - command -v {{ each_cmd }}  # [unix]
+    - where {{ each_cmd }}  # [win]
+    {% endfor %}
+
+    # verify libraries
+    {% set volk_lib = "volk" %}
+    - test -f $PREFIX/lib/lib{{ volk_lib }}${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\{{ volk_lib }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\{{ volk_lib }}.lib exit 1  # [win]
+    - conda inspect linkages -p $PREFIX volk  # [not win]
+    - conda inspect objects -p $PREFIX volk  # [osx]
+
+  imports:
+    - volk_modtool
+
+about:
+  home: http://libvolk.org/
+  license: GPL-3.0
+  license_family: GPL
+  license_file: COPYING
+  summary: 'The Vector Optimized Library of Kernels'
+  description: |
+    VOLK is the Vector-Optimized Library of Kernels. It is a free library,
+    currently offered under the GPLv3, that contains kernels of hand-written
+    SIMD code for different mathematical operations. Since each SIMD
+    architecture can be very different and no compiler has yet come along to
+    handle vectorization properly or highly efficiently, VOLK approaches the
+    problem differently.
+
+    For each architecture or platform that a developer wishes to vectorize for,
+    a new proto-kernel is added to VOLK. At runtime, VOLK will select the
+    correct proto-kernel. In this way, the users of VOLK call a kernel for
+    performing the operation that is platform/architecture agnostic. This
+    allows us to write portable SIMD code that is optimized for a variety of
+    platforms.
+
+  doc_url: http://libvolk.org/doxygen/index.html
+  dev_url: https://github.com/gnuradio/volk
+
+extra:
+  recipe-maintainers:
+    - ryanvolz

--- a/recipes/volk/meta.yaml
+++ b/recipes/volk/meta.yaml
@@ -1,6 +1,4 @@
 {% set version = "2.0.0" %}
-{% set sha256 = "d4274c4cb07d634f4d5f94f4845fb54156ad45ee03f4cd045496b91967b21c30" %}
-{% set build_number = "0" %}
 
 package:
   name: volk
@@ -8,10 +6,10 @@ package:
 
 source:
   url: https://github.com/gnuradio/volk/releases/download/v{{ version }}/volk-v{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: d4274c4cb07d634f4d5f94f4845fb54156ad45ee03f4cd045496b91967b21c30
 
 build:
-  number: {{ build_number }}
+  number: 0
   run_exports:
     - {{ pin_subpackage('volk', max_pin='x') }}
   # windows requires vs2015+ to build and therefore can't build against py2k


### PR DESCRIPTION
VOLK (vector optimized library of kernels) is a dependency of GNU Radio. The two are often released in tandem, but packaging VOLK separately will help shorten build times of GNU Radio. It is also certainly possible that a third party might want to use VOLK independently.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
