### PR TITLE
Add legacy NetCDF C++ library v4.2

### DIFF
--- a/recipes/netcdf-cxx-legacy/build.sh
+++ b/recipes/netcdf-cxx-legacy/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
+./configure --prefix=$PREFIX
 
 make
 make check

--- a/recipes/netcdf-cxx-legacy/build.sh
+++ b/recipes/netcdf-cxx-legacy/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
+
+make
+make check
+make install

--- a/recipes/netcdf-cxx-legacy/build.sh
+++ b/recipes/netcdf-cxx-legacy/build.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "$(uname)" == "Darwin" ]; then
-    export DYLD_LIBRARY_PATH=${PREFIX}/lib
-fi
-
 CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
 
 make

--- a/recipes/netcdf-cxx-legacy/build.sh
+++ b/recipes/netcdf-cxx-legacy/build.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ "$(uname)" == "Darwin" ]; then
+    export DYLD_LIBRARY_PATH=${PREFIX}/lib
+fi
+
 CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
 
 make

--- a/recipes/netcdf-cxx-legacy/configure.patch
+++ b/recipes/netcdf-cxx-legacy/configure.patch
@@ -1,0 +1,11 @@
+--- configure	2011-09-30 15:34:31.000000000 +0100
++++ configure	2019-11-19 21:32:04.000000000 +0000
+@@ -2329,8 +2329,6 @@
+
+ # Create the VERSION file, which contains the package version from
+ # AC_INIT.
+-echo -n 4.2>VERSION
+-
+
+ { $as_echo "$as_me:${as_lineno-$LINENO}: netCDF-cxx 4.2" >&5
+ $as_echo "$as_me: netCDF-cxx 4.2" >&6;}

--- a/recipes/netcdf-cxx-legacy/meta.yaml
+++ b/recipes/netcdf-cxx-legacy/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "4.2" %}
+
+package:
+  name: netcdf-cxx-legacy
+  version: {{ version }}
+
+source:
+  url: https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx-{{ version }}.tar.gz
+  sha256: 95ed6ab49a0ee001255eac4e44aacb5ca4ea96ba850c08337a3e4c9a0872ccd1
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - libnetcdf
+    - hdf5
+  run:
+    - libnetcdf
+    - hdf5
+  run_constrained:
+    - netcdf-cxx4 >=9999
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libnetcdf_c++.a
+    - test -f $PREFIX/lib/libnetcdf_c++.so  # [linux]
+    - test -f $PREFIX/lib/libnetcdf_c++.dylib  # [osx]
+
+about:
+  home: https://www.unidata.ucar.edu/downloads/netcdf/
+  license_file: COPYRIGHT
+  summary: Legacy Unidata NetCDF C++ Library
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/recipes/netcdf-cxx-legacy/meta.yaml
+++ b/recipes/netcdf-cxx-legacy/meta.yaml
@@ -33,6 +33,7 @@ test:
 
 about:
   home: https://www.unidata.ucar.edu/downloads/netcdf/
+  license: http://www.unidata.ucar.edu/software/netcdf/copyright.html
   license_file: COPYRIGHT
   summary: Legacy Unidata NetCDF C++ Library
 

--- a/recipes/netcdf-cxx-legacy/meta.yaml
+++ b/recipes/netcdf-cxx-legacy/meta.yaml
@@ -28,8 +28,10 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/lib/libnetcdf_c++.a
-    - test -f $PREFIX/lib/libnetcdf_c++.so  # [linux]
-    - test -f $PREFIX/lib/libnetcdf_c++.dylib  # [osx]
+    - test -f $PREFIX/lib/libnetcdf_c++${SHLIB_EXT}
+    - test -f $PREFIX/include/ncvalues.h
+    - test -f $PREFIX/include/netcdfcpp.h
+    - test -f $PREFIX/include/netcdf.hh
 
 about:
   home: https://www.unidata.ucar.edu/downloads/netcdf/

--- a/recipes/netcdf-cxx-legacy/meta.yaml
+++ b/recipes/netcdf-cxx-legacy/meta.yaml
@@ -7,6 +7,9 @@ package:
 source:
   url: https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx-{{ version }}.tar.gz
   sha256: 95ed6ab49a0ee001255eac4e44aacb5ca4ea96ba850c08337a3e4c9a0872ccd1
+  patches:
+    # remove VERSION file that is problematic in OSX
+    - configure.patch
 
 build:
   number: 0


### PR DESCRIPTION
This legacy version is not under development but is used by many
existing packages.

The name of the resulting library conflicts with netcdf-cxx4, so
netcdf-cxx4 > 9999 has been added as a run constraint.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams.
Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
