### PR TITLE
ENH exit early if out of API requests

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -88,6 +88,29 @@ def print_rate_limiting_info(gh):
     print("")
 
 
+def sleep_until_reset(gh):
+    # sleep the job with printing every minute if we are out 
+    # of github api requests
+
+    gh_api_remaining = gh.get_rate_limit().core.remaining
+    
+    if gh_api_remaining == 0:
+        # Compute time until GitHub API Rate Limit reset
+        gh_api_reset_time = gh.get_rate_limit().core.reset
+        gh_api_reset_time -= datetime.utcnow()
+        
+        mins_to_sleep = gh_api_reset_time // 60
+        mins_to_sleep += 1
+
+        print("Sleeping until GitHub API resets.")
+        for i in range(mins_to_sleep):
+            time.sleep(60)
+            print("slept for minute {curr} out of {tot}.".format(
+                curr=i+1, tot=mins_to_sleep))
+        return True
+    else:
+        return False
+
 
 if __name__ == '__main__':
     exit_code = 0
@@ -117,6 +140,10 @@ if __name__ == '__main__':
 
         # Get our initial rate limit info.
         print_rate_limiting_info(gh)
+        
+        # if we are out, exit early
+        if sleep_until_reset(gh):
+            sys.exit(1)
 
     gh_drone = Github(os.environ['GH_DRONE_TOKEN'])
     print_rate_limiting_info(gh_drone)

--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -99,7 +99,7 @@ def sleep_until_reset(gh):
         gh_api_reset_time = gh.get_rate_limit().core.reset
         gh_api_reset_time -= datetime.utcnow()
         
-        mins_to_sleep = gh_api_reset_time // 60
+        mins_to_sleep = gh_api_reset_time.seconds // 60
         mins_to_sleep += 1
 
         print("Sleeping until GitHub API resets.")

--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -99,7 +99,7 @@ def sleep_until_reset(gh):
         gh_api_reset_time = gh.get_rate_limit().core.reset
         gh_api_reset_time -= datetime.utcnow()
         
-        mins_to_sleep = gh_api_reset_time.seconds // 60
+        mins_to_sleep = gh_api_reset_time.total_seconds() // 60
         mins_to_sleep += 1
 
         print("Sleeping until GitHub API resets.")


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
