### PR TITLE
Adding foyer

### DIFF
--- a/recipes/foyer/meta.yaml
+++ b/recipes/foyer/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "foyer" %}
+{% set version = "0.7.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/mosdef-hub/foyer/archive/{{ version }}.tar.gz
+  sha256: b07fc28a8a403fa12e0b836d64797b61b825bdac5e8ed9491e76acf56e4df05f
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - lark-parser
+    - lxml
+    - networkx >=2.0
+    - openmm
+    - parmed
+    - protobuf
+    - python >=3.6
+    - requests
+
+test:
+  imports:
+    - foyer
+
+about:
+  home: https://github.com/mosdef-hub/foyer
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.rst
+  summary: 'Atom-typing and force field dissemination.'
+  description: |
+    Foyer is an open-source Python tool that enables users to define and apply
+    force field atom-typing rules in a format that is both human- and
+    machine-readable and provides a framework for force field dissemination,
+    thus eliminating ambiguity in atom-typing and improving reproducibility.
+    Foyer defines force fields in an XML format, where SMARTS strings are used
+    to define the chemical context of a particular atom type and "overrides"
+    are used to set rule precedence, rather than a rigid hierarchical scheme.
+  doc_url: https://foyer.mosdef.org/
+  dev_url: https://github.com/mosdef-hub/foyer
+
+extra:
+  recipe-maintainers:
+    - bdice
+    - justinGilmer


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
