### PR TITLE
Adding vtkplotter

### DIFF
--- a/recipes/vtkplotter/LICENSE.txt
+++ b/recipes/vtkplotter/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Marco Musy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/vtkplotter/meta.yaml
+++ b/recipes/vtkplotter/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/vtkplotter/meta.yaml
+++ b/recipes/vtkplotter/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "vtkplotter" %}
+{% set version = "2020.2.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: d9db1c6f1e267ef672cf7721cdc270057d8e22428b8aa04e1e0a2b119b1d28e9
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+    - vtk
+  run:
+    - python
+    - vtk
+
+test:
+  imports:
+    - vtkplotter
+
+about:
+  home: "https://github.com/marcomusy/vtkplotter"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "A python module for scientific visualization, analysis and animation of 3D objects and point clouds based on VTK."
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - your-github-id-here

--- a/recipes/vtkplotter/meta.yaml
+++ b/recipes/vtkplotter/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   run:
     - python
     - vtk
+    - numpy
 
 test:
   imports:
@@ -29,7 +30,7 @@ about:
   home: "https://github.com/marcomusy/vtkplotter"
   license: MIT
   license_family: MIT
-  license_file: 
+  license_file: LICENSE.txt
   summary: "A python module for scientific visualization, analysis and animation of 3D objects and point clouds based on VTK."
   doc_url: https://vtkplotter.embl.es/
   dev_url: https://github.com/marcomusy/vtkplotter

--- a/recipes/vtkplotter/meta.yaml
+++ b/recipes/vtkplotter/meta.yaml
@@ -17,7 +17,6 @@ requirements:
   host:
     - pip
     - python
-    - vtk
   run:
     - python
     - vtk
@@ -32,9 +31,10 @@ about:
   license_family: MIT
   license_file: 
   summary: "A python module for scientific visualization, analysis and animation of 3D objects and point clouds based on VTK."
-  doc_url: 
-  dev_url: 
+  doc_url: https://vtkplotter.embl.es/
+  dev_url: https://github.com/marcomusy/vtkplotter
 
 extra:
   recipe-maintainers:
-    - your-github-id-here
+    - RubendeBruin
+    - marcomusy

--- a/recipes/vtkplotter/run_test.sh
+++ b/recipes/vtkplotter/run_test.sh
@@ -1,0 +1,4 @@
+sudo apt-get install xvfb
+export DISPLAY=:99.0
+Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+sleep 3

--- a/recipes/vtkplotter/run_test.sh
+++ b/recipes/vtkplotter/run_test.sh
@@ -1,4 +1,0 @@
-sudo apt-get install xvfb
-export DISPLAY=:99.0
-Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-sleep 3

--- a/recipes/vtkplotter/yum_requirements.txt
+++ b/recipes/vtkplotter/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGL-devel


### PR DESCRIPTION
This is the conda-forge recipe for vtkplotter.

Checklist:
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged. (N/A)
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details) : frompypi
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there:  TODO