### PR TITLE
Add twine 3.1.1 test deps (pytest-services and jaraco.envs (and deps (tox-venv))

### DIFF
--- a/recipes/jaraco.envs/meta.yaml
+++ b/recipes/jaraco.envs/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "jaraco.envs" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 8cde95d8109f46480364437c8e33e6482c45c7bc6d7b51ce663398f6e6034ffb
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools_scm
+  run:
+    - contextlib2
+    - tox
+    - tox-venv
+    - virtualenv
+    - path.py
+    - python
+
+test:
+  imports:
+    - jaraco.envs
+
+about:
+  home: https://github.com/jaraco/jaraco.envs
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Classes for orchestrating Python (virtual) environments.'
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/pytest-services/meta.yaml
+++ b/recipes/pytest-services/meta.yaml
@@ -36,8 +36,6 @@ test:
     - astroid
     - coverage
     - mock
-    - mysqlclient
-    - pylibmc
     - pytest-pep8
   imports:
     - pytest_services

--- a/recipes/pytest-services/meta.yaml
+++ b/recipes/pytest-services/meta.yaml
@@ -36,11 +36,13 @@ test:
     - astroid
     - coverage
     - mock
+    - mysqlclient
+    - pylibmc  # [unix]
     - pytest-pep8
   imports:
     - pytest_services
   commands:
-    - cd src && pytest -vv -k "not xvfb and not mysql and not memcached"
+    - cd src && pytest -vv -k "not xvfb and not mysql and not memcached"  # [unix]
 
 about:
   home: https://github.com/pytest-dev/pytest-services

--- a/recipes/pytest-services/meta.yaml
+++ b/recipes/pytest-services/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "pytest-services" %}
+{% set version = "2.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - folder: dist
+    url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: 0848cead86d3816b9c4e37cecfda31d21a4366f0dca2313ea29f3ca375c6295d
+  - folder: src
+    url: https://github.com/pytest-dev/pytest-services/archive/{{ version }}.tar.gz
+    sha256: 5c33dcdeba0294bb209f299d58390f5c0697ada12d253fdc376aa437ce290edb
+
+build:
+  noarch: python
+  number: 0
+  script: "cd dist && {{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - psutil
+    - pytest
+    - requests
+    - setuptools
+    - zc.lockfile >=2.0
+
+test:
+  source_files:
+    - src/tests
+  requires:
+    - astroid
+    - coverage
+    - mock
+    - mysqlclient
+    - pylibmc
+    - pytest-pep8
+  imports:
+    - pytest_services
+  commands:
+    - cd src && pytest -vv -k "not xvfb and not mysql and not memcached"
+
+about:
+  home: https://github.com/pytest-dev/pytest-services
+  license: MIT
+  license_family: MIT
+  license_file: src/LICENSE.txt
+  summary: 'Collection of fixtures and utility functions to run service processes for your tests'
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/tox-venv/meta.yaml
+++ b/recipes/tox-venv/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "tox-venv" %}
+{% set version = "0.4.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ea29dc7b21a03951e1e2bd7f3474bbf315657c5454224a5674b2896e9bbb795c
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - tox >=3.8.1
+
+test:
+  requires:
+    - pytest
+    - pytest-mock
+  source_files:
+    - tests
+  imports:
+    - tox_venv
+  commands:
+    - pytest -vv -k "not matchingdependencies_latest and not result_json"
+
+about:
+  home: https://github.com/tox-dev/tox-venv
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Use Python 3 venvs for Python 3 test environments '
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged. n/a
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there