### PR TITLE
Added recipe for czifile

### DIFF
--- a/recipes/czifile/meta.yaml
+++ b/recipes/czifile/meta.yaml
@@ -25,14 +25,15 @@ requirements:
     - pip
   run:
     - python
-    - numpy
-    - tifffile
-    - imagecodecs-lite
+    - numpy >=1.11.3
+    - tifffile >=2019.7.2
+    - imagecodecs-lite >=2019.12.2
 
 test:
   imports:
     - czifile
   commands:
+    - czifile ''
     - czi2tif
 
 about:

--- a/recipes/czifile/meta.yaml
+++ b/recipes/czifile/meta.yaml
@@ -33,7 +33,7 @@ test:
   imports:
     - czifile
   commands:
-    - czifile ''
+    - czifile ""
     - czi2tif
 
 about:

--- a/recipes/czifile/meta.yaml
+++ b/recipes/czifile/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "czifile" %}
+{% set version = "2019.7.2" %}
+{% set sha256 = "04c0e6bed3b24d1bf42bc2cf899a5a08986641379305ce88600fd1c710486436" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: {{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  noarch: python
+  entry_points:
+    - czifile = czifile.czifile:main
+    - czi2tif = czifile.czi2tif:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - tifffile
+    - imagecodecs-lite
+
+test:
+  imports:
+    - czifile
+  commands:
+    - czi2tif
+
+about:
+  home: https://www.lfd.uci.edu/~gohlke/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Read Carl Zeiss(r) Image (CZI) files'
+  description: |
+    Czifile is a Python library to read Carl Zeiss Image (CZI) files, the native file format of the ZEN(r) software by Carl Zeiss Microscopy GmbH. CZI files contain multidimensional images and metadata from microscopy experiments.
+  doc_url: https://www.lfd.uci.edu/~gohlke/
+  dev_url: https://www.lfd.uci.edu/~gohlke/
+
+extra:
+  recipe-maintainers:
+    - csachs


### PR DESCRIPTION
Adding a recipe for `czifile`, Christoph Gohlke's library for reading Carl Zeiss microscopy image data. 
I had an earlier version of this recipe in the large and now inactive PR at https://github.com/conda-forge/staged-recipes/pull/6842 . While the work has been continued on individual parts, `czifile` was kinda left behind. However, it only has little dependencies, and could be merged much quicker, hence this PR.

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml" 
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Reviewers:
- python @conda-forge/help-python 