### PR TITLE
azure-pipelines-osx: Upgrade vmImage to 10.14

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,12 +17,6 @@ platform:
     - x64
 
 install:
-    # If there is a newer build queued for the same PR, cancel this one.
-    - cmd: |
-        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
-        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
-        del ff_ci_pr_build.py
-
     # Find the recipes from master in this PR and remove them.
     - cmd: echo Finding recipes merged in master and removing them.
     - cmd: cd recipes

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: osx_64
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   strategy:
     maxParallel: 8
     matrix:


### PR DESCRIPTION
This is not a new recipe; this is a change to `staged-recipes/.azure-pipelines`.

Azure is warning us that their OSX 10.13 image will be removed soon.  This PR is my naive attempt at upgrading the image used by `staged-recipes`.  Is this tiny change sufficient, or am I missing something?

BTW, it looks like y'all already upgraded `conda-smithy` to ask for 10.14, so feedstock repos are already in good shape.
