### PR TITLE
add latest javabridge1.0.18 into conda-forge

### DIFF
--- a/recipes/javabridge/LICENSE
+++ b/recipes/javabridge/LICENSE
@@ -1,0 +1,32 @@
+Copyright (c) 2003-2009 Massachusetts Institute of Technology
+Copyright (c) 2009-2013 Broad Institute
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of the Massachusetts Institute of Technology
+      nor the Broad Institute nor the names of its contributors may be
+      used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL MASSACHUSETTS
+INSTITUTE OF TECHNOLOGY OR THE BROAD INSTITUTE BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "javabridge" %}
+{% set version = "1.0.18" %}
+
+package:
+  name: '{{ name|lower }}'
+  version: '{{ version }}'
+
+source:
+  url: https://pypi.io/packages/source/j/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d6d27dad4331fd1f4cc4a82aedd168bbc3d57641def8f055e137ae3cad521737
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . "
+  skip: True # [win or osx or py3k]
+  
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+    - numpy
+    - cython
+    - openjdk 8*
+  run:
+    - python
+    - numpy
+    - openjdk 8*
+    
+test:
+  imports:
+    - javabridge
+    - javabridge.tests
+  requires:
+    - nose
+    - openjdk
+
+about:
+  home: http://github.com/CellProfiler/python-javabridge/
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE
+  summary: Python wrapper for the Java Native Interface
+  description: |
+     The python-javabridge package makes it easy to start a Java virtual machine (JVM) from Python and interact with it. Python code can interact with the JVM using a low-level API or a more convenient high-level API. Python-javabridge was developed for and is used by cell image analysis software CellProfiler.
+  doc_url: 'https://pythonhosted.org/javabridge/'
+  dev_url: 'http://github.com/CellProfiler/python-javabridge/'
+
+extra:
+  recipe-maintainers:
+    - sunyi000

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . "
-  skip: True # [win or osx or py3k]
+  skip: True  # [win or osx or py3k]
   
 requirements:
   build:

--- a/recipes/javabridge/meta.yaml
+++ b/recipes/javabridge/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . "
-  skip: True  # [win or osx or py3k]
+  skip: True  # [win or osx]
   
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
