### PR TITLE
add sphinx-js 2.8

### DIFF
--- a/recipes/sphinx-js/meta.yaml
+++ b/recipes/sphinx-js/meta.yaml
@@ -1,0 +1,70 @@
+{% set name = "sphinx-js" %}
+{% set version = "2.8" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - folder: dist
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: c7a97c4d23d592d41a38fc9c6b3a5902578ad1bfcf0ed5094691909fd5f372cd
+  - folder: src
+    url: https://github.com/mozilla/{{ name }}/archive/{{ version }}.tar.gz
+    sha256: 118f5e1d24dfefa5522e33055159822b48539fcb46c1be5f162e9d0a6842859d
+
+build:
+  noarch: python
+  number: 0
+  script: "cd dist && {{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - docutils
+    - jinja2 >2.0,<3.0
+    - parsimonious
+    - python
+    - six >=1.9.0,<2.0
+    - sphinx >=1.6,<3.0
+    - nodejs
+
+test:
+  requires:
+    - python
+    - pytest
+    - recommonmark
+    - sphinx
+    - backports.shutil_which  # [py27]
+
+  source_files:
+    - src/tests
+  imports:
+    - sphinx_js
+
+about:
+  home: https://github.com/mozilla/sphinx-js
+  license: MIT
+  license_family: MIT
+  license_file: src/LICENSE
+  summary: 'Autodoc-style extraction into Sphinx for your JS project'
+
+  description: |
+    When you write a JavaScript library, how do you explain it to people? If
+    it's a small project in a domain your users are familiar with, JSDoc's
+    alphabetical list of routines might suffice. But in a larger project, it is
+    useful to intersperse prose with your API docs without having to copy and
+    paste things.
+
+    sphinx-js lets you use the industry-leading Sphinx documentation tool with
+    JS projects. It provides a handful of directives, patterned after the
+    Python-centric autodoc ones, for pulling JSDoc-formatted documentation into
+    reStructuredText pages. And, because you can keep using JSDoc in your code,
+    you remain compatible with the rest of your JS tooling, like Google's
+    Closure Compiler.
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/sphinx-js/run_test.py
+++ b/recipes/sphinx-js/run_test.py
@@ -1,0 +1,56 @@
+from os.path import join, dirname
+from subprocess import check_call
+import json
+import re
+import shutil
+import tempfile
+
+try:
+    which = shutil.which
+except ImportError:
+    from backports.shutil_which import which
+
+NPM = which("npm")
+HERE = dirname(__file__)
+TESTS = join(HERE, "src", "tests")
+
+# TODO: hoist these to the recipe
+PKG = {
+  "devDependencies": {
+    "jsdoc": "3.6.3",
+    "typedoc": "0.15.0"
+  },
+  "scripts": {
+    "test": "python -m pytest -vv"
+  }
+}
+
+
+def test_in_tmp(tmp):
+    print("- creating package.json to ensure js/tsdoc are installed/on path...")
+    with open(join(tmp, "package.json"), "w+", encoding="utf-8") as fp:
+        json.dump(PKG, fp)
+
+    print("- installing npm packages...")
+    check_call([NPM, "install"], cwd=tmp)
+
+    print("- copying tests...")
+    shutil.copytree(TESTS, join(tmp, "tests"))
+
+    print("- running pytest inside npm...")
+    check_call([NPM, "run", "test"], cwd=tmp)
+
+
+if __name__ == "__main__":
+    print("- creating tmp directory...")
+    TMP = tempfile.mkdtemp()
+
+    try:
+        print("- ensuring no parent paths of tests start with _")
+        assert not re.findall("[\\/]_", TMP), \
+            "!!! path probably contains a child with an underscore: {}".format(TMP)
+        test_in_tmp(TMP)
+        print("SUCCESS")
+    finally:
+        print("cleaning tmp directory")
+        shutil.rmtree(TMP)


### PR DESCRIPTION
Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
  - fetching (along with tests) from github, [PR created](https://github.com/mozilla/sphinx-js/pull/123)
- [x] Source is from official source
  - pypi
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

There is some interesting interplay in (maybe just my) conda-build setup where Some Part of the test path gets an underscore, necessitating the tempdir trickery in the `run_test.py`. Interested to see how it plays out across the matrix.