### PR TITLE
DOC add command to ping the team in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,8 +20,9 @@ If your PR doesn't fall into those categories please contact
 the full review team `@conda-forge/staged-recipes`.
 
 Due to GitHub limitations first time contributors to conda-forge are unable
-to ping these teams.
-Consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
+to ping these teams. You can type `@conda-forge-admin, please ping team` in 
+a comment on the PR to get the attention of the `staged-recipes` team. You can 
+also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
 if your recipe isn't reviewed promptly.
 -->
 


### PR DESCRIPTION
This PR adds the command to ping teams to the PR template.

@conda-forge/staged-recipes for viz