### PR TITLE
Adds Thrax recipe

### DIFF
--- a/recipes/thrax/build.sh
+++ b/recipes/thrax/build.sh
@@ -1,0 +1,3 @@
+./configure --prefix="${PREFIX}"
+make -j"${CPU_COUNT}"
+make -j"${CPU_COUNT}" install

--- a/recipes/thrax/meta.yaml
+++ b/recipes/thrax/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "thrax" %}
+{% set version = "1.3.1" %}
+
+package: 
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://www.opengrm.org/twiki/pub/GRM/ThraxDownload/{{ name }}-{{ version }}.tar.gz
+  sha256: d16a24376c8e722b694825366eda8a8accfd7515abb7a3db563c19056f951203
+  
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - make
+  host:
+    - openfst ==1.7.5
+  run:
+    - openfst ==1.7.5
+    - python
+
+test:
+  commands:
+    - thraxcompiler --helpshort || [[ $? == 1 ]]
+    - thraxmakedep || [[ $? == 1 ]]
+    - thraxrewrite-tester --helpshort || [[ $? == 1 ]]
+
+about:
+  home: http://thrax.opengrm.org
+  license: Apache-2.0
+  license_file: COPYING
+  summary: Finite-state grammar compilation
+  description: |
+    A library for compiling grammars expressed as regular expressions and context-dependent rewrite rules into weighted finite-state transducers
+  doc_url: http://www.opengrm.org/twiki/bin/view/GRM/ThraxQuickTour
+
+extra:
+  recipe-maintainers:
+    - kylebgorman


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

This is a restart of #10387, which had an Azure error I couldn't sort out. @scopatz provided an earlier review.
