### PR TITLE
add python-fastjsonschema 2.14.1

### DIFF
--- a/recipes/python-fastjsonschema/meta.yaml
+++ b/recipes/python-fastjsonschema/meta.yaml
@@ -34,7 +34,11 @@ test:
   imports:
     - fastjsonschema
   commands:
-    - cd src && cd tests && pytest --cov fastjsonschema
+    - >
+      cd src &&
+      cd tests &&
+      pytest --cov fastjsonschema -k
+        "not compile_to_code_ipv6_regex"
 
 about:
   home: https://github.com/horejsek/python-fastjsonschema

--- a/recipes/python-fastjsonschema/meta.yaml
+++ b/recipes/python-fastjsonschema/meta.yaml
@@ -34,11 +34,7 @@ test:
   imports:
     - fastjsonschema
   commands:
-    - >
-      cd src &&
-      cd tests &&
-      pytest --cov fastjsonschema -k
-        "not compile_to_code_ipv6_regex"
+    - cd src && cd tests && pytest --cov fastjsonschema -k "not compile_to_code_ipv6_regex"
 
 about:
   home: https://github.com/horejsek/python-fastjsonschema

--- a/recipes/python-fastjsonschema/meta.yaml
+++ b/recipes/python-fastjsonschema/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "fastjsonschema" %}
+{% set version = "2.14.1" %}
+
+package:
+  name: python-{{ name }}
+  version: {{ version }}
+
+source:
+  - folder: dist
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: af69859de64e7ec8cc613ac7a325de00d6256d6861570fe3a6cf35f417cb4313
+  - folder: src
+    url: https://github.com/horejsek/python-{{ name }}/archive/v{{ version }}.tar.gz
+    sha256: 2b80f5c2d7e8fc2f78dedd16fe0894c5597c71c61feb7af658d309306a3c8262
+
+build:
+  noarch: python
+  number: 0
+  script: "cd dist && {{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.3
+    - pip
+  run:
+    - python >=3.3
+
+test:
+  source_files:
+    - src/tests
+  requires:
+    - pytest-cov
+    - pytest-benchmark
+  imports:
+    - fastjsonschema
+  commands:
+    - cd src && cd tests && pytest --cov fastjsonschema
+
+about:
+  home: https://github.com/horejsek/python-fastjsonschema
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: src/LICENSE
+  summary: 'Fastest Python implementation of JSON schema'
+  description: |
+    fastjsonschema implements validation of JSON documents by JSON schema. The
+    library implements JSON schema drafts 04, 06 and 07. The main purpose is to
+    have a really fast implementation.
+  doc_url: https://horejsek.github.io/python-fastjsonschema
+  doc_source_url: https://github.com/horejsek/python-fastjsonschema/tree/master/docs
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

installing from the official pypi tarball distribution, using the github tarball for the license ([PR](https://github.com/horejsek/python-fastjsonschema/pull/73)) and tests.