### PR TITLE
Firefox unbranded - Linux only for now

### DIFF
--- a/recipes/firefox-unbranded/LICENSE
+++ b/recipes/firefox-unbranded/LICENSE
@@ -1,0 +1,374 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in 
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+

--- a/recipes/firefox-unbranded/build.sh
+++ b/recipes/firefox-unbranded/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+APP_DIR=$PREFIX/bin/FirefoxApp
+LAUNCH_SCRIPT=$PREFIX/bin/firefox
+
+mkdir -p $APP_DIR
+
+if [[ $(uname) == Linux ]]; then
+  mv * $APP_DIR
+  BIN_LOCATION=$APP_DIR/firefox
+fi
+
+# Write launch script and make executable
+cat <<EOF >$LAUNCH_SCRIPT
+#!/bin/bash
+$BIN_LOCATION "\$@"
+EOF
+chmod +x $LAUNCH_SCRIPT

--- a/recipes/firefox-unbranded/meta.yaml
+++ b/recipes/firefox-unbranded/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://queue.taskcluster.net/v1/task/BalSuXWkSq6jYDVY70rtIg/runs/0/artifacts/public/build/target.tar.bz2 # [linux64]
+  url: https://queue.taskcluster.net/v1/task/BalSuXWkSq6jYDVY70rtIg/runs/0/artifacts/public/build/target.tar.bz2  # [linux64]
   # sha256: # [linux64]
 
   # fn: target.dmg  # [osx]

--- a/recipes/firefox-unbranded/meta.yaml
+++ b/recipes/firefox-unbranded/meta.yaml
@@ -17,6 +17,7 @@ source:
   # sha256: # [win]
 
 build:
+  skip: True  # [not linux64]
   number: 0
   binary_relocation:
     - bin/firefox

--- a/recipes/firefox-unbranded/meta.yaml
+++ b/recipes/firefox-unbranded/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://queue.taskcluster.net/v1/task/BalSuXWkSq6jYDVY70rtIg/runs/0/artifacts/public/build/target.tar.bz2  # [linux64]
-  # sha256: # [linux64]
+  sha256: 97eda9e466389127b048a6add64f3c9b6eca11386120de5cc828b847a0f8d66b  # [linux64]
 
   # fn: target.dmg  # [osx]
   # url: https://queue.taskcluster.net/v1/task/DCYVIUwIQmOq0CK8JsEVZQ/runs/0/artifacts/public/build/target.dmg # [osx]

--- a/recipes/firefox-unbranded/meta.yaml
+++ b/recipes/firefox-unbranded/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "70.0.1" %}
+
+package:
+  name: firefox-unbranded
+  version: {{ version }}
+
+source:
+  url: https://queue.taskcluster.net/v1/task/BalSuXWkSq6jYDVY70rtIg/runs/0/artifacts/public/build/target.tar.bz2 # [linux64]
+  # sha256: # [linux64]
+
+  # fn: target.dmg  # [osx]
+  # url: https://queue.taskcluster.net/v1/task/DCYVIUwIQmOq0CK8JsEVZQ/runs/0/artifacts/public/build/target.dmg # [osx]
+  # sha256:   # [osx]
+
+  # fn: firefox.msi  # [win]
+  # url: https://queue.taskcluster.net/v1/task/dM5dTBdjS9eB9cuTDnCIrA/runs/0/artifacts/public/build/target.zip # [win]
+  # sha256: # [win]
+
+build:
+  number: 0
+  binary_relocation:
+    - bin/firefox
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+test:
+  requires:
+    - selenium
+    - geckodriver
+
+about:
+  home: https://www.mozilla.org/en-US/firefox/releases
+  license: MPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'Unbranded Firefox web browser. Typically used for testing add-ons in release versions of Firefox (https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds)'
+
+extra:
+  recipe-maintainers:
+    - birdsarah
+    - ocefpaf

--- a/recipes/firefox-unbranded/run_test.py
+++ b/recipes/firefox-unbranded/run_test.py
@@ -1,0 +1,59 @@
+""" Test whether firefox is viable with geckodriver and selenium
+"""
+import sys
+import os
+import subprocess
+from selenium import webdriver
+from selenium.webdriver.firefox.options import Options
+
+# can't always test on linux due to gtk3
+# - https://github.com/conda-forge/staged-recipes/issues/9314
+IS_LINUX = sys.platform.startswith("linux")
+
+if sys.platform.startswith("win32"):
+    FIREFOX_BINARY = os.path.join(os.environ["LIBRARY_BIN"], "firefox.exe")
+    EXECUTABLE_PATH = os.path.join(os.environ["SCRIPTS"], "geckodriver.exe")
+else:
+    FIREFOX_BINARY = os.path.join(sys.prefix, "bin", "firefox")
+    EXECUTABLE_PATH = os.path.join(sys.prefix, "bin", "geckodriver")
+
+
+if __name__ == "__main__":
+    print("checking firefox binary at {}...".format(FIREFOX_BINARY))
+    assert os.path.exists(FIREFOX_BINARY), "couldn't find binary"
+    print("... ok")
+
+    print("checking binary version...")
+    try:
+        version = subprocess.check_output([FIREFOX_BINARY, "--version"]).decode("utf-8")
+        assert os.environ["PKG_VERSION"] in version
+        print("... ok")
+    except subprocess.CalledProcessError:
+        print("... failed to check version")
+        if IS_LINUX:
+            print("... version check failure ignored on linux due to gtk3")
+        else:
+            sys.exit(1)
+
+    print("testing about:license with selenium...")
+    driver = None
+    try:
+        options = Options()
+        options.headless = True
+        driver = webdriver.Firefox(options=options,
+                                   firefox_binary=FIREFOX_BINARY,
+                                   executable_path=EXECUTABLE_PATH)
+        driver.get("about:license")
+
+        assert "Mozilla Public License 2.0" in driver.page_source, \
+            "couldn't even load the license page"
+        print("... ok")
+        driver.quit()
+    except:
+        if driver:
+            driver.quit()
+        print("... failed to load license page")
+        if IS_LINUX:
+            print("... about:license check ignored on linux, due to gtk3")
+        else:
+            sys.exit(1)


### PR DESCRIPTION
Recipe largely copied from Firefox.

This is for the unbranded release of firefox which is used for testing addons.

Started with just the linux release as the unbranded versions available for osx and win64 are different to those we already packaged.


Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
