### PR TITLE
Add java-1.7.0 CDTs for aarch64, and dependencies

### DIFF
--- a/recipes/ca-certificates-cos7-aarch64/build.sh
+++ b/recipes/ca-certificates-cos7-aarch64/build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/java
+  rm -f cacerts
+  mkdir -p ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/java/cacerts
+  ln -s ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/java/cacerts cacerts
+popd
+
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/tls
+  rm -f cert.pem
+  echo "PLACEHOLDER"> ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  ln -s ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem cert.pem
+popd
+
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/tls/certs
+  rm -f ca-bundle.crt
+  ln -s ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem ca-bundle.crt
+popd
+
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/tls/certs
+  rm ca-bundle.trust.crt
+  echo "PLACEHOLDER"> ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+  ln -s ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt ca-bundle.trust.crt
+popd

--- a/recipes/ca-certificates-cos7-aarch64/meta.yaml
+++ b/recipes/ca-certificates-cos7-aarch64/meta.yaml
@@ -36,7 +36,7 @@ test:
 
 about:
   home: http://www.mozilla.org/
-  license: Public-Domain
+  license: CC-PDDC
   license_family: Public-Domain
   summary: "(CDT) The Mozilla CA root certificate bundle"
   description: |

--- a/recipes/ca-certificates-cos7-aarch64/meta.yaml
+++ b/recipes/ca-certificates-cos7-aarch64/meta.yaml
@@ -1,0 +1,40 @@
+package:
+  name: ca-certificates-cos7-aarch64
+  version: 2018.2.22
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/ca-certificates-2018.2.22-70.0.el7_5.noarch.rpm
+    sha256: 2861b3406be74863b56f97adb2d25133e91c2d70a7d051fdf564d0016fc11ade
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/ca-certificates-2018.2.22-70.0.el7_5.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - p11-kit-cos7-aarch64 >=0.23.5
+    - p11-kit-trust-cos7-aarch64 >=0.23.5
+  host:
+    - p11-kit-cos7-aarch64 >=0.23.5
+    - p11-kit-trust-cos7-aarch64 >=0.23.5
+  run:
+    - p11-kit-cos7-aarch64 >=0.23.5
+    - p11-kit-trust-cos7-aarch64 >=0.23.5
+
+about:
+  home: http://www.mozilla.org/
+  license: Public-Domain
+  license_family: Public-Domain
+  summary: "(CDT) The Mozilla CA root certificate bundle"
+  description: |
+        This package contains the set of CA certificates chosen by the Mozilla
+        Foundation for use with the Internet PKI.
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/ca-certificates-cos7-aarch64/meta.yaml
+++ b/recipes/ca-certificates-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/ca-certificates-2018.2.22-70.0.el7_5.src.rpm
+    sha256: 6ac196b9e021e21b6d7db15e570da5de6da500e77c77f233a78f0017a8ba8983
     folder: source
 
 build:
@@ -26,6 +27,12 @@ requirements:
   run:
     - p11-kit-cos7-aarch64 >=0.23.5
     - p11-kit-trust-cos7-aarch64 >=0.23.5
+
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
 
 about:
   home: http://www.mozilla.org/

--- a/recipes/chkconfig-cos7-aarch64/COPYING
+++ b/recipes/chkconfig-cos7-aarch64/COPYING
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/recipes/chkconfig-cos7-aarch64/build.sh
+++ b/recipes/chkconfig-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/chkconfig-cos7-aarch64/meta.yaml
+++ b/recipes/chkconfig-cos7-aarch64/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: chkconfig-cos7-aarch64
+  version: 1.7.4
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/chkconfig-1.7.4-1.el7.aarch64.rpm
+    sha256: 87a9a1358d18e73b1f4c50c68ada9f921de841240c5b62a2d72442f6715a540a
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/chkconfig-1.7.4-1.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: https://github.com/fedora-sysv/chkconfig
+  license: GPLv2
+  license_family: GPL2
+  summary: "(CDT) A system tool for maintaining the /etc/rc*.d hierarchy"
+  description: |
+        Chkconfig is a basic system utility.  It updates and queries runlevel
+        information for system services.  Chkconfig manipulates the numerous symbolic
+        links in /etc/rc.d, to relieve system administrators of some of the drudgery
+        of manually editing the symbolic links.
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/chkconfig-cos7-aarch64/meta.yaml
+++ b/recipes/chkconfig-cos7-aarch64/meta.yaml
@@ -26,7 +26,7 @@ test:
 
 about:
   home: https://github.com/fedora-sysv/chkconfig
-  license: GPL-2.0
+  license: GPL-2.0-or-later
   license_family: GPL2
   license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/licenses/chkconfig-1.7.4/COPYING"
   summary: "(CDT) A system tool for maintaining the /etc/rc*.d hierarchy"

--- a/recipes/chkconfig-cos7-aarch64/meta.yaml
+++ b/recipes/chkconfig-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/chkconfig-1.7.4-1.el7.src.rpm
+    sha256: ed7b6c9112f92cad6f26ec5ee94ac648ea429af1177d2fc5b060843413778437
     folder: source
 
 build:
@@ -16,12 +17,18 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/sbin/chkconfig"
 
 
 about:
   home: https://github.com/fedora-sysv/chkconfig
-  license: GPLv2
+  license: GPL-2.0
   license_family: GPL2
+  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/licenses/chkconfig-1.7.4/COPYING"
   summary: "(CDT) A system tool for maintaining the /etc/rc*.d hierarchy"
   description: |
         Chkconfig is a basic system utility.  It updates and queries runlevel

--- a/recipes/chkconfig-cos7-aarch64/meta.yaml
+++ b/recipes/chkconfig-cos7-aarch64/meta.yaml
@@ -28,7 +28,7 @@ about:
   home: https://github.com/fedora-sysv/chkconfig
   license: GPL-2.0-or-later
   license_family: GPL2
-  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/licenses/chkconfig-1.7.4/COPYING"
+  license_file: COPYING
   summary: "(CDT) A system tool for maintaining the /etc/rc*.d hierarchy"
   description: |
         Chkconfig is a basic system utility.  It updates and queries runlevel

--- a/recipes/copy-jdk-configs-cos7-aarch64/LICENSE
+++ b/recipes/copy-jdk-configs-cos7-aarch64/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2015 Red Hat inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms are permitted
+provided that the above copyright notice and this paragraph are
+duplicated in all such forms and that any documentation,
+advertising materials, and other materials related to such
+distribution and use acknowledge that the software was developed
+by the Red Hat inc. The name of the Red Hat inc. may not be used
+to endorse or promote products derived from this software without
+specific prior written permission. THIS SOFTWARE IS PROVIDED
+``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING,
+WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.

--- a/recipes/copy-jdk-configs-cos7-aarch64/build.sh
+++ b/recipes/copy-jdk-configs-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/copy-jdk-configs-cos7-aarch64/meta.yaml
+++ b/recipes/copy-jdk-configs-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/copy-jdk-configs-3.3-10.el7_5.src.rpm
+    sha256: 566683e89813ed5e5f190c48e51ac538aa2fb9659cd0a04c39c8e7f663c19200
     folder: source
 
 build:
@@ -16,12 +17,18 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/libexec/copy_jdk_configs_fixFiles.sh"
 
 
 about:
   home: https://pagure.io/copy_jdk_configs
-  license: BSD
+  license: BSD-1-Clause
   license_family: BSD
+  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/licenses/copy-jdk-configs-3.3/LICENSE"
   summary: "(CDT) JDKs configuration files copier"
   description: |
         Utility script to transfer JDKs configuration files between updates or for

--- a/recipes/copy-jdk-configs-cos7-aarch64/meta.yaml
+++ b/recipes/copy-jdk-configs-cos7-aarch64/meta.yaml
@@ -1,0 +1,31 @@
+package:
+  name: copy-jdk-configs-cos7-aarch64
+  version: 3.3
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/copy-jdk-configs-3.3-10.el7_5.noarch.rpm
+    sha256: 7b7ff9e72fe7a4b6c9e1aae52bdb913d2bb58ea86518e91e179a43acb93f21f8
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/copy-jdk-configs-3.3-10.el7_5.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: https://pagure.io/copy_jdk_configs
+  license: BSD
+  license_family: BSD
+  summary: "(CDT) JDKs configuration files copier"
+  description: |
+        Utility script to transfer JDKs configuration files between updates or for
+        archiving. With script to fix incorrectly created rpmnew files
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/copy-jdk-configs-cos7-aarch64/meta.yaml
+++ b/recipes/copy-jdk-configs-cos7-aarch64/meta.yaml
@@ -28,7 +28,7 @@ about:
   home: https://pagure.io/copy_jdk_configs
   license: BSD-1-Clause
   license_family: BSD
-  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/licenses/copy-jdk-configs-3.3/LICENSE"
+  license_file: LICENSE
   summary: "(CDT) JDKs configuration files copier"
   description: |
         Utility script to transfer JDKs configuration files between updates or for

--- a/recipes/gconf2-cos7-aarch64/COPYING
+++ b/recipes/gconf2-cos7-aarch64/COPYING
@@ -1,0 +1,490 @@
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1991 Free Software Foundation, Inc.
+                    675 Mass Ave, Cambridge, MA 02139, USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the library GPL.  It is
+ numbered 2 because it goes with version 2 of the ordinary GPL.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Library General Public License, applies to some
+specially designated Free Software Foundation software, and to any
+other libraries whose authors decide to use it.  You can use it for
+your libraries, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if
+you distribute copies of the library, or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link a program with the library, you must provide
+complete object files to the recipients so that they can relink them
+with the library, after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  Our method of protecting your rights has two steps: (1) copyright
+the library, and (2) offer you this license which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  Also, for each distributor's protection, we want to make certain
+that everyone understands that there is no warranty for this free
+library.  If the library is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original
+version, so that any problems introduced by others will not reflect on
+the original authors' reputations.
+
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that companies distributing free
+software will individually obtain patent licenses, thus in effect
+transforming the program into proprietary software.  To prevent this,
+we have made it clear that any patent must be licensed for everyone's
+free use or not licensed at all.
+
+  Most GNU software, including some libraries, is covered by the ordinary
+GNU General Public License, which was designed for utility programs.  This
+license, the GNU Library General Public License, applies to certain
+designated libraries.  This license is quite different from the ordinary
+one; be sure to read it in full, and don't assume that anything in it is
+the same as in the ordinary license.
+
+  The reason we have a separate public license for some libraries is that
+they blur the distinction we usually make between modifying or adding to a
+program and simply using it.  Linking a program with a library, without
+changing the library, is in some sense simply using the library, and is
+analogous to running a utility program or application program.  However, in
+a textual and legal sense, the linked executable is a combined work, a
+derivative of the original library, and the ordinary General Public License
+treats it as such.
+
+  Because of this blurred distinction, using the ordinary General
+Public License for libraries did not effectively promote software
+sharing, because most developers did not use the libraries.  We
+concluded that weaker conditions might promote sharing better.
+
+  However, unrestricted linking of non-free programs would deprive the
+users of those programs of all benefit from the free status of the
+libraries themselves.  This Library General Public License is intended to
+permit developers of non-free programs to use free libraries, while
+preserving your freedom as a user of such programs to change the free
+libraries that are incorporated in them.  (We have not seen how to achieve
+this as regards changes in header files, but we have achieved it as regards
+changes in the actual functions of the Library.)  The hope is that this
+will lead to faster development of free libraries.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, while the latter only
+works together with the library.
+
+  Note that it is possible for a library to be covered by the ordinary
+General Public License rather than by this special one.
+
+
+		  GNU LIBRARY GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library which
+contains a notice placed by the copyright holder or other authorized
+party saying it may be distributed under the terms of this Library
+General Public License (also called "this License").  Each licensee is
+addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+
+  6. As an exception to the Sections above, you may also compile or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    c) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    d) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the source code distributed need not include anything that is normally
+distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Library General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+
+     Appendix: How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Library General Public
+    License as published by the Free Software Foundation; either
+    version 2 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Library General Public License for more details.
+
+    You should have received a copy of the GNU Library General Public
+    License along with this library; if not, write to the Free
+    Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/recipes/gconf2-cos7-aarch64/build.sh
+++ b/recipes/gconf2-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/gconf2-cos7-aarch64/meta.yaml
+++ b/recipes/gconf2-cos7-aarch64/meta.yaml
@@ -34,7 +34,7 @@ about:
   home: http://projects.gnome.org/gconf/
   license: GPL-2.0-or-later
   license_family: GPL2
-  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/GConf2-3.2.6/COPYING"
+  license_file: COPYING
   summary: "(CDT) A process-transparent configuration system"
   description: |
         GConf is a process-transparent configuration database API used to store user

--- a/recipes/gconf2-cos7-aarch64/meta.yaml
+++ b/recipes/gconf2-cos7-aarch64/meta.yaml
@@ -32,7 +32,7 @@ test:
 
 about:
   home: http://projects.gnome.org/gconf/
-  license: GPL-2.0+
+  license: GPL-2.0-or-later
   license_family: GPL2
   license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/GConf2-3.2.6/COPYING"
   summary: "(CDT) A process-transparent configuration system"

--- a/recipes/gconf2-cos7-aarch64/meta.yaml
+++ b/recipes/gconf2-cos7-aarch64/meta.yaml
@@ -34,7 +34,7 @@ about:
   home: http://projects.gnome.org/gconf/
   license: GPL-2.0+
   license_family: GPL2
-  license_File: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/GConf2-3.2.6/COPYING"
+  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/GConf2-3.2.6/COPYING"
   summary: "(CDT) A process-transparent configuration system"
   description: |
         GConf is a process-transparent configuration database API used to store user

--- a/recipes/gconf2-cos7-aarch64/meta.yaml
+++ b/recipes/gconf2-cos7-aarch64/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: gconf2-cos7-aarch64
+  version: 3.2.6
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/GConf2-3.2.6-8.el7.aarch64.rpm
+    sha256: 16d8de7fdc7176e1b0273e8d8225c69d5242c72bba1b1570edfaf28849ef2ff6
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/GConf2-3.2.6-8.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+    build:
+        - orbit2-cos7-aarch64 >=2.14.19
+    run:
+        - orbit2-cos7-aarch64 >=2.14.19
+
+
+about:
+  home: http://projects.gnome.org/gconf/
+  license: LGPLv2+ and GPLv2+
+  license_family: GPL2
+  summary: "(CDT) A process-transparent configuration system"
+  description: |
+        GConf is a process-transparent configuration database API used to store user
+        preferences. It has pluggable backends and features to support workgroup
+        administration.
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/gconf2-cos7-aarch64/meta.yaml
+++ b/recipes/gconf2-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/GConf2-3.2.6-8.el7.src.rpm
+    sha256: e00a6aa768aaa258103fcf127afc5b13d8c2cc9dd26737535703f4ed4fa8848b
     folder: source
 
 build:
@@ -22,11 +23,18 @@ requirements:
     run:
         - orbit2-cos7-aarch64 >=2.14.19
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libgconf-2.so.4"
+
 
 about:
   home: http://projects.gnome.org/gconf/
-  license: LGPLv2+ and GPLv2+
+  license: GPL-2.0+
   license_family: GPL2
+  license_File: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/GConf2-3.2.6/COPYING"
   summary: "(CDT) A process-transparent configuration system"
   description: |
         GConf is a process-transparent configuration database API used to store user

--- a/recipes/java-1.7.0-openjdk-cos7-aarch64/LICENSE
+++ b/recipes/java-1.7.0-openjdk-cos7-aarch64/LICENSE
@@ -1,0 +1,348 @@
+The GNU General Public License (GPL)
+
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it.  By contrast, the GNU General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users.  This General Public License applies to
+most of the Free Software Foundation's software and to any other program whose
+authors commit to using it.  (Some other Free Software Foundation software is
+covered by the GNU Library General Public License instead.) You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not price.  Our
+General Public Licenses are designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you
+can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights.  These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for
+a fee, you must give the recipients all the rights that you have.  You must
+make sure that they, too, receive or can get the source code.  And you must
+show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2)
+offer you this license which gives you legal permission to copy, distribute
+and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software.  If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced
+by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents.  We
+wish to avoid the danger that redistributors of a free program will
+individually obtain patent licenses, in effect making the program proprietary.
+To prevent this, we have made it clear that any patent must be licensed for
+everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this General Public License.  The "Program", below, refers to any such program
+or work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language.  (Hereinafter, translation is included
+without limitation in the term "modification".) Each licensee is addressed as
+"you".
+
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope.  The act of running the Program is
+not restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program).  Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as
+you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and
+disclaimer of warranty; keep intact all the notices that refer to this License
+and to the absence of any warranty; and give any other recipients of the
+Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may
+at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus
+forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all of
+these conditions:
+
+    a) You must cause the modified files to carry prominent notices stating
+    that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in whole or
+    in part contains or is derived from the Program or any part thereof, to be
+    licensed as a whole at no charge to all third parties under the terms of
+    this License.
+
+    c) If the modified program normally reads commands interactively when run,
+    you must cause it, when started running for such interactive use in the
+    most ordinary way, to print or display an announcement including an
+    appropriate copyright notice and a notice that there is no warranty (or
+    else, saying that you provide a warranty) and that users may redistribute
+    the program under these conditions, and telling the user how to view a copy
+    of this License.  (Exception: if the Program itself is interactive but does
+    not normally print such an announcement, your work based on the Program is
+    not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works.  But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms
+of this License, whose permissions for other licensees extend to the entire
+whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on
+the Program.
+
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under
+Section 2) in object code or executable form under the terms of Sections 1 and
+2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable source
+    code, which must be distributed under the terms of Sections 1 and 2 above
+    on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three years, to
+    give any third party, for a charge no more than your cost of physically
+    performing source distribution, a complete machine-readable copy of the
+    corresponding source code, to be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer to
+    distribute corresponding source code.  (This alternative is allowed only
+    for noncommercial distribution and only if you received the program in
+    object code or executable form with such an offer, in accord with
+    Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it.  For an executable work, complete source code means all
+the source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable.  However, as a special exception, the source code
+distributed need not include anything that is normally distributed (in either
+source or binary form) with the major components (compiler, kernel, and so on)
+of the operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source
+code from the same place counts as distribution of the source code, even though
+third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License.  Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License.  However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Program
+or its derivative works.  These actions are prohibited by law if you do not
+accept this License.  Therefore, by modifying or distributing the Program (or
+any work based on the Program), you indicate your acceptance of this License to
+do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor to
+copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of the
+rights granted herein.  You are not responsible for enforcing compliance by
+third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues), conditions
+are imposed on you (whether by court order, agreement or otherwise) that
+contradict the conditions of this License, they do not excuse you from the
+conditions of this License.  If you cannot distribute so as to satisfy
+simultaneously your obligations under this License and any other pertinent
+obligations, then as a consequence you may not distribute the Program at all.
+For example, if a patent license would not permit royalty-free redistribution
+of the Program by all those who receive copies directly or indirectly through
+you, then the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and
+the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices.  Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original
+copyright holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded.  In
+such case, this License incorporates the limitation as if written in the body
+of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the
+General Public License from time to time.  Such new versions will be similar in
+spirit to the present version, but may differ in detail to address new problems
+or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any later
+version", you have the option of following the terms and conditions either of
+that version or of any later version published by the Free Software Foundation.
+If the Program does not specify a version number of this License, you may
+choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission.  For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status of
+all derivatives of our free software and of promoting the sharing and reuse of
+software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE
+PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE,
+YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE
+PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA
+BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible
+use to the public, the best way to achieve this is to make it free software
+which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach
+them to the start of each source file to most effectively convey the exclusion
+of warranty; and each file should have at least the "copyright" line and a
+pointer to where the full notice is found.
+
+    One line to give the program's name and a brief idea of what it does.
+
+    Copyright (C) <year> <name of author>
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the Free
+    Software Foundation; either version 2 of the License, or (at your option)
+    any later version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+    more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc., 59
+    Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it
+starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author Gnomovision comes
+    with ABSOLUTELY NO WARRANTY; for details type 'show w'.  This is free
+    software, and you are welcome to redistribute it under certain conditions;
+    type 'show c' for details.
+
+The hypothetical commands 'show w' and 'show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may be
+called something other than 'show w' and 'show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.  Here
+is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+    'Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+    signature of Ty Coon, 1 April 1989
+
+    Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General Public
+License instead of this License.
+
+
+"CLASSPATH" EXCEPTION TO THE GPL
+
+Certain source files distributed by Oracle America and/or its affiliates are
+subject to the following clarification and special exception to the GPL, but
+only where Oracle has expressly included in the particular source file's header
+the words "Oracle designates this particular file as subject to the "Classpath"
+exception as provided by Oracle in the LICENSE file that accompanied this code."
+
+    Linking this library statically or dynamically with other modules is making
+    a combined work based on this library.  Thus, the terms and conditions of
+    the GNU General Public License cover the whole combination.
+
+    As a special exception, the copyright holders of this library give you
+    permission to link this library with independent modules to produce an
+    executable, regardless of the license terms of these independent modules,
+    and to copy and distribute the resulting executable under terms of your
+    choice, provided that you also meet, for each linked independent module,
+    the terms and conditions of the license of that module.  An independent
+    module is a module which is not derived from or based on this library.  If
+    you modify this library, you may extend this exception to your version of
+    the library, but you are not obligated to do so.  If you do not wish to do
+    so, delete this exception statement from your version.
+

--- a/recipes/java-1.7.0-openjdk-cos7-aarch64/build.sh
+++ b/recipes/java-1.7.0-openjdk-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.src.rpm
+    sha256: 9679d4abe199845ee52ee4f5f809b9f6a1e26667bc73d1768c5d7cdeab40715a
     folder: source
 
 build:
@@ -40,9 +41,15 @@ requirements:
     - gconf2-cos7-aarch64 >=3.2.6
     - java-1.7.0-openjdk-headless-cos7-aarch64 ==1.7.0.221
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.aarch64/jre/lib/aarch64/libjavagtk.so"
+
 about:
   home: http://openjdk.java.net/
-  license: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv1.1 and MPLv2.0 and Public Domain and W3C and zlib
+  license: Apache-1.1, Apache-2.0, BSD-1-Clause, GPL-1.0-or-later, GPL-2.0-or-later, IJGi, LGPL-2.0-or-later, MIT, MPL-1.1, MPL-v2.0, W3C, zlib
   license_family: GPL2
   summary: "(CDT) OpenJDK Runtime Environment"
   description: |

--- a/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
@@ -49,8 +49,9 @@ test:
 
 about:
   home: http://openjdk.java.net/
-  license: Apache-1.1, Apache-2.0, BSD-1-Clause, GPL-1.0-or-later, GPL-2.0-or-later, IJG, LGPL-2.0-or-later, MIT, MPL-1.1, MPL-v2.0, W3C, zlib
+  license: GPL-2.0-or-later
   license_family: GPL2
+  license_file: LICENSE
   summary: "(CDT) OpenJDK Runtime Environment"
   description: |
         The OpenJDK runtime environment.

--- a/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
@@ -1,0 +1,52 @@
+package:
+  name: java-1.7.0-openjdk-cos7-aarch64
+  version: 1.7.0.221
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.aarch64.rpm
+    sha256: a8242c3efbd8875720904538afaaf1ae8e8ecbc7d558e532a1af4a97160a457e
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+requirements:
+  build:
+    - ca-certificates-cos7-aarch64 >=2018.2.22
+    - chkconfig-cos7-aarch64 >=1.7.4
+    - copy-jdk-configs-cos7-aarch64 >=3.3
+    - gconf2-cos7-aarch64 >=3.2.6
+    - java-1.7.0-openjdk-headless-cos7-aarch64 ==1.7.0.221
+    - javapackages-tools-cos7-aarch64 >=3.4.1
+    - libjpeg-turbo-cos7-aarch64 >=1.2.90
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-cos7-aarch64 >=3.34.0
+    - nss-softokn-cos7-aarch64 >=3.34.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.34.0
+    - nss-util-cos7-aarch64 >=3.34.0
+    - orbit2-cos7-aarch64 >=2.14.19
+    - p11-kit-cos7-aarch64 >=0.23.5
+    - p11-kit-trust-cos7-aarch64 >=0.23.5
+    - python-javapackages-cos7-aarch64 >=3.4.1
+  host:
+    - java-1.7.0-openjdk-headless-cos7-aarch64 ==1.7.0.221
+  run:
+    - ca-certificates-cos7-aarch64 >=2018.2.22
+    - gconf2-cos7-aarch64 >=3.2.6
+    - java-1.7.0-openjdk-headless-cos7-aarch64 ==1.7.0.221
+
+about:
+  home: http://openjdk.java.net/
+  license: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv1.1 and MPLv2.0 and Public Domain and W3C and zlib
+  license_family: GPL2
+  summary: "(CDT) OpenJDK Runtime Environment"
+  description: |
+        The OpenJDK runtime environment.
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-cos7-aarch64/meta.yaml
@@ -49,7 +49,7 @@ test:
 
 about:
   home: http://openjdk.java.net/
-  license: Apache-1.1, Apache-2.0, BSD-1-Clause, GPL-1.0-or-later, GPL-2.0-or-later, IJGi, LGPL-2.0-or-later, MIT, MPL-1.1, MPL-v2.0, W3C, zlib
+  license: Apache-1.1, Apache-2.0, BSD-1-Clause, GPL-1.0-or-later, GPL-2.0-or-later, IJG, LGPL-2.0-or-later, MIT, MPL-1.1, MPL-v2.0, W3C, zlib
   license_family: GPL2
   summary: "(CDT) OpenJDK Runtime Environment"
   description: |

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/LICENSE
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/LICENSE
@@ -1,0 +1,347 @@
+The GNU General Public License (GPL)
+
+Version 2, June 1991
+
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
+
+Preamble
+
+The licenses for most software are designed to take away your freedom to share
+and change it.  By contrast, the GNU General Public License is intended to
+guarantee your freedom to share and change free software--to make sure the
+software is free for all its users.  This General Public License applies to
+most of the Free Software Foundation's software and to any other program whose
+authors commit to using it.  (Some other Free Software Foundation software is
+covered by the GNU Library General Public License instead.) You can apply it to
+your programs, too.
+
+When we speak of free software, we are referring to freedom, not price.  Our
+General Public Licenses are designed to make sure that you have the freedom to
+distribute copies of free software (and charge for this service if you wish),
+that you receive source code or can get it if you want it, that you can change
+the software or use pieces of it in new free programs; and that you know you
+can do these things.
+
+To protect your rights, we need to make restrictions that forbid anyone to deny
+you these rights or to ask you to surrender the rights.  These restrictions
+translate to certain responsibilities for you if you distribute copies of the
+software, or if you modify it.
+
+For example, if you distribute copies of such a program, whether gratis or for
+a fee, you must give the recipients all the rights that you have.  You must
+make sure that they, too, receive or can get the source code.  And you must
+show them these terms so they know their rights.
+
+We protect your rights with two steps: (1) copyright the software, and (2)
+offer you this license which gives you legal permission to copy, distribute
+and/or modify the software.
+
+Also, for each author's protection and ours, we want to make certain that
+everyone understands that there is no warranty for this free software.  If the
+software is modified by someone else and passed on, we want its recipients to
+know that what they have is not the original, so that any problems introduced
+by others will not reflect on the original authors' reputations.
+
+Finally, any free program is threatened constantly by software patents.  We
+wish to avoid the danger that redistributors of a free program will
+individually obtain patent licenses, in effect making the program proprietary.
+To prevent this, we have made it clear that any patent must be licensed for
+everyone's free use or not licensed at all.
+
+The precise terms and conditions for copying, distribution and modification
+follow.
+
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+0. This License applies to any program or other work which contains a notice
+placed by the copyright holder saying it may be distributed under the terms of
+this General Public License.  The "Program", below, refers to any such program
+or work, and a "work based on the Program" means either the Program or any
+derivative work under copyright law: that is to say, a work containing the
+Program or a portion of it, either verbatim or with modifications and/or
+translated into another language.  (Hereinafter, translation is included
+without limitation in the term "modification".) Each licensee is addressed as
+"you".
+
+Activities other than copying, distribution and modification are not covered by
+this License; they are outside its scope.  The act of running the Program is
+not restricted, and the output from the Program is covered only if its contents
+constitute a work based on the Program (independent of having been made by
+running the Program).  Whether that is true depends on what the Program does.
+
+1. You may copy and distribute verbatim copies of the Program's source code as
+you receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice and
+disclaimer of warranty; keep intact all the notices that refer to this License
+and to the absence of any warranty; and give any other recipients of the
+Program a copy of this License along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and you may
+at your option offer warranty protection in exchange for a fee.
+
+2. You may modify your copy or copies of the Program or any portion of it, thus
+forming a work based on the Program, and copy and distribute such modifications
+or work under the terms of Section 1 above, provided that you also meet all of
+these conditions:
+
+    a) You must cause the modified files to carry prominent notices stating
+    that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in whole or
+    in part contains or is derived from the Program or any part thereof, to be
+    licensed as a whole at no charge to all third parties under the terms of
+    this License.
+
+    c) If the modified program normally reads commands interactively when run,
+    you must cause it, when started running for such interactive use in the
+    most ordinary way, to print or display an announcement including an
+    appropriate copyright notice and a notice that there is no warranty (or
+    else, saying that you provide a warranty) and that users may redistribute
+    the program under these conditions, and telling the user how to view a copy
+    of this License.  (Exception: if the Program itself is interactive but does
+    not normally print such an announcement, your work based on the Program is
+    not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If identifiable
+sections of that work are not derived from the Program, and can be reasonably
+considered independent and separate works in themselves, then this License, and
+its terms, do not apply to those sections when you distribute them as separate
+works.  But when you distribute the same sections as part of a whole which is a
+work based on the Program, the distribution of the whole must be on the terms
+of this License, whose permissions for other licensees extend to the entire
+whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest your
+rights to work written entirely by you; rather, the intent is to exercise the
+right to control the distribution of derivative or collective works based on
+the Program.
+
+In addition, mere aggregation of another work not based on the Program with the
+Program (or with a work based on the Program) on a volume of a storage or
+distribution medium does not bring the other work under the scope of this
+License.
+
+3. You may copy and distribute the Program (or a work based on it, under
+Section 2) in object code or executable form under the terms of Sections 1 and
+2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable source
+    code, which must be distributed under the terms of Sections 1 and 2 above
+    on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three years, to
+    give any third party, for a charge no more than your cost of physically
+    performing source distribution, a complete machine-readable copy of the
+    corresponding source code, to be distributed under the terms of Sections 1
+    and 2 above on a medium customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer to
+    distribute corresponding source code.  (This alternative is allowed only
+    for noncommercial distribution and only if you received the program in
+    object code or executable form with such an offer, in accord with
+    Subsection b above.)
+
+The source code for a work means the preferred form of the work for making
+modifications to it.  For an executable work, complete source code means all
+the source code for all modules it contains, plus any associated interface
+definition files, plus the scripts used to control compilation and installation
+of the executable.  However, as a special exception, the source code
+distributed need not include anything that is normally distributed (in either
+source or binary form) with the major components (compiler, kernel, and so on)
+of the operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the source
+code from the same place counts as distribution of the source code, even though
+third parties are not compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program except as
+expressly provided under this License.  Any attempt otherwise to copy, modify,
+sublicense or distribute the Program is void, and will automatically terminate
+your rights under this License.  However, parties who have received copies, or
+rights, from you under this License will not have their licenses terminated so
+long as such parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not signed it.
+However, nothing else grants you permission to modify or distribute the Program
+or its derivative works.  These actions are prohibited by law if you do not
+accept this License.  Therefore, by modifying or distributing the Program (or
+any work based on the Program), you indicate your acceptance of this License to
+do so, and all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the Program),
+the recipient automatically receives a license from the original licensor to
+copy, distribute or modify the Program subject to these terms and conditions.
+You may not impose any further restrictions on the recipients' exercise of the
+rights granted herein.  You are not responsible for enforcing compliance by
+third parties to this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues), conditions
+are imposed on you (whether by court order, agreement or otherwise) that
+contradict the conditions of this License, they do not excuse you from the
+conditions of this License.  If you cannot distribute so as to satisfy
+simultaneously your obligations under this License and any other pertinent
+obligations, then as a consequence you may not distribute the Program at all.
+For example, if a patent license would not permit royalty-free redistribution
+of the Program by all those who receive copies directly or indirectly through
+you, then the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply and
+the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any patents or
+other property right claims or to contest validity of any such claims; this
+section has the sole purpose of protecting the integrity of the free software
+distribution system, which is implemented by public license practices.  Many
+people have made generous contributions to the wide range of software
+distributed through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing to
+distribute software through any other system and a licensee cannot impose that
+choice.
+
+This section is intended to make thoroughly clear what is believed to be a
+consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in certain
+countries either by patents or by copyrighted interfaces, the original
+copyright holder who places the Program under this License may add an explicit
+geographical distribution limitation excluding those countries, so that
+distribution is permitted only in or among countries not thus excluded.  In
+such case, this License incorporates the limitation as if written in the body
+of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions of the
+General Public License from time to time.  Such new versions will be similar in
+spirit to the present version, but may differ in detail to address new problems
+or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any later
+version", you have the option of following the terms and conditions either of
+that version or of any later version published by the Free Software Foundation.
+If the Program does not specify a version number of this License, you may
+choose any version ever published by the Free Software Foundation.
+
+10. If you wish to incorporate parts of the Program into other free programs
+whose distribution conditions are different, write to the author to ask for
+permission.  For software which is copyrighted by the Free Software Foundation,
+write to the Free Software Foundation; we sometimes make exceptions for this.
+Our decision will be guided by the two goals of preserving the free status of
+all derivatives of our free software and of promoting the sharing and reuse of
+software generally.
+
+NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY FOR
+THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE
+STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE
+PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND
+PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE,
+YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL
+ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR REDISTRIBUTE THE
+PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR
+INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA
+BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER
+OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible
+use to the public, the best way to achieve this is to make it free software
+which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest to attach
+them to the start of each source file to most effectively convey the exclusion
+of warranty; and each file should have at least the "copyright" line and a
+pointer to where the full notice is found.
+
+    One line to give the program's name and a brief idea of what it does.
+
+    Copyright (C) <year> <name of author>
+
+    This program is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the Free
+    Software Foundation; either version 2 of the License, or (at your option)
+    any later version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+    more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc., 59
+    Temple Place, Suite 330, Boston, MA 02111-1307 USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this when it
+starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author Gnomovision comes
+    with ABSOLUTELY NO WARRANTY; for details type 'show w'.  This is free
+    software, and you are welcome to redistribute it under certain conditions;
+    type 'show c' for details.
+
+The hypothetical commands 'show w' and 'show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may be
+called something other than 'show w' and 'show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.  Here
+is a sample; alter the names:
+
+    Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+    'Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+    signature of Ty Coon, 1 April 1989
+
+    Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General Public
+License instead of this License.
+
+
+"CLASSPATH" EXCEPTION TO THE GPL
+
+Certain source files distributed by Oracle America and/or its affiliates are
+subject to the following clarification and special exception to the GPL, but
+only where Oracle has expressly included in the particular source file's header
+the words "Oracle designates this particular file as subject to the "Classpath"
+exception as provided by Oracle in the LICENSE file that accompanied this code."
+
+    Linking this library statically or dynamically with other modules is making
+    a combined work based on this library.  Thus, the terms and conditions of
+    the GNU General Public License cover the whole combination.
+
+    As a special exception, the copyright holders of this library give you
+    permission to link this library with independent modules to produce an
+    executable, regardless of the license terms of these independent modules,
+    and to copy and distribute the resulting executable under terms of your
+    choice, provided that you also meet, for each linked independent module,
+    the terms and conditions of the license of that module.  An independent
+    module is a module which is not derived from or based on this library.  If
+    you modify this library, you may extend this exception to your version of
+    the library, but you are not obligated to do so.  If you do not wish to do
+    so, delete this exception statement from your version.

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/build.sh
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+
+ls -l ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.aarch64/jre-abrt
+  rm -rf lib
+  ln -s ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.aarch64/jre/lib lib
+popd
+
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.aarch64/jre/lib/security
+  mkdir -p ../../../../../../../etc/pki/java/cacerts
+popd
+

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.src.rpm
+    sha256: 9679d4abe199845ee52ee4f5f809b9f6a1e26667bc73d1768c5d7cdeab40715a
     folder: source
 
 build:
@@ -51,15 +52,20 @@ requirements:
     - nss-util-cos7-aarch64 >=3.34.0
     - python-javapackages-cos7-aarch64 >=3.4.1
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.171-2.6.13.2.el7.ppc64le/jre/bin/java"
+
 about:
   home: http://openjdk.java.net/
-  license: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv1.1 and MPLv2.0 and Public Domain and W3C and zlib
+  license: GPL-2.0+
   license_family: GPL2
+  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.ppc64le/LICENSE"
   summary: "(CDT) The OpenJDK runtime environment without audio and video support"
   description: |
         The OpenJDK runtime environment without audio and video
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
@@ -56,7 +56,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.171-2.6.13.2.el7.ppc64le/jre/bin/java"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.aarch64/jre/bin/java"
 
 about:
   home: http://openjdk.java.net/

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
@@ -62,7 +62,7 @@ about:
   home: http://openjdk.java.net/
   license: GPL-2.0-or-later
   license_family: GPL2
-  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.ppc64le/LICENSE"
+  license_file: LICENSE
   summary: "(CDT) The OpenJDK runtime environment without audio and video support"
   description: |
         The OpenJDK runtime environment without audio and video

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
@@ -60,7 +60,7 @@ test:
 
 about:
   home: http://openjdk.java.net/
-  license: GPL-2.0+
+  license: GPL-2.0-or-later
   license_family: GPL2
   license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.ppc64le/LICENSE"
   summary: "(CDT) The OpenJDK runtime environment without audio and video support"

--- a/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
+++ b/recipes/java-1.7.0-openjdk-headless-cos7-aarch64/meta.yaml
@@ -1,0 +1,65 @@
+package:
+  name: java-1.7.0-openjdk-headless-cos7-aarch64
+  version: 1.7.0.221
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/java-1.7.0-openjdk-headless-1.7.0.221-2.6.18.1.el7.aarch64.rpm
+    sha256: 8ba6ec26d3086e1e417b4d3c5124e2000e0f2b7f1c026055bfeab8b66e4d0168
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/java-1.7.0-openjdk-1.7.0.221-2.6.18.1.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - chkconfig-cos7-aarch64 >=1.7
+    - copy-jdk-configs-cos7-aarch64 >=3.3
+    - javapackages-tools-cos7-aarch64 >=3.4.1
+    - libjpeg-turbo-cos7-aarch64 >=1.2.90
+    - nspr-cos7-aarch64 >=4.17.0
+    - nss-cos7-aarch64 >=3.34.0
+    - nss-softokn-cos7-aarch64 >=3.34.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.34.0
+    - nss-util-cos7-aarch64 >=3.34.0
+    - python-javapackages-cos7-aarch64 >=3.4.1
+  host:
+    - chkconfig-cos7-aarch64 >=1.7
+    - copy-jdk-configs-cos7-aarch64 >=3.3
+    - javapackages-tools-cos7-aarch64 >=3.4.1
+    - libjpeg-turbo-cos7-aarch64 >=1.2.90
+    - nspr-cos7-aarch64 >=4.17.0
+    - nss-cos7-aarch64 >=3.34.0
+    - nss-softokn-cos7-aarch64 >=3.34.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.34.0
+    - nss-util-cos7-aarch64 >=3.34.0
+    - python-javapackages-cos7-aarch64 >=3.4.1
+  run:
+    - chkconfig-cos7-aarch64 >=1.7
+    - copy-jdk-configs-cos7-aarch64 >=3.3
+    - javapackages-tools-cos7-aarch64 >=3.4.1
+    - libjpeg-turbo-cos7-aarch64 >=1.2.90
+    - nspr-cos7-aarch64 >=4.17.0
+    - nss-cos7-aarch64 >=3.34.0
+    - nss-softokn-cos7-aarch64 >=3.34.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.34.0
+    - nss-util-cos7-aarch64 >=3.34.0
+    - python-javapackages-cos7-aarch64 >=3.4.1
+
+about:
+  home: http://openjdk.java.net/
+  license: ASL 1.1 and ASL 2.0 and BSD and BSD with advertising and GPL+ and GPLv2 and GPLv2 with exceptions and IJG and LGPLv2+ and MIT and MPLv1.1 and MPLv2.0 and Public Domain and W3C and zlib
+  license_family: GPL2
+  summary: "(CDT) The OpenJDK runtime environment without audio and video support"
+  description: |
+        The OpenJDK runtime environment without audio and video
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/javapackages-tools-cos7-aarch64/LICENSE
+++ b/recipes/javapackages-tools-cos7-aarch64/LICENSE
@@ -1,0 +1,58 @@
+Copyright (c) 2011-2013 Red Hat, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+3. Neither the name of Red Hat nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Copyright (c) 2000-2006, JPackage Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+3. Neither the name of the JPackage Project nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/javapackages-tools-cos7-aarch64/build.sh
+++ b/recipes/javapackages-tools-cos7-aarch64/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .
+
+pushd ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/java-utils/
+  rm -f abs2rel.sh
+  ln -s ${PREFIX}/aarch64-conda_cos7-linux-gnu/sysroot/usr/bin/abs2rel abs2rel.sh
+popd

--- a/recipes/javapackages-tools-cos7-aarch64/meta.yaml
+++ b/recipes/javapackages-tools-cos7-aarch64/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: javapackages-tools-cos7-aarch64
+  version: 3.4.1
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/javapackages-tools-3.4.1-11.el7.noarch.rpm
+    sha256: cb9d2fd9d743bf4cb28b4afec7e8d1891fcca6f63f00ba7a60aadfe337527e1c
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/javapackages-tools-3.4.1-11.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - python-javapackages-cos7-aarch64 ==3.4.1
+  host:
+    - python-javapackages-cos7-aarch64 ==3.4.1
+  run:
+    - python-javapackages-cos7-aarch64 ==3.4.1
+
+about:
+  home: https://fedorahosted.org/javapackages/
+  license: BSD
+  license_family: BSD
+  summary: "(CDT) Macros and scripts for Java packaging support"
+  description: |
+        This package provides macros and scripts to support Java packaging.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/javapackages-tools-cos7-aarch64/meta.yaml
+++ b/recipes/javapackages-tools-cos7-aarch64/meta.yaml
@@ -35,7 +35,7 @@ about:
   home: https://fedorahosted.org/javapackages/
   license: BSD-3-Clause
   license_family: BSD
-  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/javapackages-tools-3.4.1/LICENSE"
+  license_file: LICENSE
   summary: "(CDT) Macros and scripts for Java packaging support"
   description: |
         This package provides macros and scripts to support Java packaging.

--- a/recipes/javapackages-tools-cos7-aarch64/meta.yaml
+++ b/recipes/javapackages-tools-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/javapackages-tools-3.4.1-11.el7.src.rpm
+    sha256: 5fb0c2d84e98883219d4e9c5ca64d1fc1c23c654f396cb841e63dc980c1ba4bb
     folder: source
 
 build:
@@ -24,15 +25,20 @@ requirements:
   run:
     - python-javapackages-cos7-aarch64 ==3.4.1
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/bin/jvmjar"
+
 about:
   home: https://fedorahosted.org/javapackages/
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
+  license_file: "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/share/doc/javapackages-tools-3.4.1/LICENSE"
   summary: "(CDT) Macros and scripts for Java packaging support"
   description: |
         This package provides macros and scripts to support Java packaging.
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/libjpeg-turbo-cos7-aarch64/LICENSE
+++ b/recipes/libjpeg-turbo-cos7-aarch64/LICENSE
@@ -1,0 +1,282 @@
+libjpeg-turbo note:  This file has been modified by The libjpeg-turbo Project
+to include only information relevant to libjpeg-turbo, to wordsmith certain
+sections, and to remove impolitic language that existed in the libjpeg v8
+README.  It is included only for reference.  Please see README-turbo.txt for
+information specific to libjpeg-turbo.
+
+
+The Independent JPEG Group's JPEG software
+==========================================
+
+This distribution contains a release of the Independent JPEG Group's free JPEG
+software.  You are welcome to redistribute this software and to use it for any
+purpose, subject to the conditions under LEGAL ISSUES, below.
+
+This software is the work of Tom Lane, Guido Vollbeding, Philip Gladstone,
+Bill Allombert, Jim Boucher, Lee Crocker, Bob Friesenhahn, Ben Jackson,
+Julian Minguillon, Luis Ortiz, George Phillips, Davide Rossi, Ge' Weijers,
+and other members of the Independent JPEG Group.
+
+IJG is not affiliated with the ISO/IEC JTC1/SC29/WG1 standards committee
+(also known as JPEG, together with ITU-T SG16).
+
+
+DOCUMENTATION ROADMAP
+=====================
+
+This file contains the following sections:
+
+OVERVIEW            General description of JPEG and the IJG software.
+LEGAL ISSUES        Copyright, lack of warranty, terms of distribution.
+REFERENCES          Where to learn more about JPEG.
+ARCHIVE LOCATIONS   Where to find newer versions of this software.
+FILE FORMAT WARS    Software *not* to get.
+TO DO               Plans for future IJG releases.
+
+Other documentation files in the distribution are:
+
+User documentation:
+  install.txt       How to configure and install the IJG software.
+  usage.txt         Usage instructions for cjpeg, djpeg, jpegtran,
+                    rdjpgcom, and wrjpgcom.
+  *.1               Unix-style man pages for programs (same info as usage.txt).
+  wizard.txt        Advanced usage instructions for JPEG wizards only.
+  change.log        Version-to-version change highlights.
+Programmer and internal documentation:
+  libjpeg.txt       How to use the JPEG library in your own programs.
+  example.c         Sample code for calling the JPEG library.
+  structure.txt     Overview of the JPEG library's internal structure.
+  coderules.txt     Coding style rules --- please read if you contribute code.
+
+Please read at least the files install.txt and usage.txt.  Some information
+can also be found in the JPEG FAQ (Frequently Asked Questions) article.  See
+ARCHIVE LOCATIONS below to find out where to obtain the FAQ article.
+
+If you want to understand how the JPEG code works, we suggest reading one or
+more of the REFERENCES, then looking at the documentation files (in roughly
+the order listed) before diving into the code.
+
+
+OVERVIEW
+========
+
+This package contains C software to implement JPEG image encoding, decoding,
+and transcoding.  JPEG (pronounced "jay-peg") is a standardized compression
+method for full-color and gray-scale images.  JPEG's strong suit is compressing
+photographic images or other types of images that have smooth color and
+brightness transitions between neighboring pixels.  Images with sharp lines or
+other abrupt features may not compress well with JPEG, and a higher JPEG
+quality may have to be used to avoid visible compression artifacts with such
+images.
+
+JPEG is lossy, meaning that the output pixels are not necessarily identical to
+the input pixels.  However, on photographic content and other "smooth" images,
+very good compression ratios can be obtained with no visible compression
+artifacts, and extremely high compression ratios are possible if you are
+willing to sacrifice image quality (by reducing the "quality" setting in the
+compressor.)
+
+This software implements JPEG baseline, extended-sequential, and progressive
+compression processes.  Provision is made for supporting all variants of these
+processes, although some uncommon parameter settings aren't implemented yet.
+We have made no provision for supporting the hierarchical or lossless
+processes defined in the standard.
+
+We provide a set of library routines for reading and writing JPEG image files,
+plus two sample applications "cjpeg" and "djpeg", which use the library to
+perform conversion between JPEG and some other popular image file formats.
+The library is intended to be reused in other applications.
+
+In order to support file conversion and viewing software, we have included
+considerable functionality beyond the bare JPEG coding/decoding capability;
+for example, the color quantization modules are not strictly part of JPEG
+decoding, but they are essential for output to colormapped file formats or
+colormapped displays.  These extra functions can be compiled out of the
+library if not required for a particular application.
+
+We have also included "jpegtran", a utility for lossless transcoding between
+different JPEG processes, and "rdjpgcom" and "wrjpgcom", two simple
+applications for inserting and extracting textual comments in JFIF files.
+
+The emphasis in designing this software has been on achieving portability and
+flexibility, while also making it fast enough to be useful.  In particular,
+the software is not intended to be read as a tutorial on JPEG.  (See the
+REFERENCES section for introductory material.)  Rather, it is intended to
+be reliable, portable, industrial-strength code.  We do not claim to have
+achieved that goal in every aspect of the software, but we strive for it.
+
+We welcome the use of this software as a component of commercial products.
+No royalty is required, but we do ask for an acknowledgement in product
+documentation, as described under LEGAL ISSUES.
+
+
+LEGAL ISSUES
+============
+
+In plain English:
+
+1. We don't promise that this software works.  (But if you find any bugs,
+   please let us know!)
+2. You can use this software for whatever you want.  You don't have to pay us.
+3. You may not pretend that you wrote this software.  If you use it in a
+   program, you must acknowledge somewhere in your documentation that
+   you've used the IJG code.
+
+In legalese:
+
+The authors make NO WARRANTY or representation, either express or implied,
+with respect to this software, its quality, accuracy, merchantability, or
+fitness for a particular purpose.  This software is provided "AS IS", and you,
+its user, assume the entire risk as to its quality and accuracy.
+
+This software is copyright (C) 1991-2012, Thomas G. Lane, Guido Vollbeding.
+All Rights Reserved except as specified below.
+
+Permission is hereby granted to use, copy, modify, and distribute this
+software (or portions thereof) for any purpose, without fee, subject to these
+conditions:
+(1) If any part of the source code for this software is distributed, then this
+README file must be included, with this copyright and no-warranty notice
+unaltered; and any additions, deletions, or changes to the original files
+must be clearly indicated in accompanying documentation.
+(2) If only executable code is distributed, then the accompanying
+documentation must state that "this software is based in part on the work of
+the Independent JPEG Group".
+(3) Permission for use of this software is granted only if the user accepts
+full responsibility for any undesirable consequences; the authors accept
+NO LIABILITY for damages of any kind.
+
+These conditions apply to any software derived from or based on the IJG code,
+not just to the unmodified library.  If you use our work, you ought to
+acknowledge us.
+
+Permission is NOT granted for the use of any IJG author's name or company name
+in advertising or publicity relating to this software or products derived from
+it.  This software may be referred to only as "the Independent JPEG Group's
+software".
+
+We specifically permit and encourage the use of this software as the basis of
+commercial products, provided that all warranty or liability claims are
+assumed by the product vendor.
+
+
+The Unix configuration script "configure" was produced with GNU Autoconf.
+It is copyright by the Free Software Foundation but is freely distributable.
+The same holds for its supporting scripts (config.guess, config.sub,
+ltmain.sh).  Another support script, install-sh, is copyright by X Consortium
+but is also freely distributable.
+
+The IJG distribution formerly included code to read and write GIF files.
+To avoid entanglement with the Unisys LZW patent, GIF reading support has
+been removed altogether, and the GIF writer has been simplified to produce
+"uncompressed GIFs".  This technique does not use the LZW algorithm; the
+resulting GIF files are larger than usual, but are readable by all standard
+GIF decoders.
+
+We are required to state that
+    "The Graphics Interchange Format(c) is the Copyright property of
+    CompuServe Incorporated.  GIF(sm) is a Service Mark property of
+    CompuServe Incorporated."
+
+
+REFERENCES
+==========
+
+We recommend reading one or more of these references before trying to
+understand the innards of the JPEG software.
+
+The best short technical introduction to the JPEG compression algorithm is
+	Wallace, Gregory K.  "The JPEG Still Picture Compression Standard",
+	Communications of the ACM, April 1991 (vol. 34 no. 4), pp. 30-44.
+(Adjacent articles in that issue discuss MPEG motion picture compression,
+applications of JPEG, and related topics.)  If you don't have the CACM issue
+handy, a PostScript file containing a revised version of Wallace's article is
+available at http://www.ijg.org/files/wallace.ps.gz.  The file (actually
+a preprint for an article that appeared in IEEE Trans. Consumer Electronics)
+omits the sample images that appeared in CACM, but it includes corrections
+and some added material.  Note: the Wallace article is copyright ACM and IEEE,
+and it may not be used for commercial purposes.
+
+A somewhat less technical, more leisurely introduction to JPEG can be found in
+"The Data Compression Book" by Mark Nelson and Jean-loup Gailly, published by
+M&T Books (New York), 2nd ed. 1996, ISBN 1-55851-434-1.  This book provides
+good explanations and example C code for a multitude of compression methods
+including JPEG.  It is an excellent source if you are comfortable reading C
+code but don't know much about data compression in general.  The book's JPEG
+sample code is far from industrial-strength, but when you are ready to look
+at a full implementation, you've got one here...
+
+The best currently available description of JPEG is the textbook "JPEG Still
+Image Data Compression Standard" by William B. Pennebaker and Joan L.
+Mitchell, published by Van Nostrand Reinhold, 1993, ISBN 0-442-01272-1.
+Price US$59.95, 638 pp.  The book includes the complete text of the ISO JPEG
+standards (DIS 10918-1 and draft DIS 10918-2).
+
+The original JPEG standard is divided into two parts, Part 1 being the actual
+specification, while Part 2 covers compliance testing methods.  Part 1 is
+titled "Digital Compression and Coding of Continuous-tone Still Images,
+Part 1: Requirements and guidelines" and has document numbers ISO/IEC IS
+10918-1, ITU-T T.81.  Part 2 is titled "Digital Compression and Coding of
+Continuous-tone Still Images, Part 2: Compliance testing" and has document
+numbers ISO/IEC IS 10918-2, ITU-T T.83.
+
+The JPEG standard does not specify all details of an interchangeable file
+format.  For the omitted details we follow the "JFIF" conventions, revision
+1.02.  JFIF 1.02 has been adopted as an Ecma International Technical Report
+and thus received a formal publication status.  It is available as a free
+download in PDF format from
+http://www.ecma-international.org/publications/techreports/E-TR-098.htm.
+A PostScript version of the JFIF document is available at
+http://www.ijg.org/files/jfif.ps.gz.  There is also a plain text version at
+http://www.ijg.org/files/jfif.txt.gz, but it is missing the figures.
+
+The TIFF 6.0 file format specification can be obtained by FTP from
+ftp://ftp.sgi.com/graphics/tiff/TIFF6.ps.gz.  The JPEG incorporation scheme
+found in the TIFF 6.0 spec of 3-June-92 has a number of serious problems.
+IJG does not recommend use of the TIFF 6.0 design (TIFF Compression tag 6).
+Instead, we recommend the JPEG design proposed by TIFF Technical Note #2
+(Compression tag 7).  Copies of this Note can be obtained from
+http://www.ijg.org/files/.  It is expected that the next revision
+of the TIFF spec will replace the 6.0 JPEG design with the Note's design.
+Although IJG's own code does not support TIFF/JPEG, the free libtiff library
+uses our library to implement TIFF/JPEG per the Note.
+
+
+ARCHIVE LOCATIONS
+=================
+
+The "official" archive site for this software is www.ijg.org.
+The most recent released version can always be found there in
+directory "files".  This particular version will be archived as
+http://www.ijg.org/files/jpegsrc.v8d.tar.gz, and in Windows-compatible
+"zip" archive format as http://www.ijg.org/files/jpegsr8d.zip.
+
+The JPEG FAQ (Frequently Asked Questions) article is a source of some
+general information about JPEG.
+It is available on the World Wide Web at http://www.faqs.org/faqs/jpeg-faq/
+and other news.answers archive sites, including the official news.answers
+archive at rtfm.mit.edu: ftp://rtfm.mit.edu/pub/usenet/news.answers/jpeg-faq/.
+If you don't have Web or FTP access, send e-mail to mail-server@rtfm.mit.edu
+with body
+	send usenet/news.answers/jpeg-faq/part1
+	send usenet/news.answers/jpeg-faq/part2
+
+
+FILE FORMAT WARS
+================
+
+The ISO/IEC JTC1/SC29/WG1 standards committee (also known as JPEG, together
+with ITU-T SG16) currently promotes different formats containing the name
+"JPEG" which are incompatible with original DCT-based JPEG.  IJG therefore does
+not support these formats (see REFERENCES).  Indeed, one of the original
+reasons for developing this free software was to help force convergence on
+common, interoperable format standards for JPEG files.
+Don't use an incompatible file format!
+(In any case, our decoder will remain capable of reading existing JPEG
+image files indefinitely.)
+
+
+TO DO
+=====
+
+Please send bug reports, offers of help, etc. to jpeg-info@jpegclub.org.

--- a/recipes/libjpeg-turbo-cos7-aarch64/build.sh
+++ b/recipes/libjpeg-turbo-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
+++ b/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: libjpeg-turbo-cos7-aarch64
+  version: 1.2.90
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/libjpeg-turbo-1.2.90-8.el7.aarch64.rpm
+    sha256: 180b1ded365097616e810bf12a905394e0d275c49d348430ffaf3c014037080b
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/libjpeg-turbo-1.2.90-8.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: http://sourceforge.net/projects/libjpeg-turbo
+  license: IJG
+  license_family: Other
+  summary: "(CDT) A MMX/SSE2 accelerated library for manipulating JPEG image files"
+  description: |
+        The libjpeg-turbo package contains a library of functions for manipulating
+        JPEG images.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
+++ b/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
@@ -28,7 +28,7 @@ about:
   home: http://sourceforge.net/projects/libjpeg-turbo
   license: IJG
   license_family: Other
-  license_file: sysroot/usr/share/doc/libjpeg-turbo-1.2.90/README
+  license_file: LICENSE
   summary: "(CDT) A MMX/SSE2 accelerated library for manipulating JPEG image files"
   description: |
         The libjpeg-turbo package contains a library of functions for manipulating

--- a/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
+++ b/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
@@ -21,7 +21,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/libjpeg.so.62.1.0"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libjpeg.so.62.1.0"
 
 
 about:

--- a/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
+++ b/recipes/libjpeg-turbo-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/libjpeg-turbo-1.2.90-8.el7.src.rpm
+    sha256: a1bf79998a7b88a5673a9e76fd5b28bb43558010a726a8468c436857fdc8672b
     folder: source
 
 build:
@@ -16,12 +17,18 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/libjpeg.so.62.1.0"
 
 
 about:
   home: http://sourceforge.net/projects/libjpeg-turbo
   license: IJG
   license_family: Other
+  license_file: sysroot/usr/share/doc/libjpeg-turbo-1.2.90/README
   summary: "(CDT) A MMX/SSE2 accelerated library for manipulating JPEG image files"
   description: |
         The libjpeg-turbo package contains a library of functions for manipulating
@@ -29,5 +36,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/nspr-cos7-aarch64/build.sh
+++ b/recipes/nspr-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/nspr-cos7-aarch64/meta.yaml
+++ b/recipes/nspr-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nspr-4.21.0-1.el7.src.rpm
+    sha256: 1719b67f036c744a396d7ec006f4fc62643bd4c14c8be1ca36b1ae0cf317e78d
     folder: source
 
 build:
@@ -16,11 +17,16 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libnspr4.so"
 
 
 about:
   home: http://www.mozilla.org/projects/nspr/
-  license: MPLv2.0
+  license: MPL-2.0
   license_family: Other
   summary: "(CDT) Netscape Portable Runtime"
   description: |
@@ -31,5 +37,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/nspr-cos7-aarch64/meta.yaml
+++ b/recipes/nspr-cos7-aarch64/meta.yaml
@@ -1,0 +1,35 @@
+package:
+  name: nspr-cos7-aarch64
+  version: 4.21.0
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/nspr-4.21.0-1.el7.aarch64.rpm
+    sha256: 358f430d3b2ac45d78089ee70f9be181fa1dc67d3b30d8f323041fa9b933e6c2
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nspr-4.21.0-1.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: http://www.mozilla.org/projects/nspr/
+  license: MPLv2.0
+  license_family: Other
+  summary: "(CDT) Netscape Portable Runtime"
+  description: |
+        NSPR provides platform independence for non-GUI operating system facilities.
+        These facilities include threads, thread synchronization, normal file and
+        network I/O, interval timing and calendar time, basic memory management
+        (malloc and free) and shared library linking.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/nss-cos7-aarch64/build.sh
+++ b/recipes/nss-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/nss-cos7-aarch64/meta.yaml
+++ b/recipes/nss-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-3.44.0-4.el7.src.rpm
+    sha256: fe22bd9929a98e664a5e38d2261bcd298bc39b0355c3eda346eb44f78ab1ba79
     folder: source
 
 build:
@@ -27,9 +28,15 @@ requirements:
     - nspr-cos7-aarch64 >=4.21.0
     - nss-util-cos7-aarch64 >=3.44.0
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libnss3.so"
+
 about:
   home: http://www.mozilla.org/projects/security/pki/nss/
-  license: MPLv2.0
+  license: MPL-2.0
   license_family: Other
   summary: "(CDT) Network Security Services"
   description: |
@@ -41,5 +48,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/nss-cos7-aarch64/meta.yaml
+++ b/recipes/nss-cos7-aarch64/meta.yaml
@@ -1,0 +1,45 @@
+package:
+  name: nss-cos7-aarch64
+  version: 3.44.0
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/nss-3.44.0-4.el7.aarch64.rpm
+    sha256: 1b24997f9f83b8e7e6849f2dc397c8ecb00c002fb1722dfe271e97f6cd65c652
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-3.44.0-4.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+  host:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+  run:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+
+about:
+  home: http://www.mozilla.org/projects/security/pki/nss/
+  license: MPLv2.0
+  license_family: Other
+  summary: "(CDT) Network Security Services"
+  description: |
+        Network Security Services (NSS) is a set of libraries designed to support
+        cross-platform development of security-enabled client and server applications.
+        Applications built with NSS can support SSL v2 and v3, TLS, PKCS #5, PKCS #7,
+        PKCS #11, PKCS #12, S/MIME, X.509 v3 certificates, and other security
+        standards.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/nss-softokn-cos7-aarch64/build.sh
+++ b/recipes/nss-softokn-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/nss-softokn-cos7-aarch64/meta.yaml
+++ b/recipes/nss-softokn-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-softokn-3.44.0-5.el7.src.rpm
+    sha256: bf9f73413f75976e88f41b3af60c17e9b77e3ba6b88652d5a10bf22bcbc2f623
     folder: source
 
 build:
@@ -30,10 +31,20 @@ requirements:
     - nss-util-cos7-aarch64 >=3.44.0
     - nss-softokn-freebl-cos7-aarch64 >=3.44.0
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libsoftokn3.so"
+
+
 about:
   home: http://www.mozilla.org/projects/security/pki/nss/
-  license: MPLv2.0
+  license: MPL-2.0
   license_family: Other
   summary: "(CDT) Network Security Services Softoken Module"
   description: |
         Network Security Services Softoken Cryptographic Module
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/nss-softokn-cos7-aarch64/meta.yaml
+++ b/recipes/nss-softokn-cos7-aarch64/meta.yaml
@@ -1,0 +1,39 @@
+package:
+  name: nss-softokn-cos7-aarch64
+  version: 3.44.0
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/nss-softokn-3.44.0-5.el7.aarch64.rpm
+    sha256: dba2e929ec2ab502f2002cc26285f67cbbdfcefefab4f1d5af454904b45f091d
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-softokn-3.44.0-5.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.44.0
+  host:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.44.0
+  run:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+    - nss-softokn-freebl-cos7-aarch64 >=3.44.0
+
+about:
+  home: http://www.mozilla.org/projects/security/pki/nss/
+  license: MPLv2.0
+  license_family: Other
+  summary: "(CDT) Network Security Services Softoken Module"
+  description: |
+        Network Security Services Softoken Cryptographic Module

--- a/recipes/nss-softokn-cos7-aarch64/meta.yaml
+++ b/recipes/nss-softokn-cos7-aarch64/meta.yaml
@@ -35,7 +35,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libsoftokn3.so"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libsoftokn3.so"
 
 
 about:

--- a/recipes/nss-softokn-freebl-cos7-aarch64/build.sh
+++ b/recipes/nss-softokn-freebl-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/nss-softokn-freebl-cos7-aarch64/meta.yaml
+++ b/recipes/nss-softokn-freebl-cos7-aarch64/meta.yaml
@@ -32,7 +32,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libfreebl3.so"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libfreebl3.so"
 
 
 about:

--- a/recipes/nss-softokn-freebl-cos7-aarch64/meta.yaml
+++ b/recipes/nss-softokn-freebl-cos7-aarch64/meta.yaml
@@ -1,0 +1,37 @@
+package:
+  name: nss-softokn-freebl-cos7-aarch64
+  version: 3.44.0
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/nss-softokn-freebl-3.44.0-5.el7.aarch64.rpm
+    sha256: 0fef4691e52e4743b49560df0136b869b9b2a77d631f0d58fdb574515f24ea9d
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-softokn-3.44.0-5.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+  host:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+  run:
+    - nspr-cos7-aarch64 >=4.21.0
+    - nss-util-cos7-aarch64 >=3.44.0
+
+about:
+  home: http://www.mozilla.org/projects/security/pki/nss/
+  license: MPLv2.0
+  license_family: Other
+  summary: "(CDT) Freebl library for the Network Security Services"
+  description: |
+        NSS Softoken Cryptographic Module Freebl Library  Install the nss-softokn-
+        freebl package if you need the freebl library.

--- a/recipes/nss-softokn-freebl-cos7-aarch64/meta.yaml
+++ b/recipes/nss-softokn-freebl-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-softokn-3.44.0-5.el7.src.rpm
+    sha256: bf9f73413f75976e88f41b3af60c17e9b77e3ba6b88652d5a10bf22bcbc2f623
     folder: source
 
 build:
@@ -27,11 +28,21 @@ requirements:
     - nspr-cos7-aarch64 >=4.21.0
     - nss-util-cos7-aarch64 >=3.44.0
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libfreebl3.so"
+
+
 about:
   home: http://www.mozilla.org/projects/security/pki/nss/
-  license: MPLv2.0
+  license: MPL-2.0
   license_family: Other
   summary: "(CDT) Freebl library for the Network Security Services"
   description: |
         NSS Softoken Cryptographic Module Freebl Library  Install the nss-softokn-
         freebl package if you need the freebl library.
+extra:
+  recipe-maintainers:
+    - jayfurmanek

--- a/recipes/nss-util-cos7-aarch64/build.sh
+++ b/recipes/nss-util-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/nss-util-cos7-aarch64/meta.yaml
+++ b/recipes/nss-util-cos7-aarch64/meta.yaml
@@ -29,7 +29,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libnssutil3.so"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libnssutil3.so"
 
 
 about:

--- a/recipes/nss-util-cos7-aarch64/meta.yaml
+++ b/recipes/nss-util-cos7-aarch64/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: nss-util-cos7-aarch64
+  version: 3.44.0
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/nss-util-3.44.0-3.el7.aarch64.rpm
+    sha256: cb62d417a1ae1fc2b807273745f09949606b3e5d7ae03fd90dc1a1dcf49011b8
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-util-3.44.0-3.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+requirements:
+  build:
+    - nspr-cos7-aarch64 >=4.21.0
+  host:
+    - nspr-cos7-aarch64 >=4.21.0
+  run:
+    - nspr-cos7-aarch64 >=4.21.0
+
+about:
+  home: http://www.mozilla.org/projects/security/pki/nss/
+  license: MPLv2.0
+  license_family: Other
+  summary: "(CDT) Network Security Services Utilities Library"
+  description: |
+        Utilities for Network Security Services and the Softoken module
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/nss-util-cos7-aarch64/meta.yaml
+++ b/recipes/nss-util-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/nss-util-3.44.0-3.el7.src.rpm
+    sha256: 1854c7ac191d92ec57a2a5774b23cd99133eb4b68bd2b140394c02d8856519c0
     folder: source
 
 build:
@@ -24,9 +25,16 @@ requirements:
   run:
     - nspr-cos7-aarch64 >=4.21.0
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libnssutil3.so"
+
+
 about:
   home: http://www.mozilla.org/projects/security/pki/nss/
-  license: MPLv2.0
+  license: MPL-2.0
   license_family: Other
   summary: "(CDT) Network Security Services Utilities Library"
   description: |
@@ -34,5 +42,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/orbit2-cos7-aarch64/COPYING
+++ b/recipes/orbit2-cos7-aarch64/COPYING
@@ -1,0 +1,346 @@
+		    GNU GENERAL PUBLIC LICENSE
+		       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+     51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Library General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+
+		    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+			    NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+
+	    How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year  name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Library General
+Public License instead of this License.
+

--- a/recipes/orbit2-cos7-aarch64/build.sh
+++ b/recipes/orbit2-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/orbit2-cos7-aarch64/meta.yaml
+++ b/recipes/orbit2-cos7-aarch64/meta.yaml
@@ -21,7 +21,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libORBit-2.so.0"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libORBit-2.so.0"
 
 
 about:

--- a/recipes/orbit2-cos7-aarch64/meta.yaml
+++ b/recipes/orbit2-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/ORBit2-2.14.19-13.el7.src.rpm
+    sha256: c8c532427e900e7cdef5f8c937659858855f1271bc34ff5ac006e9fc45018072
     folder: source
 
 build:
@@ -16,12 +17,18 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libORBit-2.so.0"
 
 
 about:
   home: http://www.gnome.org/projects/ORBit2
-  license: LGPLv2+ and GPLv2+
-  license_family: GPL2
+  license: LGPL-2.0+ and GPL-2.0+
+  license_family: GPL-2
+  license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/ORBit2-2.14.19/COPYING"
   summary: "(CDT) A high-performance CORBA Object Request Broker"
   description: |
         ORBit is a high-performance CORBA (Common Object Request Broker Architecture)
@@ -34,5 +41,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-
-

--- a/recipes/orbit2-cos7-aarch64/meta.yaml
+++ b/recipes/orbit2-cos7-aarch64/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: orbit2-cos7-aarch64
+  version: 2.14.19
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/ORBit2-2.14.19-13.el7.aarch64.rpm
+    sha256: 376ecf27cfc93e6d1d3bb1344a5e1dd82e493828213122c5bbc6c48f48803127
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/ORBit2-2.14.19-13.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: http://www.gnome.org/projects/ORBit2
+  license: LGPLv2+ and GPLv2+
+  license_family: GPL2
+  summary: "(CDT) A high-performance CORBA Object Request Broker"
+  description: |
+        ORBit is a high-performance CORBA (Common Object Request Broker Architecture)
+        ORB (object request broker). It allows programs to send requests and receive
+        replies from other programs, regardless of the locations of the two programs.
+        CORBA is an architecture that enables communication between program objects,
+        regardless of the programming language they're written in or the operating
+        system they run on.  You will need to install this package and ORBit-devel if
+        you want to write programs that use CORBA technology.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+
+

--- a/recipes/orbit2-cos7-aarch64/meta.yaml
+++ b/recipes/orbit2-cos7-aarch64/meta.yaml
@@ -26,7 +26,7 @@ test:
 
 about:
   home: http://www.gnome.org/projects/ORBit2
-  license: LGPL-2.0+ and GPL-2.0+
+  license: GPL-2.0-or-later
   license_family: GPL-2
   license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/ORBit2-2.14.19/COPYING"
   summary: "(CDT) A high-performance CORBA Object Request Broker"

--- a/recipes/orbit2-cos7-aarch64/meta.yaml
+++ b/recipes/orbit2-cos7-aarch64/meta.yaml
@@ -28,7 +28,7 @@ about:
   home: http://www.gnome.org/projects/ORBit2
   license: GPL-2.0-or-later
   license_family: GPL-2
-  license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/ORBit2-2.14.19/COPYING"
+  license_file: COPYING
   summary: "(CDT) A high-performance CORBA Object Request Broker"
   description: |
         ORBit is a high-performance CORBA (Common Object Request Broker Architecture)

--- a/recipes/p11-kit-cos7-aarch64/COPYING
+++ b/recipes/p11-kit-cos7-aarch64/COPYING
@@ -1,0 +1,27 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the
+      following disclaimer.
+    * Redistributions in binary form must reproduce the
+      above copyright notice, this list of conditions and
+      the following disclaimer in the documentation and/or
+      other materials provided with the distribution.
+    * The names of contributors to this software may not be
+      used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipes/p11-kit-cos7-aarch64/build.sh
+++ b/recipes/p11-kit-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/p11-kit-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-cos7-aarch64/meta.yaml
@@ -1,0 +1,33 @@
+package:
+  name: p11-kit-cos7-aarch64
+  version: 0.23.5
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/p11-kit-0.23.5-3.el7.aarch64.rpm
+    sha256: eb5bd186fe148b1d86a6cabe462fa0abe70d2856dcb21e25b74ff8597420a585
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/p11-kit-0.23.5-3.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: http://p11-glue.freedesktop.org/p11-kit.html
+  license: BSD
+  license_family: BSD
+  summary: "(CDT) Library for loading and sharing PKCS#11 modules"
+  description: |
+        p11-kit provides a way to load and enumerate PKCS#11 modules, as well as a
+        standard configuration setup for installing PKCS#11 modules in such a way that
+        they're discoverable.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+

--- a/recipes/p11-kit-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-cos7-aarch64/meta.yaml
@@ -21,14 +21,14 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libp11-kit.so.0"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/libp11-kit.so.0"
 
 
 about:
   home: http://p11-glue.freedesktop.org/p11-kit.html
   license: BSD-3-Clause
   license_family: BSD
-  license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/p11-kit-0.23.5/COPYING"
+  license_file: COPYING
   summary: "(CDT) Library for loading and sharing PKCS#11 modules"
   description: |
         p11-kit provides a way to load and enumerate PKCS#11 modules, as well as a

--- a/recipes/p11-kit-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/p11-kit-0.23.5-3.el7.src.rpm
+    sha256: 285f7f81b15d312e32e8bd6b8bd339b586214971272d26c4204a319d318110ba
     folder: source
 
 build:
@@ -16,12 +17,18 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/libp11-kit.so.0"
 
 
 about:
   home: http://p11-glue.freedesktop.org/p11-kit.html
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
+  license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/p11-kit-0.23.5/COPYING"
   summary: "(CDT) Library for loading and sharing PKCS#11 modules"
   description: |
         p11-kit provides a way to load and enumerate PKCS#11 modules, as well as a
@@ -30,4 +37,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-

--- a/recipes/p11-kit-trust-cos7-aarch64/COPYING
+++ b/recipes/p11-kit-trust-cos7-aarch64/COPYING
@@ -1,0 +1,27 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the
+      following disclaimer.
+    * Redistributions in binary form must reproduce the
+      above copyright notice, this list of conditions and
+      the following disclaimer in the documentation and/or
+      other materials provided with the distribution.
+    * The names of contributors to this software may not be
+      used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipes/p11-kit-trust-cos7-aarch64/build.sh
+++ b/recipes/p11-kit-trust-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
@@ -33,6 +33,7 @@ about:
   home: http://p11-glue.freedesktop.org/p11-kit.html
   license: BSD-3-Clause
   license_family: BSD
+  license_file: COPYING
   summary: "(CDT) System trust module from p11-kit"
   description: |
         The p11-kit-trust package contains a system trust PKCS#11 module which

--- a/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
@@ -1,0 +1,38 @@
+package:
+  name: p11-kit-trust-cos7-aarch64
+  version: 0.23.5
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/p11-kit-trust-0.23.5-3.el7.aarch64.rpm
+    sha256: de5e0b87ee6d8d13852c2ffb7f03cdb60d4c37e40502156030516f8a0bbd6dea
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/p11-kit-0.23.5-3.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+requirements:
+    build:
+        - p11-kit-cos7-aarch64 >=0.23.5
+    run:
+        - p11-kit-cos7-aarch64 >=0.23.5
+
+
+
+
+about:
+  home: http://p11-glue.freedesktop.org/p11-kit.html
+  license: BSD
+  license_family: BSD
+  summary: "(CDT) System trust module from p11-kit"
+  description: |
+        The p11-kit-trust package contains a system trust PKCS#11 module which
+        contains certificate anchors and black lists.
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+

--- a/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
@@ -26,7 +26,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/pkcs11/p11-kit-trust.so"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib64/pkcs11/p11-kit-trust.so"
 
 
 about:

--- a/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
+++ b/recipes/p11-kit-trust-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/p11-kit-0.23.5-3.el7.src.rpm
+    sha256: 285f7f81b15d312e32e8bd6b8bd339b586214971272d26c4204a319d318110ba
     folder: source
 
 build:
@@ -21,12 +22,16 @@ requirements:
     run:
         - p11-kit-cos7-aarch64 >=0.23.5
 
-
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib64/pkcs11/p11-kit-trust.so"
 
 
 about:
   home: http://p11-glue.freedesktop.org/p11-kit.html
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
   summary: "(CDT) System trust module from p11-kit"
   description: |
@@ -35,4 +40,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-

--- a/recipes/python-javapackages-cos7-aarch64/LICENSE
+++ b/recipes/python-javapackages-cos7-aarch64/LICENSE
@@ -1,0 +1,58 @@
+Copyright (c) 2011-2013 Red Hat, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+3. Neither the name of Red Hat nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Copyright (c) 2000-2006, JPackage Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+3. Neither the name of the JPackage Project nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/python-javapackages-cos7-aarch64/build.sh
+++ b/recipes/python-javapackages-cos7-aarch64/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+mkdir -p "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot
+if [[ -d usr/lib ]]; then
+  if [[ ! -d lib ]]; then
+    ln -s usr/lib lib
+  fi
+fi
+if [[ -d usr/lib64 ]]; then
+  if [[ ! -d lib64 ]]; then
+    ln -s usr/lib64 lib64
+  fi
+fi
+pushd "${PREFIX}"/aarch64-conda_cos7-linux-gnu/sysroot > /dev/null 2>&1
+cp -Rf "${SRC_DIR}"/binary/* .

--- a/recipes/python-javapackages-cos7-aarch64/meta.yaml
+++ b/recipes/python-javapackages-cos7-aarch64/meta.yaml
@@ -28,7 +28,7 @@ about:
   home: https://fedorahosted.org/javapackages/
   license: BSD-3-Clause
   license_family: BSD
-  license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/python-javapackages-3.4.1/LICENSE"
+  license_file: LICENSE
   summary: "(CDT) Module for handling various files for Java packaging"
   description: |
         Module for handling, querying and manipulating of various files for Java

--- a/recipes/python-javapackages-cos7-aarch64/meta.yaml
+++ b/recipes/python-javapackages-cos7-aarch64/meta.yaml
@@ -8,6 +8,7 @@ source:
     no_hoist: true
     folder: binary
   - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/javapackages-tools-3.4.1-11.el7.src.rpm
+    sha256: 5fb0c2d84e98883219d4e9c5ca64d1fc1c23c654f396cb841e63dc980c1ba4bb
     folder: source
 
 build:
@@ -16,12 +17,18 @@ build:
   missing_dso_whitelist:
     - '*'
 
+test:
+  requires:
+    - zlib
+  commands:
+    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib/python2.7/site-packages/javapackages/pom.py"
 
 
 about:
   home: https://fedorahosted.org/javapackages/
-  license: BSD
+  license: BSD-3-Clause
   license_family: BSD
+  license_file: "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/share/doc/python-javapackages-3.4.1/LICENSE"
   summary: "(CDT) Module for handling various files for Java packaging"
   description: |
         Module for handling, querying and manipulating of various files for Java
@@ -29,4 +36,3 @@ about:
 extra:
   recipe-maintainers:
     - jayfurmanek
-

--- a/recipes/python-javapackages-cos7-aarch64/meta.yaml
+++ b/recipes/python-javapackages-cos7-aarch64/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: python-javapackages-cos7-aarch64
+  version: 3.4.1
+
+source:
+  - url: http://mirror.centos.org/altarch/7/os/aarch64/Packages/python-javapackages-3.4.1-11.el7.noarch.rpm
+    sha256: 8d867ffbfaf2bc76f13c1fc624e12d75f84e0ff22636a52171e20af579c63801
+    no_hoist: true
+    folder: binary
+  - url: http://vault.centos.org/7.7.1908/os/Source/SPackages/javapackages-tools-3.4.1-11.el7.src.rpm
+    folder: source
+
+build:
+  number: 2
+  noarch: generic
+  missing_dso_whitelist:
+    - '*'
+
+
+
+about:
+  home: https://fedorahosted.org/javapackages/
+  license: BSD
+  license_family: BSD
+  summary: "(CDT) Module for handling various files for Java packaging"
+  description: |
+        Module for handling, querying and manipulating of various files for Java
+        packaging in Linux distributions
+extra:
+  recipe-maintainers:
+    - jayfurmanek
+

--- a/recipes/python-javapackages-cos7-aarch64/meta.yaml
+++ b/recipes/python-javapackages-cos7-aarch64/meta.yaml
@@ -21,7 +21,7 @@ test:
   requires:
     - zlib
   commands:
-    - test -f "$PREFIX/aarch64-conda_ cos7-linux-gnu/sysroot/usr/lib/python2.7/site-packages/javapackages/pom.py"
+    - test -f "$PREFIX/aarch64-conda_cos7-linux-gnu/sysroot/usr/lib/python2.7/site-packages/javapackages/pom.py"
 
 
 about:


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

The java-1.7.0 CDT package has lots of dependencies. 
I used `conda skeleton rpm java-1.7.0-openjdk-cos7-aarch64 --recursive --architecture aarch64`--distro centos7`
That caught most of them, but I also added ca-certificates and its dependencies because defaults did for the ppc64le version in defaults/noarch.

A few of the build.sh scripts needed some editing to correct symlinks that originally pointed to `/usr/bin`

This is needed for r-base.
See: https://github.com/conda-forge/r-base-feedstock/pull/118