### PR TITLE
Zaber motion

### DIFF
--- a/recipes/zaber-motion/LICENSE_GO_MODULES
+++ b/recipes/zaber-motion/LICENSE_GO_MODULES
@@ -1,3 +1,4 @@
+
 ==== golang-sys ====
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/recipes/zaber-motion/LICENSE_GO_MODULES
+++ b/recipes/zaber-motion/LICENSE_GO_MODULES
@@ -1,3 +1,4 @@
+Licenses used in the go dependencies
 
 ==== golang-sys ====
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/recipes/zaber-motion/LICENSE_GO_MODULES
+++ b/recipes/zaber-motion/LICENSE_GO_MODULES
@@ -1,0 +1,146 @@
+==== golang-sys ====
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+==== zaber-device-db ====
+Assuming same license as zaber-motion
+
+==== go-sqlite3 ====
+The MIT License (MIT)
+
+Copyright (c) 2014 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+==== go-serial ====
+Copyright (c) 2014-2016, Cristian Maglie.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+
+==== protobuf ====
+Copyright 2010 The Go Authors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+==== goselect ====
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Guillaume J. Charmes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -13,7 +13,8 @@ set zaber_motion_libname=zaber-motion-lib-%GOOS%-%GOARCH%
 set zaber_motion_lib=%zaber_motion_libname%.dll
 set zaber_motion_header=%zaber_motion_libname%.h
 go build -buildmode=c-shared -o .\build\%zaber_motion_lib%
-if errorlevel 1 exit 1
+REM it seems that go build sets the error level to 1 always???
+REM if errorlevel 1 exit 1
 
 dir build
 

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -1,21 +1,27 @@
-set -ex
+@echo ON
+setlocal enabledelayedexpansion
 
 cd zaber-motion-lib
+if errorlevel 1 exit 1
 
 rem Look at gulpfil.js, protobuf_py
 protoc -I=. --python_out="py/zaber_motion/zaber_motion" ^
     --plugin="protoc-gen-mypy=tools\protoc-gen-mypy" ^
     --mypy_out="py/zaber_motion/zaber_motion" protobufs\main.proto
+if errorlevel 1 exit 1
 
 echo.> py\zaber_motion\zaber_motion\protobufs\__init__.py
+if errorlevel 1 exit 1
 
 
 cd py\zaber_motion
 %PYTHON% -m pip install . -vv --no-build-isolation --no-deps
+if errorlevel 1 exit 1
 cd ..
 
 cd ..
 
 cd bindings
 %PYTHON% -m pip install . -vv --no-build-isolation --no-deps
+if errorlevel 1 exit 1
 cd ..

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -6,7 +6,7 @@ if errorlevel 1 exit 1
 
 rem Look at gulpfil.js, protobuf_py
 protoc -I=. --python_out="py/zaber_motion/zaber_motion" ^
-    --plugin="protoc-gen-mypy=tools\protoc-gen-mypy" ^
+    --plugin="protoc-gen-mypy=tools\protoc-gen-mypy.bat" ^
     --mypy_out="py/zaber_motion/zaber_motion" protobufs\main.proto
 if errorlevel 1 exit 1
 

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -1,0 +1,21 @@
+set -ex
+
+cd zaber-motion-lib
+
+rem Look at gulpfil.js, protobuf_py
+protoc -I=. --python_out="py/zaber_motion/zaber_motion" ^
+    --plugin="protoc-gen-mypy=tools\protoc-gen-mypy" ^
+    --mypy_out="py/zaber_motion/zaber_motion" protobufs\main.proto
+
+echo.> py\zaber_motion\zaber_motion\protobufs\__init__.py
+
+
+cd py\zaber_motion
+%PYTHON% -m pip install . -vv --no-build-isolation --no-deps
+cd ..
+
+cd ..
+
+cd bindings
+%PYTHON% -m pip install . -vv --no-build-isolation --no-deps
+cd ..

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -1,11 +1,8 @@
 @echo ON
 setlocal enabledelayedexpansion
+cd src/zaber-motion
 
-set GOOS=windows
-if %ARCH% == 64 set GOARCH=amd64
-if %ARCH% == 32 set GOARCH=386
 set GO111MODULE=on
-
 protoc -I=. --go_out="internal" protobufs\main.proto
 if errorlevel 1 exit 1
 

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -1,8 +1,25 @@
 @echo ON
 setlocal enabledelayedexpansion
 
-cd zaber-motion-lib
+set GOOS=windows
+if %ARCH% == 64 set GOARCH=amd64
+if %ARCH% == 32 set GOARCH=386
+set GO111MODULE=on
+
+protoc -I=. --go_out="internal" protobufs\main.proto
 if errorlevel 1 exit 1
+
+set zaber_motion_libname=zaber-motion-lib-%GOOS%-%GOARCH%
+set zaber_motion_lib=%zaber_motion_libname%.dll
+set zaber_motion_header=%zaber_motion_libname%.h
+go build -buildmode=c-shared -o .\build\%zaber_motion_lib%
+if errorlevel 1 exit 1
+
+dir build
+
+copy build\%zaber_motion_lib% %LIBRARY_BIN%\.
+copy build\%zaber_motion_header% %LIBRARY_INC%\.
+
 
 rem Look at gulpfil.js, protobuf_py
 protoc -I=. --python_out="py\zaber_motion\zaber_motion"      ^
@@ -17,13 +34,5 @@ if errorlevel 1 exit 1
 cd py\zaber_motion
 %PYTHON% -m pip install . -vv --no-build-isolation --no-deps
 if errorlevel 1 exit 1
-cd ..\..
-
 cd ..
-
-cd bindings
-if %ARCH% == 64 del zaber_motion_bindings_windows\zaber-motion-lib-windows-386.dll
-if %ARCH% == 32 del zaber_motion_bindings_windows\zaber-motion-lib-windows-amd64.dll
-%PYTHON% -m pip install . -vv --no-build-isolation --no-deps
-if errorlevel 1 exit 1
 cd ..

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -17,11 +17,13 @@ if errorlevel 1 exit 1
 cd py\zaber_motion
 %PYTHON% -m pip install . -vv --no-build-isolation --no-deps
 if errorlevel 1 exit 1
-cd ..
+cd ..\..
 
 cd ..
 
 cd bindings
+if %ARCH% == 64 del zaber_motion_bindings_windows\zaber-motion-lib-windows-386.dll
+if %ARCH% == 32 del zaber_motion_bindings_windows\zaber-motion-lib-windows-amd64.dll
 %PYTHON% -m pip install . -vv --no-build-isolation --no-deps
 if errorlevel 1 exit 1
 cd ..

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -5,9 +5,9 @@ cd zaber-motion-lib
 if errorlevel 1 exit 1
 
 rem Look at gulpfil.js, protobuf_py
-protoc -I=. --python_out="py/zaber_motion/zaber_motion" ^
-    --plugin="protoc-gen-mypy=tools\protoc-gen-mypy.bat" ^
-    --mypy_out="py/zaber_motion/zaber_motion" protobufs\main.proto
+protoc -I=. --python_out="py\zaber_motion\zaber_motion"      ^
+    --plugin="protoc-gen-mypy=tools\protoc-gen-mypy.bat"     ^
+    --mypy_out="py\zaber_motion\zaber_motion" protobufs\main.proto
 if errorlevel 1 exit 1
 
 echo.> py\zaber_motion\zaber_motion\protobufs\__init__.py

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -18,7 +18,9 @@ if errorlevel 1 exit 1
 dir build
 
 copy build\%zaber_motion_lib% %LIBRARY_BIN%\.
+if errorlevel 1 exit 1
 copy build\%zaber_motion_header% %LIBRARY_INC%\.
+if errorlevel 1 exit 1
 
 
 rem Look at gulpfil.js, protobuf_py

--- a/recipes/zaber-motion/bld.bat
+++ b/recipes/zaber-motion/bld.bat
@@ -12,9 +12,8 @@ if errorlevel 1 exit 1
 set zaber_motion_libname=zaber-motion-lib-%GOOS%-%GOARCH%
 set zaber_motion_lib=%zaber_motion_libname%.dll
 set zaber_motion_header=%zaber_motion_libname%.h
-go build -buildmode=c-shared -o .\build\%zaber_motion_lib%
-REM it seems that go build sets the error level to 1 always???
-REM if errorlevel 1 exit 1
+go build -buildmode=c-shared -o ./build/%zaber_motion_lib%
+if errorlevel 1 exit 1
 
 dir build
 

--- a/recipes/zaber-motion/build.sh
+++ b/recipes/zaber-motion/build.sh
@@ -1,29 +1,40 @@
 set -x
+SHORT_OS_STR=$(uname -s)
+
+# Follow upstream's naming convention, even though it is a little crazy
+# TODO: detect arm build correctly when desired.
+# Look at the function build_go_temp in their `gulpfile.js`
+# to follow their convention
+if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
+  GOOS=linux
+  GOARCH=amd64
+fi
+if [ "${SHORT_OS_STR}" == "Darwin" ]; then
+  GOOS=darwin
+  GOARCH=amd64
+fi
 
 # Build Go package
 export GO111MODULE=on
 protoc -I=. --go_out="internal" protobufs/main.proto
 
-# Follow upstream's naming convention, even though it is a little crazy
-export GOOS=linux
-export GOARCH=amd64
-export ext=so
-zaber_motion_lib=zaber-motion-lib-${GOOS}-${GOARCH}.${ext}
-
+zaber_motion_libname=zaber-motion-lib-${GOOS}-${GOARCH}
+zaber_motion_lib=${zaber_motion_libname}${SHLIB_EXT}
+zaber_motion_header=${zaber_motion_libname}.h
 go build -buildmode=c-shared -o ./build/${zaber_motion_lib}
+
+# Copy the files in the correct locations
+cp build/${zaber_motion_lib} $PREFIX/lib/.
+cp build/${zaber_motion_header} $PREFIX/include/.
 
 # Now compile the python bindings
 protoc -I=. --python_out="py/zaber_motion/zaber_motion" \
   --plugin="protoc-gen-mypy=tools/protoc-gen-mypy" \
   --mypy_out="py/zaber_motion/zaber_motion" protobufs/main.proto
+
 # without the __init__ file, it won't install correctly
 touch py/zaber_motion/zaber_motion/protobufs/__init__.py
 
-cp ./build/${zaber_motion_lib} ./py/bindings_linux/zaber_motion_bindings_linux/.
-
-pushd py/bindings_linux
-$PYTHON -m pip install . -vv
-popd
 pushd py/zaber_motion
 $PYTHON -m pip install . -vv
 popd

--- a/recipes/zaber-motion/build.sh
+++ b/recipes/zaber-motion/build.sh
@@ -1,18 +1,6 @@
 set -x
 SHORT_OS_STR=$(uname -s)
-
-# Follow upstream's naming convention, even though it is a little crazy
-# TODO: detect arm build correctly when desired.
-# Look at the function build_go_temp in their `gulpfile.js`
-# to follow their convention
-if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
-  GOOS=linux
-  GOARCH=amd64
-fi
-if [ "${SHORT_OS_STR}" == "Darwin" ]; then
-  GOOS=darwin
-  GOARCH=amd64
-fi
+cd src/zaber-motion
 
 # Build Go package
 export GO111MODULE=on

--- a/recipes/zaber-motion/build.sh
+++ b/recipes/zaber-motion/build.sh
@@ -1,33 +1,29 @@
-set -ex
+set -x
 
-pushd zaber-motion-lib
+# Build Go package
+export GO111MODULE=on
+protoc -I=. --go_out="internal" protobufs/main.proto
 
-# Look at gulpfil.js, protobuf_py
-protocGenMypy=tools/protoc-gen-mypy
+# Follow upstream's naming convention, even though it is a little crazy
+export GOOS=linux
+export GOARCH=amd64
+export ext=so
+zaber_motion_lib=zaber-motion-lib-${GOOS}-${GOARCH}.${ext}
+
+go build -buildmode=c-shared -o ./build/${zaber_motion_lib}
+
+# Now compile the python bindings
 protoc -I=. --python_out="py/zaber_motion/zaber_motion" \
-    --plugin="protoc-gen-mypy=${protocGenMypy}" \
-    --mypy_out="py/zaber_motion/zaber_motion" protobufs/main.proto
-
+  --plugin="protoc-gen-mypy=tools/protoc-gen-mypy" \
+  --mypy_out="py/zaber_motion/zaber_motion" protobufs/main.proto
+# without the __init__ file, it won't install correctly
 touch py/zaber_motion/zaber_motion/protobufs/__init__.py
 
+cp ./build/${zaber_motion_lib} ./py/bindings_linux/zaber_motion_bindings_linux/.
 
+pushd py/bindings_linux
+$PYTHON -m pip install . -vv
+popd
 pushd py/zaber_motion
-${PYTHON} -m pip install . -vv --no-build-isolation --no-deps
-popd
-
-popd
-
-pushd bindings
-# TODO: make this dependent on OSX/Linux/ARM
-SHORT_OS_STR=$(uname -s)
-if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
-    rm -f zaber_motion_bindings_linux/zaber-motion-lib-linux-386.so
-    if [ `uname -m` == "x86_64" ]; then
-        rm -f zaber_motion_bindings_linux/zaber-motion-lib-linux-arm.so
-    else  # == "arm"
-        rm -f zaber_motion_bindings_linux/zaber-motion-lib-linux-amd64.so
-    fi
-fi
-
-${PYTHON} -m pip install . -vv --no-build-isolation --no-deps
+$PYTHON -m pip install . -vv
 popd

--- a/recipes/zaber-motion/build.sh
+++ b/recipes/zaber-motion/build.sh
@@ -1,0 +1,33 @@
+set -ex
+
+pushd zaber-motion-lib
+
+# Look at gulpfil.js, protobuf_py
+protocGenMypy=tools/protoc-gen-mypy
+protoc -I=. --python_out="py/zaber_motion/zaber_motion" \
+    --plugin="protoc-gen-mypy=${protocGenMypy}" \
+    --mypy_out="py/zaber_motion/zaber_motion" protobufs/main.proto
+
+touch py/zaber_motion/zaber_motion/protobufs/__init__.py
+
+
+pushd py/zaber_motion
+${PYTHON} -m pip install . -vv --no-build-isolation --no-deps
+popd
+
+popd
+
+pushd bindings
+# TODO: make this dependent on OSX/Linux/ARM
+SHORT_OS_STR=$(uname -s)
+if [ "${SHORT_OS_STR:0:5}" == "Linux" ]; then
+    rm -f zaber_motion_bindings_linux/zaber-motion-lib-linux-386.so
+    if [ `uname -m` == "x86_64" ]; then
+        rm -f zaber_motion_bindings_linux/zaber-motion-lib-linux-arm.so
+    else  # == "arm"
+        rm -f zaber_motion_bindings_linux/zaber-motion-lib-linux-amd64.so
+    fi
+fi
+
+${PYTHON} -m pip install . -vv --no-build-isolation --no-deps
+popd

--- a/recipes/zaber-motion/conda_build_config.yaml
+++ b/recipes/zaber-motion/conda_build_config.yaml
@@ -1,0 +1,4 @@
+macos_min_version:             # [osx]
+  - 10.10                      # [osx]
+MACOSX_DEPLOYMENT_TARGET:      # [osx]
+  - 10.10                      # [osx]

--- a/recipes/zaber-motion/dont_specify_python_3_in_executable_name.patch
+++ b/recipes/zaber-motion/dont_specify_python_3_in_executable_name.patch
@@ -1,0 +1,8 @@
+diff --git a/tools/protoc-gen-mypy.bat b/tools/protoc-gen-mypy.bat
+index 8f36ecda..9d85a785 100755
+--- a/tools/protoc-gen-mypy.bat
++++ b/tools/protoc-gen-mypy.bat
+@@ -1,2 +1,2 @@
+ @echo off
+-python3 -u %0\..\protoc-gen-mypy
++python -u %0\..\protoc-gen-mypy

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -49,7 +49,7 @@ requirements:
   host:
     - python
     - pip
-    - protobuf
+    - libprotobuf
     # - mypy-protobuf
   run:
     - python

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -42,7 +42,7 @@ source:
 build:
   skip: True  # [py==27]
   number: 0
-  
+
   # On linux, the binaries are precompiled to refer to the root level /lib64
   # Can't do much at this stage unless I compile things myself, which
   # I submitted a request upstream for
@@ -71,7 +71,6 @@ about:
   license_family: MIT
   license_file: zaber-motion-lib/licensing/LICENSE
   summary: 'A Python library used to operate Zaber devices.'
-
   doc_url: https://www.zaber.com/software/docs/motion-library/
   dev_url: https://gitlab.com/zaber-core-libs/zaber-motion-lib
 

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -40,6 +40,10 @@ build:
   skip: True  # [py==27]
   number: 0
   detect_binary_files_with_prefix: False
+  # On linux, the binaries are precompiled to refer to the root level /lib64
+  # Can't do much at this stage unless I compile things myself, which
+  # I submitted a request upstream for
+  binary_relocation: False
 
 requirements:
   host:

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -8,9 +8,10 @@ package:
 source:
   url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
   sha256: ee76829d2fb98f2c071b9f92375958b4fa1cc23c6cef1781d97c0cc089dede5e
+  folder: src/zaber-motion
   patches:
     - no_bindings_install.patch
-    - dont_specify_python_3_in_executable_name.patch  # [win]
+    - dont_specify_python_3_in_executable_name.patch
 
 build:
   # For some reason, python 2.7 doesn't work, too lazy for now
@@ -19,12 +20,9 @@ build:
 
 requirements:
   build:
-    # for some reason, compiler cgo doesn't seem to work
-    # - {{ compiler('cgo') }}        # [win or osx]
-    - go-cgo
+    - {{ compiler('cgo') }}
     - {{ compiler('m2w64_c') }}    # [win]
     - {{ compiler('m2w64_cxx') }}  # [win]
-    # - m2w64-toolchain            # [win]
     - {{ compiler('c') }}          # [not win]
     - {{ compiler('cxx') }}        # [not win]
   host:
@@ -33,7 +31,6 @@ requirements:
     - libprotobuf
     - protobuf
     - protoc-gen-go
-    # - mypy-protobuf
   run:
     - python
     - protobuf
@@ -47,7 +44,7 @@ about:
   home: https://gitlab.com/zaber-core-libs/zaber-motion-lib
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: src/zaber-motion/LICENSE
   summary: 'A Python library used to operate Zaber devices.'
   doc_url: https://www.zaber.com/software/docs/motion-library/
   dev_url: https://gitlab.com/zaber-core-libs/zaber-motion-lib

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -14,17 +14,22 @@ source:
   - url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
     sha256: 2dd67fea9df9439b8b9774c777a1ad501b13615b00243a5582d0c318e89d17a6
     folder: zaber-motion-lib
-  # From what I can they, they compile alot of opensource go code
-  # into statically linked libraries. This code migth be using protobuf 3.7.0.....
+
+  # From what I can they, they compile alot of opensource go code into
+  # statically linked libraries. This code migth be using protobuf 3.7.0.....
   # lets ignore that for now.
   #
-  # This statically linked code becomes this binary package, which they
-  # create universal wheels for, even though the package isn't a universal
-  # wheel.
+  # I can't actually build the whole thing myself because they use a private
+  # library in their build
   #
-  # because I don't feel like patching their code too much, I'm just leaving the
-  # packages as is.
-  # It could be that this is incompatible with conda-forge's cos6
+  # https://gitlab.com/zaber-core-libs/zaber-motion-lib/issues/1
+  #
+  # This statically linked code becomes this binary package, which they create
+  # universal wheels for, even though the package isn't a universal wheel.
+  #
+  # because I don't feel like patching their code too much, I'm just leaving
+  # the packages as is.  It could be that this is incompatible with
+  # conda-forge's cos6
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}-bindings-{{ platform }}/zaber_motion_bindings_{{ platform }}-{{ version }}.tar.gz
     sha256: 29b9859c6a7ddf95961ce4d470bcefb58dba3d713b9771b2eca446cef0b43354  # [osx]
     sha256: 1f26c2d64b4e051629621c508183329268d453716ac3b7fc1746ecd8776785f0  # [linux]

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - python
     - pip
     - protobuf
-    - mypy-protobuf
+    # - mypy-protobuf
   run:
     - python
     - protobuf

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "zaber-motion" %}
 # They technically have a 1.0.7 that JUST came out, but they didn't tag their repo
-{% set version = "1.0.6" %}
+{% set version = "1.0.8" %}
+{% set git_hash = "a5b21a6e72feb81bf2860b42e0d5a9d01ec74dad" %}
 
 # Should work with upstream to help them create platform dependent wheels.
 {% set bindings = name + "-bindings-windows" %}  # [win]
@@ -12,49 +13,26 @@ package:
   version: {{ version }}
 
 source:
-  - url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
-    sha256: 2dd67fea9df9439b8b9774c777a1ad501b13615b00243a5582d0c318e89d17a6
-    folder: zaber-motion-lib
-    patches:
-      - dont_specify_python_3_in_executable_name.patch
-
-  # From what I can they, they compile alot of opensource go code into
-  # statically linked libraries. This code migth be using protobuf 3.7.0.....
-  # lets ignore that for now.
-  #
-  # I can't actually build the whole thing myself because they use a private
-  # library in their build
-  #
-  # https://gitlab.com/zaber-core-libs/zaber-motion-lib/issues/1
-  #
-  # This statically linked code becomes this binary package, which they create
-  # universal wheels for, even though the package isn't a universal wheel.
-  #
-  # because I don't feel like patching their code too much, I'm just leaving
-  # the packages as is.  It could be that this is incompatible with
-  # conda-forge's cos6
-  - url: https://pypi.io/packages/source/{{ bindings[0] }}/{{ bindings }}/{{ bindings | replace("-", "_") }}-{{ version }}.tar.gz
-    sha256: 29b9859c6a7ddf95961ce4d470bcefb58dba3d713b9771b2eca446cef0b43354  # [osx]
-    sha256: 1f26c2d64b4e051629621c508183329268d453716ac3b7fc1746ecd8776785f0  # [linux]
-    sha256: 9124598b1ba46043748cc288e408a4bd673d2dcfe797904a41961d803ce1c948  # [win]
-    folder: bindings
+  # url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
+  url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/{{ git_hash }}/zaber-motion-lib-{{ git_hash }}.tar.gz
+  # sha256: 2dd67fea9df9439b8b9774c777a1ad501b13615b00243a5582d0c318e89d17a6
 
 build:
   skip: True  # [py==27]
   number: 0
 
-  # On linux, the binaries are precompiled to refer to the root level /lib64
-  # Can't do much at this stage unless I compile things myself, which
-  # I submitted a request upstream for
-  detect_binary_files_with_prefix: False  # [linux]
-  binary_relocation: False                # [linux]
-
 requirements:
+  build:
+    # - {{ compiler('cgo') }}
+    - go-cgo
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - python
     - pip
     - libprotobuf
     - protobuf
+    - protoc-gen-go
     # - mypy-protobuf
   run:
     - python
@@ -69,7 +47,7 @@ about:
   home: https://gitlab.com/zaber-core-libs/zaber-motion-lib
   license: MIT
   license_family: MIT
-  license_file: zaber-motion-lib/licensing/LICENSE
+  license_file: LICENSE
   summary: 'A Python library used to operate Zaber devices.'
   doc_url: https://www.zaber.com/software/docs/motion-library/
   dev_url: https://gitlab.com/zaber-core-libs/zaber-motion-lib

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -44,7 +44,9 @@ about:
   home: https://gitlab.com/zaber-core-libs/zaber-motion-lib
   license: MIT
   license_family: MIT
-  license_file: src/zaber-motion/LICENSE
+  license_file:
+    - src/zaber-motion/LICENSE
+    - LICENSE_GO_MODULES
   summary: 'A Python library used to operate Zaber devices.'
   doc_url: https://www.zaber.com/software/docs/motion-library/
   dev_url: https://gitlab.com/zaber-core-libs/zaber-motion-lib

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "zaber-motion" %}
+{% set version = "1.0.6" %}
+#{% set bindings_version = "1.0.7" %}
+{% set bindings_version = "1.0.6" %}
+
+{% set platform = "windows" %}  # [win]
+{% set platform = "darwin"  %}  # [osx]
+{% set platform = "linux"   %}  # [linux]
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
+    sha256: 2dd67fea9df9439b8b9774c777a1ad501b13615b00243a5582d0c318e89d17a6
+    folder: zaber-motion-lib
+  # From what I can they, they compile alot of opensource go code
+  # into statically linked libraries. This code migth be using protobuf 3.7.0.....
+  # lets ignore that for now.
+  #
+  # This statically linked code becomes this binary package, which they
+  # create universal wheels for, even though the package isn't a universal
+  # wheel.
+  #
+  # because I don't feel like patching their code too much, I'm just leaving the
+  # packages as is.
+  # It could be that this is incompatible with conda-forge's cos6
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}-bindings-{{ platform }}/zaber_motion_bindings_{{ platform }}-{{ bindings_version }}.tar.gz
+    sha256: 29b9859c6a7ddf95961ce4d470bcefb58dba3d713b9771b2eca446cef0b43354  # [osx]
+    sha256: 1f26c2d64b4e051629621c508183329268d453716ac3b7fc1746ecd8776785f0  # [linux]
+    sha256: 9124598b1ba46043748cc288e408a4bd673d2dcfe797904a41961d803ce1c948  # [win]
+    # 1.0.7
+    # sha256: 61e3bca94b23188c99364c07b140ccc5dba4a489e0a871dada73ec9a905cec4f  # [osx]
+    # sha256: 25b36516e3c1ccfeeeef47ed08dfd38d7000cfbdfa200ade28cacfbac8eed6a6  # [linux]
+    # sha256: 037ecaeb234a3f237f9212280ceac2bc42b215ca988b182a7f45199f39c41be4  # [win]
+    folder: bindings
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: False
+
+requirements:
+  host:
+    - python
+    - pip
+    - protobuf
+  run:
+    - python
+    - protobuf
+    - rx
+
+test:
+  imports:
+    - zaber_motion
+
+about:
+  home: https://gitlab.com/zaber-core-libs/zaber-motion-lib
+  license: MIT
+  license_family: MIT
+  license_file: zaber-motion-lib/licensing/LICENSE
+  summary: 'A Python library used to operate Zaber devices.'
+
+  doc_url: https://www.zaber.com/software/docs/motion-library/
+  dev_url: https://gitlab.com/zaber-core-libs/zaber-motion-lib
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -14,6 +14,8 @@ source:
     - no_bindings_install.patch
 
 build:
+  # For some reason, python 2.7 doesn't work
+  skip: true  # [py==27]
   number: 0
 
 requirements:

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -1,28 +1,24 @@
 {% set name = "zaber-motion" %}
-# They technically have a 1.0.7 that JUST came out, but they didn't tag their repo
 {% set version = "1.0.8" %}
+# upstream didn't create a tag for 1.0.8
 {% set git_hash = "a5b21a6e72feb81bf2860b42e0d5a9d01ec74dad" %}
-
-# Should work with upstream to help them create platform dependent wheels.
-{% set bindings = name + "-bindings-windows" %}  # [win]
-{% set bindings = name + "-bindings-darwin" %}   # [osx]
-{% set bindings = name + "-bindings-linux" %}    # [linux]
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
   url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/{{ git_hash }}/zaber-motion-lib-{{ git_hash }}.tar.gz
-  # sha256: 2dd67fea9df9439b8b9774c777a1ad501b13615b00243a5582d0c318e89d17a6
+  sha256: 9c8e36bf71bb9164f6742103052e294c70b3b7707d0fad43ae517829102422b7
+  patches:
+    - no_bindings_install.patch
 
 build:
-  skip: True  # [py==27]
   number: 0
 
 requirements:
   build:
+    # for some reason, compiler cgo doesn't seem to work
     # - {{ compiler('cgo') }}
     - go-cgo
     - {{ compiler('c') }}

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -1,17 +1,16 @@
 {% set name = "zaber-motion" %}
 {% set version = "1.0.8" %}
-# upstream didn't create a tag for 1.0.8
-{% set git_hash = "a5b21a6e72feb81bf2860b42e0d5a9d01ec74dad" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/{{ git_hash }}/zaber-motion-lib-{{ git_hash }}.tar.gz
-  sha256: 9c8e36bf71bb9164f6742103052e294c70b3b7707d0fad43ae517829102422b7
+  url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
+  sha256: ee76829d2fb98f2c071b9f92375958b4fa1cc23c6cef1781d97c0cc089dede5e
   patches:
     - no_bindings_install.patch
+    - dont_specify_python_3_in_executable_name.patch  # [win]
 
 build:
   # For some reason, python 2.7 doesn't work

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -40,17 +40,19 @@ source:
 build:
   skip: True  # [py==27]
   number: 0
-  detect_binary_files_with_prefix: False
+  
   # On linux, the binaries are precompiled to refer to the root level /lib64
   # Can't do much at this stage unless I compile things myself, which
   # I submitted a request upstream for
-  binary_relocation: False
+  detect_binary_files_with_prefix: False  # [linux]
+  binary_relocation: False                # [linux]
 
 requirements:
   host:
     - python
     - pip
     - libprotobuf
+    - protobuf
     # - mypy-protobuf
   run:
     - python

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -15,6 +15,8 @@ source:
   - url: https://gitlab.com/zaber-core-libs/zaber-motion-lib/-/archive/v{{ version }}/zaber-motion-lib-v{{ version }}.tar.gz
     sha256: 2dd67fea9df9439b8b9774c777a1ad501b13615b00243a5582d0c318e89d17a6
     folder: zaber-motion-lib
+    patches:
+      - dont_specify_python_3_in_executable_name.patch
 
   # From what I can they, they compile alot of opensource go code into
   # statically linked libraries. This code migth be using protobuf 3.7.0.....

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -37,6 +37,7 @@ source:
     folder: bindings
 
 build:
+  skip: True  # [py==27]
   number: 0
   detect_binary_files_with_prefix: False
 
@@ -45,6 +46,8 @@ requirements:
     - python
     - pip
     - protobuf
+    - mypy
+    - mypy-protobuf
   run:
     - python
     - protobuf

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "zaber-motion" %}
+# They technically have a 1.0.7 that JUST came out, but they didn't tag their repo
 {% set version = "1.0.6" %}
-#{% set bindings_version = "1.0.7" %}
-{% set bindings_version = "1.0.6" %}
 
 {% set platform = "windows" %}  # [win]
 {% set platform = "darwin"  %}  # [osx]
@@ -26,14 +25,10 @@ source:
   # because I don't feel like patching their code too much, I'm just leaving the
   # packages as is.
   # It could be that this is incompatible with conda-forge's cos6
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}-bindings-{{ platform }}/zaber_motion_bindings_{{ platform }}-{{ bindings_version }}.tar.gz
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}-bindings-{{ platform }}/zaber_motion_bindings_{{ platform }}-{{ version }}.tar.gz
     sha256: 29b9859c6a7ddf95961ce4d470bcefb58dba3d713b9771b2eca446cef0b43354  # [osx]
     sha256: 1f26c2d64b4e051629621c508183329268d453716ac3b7fc1746ecd8776785f0  # [linux]
     sha256: 9124598b1ba46043748cc288e408a4bd673d2dcfe797904a41961d803ce1c948  # [win]
-    # 1.0.7
-    # sha256: 61e3bca94b23188c99364c07b140ccc5dba4a489e0a871dada73ec9a905cec4f  # [osx]
-    # sha256: 25b36516e3c1ccfeeeef47ed08dfd38d7000cfbdfa200ade28cacfbac8eed6a6  # [linux]
-    # sha256: 037ecaeb234a3f237f9212280ceac2bc42b215ca988b182a7f45199f39c41be4  # [win]
     folder: bindings
 
 build:

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -3,8 +3,8 @@
 {% set version = "1.0.6" %}
 
 {% set platform = "windows" %}  # [win]
-{% set platform = "darwin"  %}  # [osx]
-{% set platform = "linux"   %}  # [linux]
+{% set platform = "darwin" %}   # [osx]
+{% set platform = "linux" %}    # [linux]
 
 package:
   name: {{ name|lower }}

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -46,7 +46,6 @@ requirements:
     - python
     - pip
     - protobuf
-    - mypy
     - mypy-protobuf
   run:
     - python

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -2,9 +2,10 @@
 # They technically have a 1.0.7 that JUST came out, but they didn't tag their repo
 {% set version = "1.0.6" %}
 
-{% set platform = "windows" %}  # [win]
-{% set platform = "darwin" %}   # [osx]
-{% set platform = "linux" %}    # [linux]
+# Should work with upstream to help them create platform dependent wheels.
+{% set bindings = name + "-bindings-windows" %}  # [win]
+{% set bindings = name + "-bindings-darwin" %}   # [osx]
+{% set bindings = name + "-bindings-linux" %}    # [linux]
 
 package:
   name: {{ name|lower }}
@@ -30,7 +31,7 @@ source:
   # because I don't feel like patching their code too much, I'm just leaving
   # the packages as is.  It could be that this is incompatible with
   # conda-forge's cos6
-  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}-bindings-{{ platform }}/zaber_motion_bindings_{{ platform }}-{{ version }}.tar.gz
+  - url: https://pypi.io/packages/source/{{ bindings[0] }}/{{ bindings }}/{{ bindings | replace("-", "_") }}-{{ version }}.tar.gz
     sha256: 29b9859c6a7ddf95961ce4d470bcefb58dba3d713b9771b2eca446cef0b43354  # [osx]
     sha256: 1f26c2d64b4e051629621c508183329268d453716ac3b7fc1746ecd8776785f0  # [linux]
     sha256: 9124598b1ba46043748cc288e408a4bd673d2dcfe797904a41961d803ce1c948  # [win]

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -15,6 +15,7 @@ source:
 build:
   # For some reason, python 2.7 doesn't work
   skip: true  # [py==27]
+  skip: true  # [win and vc<14]
   number: 0
 
 requirements:

--- a/recipes/zaber-motion/meta.yaml
+++ b/recipes/zaber-motion/meta.yaml
@@ -13,18 +13,20 @@ source:
     - dont_specify_python_3_in_executable_name.patch  # [win]
 
 build:
-  # For some reason, python 2.7 doesn't work
+  # For some reason, python 2.7 doesn't work, too lazy for now
   skip: true  # [py==27]
-  skip: true  # [win and vc<14]
   number: 0
 
 requirements:
   build:
     # for some reason, compiler cgo doesn't seem to work
-    # - {{ compiler('cgo') }}
+    # - {{ compiler('cgo') }}        # [win or osx]
     - go-cgo
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
+    # - m2w64-toolchain            # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('cxx') }}        # [not win]
   host:
     - python
     - pip

--- a/recipes/zaber-motion/no_bindings_install.patch
+++ b/recipes/zaber-motion/no_bindings_install.patch
@@ -1,0 +1,38 @@
+diff --git a/go.mod b/go.mod
+index dac57141..fff8a77c 100644
+--- a/go.mod
++++ b/go.mod
+@@ -8,3 +8,5 @@ require (
+ 	gitlab.com/ZaberTech/zaber-device-db-service v0.0.0-20191130221157-4b4564b0b58e
+ 	gotest.tools v2.2.0+incompatible
+ )
++
++go 1.13
+diff --git a/py/zaber_motion/zaber_motion/bindings.py b/py/zaber_motion/zaber_motion/bindings.py
+index e3ef5c91..6c785757 100644
+--- a/py/zaber_motion/zaber_motion/bindings.py
++++ b/py/zaber_motion/zaber_motion/bindings.py
+@@ -1,8 +1,12 @@
+ from ctypes import c_void_p, c_int, c_int64, c_uint8, CFUNCTYPE
++from ctypes import cdll
+ from typing import Any
+ import platform
+ import sys
+-import importlib
++
++
++def load_library(name):
++    return cdll.LoadLibrary(name)
+ 
+ 
+ def _load_library() -> Any:
+@@ -18,8 +22,7 @@ def _load_library() -> Any:
+     if os_system == "darwin":
+         ext = ".dylib"
+     lib_name = "zaber-motion-lib-{}-{}{}".format(os_system, arch, ext)
+-    module_name = "zaber_motion_bindings_{}".format(os_system)
+-    return importlib.import_module(module_name).load_library(lib_name)  # type: ignore
++    return load_library(lib_name)
+ 
+ 
+ lib = _load_library()


### PR DESCRIPTION
In talking to upstream, i got them to fixup their code to point to a public repo for their go module.

Needs: https://github.com/conda-forge/staged-recipes/pull/10515

OSX will work after re-rendering since it needs 10.10 instead of 10.9: https://github.com/ramonaoptics/zaber-motion-feedstock

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
