### PR TITLE
recipe for de421 a very old jplephem package

### DIFF
--- a/recipes/de421/LICENSE.txt
+++ b/recipes/de421/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright 2012-2018 Brandon Rhodes (brandon@rhodesmill.org)
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/recipes/de421/meta.yaml
+++ b/recipes/de421/meta.yaml
@@ -40,4 +40,3 @@ about:
 extra:
   recipe-maintainers:
     - ReimarBauer
-

--- a/recipes/de421/meta.yaml
+++ b/recipes/de421/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "de421" %}
+{% set version = "2008.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a66faf7be328573d0028e45632ba614dd573cee88e3b6f099059149acc024df8
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - de421
+
+about:
+  home: https://github.com/brandon-rhodes/python-jplephem/ 
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'This is a recent short-period ephemeris published by the Jet Propulsion Laboratory. It requires only 27 MB of storage and is specially accurate with respect to the position of Earth’s Moon.'
+
+  description: |
+    The JPL called this ephemeris is a “significant advance” over predecessors like DE405 / DE406 and cited accuracies that are in many cases ten times greater, such as giving the position of Venus within 200m and the positions of Earth and Mars within 300m over the last decade. Note that even greater accuracies are achieved, for Mercury and Venus in particular (but not for the Moon), by DE423 which also has the advantage of covering a 400-year period instead of only 150 years.
+  doc_url: https://github.com/brandon-rhodes/python-jplephem/
+  dev_url: https://github.com/brandon-rhodes/python-jplephem/
+
+extra:
+  recipe-maintainers:
+    - ReimarBauer
+

--- a/recipes/de421/meta.yaml
+++ b/recipes/de421/meta.yaml
@@ -31,12 +31,10 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: 'This is a recent short-period ephemeris published by the Jet Propulsion Laboratory. It requires only 27 MB of storage and is specially accurate with respect to the position of Earth’s Moon.'
-
   description: |
-    The JPL called this ephemeris is a “significant advance” over predecessors like DE405 / DE406 and cited accuracies that are in many cases ten times greater, such as giving the position of Venus within 200m and the positions of Earth and Mars within 300m over the last decade. Note that even greater accuracies are achieved, for Mercury and Venus in particular (but not for the Moon), by DE423 which also has the advantage of covering a 400-year period instead of only 150 years.
+    The JPL called this ephemeris is a “significant advance” over predecessors like DE405 / DE406 and cited accuracies that are in many cases ten times greater, such as giving the position of Venus within 200m and the positions of Earth and Mars within 300m over the last decade.
   doc_url: https://github.com/brandon-rhodes/python-jplephem/
   dev_url: https://github.com/brandon-rhodes/python-jplephem/
-
 extra:
   recipe-maintainers:
     - ReimarBauer


### PR DESCRIPTION
It seems the jplephem-feedstock needs a package de421. This lives on pypi. I added the License file to the recipe

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
