### PR TITLE
Add rstr package to conda-forge

### DIFF
--- a/recipes/rstr/meta.yaml
+++ b/recipes/rstr/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "rstr" %}
+{% set version = "2.2.6" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 5dea822326e418e0c9816c9cd14ae9c7be2d4cd4334043c397f202bc2ae2eda4
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - rstr
+    - rstr.tests
+
+about:
+  home: "http://bitbucket.org/leapfrogdevelopment/rstr/overview"
+  license: BSD
+  license_family: BSD
+  license_file: License.txt
+  summary: "Generate random strings in Python"
+  doc_url: "http://bitbucket.org/leapfrogdevelopment/rstr/overview"
+  dev_url: "http://bitbucket.org/leapfrogdevelopment/rstr/overview"

--- a/recipes/rstr/meta.yaml
+++ b/recipes/rstr/meta.yaml
@@ -30,7 +30,11 @@ about:
   home: "http://bitbucket.org/leapfrogdevelopment/rstr/overview"
   license: BSD
   license_family: BSD
-  license_file: License.txt
+  license_file: LICENSE.txt
   summary: "Generate random strings in Python"
   doc_url: "http://bitbucket.org/leapfrogdevelopment/rstr/overview"
   dev_url: "http://bitbucket.org/leapfrogdevelopment/rstr/overview"
+
+extra:
+  recipe-maintainers:
+    - claymcleod


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
