### PR TITLE
Add dependency-walker

### DIFF
--- a/recipes/dependency-walker/LICENSE
+++ b/recipes/dependency-walker/LICENSE
@@ -1,0 +1,3 @@
+from http://www.dependencywalker.com/:
+
+Dependency Walker is completely free to use. However, you may not profit from the distribution of it, nor may you bundle it with another product.

--- a/recipes/dependency-walker/bld.bat
+++ b/recipes/dependency-walker/bld.bat
@@ -1,0 +1,2 @@
+xcopy depends.* %LIBRARY_BIN% || exit 1
+copy depends.dll %LIBRARY_BIN%\mfc42.dll || exit 1

--- a/recipes/dependency-walker/bld.bat
+++ b/recipes/dependency-walker/bld.bat
@@ -1,2 +1,4 @@
 xcopy depends.* %LIBRARY_BIN% || exit 1
 copy depends.dll %LIBRARY_BIN%\mfc42.dll || exit 1
+
+python %RECIPE_DIR%\ldd.py "%LIBRARY_BIN%\depends.exe" "%LIBRARY_BIN%"

--- a/recipes/dependency-walker/ldd.py
+++ b/recipes/dependency-walker/ldd.py
@@ -1,0 +1,27 @@
+import pefile
+import sys
+import os
+
+def get_dependency(root):
+    deps = []
+    pe = pefile.PE(root)
+    for imp in pe.DIRECTORY_ENTRY_IMPORT:
+        deps.append(imp.dll.decode())
+    return deps
+
+root = sys.argv[1]
+prefix = sys.argv[2]
+dep_dlls = dict()
+def dep_tree_impl(root, prefix):
+    for dll in get_dependency(root):
+        if dll in dep_dlls:
+            continue
+        full_path = os.path.join(prefix, dll)
+        if os.path.exists(full_path):
+            dep_dlls[dll] = full_path
+            dep_tree_impl(full_path, prefix)
+        else:
+            dep_dlls[dll] = 'not found'
+dep_tree_impl(root, prefix)
+for dll, full_path in dep_dlls.items():
+    print(' ' * 7, dll, '=>', full_path)

--- a/recipes/dependency-walker/meta.yaml
+++ b/recipes/dependency-walker/meta.yaml
@@ -1,0 +1,32 @@
+{% set version = "2.2" %}
+
+package:
+  name: dependency-walker
+  version: {{ version }}
+
+source:
+  url: http://www.dependencywalker.com/depends22_x64.zip
+  sha256: 35db68a613874a2e8c1422eb0ea7861f825fc71717d46dabf1f249ce9634b4f1
+
+build:
+  number: 0
+  skip: true  # [not win]
+
+requirements:
+  build:
+    - vc 14
+
+test:
+  commands:
+    - depends /c "%LIBRARY_BIN%\depends.exe"
+
+about:
+  home: http://www.dependencywalker.com/
+  license: PROPRIETARY
+  license_family: PROPRIETARY
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: Dependency Walker is a free utility that scans any Windows module (exe, dll, ...)
+
+extra:
+  recipe-maintainers:
+    - jschueller

--- a/recipes/dependency-walker/meta.yaml
+++ b/recipes/dependency-walker/meta.yaml
@@ -14,11 +14,13 @@ build:
 
 requirements:
   build:
-    - vc 14
+    - pefile
+  host:
+    - python
 
 test:
   commands:
-    - depends /c "%LIBRARY_BIN%\depends.exe"
+    - "%LIBRARY_BIN%\depends.exe" /c "%LIBRARY_BIN%\depends.exe"
 
 about:
   home: http://www.dependencywalker.com/


### PR DESCRIPTION
This is a proprietary sofware. The goal is to help debugging conda-forge recipes.