### PR TITLE
Add recipe for pyobjc-framework-fsevents

### DIFF
--- a/recipes/pyobjc-framework-fsevents/meta.yaml
+++ b/recipes/pyobjc-framework-fsevents/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: true  # [not osx]
+  skip: true  # [(not osx) or py2k]
 
 requirements:
   host:

--- a/recipes/pyobjc-framework-fsevents/meta.yaml
+++ b/recipes/pyobjc-framework-fsevents/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "pyobjc-framework-FSEvents" %}
+{% set version = "6.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 7a635c86af744a1d17f0c6c3913bef87b5fd146e0311c03229eba9e512b81520
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [not osx]
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - python
+    - pyobjc-core >=6.1
+    - pyobjc-framework-cocoa >=6.1
+
+test:
+  imports:
+    - FSEvents
+
+about:
+  home: "https://bitbucket.org/ronaldoussoren/pyobjc"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: "Wrappers for the framework FSEvents on macOS"
+
+extra:
+  recipe-maintainers:
+    - xhochy


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
