### PR TITLE
Add plotly chart-studio package

### DIFF
--- a/recipes/chart-studio/LICENSE.txt
+++ b/recipes/chart-studio/LICENSE.txt
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2019 Plotly, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/recipes/chart-studio/meta.yaml
+++ b/recipes/chart-studio/meta.yaml
@@ -43,3 +43,5 @@ extra:
     - jonmmease
     - timkpaine
     - dhirschfeld
+    - nicolaskruchten
+    - emmanuelle

--- a/recipes/chart-studio/meta.yaml
+++ b/recipes/chart-studio/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "chart-studio" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1293776553a552bb3ff918c33d70f3b0794103b8cb0ac08aad8bde1c94ee65e3
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - plotly
+    - requests
+    - retrying >=1.3.3
+    - six
+
+test:
+  imports:
+    - chart_studio
+
+about:
+  home: https://github.com/plotly/plotly.py
+  license: MIT
+  license_family: MIT
+  license_file: "/packages/python/chart-studio/LICENSE.txt"
+  summary: "This package contains utilities for interfacing with Plotly's Chart Studio service"
+  doc_url: https://help.plot.ly/tutorials/#fundamentals
+  dev_url: https://github.com/plotly/plotly.py/tree/master/packages/python/chart-studio
+
+extra:
+  recipe-maintainers:
+    - jonmmease
+    - timkpaine
+    - dhirschfeld
+
+

--- a/recipes/chart-studio/meta.yaml
+++ b/recipes/chart-studio/meta.yaml
@@ -33,7 +33,7 @@ about:
   home: https://github.com/plotly/plotly.py
   license: MIT
   license_family: MIT
-  license_file: "/packages/python/chart-studio/LICENSE.txt"
+  license_file: LICENSE.txt
   summary: "This package contains utilities for interfacing with Plotly's Chart Studio service"
   doc_url: https://help.plot.ly/tutorials/#fundamentals
   dev_url: https://github.com/plotly/plotly.py/tree/master/packages/python/chart-studio
@@ -43,5 +43,3 @@ extra:
     - jonmmease
     - timkpaine
     - dhirschfeld
-
-


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist

- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
