### PR TITLE
Add GWOLLUM and Omicron

### DIFF
--- a/recipes/gwollum/build.sh
+++ b/recipes/gwollum/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mkdir -p _build
+pushd _build
+
+# configure
+cmake ${SRC_DIR} \
+	-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+	-DCMAKE_INSTALL_DOCDIR:PATH=${SRC_DIR}/trash \
+	-DCMAKE_INSTALL_LIBDIR:PATH="lib" \
+	-DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} \
+	-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+;
+
+# build
+cmake --build . --parallel ${CPU_COUNT}
+
+# install
+cmake --build . --parallel ${CPU_COUNT} --target install

--- a/recipes/gwollum/c++17.patch
+++ b/recipes/gwollum/c++17.patch
@@ -1,0 +1,14 @@
+Index: CMakeLists.txt
+===================================================================
+diff --git a/GWOLLUM/trunk/CMakeLists.txt b/GWOLLUM/trunk/CMakeLists.txt
+--- a/GWOLLUM/trunk/CMakeLists.txt	(revision 82556)
++++ b/GWOLLUM/trunk/CMakeLists.txt	(working copy)
+@@ -30,7 +30,7 @@
+ find_package(PkgConfig)
+
+ # specify the C++ standard
+-set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+ # -- set install paths ------

--- a/recipes/gwollum/gsl-library.patch
+++ b/recipes/gwollum/gsl-library.patch
@@ -1,0 +1,14 @@
+Index: src/Streams/CMakeLists.txt
+===================================================================
+diff --git a/GWOLLUM/trunk/src/Streams/CMakeLists.txt b/GWOLLUM/trunk/src/Streams/CMakeLists.txt
+--- a/GWOLLUM/trunk/src/Streams/CMakeLists.txt	(revision 82556)
++++ b/GWOLLUM/trunk/src/Streams/CMakeLists.txt	(working copy)
+@@ -45,7 +45,7 @@
+   Time
+   RootUtils
+   Segments
+-  ${GSL_LIBRARIES}
++  ${GSL_LIBRARY}
+   Frame
+   )
+ set_target_properties(

--- a/recipes/gwollum/meta.yaml
+++ b/recipes/gwollum/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.9.0
+    - make  # [unix]
     - pkg-config  # [unix]
   host:
     - fftw

--- a/recipes/gwollum/meta.yaml
+++ b/recipes/gwollum/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "gwollum" %}
+{% set version = "2.3.12" %}
+{% set versions = version.split('.') %}
+
+package:
+   name: "{{ name|lower }}"
+   version: "{{ version }}"
+
+source:
+   url: "http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.xz"
+   sha256: 4416c3ccd18e37f9de00fc29a0dff0c25fc9fd511e542611b25c642fac882edc
+   patches:
+     # use C++17 standard (required to link against ROOT>=6.14)
+     - c++17.patch
+     # link only against libgsl, not libgslcblas
+     - gsl-library.patch
+
+build:
+  error_overdepending: true
+  error_overlinking: true
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage("gwollum", max_pin="x.x.x") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=3.9.0
+    - pkg-config  # [unix]
+  host:
+    - fftw
+    - gsl
+    - hdf5
+    - libframe
+    - root_base
+    - root-binaries
+  run:
+    - fftw
+    - gsl
+    - hdf5
+    - libframe
+    - root_base
+
+test:
+  requires:
+    - pkg-config
+  commands:
+    # sanity check
+    - echo -e "1 2 3\n4 5 6" > triggers.txt
+    - TxtToTree triggers.txt triggers a/I:b/I:c/I
+    # check pkg-config
+    - test "$(pkg-config --print-errors --modversion gwollum)" == "${PKG_VERSION}"  # [unix]
+
+about:
+  home: "http://virgo.in2p3.fr/GWOLLUM/v{{ versions[0] }}r{{ versions[1] }}/index.html?Main"
+  license: "GPL-3.0-or-later"
+  license_family: "GPL"
+  license_file: "LICENSE"
+  summary: "Tools for gravitational-wave analyses"
+  description: |
+    The GWOLLUM package contains a set of software tools designed to perform
+    GW analyses.  Most of the code source is written with the C++ language
+    and it also heavily relies on the CERN ROOT libraries (also C++).
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/gwollum/meta.yaml
+++ b/recipes/gwollum/meta.yaml
@@ -37,12 +37,14 @@ requirements:
     - libframe
     - root_base 6.18.04
     - root-binaries 6.18.04
+    - zlib  # [osx]
   run:
     - fftw
     - gsl
     - hdf5
     - libframe
     - root_base
+    - zlib  # [osx]
 
 test:
   requires:

--- a/recipes/gwollum/meta.yaml
+++ b/recipes/gwollum/meta.yaml
@@ -35,8 +35,8 @@ requirements:
     - gsl
     - hdf5
     - libframe
-    - root_base
-    - root-binaries
+    - root_base 6.18.04
+    - root-binaries 6.18.04
   run:
     - fftw
     - gsl

--- a/recipes/omicron/build.sh
+++ b/recipes/omicron/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mkdir -p _build
+pushd _build
+
+# configure
+cmake ${SRC_DIR} \
+	-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+	-DCMAKE_INSTALL_DATADIR:PATH=${SRC_DIR}/trash \
+	-DCMAKE_INSTALL_LIBDIR:PATH="lib" \
+	-DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} \
+	-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+;
+
+# build
+cmake --build . --parallel ${CPU_COUNT}
+
+# install
+cmake --build . --parallel ${CPU_COUNT} --target install

--- a/recipes/omicron/c++17.patch
+++ b/recipes/omicron/c++17.patch
@@ -1,0 +1,14 @@
+Index: CMakeLists.txt
+===================================================================
+diff --git a/Omicron/trunk/CMakeLists.txt b/Omicron/trunk/CMakeLists.txt
+--- a/Omicron/trunk/CMakeLists.txt	(revision 82557)
++++ b/Omicron/trunk/CMakeLists.txt	(working copy)
+@@ -24,7 +24,7 @@
+ find_package(PkgConfig REQUIRED)
+
+ # specify the C++ standard
+-set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+ # -- set install paths ------

--- a/recipes/omicron/fft-include.patch
+++ b/recipes/omicron/fft-include.patch
@@ -1,0 +1,45 @@
+Index: src/CMakeLists.txt
+===================================================================
+diff --git a/Omicron/trunk/src/CMakeLists.txt b/Omicron/trunk/src/CMakeLists.txt
+--- a/Omicron/trunk/src/CMakeLists.txt	(revision 82562)
++++ b/Omicron/trunk/src/CMakeLists.txt	(working copy)
+@@ -1,5 +1,8 @@
+ # -- dependencies -----------
+
++# FFTW
++pkg_check_modules(FFTW REQUIRED "fftw3")
++
+ # FrameL
+ pkg_check_modules(FRAMEL REQUIRED "libframe")
+
+@@ -22,7 +25,7 @@
+ message(STATUS "HDF5 libraries: ${HDF5_INCLUDE_DIRS}")
+
+ # add link paths
+-link_directories(${FRAMEL_LIBRARY_DIRS} ${GWOLLUM_LIBRARY_DIRS})
++link_directories(${FFTW_LIBRARY_DIRS} ${FRAMEL_LIBRARY_DIRS} ${GWOLLUM_LIBRARY_DIRS})
+
+ # versioning
+ configure_file(Oconfig.h.in ${CMAKE_CURRENT_BINARY_DIR}/Oconfig.h @ONLY)
+@@ -81,7 +84,8 @@
+   ${ROOT_Core_LIBRARY}
+   ${ROOT_Hist_LIBRARY}
+   ${ROOT_MathCore_LIBRARY}
+   ${ROOT_RIO_LIBRARY}
++  ${FFTW_LIBRARIES}
+   CUtils
+   Inject
+   RootUtils
+Index: src/Oomicron.h
+===================================================================
+diff --git a/Omicron/trunk/src/Oomicron.h b/Omicron/trunk/src/Oomicron.h
+--- a/Omicron/trunk/src/Oomicron.h	(revision 82562)
++++ b/Omicron/trunk/src/Oomicron.h	(working copy)
+@@ -11,6 +11,7 @@
+ #include <Date.h>
+ #include <InjEct.h>
+ #include <ffl.h>
++#include <FFT.h>
+ #include <TRandom.h>
+ #include <TRandom3.h>
+ #include <TriggerBuffer.h>

--- a/recipes/omicron/meta.yaml
+++ b/recipes/omicron/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "omicron" %}
+{% set version = "2.3.12" %}
+{% set versions = version.split('.') %}
+
+package:
+   name: "{{ name|lower }}"
+   version: "{{ version }}"
+
+source:
+   url: "http://software.ligo.org/lscsoft/source/{{ name }}-{{ version }}.tar.xz"
+   sha256: d66642ce2641f019c47059ccbaa468e024cc846ab38e0855f4dac19147a84b3c
+   patches:
+     # use C++17 standard (required to link against ROOT>=6.14)
+     - c++17.patch
+     # add missing fftw link (only required on macos for some reason)
+     - fft-include.patch  # [osx]
+
+build:
+  error_overdepending: true
+  error_overlinking: true
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake >=3.9.0
+    - pkg-config
+  host:
+    - fftw  # [osx]
+    - gwollum {{ version }}
+    - root_base
+    - root-binaries
+  run:
+    - fftw  # [osx]
+    - gwollum
+    - root_base
+
+test:
+  requires:
+    - pkg-config
+  commands:
+    # sanity check
+    - omicron version
+    - test -x ${PREFIX}/bin/omicron-listfile  # [unix]
+    - test -x ${PREFIX}/bin/omicron-plot  # [unix]
+    - test -x ${PREFIX}/bin/omicron-print  # [unix]
+    - test -x ${PREFIX}/bin/omicron-scanfile  # [unix]
+    # check pkg-config
+    - test "$(pkg-config --print-errors --modversion omicron)" == "${PKG_VERSION}"  # [unix]
+
+about:
+  home: "http://virgo.in2p3.fr/GWOLLUM/v{{ versions[0] }}r{{ versions[1] }}/Friends/omicron.html"
+  license: "GPL-3.0-or-later"
+  license_family: "GPL"
+  license_file: "LICENSE"
+  summary: "An algorithm to detect and characterize transient events in gravitational-wave detectors"
+  description: |
+    Omicron has been derived from a well-known 'burst-type' search pipeline
+    called Q-pipeline (a.k.a Omega).  Q-pipeline is able to detect and
+    characterize detector glitches with a very good efficiency and precision.
+    So, the idea was to adapt it for detector characterization purposes,
+    i.e. to run it over many auxiliary channels.  To achieve this, the
+    original matlab code has been replaced by a C++ architecture and many
+    steps have been removed to run faster.  The name Omicron was chosen to
+    recall the Omega inheritance.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/omicron/meta.yaml
+++ b/recipes/omicron/meta.yaml
@@ -26,7 +26,8 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake >=3.9.0
-    - pkg-config
+    - make  # [unix]
+    - pkg-config  # [unix]
   host:
     - fftw  # [osx]
     - gwollum {{ version }}

--- a/recipes/omicron/meta.yaml
+++ b/recipes/omicron/meta.yaml
@@ -31,8 +31,8 @@ requirements:
   host:
     - fftw  # [osx]
     - gwollum {{ version }}
-    - root_base
-    - root-binaries
+    - root_base 6.18.04
+    - root-binaries 6.18.04
   run:
     - fftw  # [osx]
     - gwollum


### PR DESCRIPTION
This PR adds recipes for `GWOLLUM`, a utility library for gravitational-wave data analysis; and `Omicron`, a sine-Gaussian wavelet-based signal processing tool used in GW detector characterisation.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
