### PR TITLE
Added recipe for webhelpers2

### DIFF
--- a/recipes/webhelpers2/meta.yaml
+++ b/recipes/webhelpers2/meta.yaml
@@ -20,8 +20,8 @@ requirements:
     - pip
   run:
     - python
-    - markupsafe>=0.9.2
-    - six>=1.4.0
+    - markupsafe >=0.9.2
+    - six >=1.4.0
 
 test:
   requires:

--- a/recipes/webhelpers2/meta.yaml
+++ b/recipes/webhelpers2/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "webhelpers2" %}
+{% set version = "2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/mikeorr/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: ebb7ce6239cb57ddcdb532c72172e28fac93315c7ea234439a821f4c443ba54e
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - markupsafe>=0.9.2
+    - six>=1.4.0
+
+test:
+  requires:
+    - pytest
+  imports:
+    - {{ name }}
+  commands:
+    - pytest --pyargs {{ name }}
+
+about:
+  home: https://webhelpers2.readthedocs.io/en/latest
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Convenience functions for generating html'
+  description: |
+    WebHelpers2 is the successor to the widely-used WebHelpers utilities.
+    It contains convenience functions to make HTML tags, process text,
+    format numbers, do basic statistics, work with collections, and more.
+  doc_url: https://webhelpers2.readthedocs.io/en/latest
+  dev_url: https://github.com/mikeorr/WebHelpers2
+
+extra:
+  recipe-maintainers:
+    - ChrisBarker-NOAA
+    - mikeorr


### PR DESCRIPTION
@conda-forge/help-python

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

@mikeorr: Could you please post a comment indicating that you'll be a maintainer