### PR TITLE
Add hurry.filesize [migrating from bioconda]

### DIFF
--- a/recipes/hurry.filesize/LICENSE.txt
+++ b/recipes/hurry.filesize/LICENSE.txt
@@ -1,0 +1,51 @@
+Zope Public License (ZPL) Version 2.1
+
+A copyright notice accompanies this license document that identifies
+the copyright holders.
+
+This license has been certified as open source. It has also been
+designated as GPL compatible by the Free Software Foundation (FSF).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ 1. Redistributions in source code must retain the accompanying
+    copyright notice, this list of conditions, and the following
+    disclaimer.
+
+ 2. Redistributions in binary form must reproduce the accompanying
+    copyright notice, this list of conditions, and the following
+    disclaimer in the documentation and/or other materials provided
+    with the distribution.
+
+ 3. Names of the copyright holders must not be used to endorse or
+    promote products derived from this software without prior written
+    permission from the copyright holders.
+
+ 4. The right to distribute this software or to use it for any purpose
+    does not give you the right to use Servicemarks (sm) or Trademarks
+    (tm) of the copyright holders. Use of them is covered by separate
+    agreement with the copyright holders.
+
+ 5. If any files are modified, you must cause the modified files to
+    carry prominent notices stating that you changed the files and the
+    date of any change.
+
+Disclaimer
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+This software consists of contributions made by Zope Corporation and
+many individuals on behalf of Zope Corporation. Specific attributions
+are listed in the accompanying credits file. 

--- a/recipes/hurry.filesize/meta.yaml
+++ b/recipes/hurry.filesize/meta.yaml
@@ -30,6 +30,7 @@ test:
 about:
   home: https://pypi.org/project/hurry.filesize/
   license: ZPL 2.1
+  license_file: LICENSE.txt
   summary: Python library for human readable file sizes (or anything sized in bytes)
 
 extra:

--- a/recipes/hurry.filesize/meta.yaml
+++ b/recipes/hurry.filesize/meta.yaml
@@ -1,0 +1,37 @@
+{% set version = '0.9' %}
+{% set sha256 = 'f5368329adbef86accd3bc9490522340bb79260455ae89b1a42c10f63801b9a6' %}
+
+package:
+  name: hurry.filesize
+  version: {{ version }}
+
+source:
+  url: https://pypi.python.org/packages/source/h/hurry.filesize/hurry.filesize-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv
+
+requirements:
+  host:
+    - python
+    - pip
+
+  run:
+    - python
+
+test:
+  imports:
+    - hurry
+    - hurry.filesize
+
+about:
+  home: https://pypi.org/project/hurry.filesize/
+  license: ZPL 2.1
+  summary: Python library for human readable file sizes (or anything sized in bytes)
+
+extra:
+  recipe-maintainers:
+    - raivivek

--- a/recipes/hurry.filesize/meta.yaml
+++ b/recipes/hurry.filesize/meta.yaml
@@ -31,6 +31,7 @@ about:
   home: https://pypi.org/project/hurry.filesize/
   license: ZPL 2.1
   license_file: LICENSE.txt
+  license_family: OTHER
   summary: Python library for human readable file sizes (or anything sized in bytes)
 
 extra:


### PR DESCRIPTION
Signed-off-by: Vivek Rai <mail@raivivek.in>

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in 
a comment on the PR to get the attention of the `staged-recipes` team. You can 
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
