### PR TITLE
Add jupyter_telemetry

### DIFF
--- a/recipes/jupyter_telemetry/meta.yaml
+++ b/recipes/jupyter_telemetry/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "jupyter_telemetry" %}
+{% set version = "0.0.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 507d66f70ce89fde1c7541d82d74c243136d7e3a9105487ec6ca0dc8cb836b7b
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+    - jsonschema
+    - traitlets
+    - ruamel.yaml
+    - python-json-logger
+
+test:
+  imports:
+    - jupyter_telemetry
+
+about:
+  home: https://jupyter-telemetry.readthedocs.io
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Telemetry for Jupyter Applications and extensions.'
+
+  description: |
+    Telemetry provides a configurable traitlets object, EventLog,
+    for structured event-logging in Python.
+    It leverages Python’s standard logging library for filtering, handling, and recording events.
+    All events are validated (using jsonschema) against registered JSON schemas.
+  doc_url: https://jupyter-telemetry.readthedocs.io
+  dev_url: https://github.com/jupyter/telemetry
+
+extra:
+  recipe-maintainers:
+    - minrk


### PR DESCRIPTION
required for https://github.com/conda-forge/jupyterhub-feedstock/pull/27


<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there