### PR TITLE
rename citop to cistern

### DIFF
--- a/recipes/cistern/conda_build_config.yaml
+++ b/recipes/cistern/conda_build_config.yaml
@@ -1,0 +1,2 @@
+go_compiler:
+  - go-nocgo

--- a/recipes/cistern/meta.yaml
+++ b/recipes/cistern/meta.yaml
@@ -1,0 +1,45 @@
+{% set goname = "github.com/nbedos/cistern" %}
+{% set version = "0.2.0" %}
+
+{% set name = goname.split('/')[-1] %}
+{% set pkg_src = ('src/'+goname).replace("/",os.sep) %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - folder: {{ pkg_src }}
+    url: https://{{ goname }}/archive/{{ version }}.tar.gz
+    sha256: bf1c33c593cefd5360f8881a603f2f7204ea700d5f05601382df17730b687d47
+
+build:
+  number: 0
+  skip: true  # [win]
+  script:
+    - pushd {{ pkg_src }}
+    - go build -ldflags "-X main.Version={{ version }}" -v -o $GOBIN/{{ name }} .       # [unix]
+
+requirements:
+  build:
+    - {{ compiler("go") }} >=1.11
+
+test:
+  commands:
+    - cistern --version
+
+about:
+  home: https://github.com/nbedos/cistern
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: {{ pkg_src }}/LICENSE
+  summary: |
+    A top-like utility for Unix to monitor Continuous Integration pipelines from the
+    command line. Think of cistern as the receptacle that holds the results of your
+    CI pipelines. cistern stands for Continuous Integration Services Terminal for Unix.
+  dev_url: https://github.com/nbedos/cistern
+  doc_url: https://nbedos.github.io/cistern/cistern.man
+
+extra:
+  recipe-maintainers:
+    - luizirber

--- a/recipes/cistern/meta.yaml
+++ b/recipes/cistern/meta.yaml
@@ -18,7 +18,7 @@ build:
   skip: true  # [win]
   script:
     - pushd {{ pkg_src }}
-    - go build -ldflags "-X main.Version={{ version }}" -v -o $GOBIN/{{ name }} .       # [unix]
+    - go build -ldflags "-X main.Version={{ version }}" -v -o $GOBIN/{{ name }} ./cmd/cistern   # [unix]
 
 requirements:
   build:


### PR DESCRIPTION
`citop` changed name to `cistern`, so adding as a new recipe.

And https://github.com/conda-forge/citop-feedstock/ should be archived (as discussed in https://gitter.im/conda-forge/conda-forge.github.io?at=5e02bd7b3e3f133894f0f1a4)

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there