### PR TITLE
add stringcase 1.2.0

### DIFF
--- a/recipes/python-stringcase/meta.yaml
+++ b/recipes/python-stringcase/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "stringcase" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: python-{{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - stringcase
+
+about:
+  home: https://github.com/okunishinishi/python-stringcase
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Convert string cases between camel case, pascal case, snake case etc...'
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/stringcase/meta.yaml
+++ b/recipes/stringcase/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.2.0" %}
 
 package:
-  name: python-{{ name }}
+  name: {{ name }}
   version: {{ version }}
 
 source:


### PR DESCRIPTION
Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

A new dependency of https://github.com/conda-forge/monkeytype-feedstock/pull/11, but have actually wanted in the past anyway.

- tests are not packaged
- upstream does not have tags from which to grab the tests

So import test it is!