### PR TITLE
Add argparse-manpage

### DIFF
--- a/recipes/argparse-manpage/meta.yaml
+++ b/recipes/argparse-manpage/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "argparse-manpage" %}
+{% set version = "1.2.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: daffa8e2d1bbcb1334c842ee2529bb1e1b58f4b17ed60f4b27891520e28cd842
+  patches:
+    # remove script, we handle it as an entry_point here
+    - no-scripts.patch
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - argparse-manpage = build_manpages.cli:main
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - python
+
+test:
+  imports:
+    - build_manpages
+    - build_manpages.cli
+  commands:
+    - argparse-manpage --help
+
+about:
+  home: "https://github.com/praiskup/argparse-manpage"
+  license: "Apache-2.0"
+  license_family: "APACHE"
+  license_file: "LICENSE"
+  summary: "Build manual page from python's ArgumentParser object."
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/argparse-manpage/no-scripts.patch
+++ b/recipes/argparse-manpage/no-scripts.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 6c736c6..904464f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -26,7 +26,6 @@ setup(
+     maintainer='Pavel Raiskup',
+     maintainer_email='praiskup@redhat.com',
+     packages=find_packages(),
+-    scripts=['bin/argparse-manpage'],
+     description='Build manual page from python\'s ArgumentParser object.',
+     long_description=get_readme(),
+     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR adds a recipe for [`argparse-manpage`](https://pypi.org/project/argparse-manpage/).

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
