### PR TITLE
Add requests-kerberos

### DIFF
--- a/recipes/requests-kerberos/meta.yaml
+++ b/recipes/requests-kerberos/meta.yaml
@@ -28,8 +28,6 @@ requirements:
 test:
   imports:
     - requests_kerberos
-  requires:
-    - mock
 
 about:
   home: "https://github.com/requests/requests-kerberos"

--- a/recipes/requests-kerberos/meta.yaml
+++ b/recipes/requests-kerberos/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "requests-kerberos" %}
+{% set version = "0.12.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "9d21f15241c53c2ad47e813138b9aee4b9acdd04b82048c4388ade15f40a52fd"
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python
+    - setuptools
+  run:
+    - cryptography >=1.3
+    - pykerberos >=1.1.8,<2.0.0  # [not win]
+    - python
+    - requests >=1.1.0
+    - winkerberos >=0.5.0  # [win]
+
+test:
+  imports:
+    - requests_kerberos
+  requires:
+    - mock
+
+about:
+  home: "https://github.com/requests/requests-kerberos"
+  dev_url: "https://github.com/requests/requests-kerberos"
+  doc_url: "https://pypi.org/project/requests-kerberos/"
+  license: "ISC"
+  license_family: "MIT"
+  license_file: "LICENSE"
+  summary: "A Kerberos authentication handler for python-requests"
+  description: |
+    Requests is an HTTP library, written in Python, for human beings.
+    This library adds optional Kerberos/GSSAPI authentication support
+    and supports mutual authentication.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds a recipe for [`requests-kerberos`](https://pypi.org/project/requests-kerberos/).

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
