### PR TITLE
add PySTAC

### DIFF
--- a/recipes/PySTAC/LICENSE
+++ b/recipes/PySTAC/LICENSE
@@ -1,0 +1,15 @@
+This software is licensed under the Apache 2 license, quoted below.
+
+Copyright 2017 Azavea [http://www.azavea.com]
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+    [http://www.apache.org/licenses/LICENSE-2.0]
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.

--- a/recipes/PySTAC/meta.yaml
+++ b/recipes/PySTAC/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.3.3" %}
+
+
+package:
+  name: pystac
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/pystac/pystac-{{ version }}.tar.gz
+  sha256: 70be509476b49106f4b1157334ccdb5de10c57cd1a4e2dbde191951ccf0e065d
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - python-dateutil >=2.7.0
+
+test:
+  imports:
+    - pystac
+    - pystac.serialization
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/pystac/
+  summary: Python library for working with Spatiotemporal Asset Catalog (STAC).
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
@rsignell-usgs this is still missing `sat-fetch` which depends on `gippy`. I could not get `gippy` to work on modern Python. The metadata says it works up to Python 3.5 but even there it seems to be broken.

I'm pretty sure `sat-fetch` can be re-written to use `rasterio` though.