### PR TITLE
add openapi-spec-validator

### DIFF
--- a/recipes/openapi-spec-validator/meta.yaml
+++ b/recipes/openapi-spec-validator/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 49a0c4dbd89fa66737fd8e93d71071d93c65c8586a4bff89771c65ec897916af
 
 build:
-  noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
 

--- a/recipes/openapi-spec-validator/meta.yaml
+++ b/recipes/openapi-spec-validator/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - six
     - setuptools
     - pyyaml
-    - pathlib2  # [py27]
+    - pathlib2
 
 test:
   imports:

--- a/recipes/openapi-spec-validator/meta.yaml
+++ b/recipes/openapi-spec-validator/meta.yaml
@@ -10,8 +10,11 @@ source:
   sha256: 49a0c4dbd89fa66737fd8e93d71071d93c65c8586a4bff89771c65ec897916af
 
 build:
+  noarch: python
   number: 0
   script: python -m pip install --no-deps --ignore-installed .
+  entry_points:
+    - openapi-spec-validator = openapi_spec_validator.__main__:main
 
 requirements:
   host:

--- a/recipes/openapi-spec-validator/meta.yaml
+++ b/recipes/openapi-spec-validator/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.2.8" %}
+
+package:
+  name: openapi-spec-validator
+  version: {{ version }}
+
+source:
+  fn: {{ version }}.tar.gz
+  url: https://github.com/p1c2u/openapi-spec-validator/archive/{{ version }}.tar.gz
+  sha256: 49a0c4dbd89fa66737fd8e93d71071d93c65c8586a4bff89771c65ec897916af
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install --no-deps --ignore-installed .
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - pyyaml
+
+  run:
+    - python
+    - jsonschema
+    - six
+    - setuptools
+    - pyyaml
+    - pathlib2  # [py27]
+
+test:
+  imports:
+    - openapi_spec_validator
+
+about:
+  home: https://github.com/p1c2u/openapi-spec-validator
+  license: Apache-2.0
+  summary: 'OpenAPI Spec validator'
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/p1c2u/openapi-spec-validator
+
+extra:
+  recipe-maintainers:
+    - rvalieris


### PR DESCRIPTION

this package is required to update [connexion](https://github.com/conda-forge/connexion-feedstock) to the latest version.

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
