### PR TITLE
Adding juliart module for Julia Set images and animations

### DIFF
--- a/recipes/juliart/meta.yaml
+++ b/recipes/juliart/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "juliart" %}
+{% set version = "0.0.13" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b9bbfe8debbd9dd2c14b7f7ce3b27f94c696a21ee82a0cbbe0c62c7659b7749a
+
+build:
+  number: 0
+  entry_points:
+    - juliart=juliart.client:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  skip: True  # [win or py2k]
+  
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+    - pytest-runner
+  run:
+    - python
+    - Pillow >=6.0.0
+    - imageio >=2.5.0
+
+test:
+  imports:
+    - juliart
+    - juliart.colors
+    - juliart.client
+    - juliart.main
+    - juliart.namer
+    - juliart.utils
+    - juliart.version
+  commands:
+    - juliart --help
+
+about:
+  home: https://www.github.com/vsoch/juliart
+  license: MPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: Command line tool for generating Julia Set images and animations
+  doc_url: https://github.com/vsoch/juliart
+  dev_url: https://github.com/vsoch/juliart
+
+extra:
+  recipe-maintainers:
+    - vsoch


### PR DESCRIPTION
This pull request will add the [juliart](https://pypi.org/project/juliart) module to conda, a Julia Set graphic and animation generator.

Happy Holidays!

![angry-latke-9194](https://user-images.githubusercontent.com/814322/71536562-e1cdf780-28cd-11ea-8ea0-2d7cb8b32160.gif)


Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
