### PR TITLE
Add recipe for threadpoolctl

### DIFF
--- a/recipes/threadpoolctl/meta.yaml
+++ b/recipes/threadpoolctl/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "2.0.0" %}
+
+package:
+  name: threadpoolctl
+  version: {{ version }}
+
+source:
+  url: https://github.com/joblib/threadpoolctl/archive/{{ version }}.tar.gz
+  sha256: 49b987e9e86168eec68d0c706091bd6a8590268abc249b32bcd2a3909d331a04
+
+build:
+  number: 0
+  skip: true  # [py<35]
+  script:
+    - {{ PYTHON }} -m flit install
+
+requirements:
+  host:
+    - python
+    - flit
+  run:
+    - python
+
+test:
+  requires:
+    - numpy
+  imports:
+    - threadpoolctl
+  commands:
+    - python -c "import numpy; from threadpoolctl import threadpool_info; threadpool_info()"
+    - python -c "import numpy; from threadpoolctl import threadpool_limits; threadpool_limits(1)"
+    - python -m threadpoolctl -i numpy
+
+about:
+  home: https://github.com/joblib/threadpoolctl
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Python helpers to control the threadpools of native libraries'
+
+  description: |
+    Python helpers to introspect and limit the number of threads used
+    in native libraries that handle their own internal threadpool
+    (BLAS and OpenMP implementations).
+  doc_url: https://github.com/joblib/threadpoolctl
+  dev_url: https://github.com/joblib/threadpoolctl
+
+extra:
+  recipe-maintainers:
+    - ogrisel
+    - tomMoral
+    - jeremiedbb


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
