### PR TITLE
[wip] add neuralcoref model from s3

### DIFF
--- a/recipes/neuralcoref-model/copy_model.py
+++ b/recipes/neuralcoref-model/copy_model.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import shutil
+import os
+
+PKG_NAME = os.environ["PKG_NAME"]
+SRC_DIR = Path(os.environ["SRC_DIR"])
+RECIPE_DIR = Path(os.environ["RECIPE_DIR"])
+PREFIX = Path(os.environ["PREFIX"])
+
+ETC = PREFIX / "conda"
+SCRIPTS = RECIPE_DIR / "scripts"
+
+CACHE_NAME = "neuralcoref_cache"
+SHARE = PREFIX / "share"
+CACHE_PATH = SHARE / CACHE_NAME
+
+MODEL_DIR = SRC_DIR / CACHE_NAME
+
+SHARE.mkdir(exist_ok=True)
+
+# actually copy
+shutil.copytree(MODEL_DIR, CACHE_PATH)
+
+# add the (de)activate scripts
+for ext in ["bat", "sh"]:
+    for change in ["activate", "deactivate"]:
+        dest = ETC / f"{change}.d" / f"{PKG_NAME}_{change}.{ext}"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(SCRIPTS / f"{change}.{ext}", dest)

--- a/recipes/neuralcoref-model/meta.yaml
+++ b/recipes/neuralcoref-model/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "neuralcoref-model" %}
+{% set version = "4.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - folder: neuralcoref_cache/neuralcoref
+    url: https://s3.amazonaws.com/models.huggingface.co/neuralcoref/neuralcoref.tar.gz
+    sha256: e6140dc57e67e6f2978f21a645457066b1bb66b64f5b1f4949b1ffc7342e699d
+
+build:
+  noarch: generic
+  number: 0
+  script: cd {{ RECIPE_DIR }} && {{ PYTHON }} copy_model.py
+
+requirements:
+  build:
+    - python >=3.6
+  run:
+    - neuralcoref ={{ version }}
+
+test:
+  requires:
+    - python
+  downstreams:
+    - neuralcoref
+
+about:
+  home: https://huggingface.co/coref
+  license: MIT
+  license_family: MIT
+  license_file: mit.txt
+  summary: 'Pre-trained model for neuralcoref'
+  dev_url: https://github.com/huggingface/neuralcoref
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/neuralcoref-model/mit.txt
+++ b/recipes/neuralcoref-model/mit.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Huggingface Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/neuralcoref-model/scripts/activate.bat
+++ b/recipes/neuralcoref-model/scripts/activate.bat
@@ -1,0 +1,7 @@
+@REM Store existing neuralcoref env vars and set to this conda env
+@REM so other neuralcoref installs don't pollute the environment
+
+@if defined NEURALCOREF_CACHE (
+    set "_CONDA_SET_NEURALCOREF_CACHE=%NEURALCOREF_CACHE%"
+)
+@set "NEURALCOREF_CACHE=%CONDA_PREFIX%\share\neuralcoref_cache"

--- a/recipes/neuralcoref-model/scripts/activate.sh
+++ b/recipes/neuralcoref-model/scripts/activate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Store existing neuralcoref env vars and set to this conda env
+# so other neuralcoref installs don't pollute the environment
+
+if [[ -n "$NEURALCOREF_CACHE" ]]; then
+    export _CONDA_SET_NEURALCOREF_CACHE=$NEURALCOREF_CACHE
+fi
+
+export NEURALCOREF_CACHE=$CONDA_PREFIX/share/neuralcoref_cache

--- a/recipes/neuralcoref-model/scripts/deactivate.bat
+++ b/recipes/neuralcoref-model/scripts/deactivate.bat
@@ -1,0 +1,7 @@
+@REM Restore previous neuralcoref env vars if they were set
+
+@set "NEURALCOREF_CACHE="
+@if defined _CONDA_SET_NEURALCOREF_CACHE (
+  set "NEURALCOREF_CACHE=%_CONDA_SET_NEURALCOREF_CACHE%"
+  set "_CONDA_SET_NEURALCOREF_CACHE="
+)

--- a/recipes/neuralcoref-model/scripts/deactivate.sh
+++ b/recipes/neuralcoref-model/scripts/deactivate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Restore previous neuralcoref env vars if they were set
+
+unset NEURALCOREF_CACHE
+if [[ -n "$_CONDA_SET_NEURALCOREF_CACHE" ]]; then
+    export NEURALCOREF_CACHE=$_CONDA_SET_NEURALCOREF_CACHE
+    unset _CONDA_SET_NEURALCOREF_CACHE
+fi


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

The upstream model has no version or license information associated with it, and activation scripts are no fun, but this does appear to work (there is no s3 progress bar during the `downstream` test).

The pins are pretty exact, as I have no idea how this is going to work in the future... it seems preferable to push out new, more relaxed versions in the future rather than fix emergent broken-by-default solving.

Some of these issues have been raised upstream: https://github.com/huggingface/neuralcoref/issues/235

:bellhop_bell: @oblute @benhuff @rluria14 I'd be happy to get this working, and add @conda-forge/neuralcoref to the maintainers, but kinda can't start using (and therefore maintain) that as long as it does the runtime s3 thing.