### PR TITLE
Add r-inctools

### DIFF
--- a/recipes/r-inctools/bld.bat
+++ b/recipes/r-inctools/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-inctools/build.sh
+++ b/recipes/r-inctools/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -o errexit -o pipefail
+if [[ ${target_platform} =~ linux.* ]] || [[ ${target_platform} == win-32 ]] || [[ ${target_platform} == win-64 ]] || [[ ${target_platform} == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  ${R} CMD INSTALL --build .
+else
+  mkdir -p "${PREFIX}"/lib/R/library/inctools
+  mv ./* "${PREFIX}"/lib/R/library/inctools
+  if [[ ${target_platform} == osx-64 ]]; then
+    pushd "${PREFIX}"
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd "${libdir}" || exit 1
+          while IFS= read -r -d '' SHARED_LIB
+          do
+            echo "fixing SHARED_LIB ${SHARED_LIB}"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "${PREFIX}"/lib/libomp.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "${PREFIX}"/lib/libgfortran.3.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "${PREFIX}"/lib/libquadmath.0.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "${PREFIX}"/lib/libquadmath.0.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "${PREFIX}"/lib/libgfortran.3.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "${PREFIX}"/lib/libgcc_s.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "${PREFIX}"/sysroot/usr/lib/libiconv.2.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "${PREFIX}"/sysroot/usr/lib/libncurses.5.4.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "${PREFIX}"/sysroot/usr/lib/libicucore.A.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "${PREFIX}"/lib/libexpat.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "${PREFIX}"/lib/libcurl.4.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "${PREFIX}"/lib/libc++.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "${PREFIX}"/lib/libc++.1.dylib "${SHARED_LIB}" || true
+          done <   <(find . \( -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R" \) -print0)
+        popd
+      done
+    popd
+  fi
+fi

--- a/recipes/r-inctools/meta.yaml
+++ b/recipes/r-inctools/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '1.0.14' %}
+{% set version = '1.0.15' %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 
@@ -10,7 +10,7 @@ source:
   url:
     - {{ cran_mirror }}/src/contrib/inctools_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/inctools/inctools_{{ version }}.tar.gz
-  sha256: bb33cf6354beda05b4531450b0315ebc8edfa1a249d1fd3908a39bb444415445
+  sha256: 8e36a7e2e192bef49607d192ecadf6799adc92386552c576ba42fff8786c7446
 
 build:
   merge_build_host: True  # [win]
@@ -25,6 +25,7 @@ requirements:
     - {{posix}}zip               # [win]
   host:
     - r-base
+    - r-binom
     - r-cubature
     - r-doparallel
     - r-dplyr
@@ -39,6 +40,7 @@ requirements:
     - r-tmvtnorm
   run:
     - r-base
+    - r-binom
     - r-cubature
     - r-doparallel
     - r-dplyr
@@ -76,22 +78,22 @@ extra:
 # Package: inctools
 # Type: Package
 # Title: Incidence Estimation Tools
-# Version: 1.0.14
-# Date: 2018-09-21
-# Authors@R: c( person("Alex","Welte", email="alexwelte@sun.ac.za", role="aut"), person("Eduard","Grebe",email="eduardgrebe@sun.ac.za",role=c("cre","aut")), person("Avery","McIntosh",email="avery.i.mcintosh@gmail.com",role="aut"), person("Petra","Baumler",email="petra.baeumler@med.uni-muenich.de",role="aut"), person("Reshma","Kassanjee", role="ctb"), person("Hilmarie","Brand", role="ctb"), person("Cari","Van Schalkwyk", role="ctb"), person("Yuruo","Li",email="yul123@pitt.edu", role="ctb"), person("Simon","Daniel",email="skjdaniel@gmail.com", role="ctb"), person("Stefano","Ongarello", email="stefano.ongarello@finddx.org", role="aut"), person("Yusuke","Asai", email="yusuke.asai@yahoo.de", role="ctb"), person("Jeffrey","Eaton", email="jeffrey.eaton@imperial.ac.uk", role="ctb") )
+# Version: 1.0.15
+# Date: 2019-11-05
+# Authors@R: c( person("Eduard","Grebe",email="Eduard.Grebe@ucsf.edu",role=c("cre","aut")), person("Alex","Welte", email="alexwelte@sun.ac.za", role="aut"), person("Avery","McIntosh",email="avery.i.mcintosh@gmail.com",role="aut"), person("Petra","Baumler",email="petra.baeumler@med.uni-muenich.de",role="aut"), person("Reshma","Kassanjee", role="ctb"), person("Hilmarie","Brand", role="ctb"), person("Cari","Van Schalkwyk", role="ctb"), person("Yuruo","Li",email="yul123@pitt.edu", role="ctb"), person("Simon","Daniel",email="skjdaniel@gmail.com", role="ctb"), person("Stefano","Ongarello", email="stefano.ongarello@finddx.org", role="aut"), person("Yusuke","Asai", email="yusuke.asai@yahoo.de", role="ctb"), person("Jeffrey","Eaton", email="jeffrey.eaton@imperial.ac.uk", role="ctb") )
 # Description: Tools for estimating incidence from biomarker data in cross- sectional surveys, and for calibrating tests for recent infection. Implements and extends the method of Kassanjee et al. (2012) <doi:10.1097/EDE.0b013e3182576c07>.
 # URL: http://www.incidence-estimation.org/page/inctools
 # BugReports: https://github.com/SACEMA/inctools/issues
 # Depends: R (>= 3.4.0)
 # License: GPL-3
 # LazyData: True
-# Imports: stats, utils, magrittr, rlang, dplyr, tibble, cubature, tmvtnorm, ggplot2, glm2, plyr, pracma, foreach, parallel, doParallel
+# Imports: stats, utils, magrittr, rlang, dplyr, tibble, cubature, tmvtnorm, ggplot2, glm2, plyr, pracma, foreach, parallel, doParallel, binom
 # Suggests: survey, knitr, rmarkdown
 # VignetteBuilder: knitr
-# RoxygenNote: 6.1.0
+# RoxygenNote: 6.1.1
 # NeedsCompilation: no
-# Packaged: 2018-09-21 22:19:07 UTC; eduardgrebe
-# Author: Alex Welte [aut], Eduard Grebe [cre, aut], Avery McIntosh [aut], Petra Baumler [aut], Reshma Kassanjee [ctb], Hilmarie Brand [ctb], Cari Van Schalkwyk [ctb], Yuruo Li [ctb], Simon Daniel [ctb], Stefano Ongarello [aut], Yusuke Asai [ctb], Jeffrey Eaton [ctb]
-# Maintainer: Eduard Grebe <eduardgrebe@sun.ac.za>
+# Packaged: 2019-11-06 00:19:59 UTC; eduard
+# Author: Eduard Grebe [cre, aut], Alex Welte [aut], Avery McIntosh [aut], Petra Baumler [aut], Reshma Kassanjee [ctb], Hilmarie Brand [ctb], Cari Van Schalkwyk [ctb], Yuruo Li [ctb], Simon Daniel [ctb], Stefano Ongarello [aut], Yusuke Asai [ctb], Jeffrey Eaton [ctb]
+# Maintainer: Eduard Grebe <Eduard.Grebe@ucsf.edu>
 # Repository: CRAN
-# Date/Publication: 2018-09-21 22:40:10 UTC
+# Date/Publication: 2019-11-07 14:20:02 UTC

--- a/recipes/r-inctools/meta.yaml
+++ b/recipes/r-inctools/meta.yaml
@@ -1,0 +1,97 @@
+{% set version = '1.0.14' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-inctools
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/inctools_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/inctools/inctools_{{ version }}.tar.gz
+  sha256: bb33cf6354beda05b4531450b0315ebc8edfa1a249d1fd3908a39bb444415445
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{posix}}zip               # [win]
+  host:
+    - r-base
+    - r-cubature
+    - r-doparallel
+    - r-dplyr
+    - r-foreach
+    - r-ggplot2
+    - r-glm2
+    - r-magrittr
+    - r-plyr
+    - r-pracma
+    - r-rlang
+    - r-tibble
+    - r-tmvtnorm
+  run:
+    - r-base
+    - r-cubature
+    - r-doparallel
+    - r-dplyr
+    - r-foreach
+    - r-ggplot2
+    - r-glm2
+    - r-magrittr
+    - r-plyr
+    - r-pracma
+    - r-rlang
+    - r-tibble
+    - r-tmvtnorm
+
+test:
+  commands:
+    - $R -e "library('inctools')"           # [not win]
+    - "\"%R%\" -e \"library('inctools')\""  # [win]
+
+about:
+  home: http://www.incidence-estimation.org/page/inctools
+  license: GPL-3
+  summary: Tools for estimating incidence from biomarker data in cross- sectional surveys, and
+    for calibrating tests for recent infection. Implements and extends the method of
+    Kassanjee et al. (2012) <doi:10.1097/EDE.0b013e3182576c07>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+  dev_url: https://github.com/SACEMA/inctools
+
+extra:
+  recipe-maintainers:
+    - eduardgrebe
+
+# Encoding: UTF-8
+# Package: inctools
+# Type: Package
+# Title: Incidence Estimation Tools
+# Version: 1.0.14
+# Date: 2018-09-21
+# Authors@R: c( person("Alex","Welte", email="alexwelte@sun.ac.za", role="aut"), person("Eduard","Grebe",email="eduardgrebe@sun.ac.za",role=c("cre","aut")), person("Avery","McIntosh",email="avery.i.mcintosh@gmail.com",role="aut"), person("Petra","Baumler",email="petra.baeumler@med.uni-muenich.de",role="aut"), person("Reshma","Kassanjee", role="ctb"), person("Hilmarie","Brand", role="ctb"), person("Cari","Van Schalkwyk", role="ctb"), person("Yuruo","Li",email="yul123@pitt.edu", role="ctb"), person("Simon","Daniel",email="skjdaniel@gmail.com", role="ctb"), person("Stefano","Ongarello", email="stefano.ongarello@finddx.org", role="aut"), person("Yusuke","Asai", email="yusuke.asai@yahoo.de", role="ctb"), person("Jeffrey","Eaton", email="jeffrey.eaton@imperial.ac.uk", role="ctb") )
+# Description: Tools for estimating incidence from biomarker data in cross- sectional surveys, and for calibrating tests for recent infection. Implements and extends the method of Kassanjee et al. (2012) <doi:10.1097/EDE.0b013e3182576c07>.
+# URL: http://www.incidence-estimation.org/page/inctools
+# BugReports: https://github.com/SACEMA/inctools/issues
+# Depends: R (>= 3.4.0)
+# License: GPL-3
+# LazyData: True
+# Imports: stats, utils, magrittr, rlang, dplyr, tibble, cubature, tmvtnorm, ggplot2, glm2, plyr, pracma, foreach, parallel, doParallel
+# Suggests: survey, knitr, rmarkdown
+# VignetteBuilder: knitr
+# RoxygenNote: 6.1.0
+# NeedsCompilation: no
+# Packaged: 2018-09-21 22:19:07 UTC; eduardgrebe
+# Author: Alex Welte [aut], Eduard Grebe [cre, aut], Avery McIntosh [aut], Petra Baumler [aut], Reshma Kassanjee [ctb], Hilmarie Brand [ctb], Cari Van Schalkwyk [ctb], Yuruo Li [ctb], Simon Daniel [ctb], Stefano Ongarello [aut], Yusuke Asai [ctb], Jeffrey Eaton [ctb]
+# Maintainer: Eduard Grebe <eduardgrebe@sun.ac.za>
+# Repository: CRAN
+# Date/Publication: 2018-09-21 22:40:10 UTC

--- a/recipes/r-inctools/meta.yaml
+++ b/recipes/r-inctools/meta.yaml
@@ -73,6 +73,7 @@ about:
 extra:
   recipe-maintainers:
     - eduardgrebe
+    - conda-forge/r
 
 # Encoding: UTF-8
 # Package: inctools


### PR DESCRIPTION
Added recipe for inctools R package on CRAN. I used @bgruening 's conda r skeleton helpers to create the conda recipe. @conda-forge/help-r . 

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
