### PR TITLE
feat: add recipe for metanetx-post

### DIFF
--- a/recipes/metanetx-post/meta.yaml
+++ b/recipes/metanetx-post/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   host:
     - pip
     - python >=3.8
-    - setuptools
   run:
     - aioftp
     - Click

--- a/recipes/metanetx-post/meta.yaml
+++ b/recipes/metanetx-post/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - python >=3.8
   run:
     - aioftp
-    - Click
+    - click
     - click-log
     - cobra-component-models
     - depinfo
@@ -34,7 +34,7 @@ requirements:
     - python >=3.8
     - rdflib
     - rdkit
-    - SQLAlchemy
+    - sqlalchemy
     - tqdm
 
 test:

--- a/recipes/metanetx-post/meta.yaml
+++ b/recipes/metanetx-post/meta.yaml
@@ -48,9 +48,9 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: "Enrich the information coming from [MetaNetX](https://metanetx.org) from additional sources."
+  summary: "Enrich the information coming from MetaNetX (https://metanetx.org) with additional sources."
   description: |
-    This package provides a command line program `mnx-post` that has a number of
+    This package provides a command line program 'mnx-post' that has a number of
     commands to augment the existing information from MetaNetX from other
     sources, among them BiGG, ExPASy, KEGG, and SEED.
   dev_url: https://github.com/Midnighter/metanetx-post

--- a/recipes/metanetx-post/meta.yaml
+++ b/recipes/metanetx-post/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "metanetx-post" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 578bcd1080a55ef46c86f37eec1f0bbe5331dc8b583ff982f055e9db9baae781
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --ignore-installed"
+  entry_points:
+    - "mnx-post = metanetx_post.cli.main:cli"
+
+requirements:
+  host:
+    - pip
+    - python >=3.8
+    - setuptools
+  run:
+    - aioftp
+    - Click
+    - click-log
+    - cobra-component-models
+    - depinfo
+    - httpx
+    - metanetx-sdk
+    - pandas
+    - pydantic
+    - pyparsing
+    - python >=3.8
+    - rdflib
+    - rdkit
+    - SQLAlchemy
+    - tqdm
+
+test:
+  imports:
+    - metanetx_post
+  commands:
+    - "mnx-post --help"
+
+about:
+  home: https://pypi.org/project/metanetx-post/
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: "Enrich the information coming from [MetaNetX](https://metanetx.org) from additional sources."
+  description: |
+    This package provides a command line program `mnx-post` that has a number of
+    commands to augment the existing information from MetaNetX from other
+    sources, among them BiGG, ExPASy, KEGG, and SEED.
+  dev_url: https://github.com/Midnighter/metanetx-post
+
+extra:
+  recipe-maintainers:
+    - Midnighter


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
