### PR TITLE
ENH adding stale bot config per CFEP-11

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,6 +1,7 @@
 daysUntilStale: 300
 daysUntilClose: 30
 only: pulls
+limitPerRun: 1
 exemptLabels:
   - Package request
   - bug

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,47 @@
+daysUntilStale: 300
+daysUntilClose: 30
+exemptLabels:
+  - Package request
+  - bug
+  - Discussion
+  - docs
+  - enhancement
+  - Examples
+  - Guidelines
+  - help wanted
+  - in progress
+  - hacktoberfest
+  - maintenance
+  - Needs Decision
+  - question
+  - Mac
+  - R
+  - readd
+  - Windows
+  - Work in progress - don't reviw yet
+  - nodejs
+  - in progress
+  - Guidelines (not yet agreed)
+  - Continuum question
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Hi friend! We really, really, really appreciate that you have taken the time
+  to make a PR/issue on `conda-forge/staged-recipes`! `conda-forge` only exists
+  because people like you donate their time to build and maintain conda recipes
+  for use by the community. In an effort to maintain this repository and increase
+  the signal-to-noise for open PRs/issues, the maintainers of `staged-recipes` close
+  excessively old PRs/issues after six months. This PR/issue will remain open
+  for another month, and then will be closed. If you'd like to keep it open,
+  please comment and we will be happy to oblige! Cheers and thank you for
+  contributing to this community effort!
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Hi again! About a month ago, we commented on this PR/issue saying it would be
+  closed in another month if it was still inactive. It has been a month and
+  so now it is being closed. Thank you so much for making it in the first place
+  and contributing to the community project that is `conda-forge`. If you'd like
+  to reopen this issue, please feel free to do so at any time!
+  Cheers and have a great day!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,6 @@
 daysUntilStale: 300
 daysUntilClose: 30
+only: pulls
 exemptLabels:
   - Package request
   - bug

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,29 +2,6 @@ daysUntilStale: 300
 daysUntilClose: 30
 only: pulls
 limitPerRun: 1
-exemptLabels:
-  - Package request
-  - bug
-  - Discussion
-  - docs
-  - enhancement
-  - Examples
-  - Guidelines
-  - help wanted
-  - in progress
-  - hacktoberfest
-  - maintenance
-  - Needs Decision
-  - question
-  - Mac
-  - R
-  - readd
-  - Windows
-  - Work in progress - don't reviw yet
-  - nodejs
-  - in progress
-  - Guidelines (not yet agreed)
-  - Continuum question
 staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,21 +6,39 @@ staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  Hi friend! We really, really, really appreciate that you have taken the time
-  to make a PR/issue on `conda-forge/staged-recipes`! `conda-forge` only exists
+  Hi friend! 
+  
+  
+  We really, really, really appreciate that you have taken the time
+  to make a PR on `conda-forge/staged-recipes`! `conda-forge` only exists
   because people like you donate their time to build and maintain conda recipes
-  for use by the community. In an effort to maintain this repository and increase
-  the signal-to-noise for open PRs/issues, the maintainers of `staged-recipes` close
-  excessively old PRs/issues after six months. This PR/issue will remain open
-  for another month, and then will be closed. If you'd like to keep it open,
-  please comment and we will be happy to oblige! Cheers and thank you for
-  contributing to this community effort!
+  for use by the community. 
+  
+  
+  In an effort to maintain this repository and increase
+  the signal-to-noise for open PRs, the maintainers of `staged-recipes` close
+  excessively old PRs after six months. This PR will remain open
+  for another month, and then will be closed. 
+  
+  
+  If you'd like to keep it open, please comment/push and we will be happy to oblige!
+  Note that very old PRs will likely need to be rebased on master so that they can 
+  be rebuilt with the most recent CI scripts. If you have any trouble, or we missed 
+  reviewing this PR in the first place (sorry!), feel free 
+  to [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) 
+  using a special command in a comment on the PR to get the attention of the 
+  `staged-recipes` team.
+  
+  
+  Cheers and thank you for contributing to this community effort!
 
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: >
-  Hi again! About a month ago, we commented on this PR/issue saying it would be
+  Hi again! About a month ago, we commented on this PR saying it would be
   closed in another month if it was still inactive. It has been a month and
   so now it is being closed. Thank you so much for making it in the first place
   and contributing to the community project that is `conda-forge`. If you'd like
-  to reopen this issue, please feel free to do so at any time!
+  to reopen this PR, please feel free to do so at any time!
+  
+  
   Cheers and have a great day!


### PR DESCRIPTION
Here is the stale bot config. 

To do
- [x] We should have @conda-forge/staged-recipes and @conda-forge/core comment here before we merge. 
- [x] we should understand how the bot will behave with PRs from 2 years ago before we merge.

cc @isuruf 

closes #10168