### PR TITLE
Adding urlchecker python package recipe

### DIFF
--- a/recipes/urlchecker/meta.yaml
+++ b/recipes/urlchecker/meta.yaml
@@ -20,10 +20,10 @@ requirements:
   host:
     - pip
     - python >=3
+    - pytest-runner
   run:
     - python >=3
     - requests
-    - pytest-runner
 
 test:
   imports:

--- a/recipes/urlchecker/meta.yaml
+++ b/recipes/urlchecker/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "urlchecker" %}
+{% set version = "0.0.13" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9a887fcc0c999bc1a4157fcb140984f46c3fad597a027aaab607365b4106f84c
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - urlchecker=urlchecker.client:main
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+
+requirements:
+  host:
+    - pip
+    - python >=3
+  run:
+    - python >=3
+    - requests
+
+test:
+  imports:
+    - urlchecker
+    - urlchecker.client
+    - urlchecker.client.check
+    - urlchecker.client.github
+    - urlchecker.core
+    - urlchecker.core.check
+    - urlchecker.core.fileproc
+    - urlchecker.core.urlmarker
+    - urlchecker.core.urlproc
+    - urlchecker.core.whitelist
+    - urlchecker.main
+    - urlchecker.main.github
+    - urlchecker.version
+
+about:
+  home: https://github.com/urlstechie/urlchecker-python
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'tool to collect and validate urls over static files (code and documentation)'
+  description: |
+    urlchecker-python is a python module and command line client to allow for extraction
+    and checking of urls in static files, whether they be documentation or code. You can
+    also use the library via the urlstechie/urlchecker-action as a GitHub action.
+  doc_url: https://urlchecker-python.readthedocs.io/en/latest/
+  dev_url: https://github.com/urlstechie/urlchecker-python
+
+extra:
+  recipe-maintainers:
+    - vsoch
+    - SuperKogito

--- a/recipes/urlchecker/meta.yaml
+++ b/recipes/urlchecker/meta.yaml
@@ -39,6 +39,9 @@ test:
     - urlchecker.main
     - urlchecker.main.github
     - urlchecker.version
+  commands:
+    - urlchecker --help
+
 
 about:
   home: https://github.com/urlstechie/urlchecker-python

--- a/recipes/urlchecker/meta.yaml
+++ b/recipes/urlchecker/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   run:
     - python >=3
     - requests
+    - pytest-runner
 
 test:
   imports:

--- a/recipes/urlchecker/meta.yaml
+++ b/recipes/urlchecker/meta.yaml
@@ -30,7 +30,6 @@ test:
     - urlchecker
     - urlchecker.client
     - urlchecker.client.check
-    - urlchecker.client.github
     - urlchecker.core
     - urlchecker.core.check
     - urlchecker.core.fileproc


### PR DESCRIPTION
This will add the urlchecker library (deployed on pypi) to conda. I am pinging the other maintainer, @SuperKogito so he can approve being added as a maintainer.

Signed-off-by: vsoch <vsochat@stanford.edu>

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

For the last point, @SuperKogito can comment here.