### PR TITLE
Added recipe for roifile

### DIFF
--- a/recipes/roifile/meta.yaml
+++ b/recipes/roifile/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "roifile" %}
+{% set version = "2020.2.12" %}
+{% set sha256 = "e7c140117d5d9cd48a0902ac1284a6be09c3bc936d6ff1a1c07118c991abcd50" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  noarch: python
+  entry_points:
+    - roifile = roifile.roifile:main
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - numpy >=1.14.5
+
+test:
+  imports:
+    - roifile
+  commands:
+    - roifile
+
+about:
+  home: https://github.com/cgohlke/roifile
+  license: BSD
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Read and write ImageJ ROI format.'
+  description: |
+    Roifile is a Python library to read, write, create, and plot ImageJ ROIs, an undocumented and ImageJ application specific format to store regions of interest, geometric shapes, paths, text, and whatnot for image overlays.
+  doc_url: https://github.com/cgohlke/roifile
+  dev_url: https://github.com/cgohlke/roifile
+
+extra:
+  recipe-maintainers:
+    - csachs

--- a/recipes/roifile/meta.yaml
+++ b/recipes/roifile/meta.yaml
@@ -34,7 +34,7 @@ test:
 
 about:
   home: https://github.com/cgohlke/roifile
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
   summary: 'Read and write ImageJ ROI format.'


### PR DESCRIPTION
`roifile` is a new package by Christoph Gohlke (https://github.com/cgohlke/roifile/), which is, jointly with already existing conda-forge package `tifffile`, very useful for developing scientific imaging applications within the Fiji/ImageJ tooling context.

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
Applicable Team:
- python @conda-forge/help-python