### PR TITLE
add recipe for pytest-notification

### DIFF
--- a/recipes/pytest-notification/LICENSE
+++ b/recipes/pytest-notification/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Leiden University Medical Center
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pytest-notification/meta.yaml
+++ b/recipes/pytest-notification/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "pytest-notification" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: e6939b1ae54b7f13721516a37204db9a1ccf278b91c5e0d8491f00ab73be7bcc
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - pytest >=4
+    - python >=3.5
+    - setuptools
+  run:
+    - pytest >=4
+    - python >=3.5
+    - setuptools
+
+test:
+  imports:
+    - pytest_notification
+
+about:
+  home: "https://github.com/rhpvorderman/pytest-notification"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "A pytest plugin for sending a desktop notification and playing a sound upon completion of tests"
+  doc_url: "https://github.com/rhpvorderman/pytest-notification"
+  dev_url: "https://github.com/rhpvorderman/pytest-notification"
+
+extra:
+  recipe-maintainers:
+    - rhpvorderman

--- a/recipes/pytest-notification/meta.yaml
+++ b/recipes/pytest-notification/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: e6939b1ae54b7f13721516a37204db9a1ccf278b91c5e0d8491f00ab73be7bcc
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipes/pytest-notification/meta.yaml
+++ b/recipes/pytest-notification/meta.yaml
@@ -23,7 +23,6 @@ requirements:
   run:
     - pytest >=4
     - python >=3.5
-    - setuptools
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
