### PR TITLE
adding azure-c-shared-utility.

### DIFF
--- a/recipes/azure-c-shared-utility/bld.bat
+++ b/recipes/azure-c-shared-utility/bld.bat
@@ -1,0 +1,21 @@
+:: MSVC is preferred.
+set CC=cl.exe
+set CXX=cl.exe
+
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -Duse_installed_dependencies=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/azure-c-shared-utility/meta.yaml
+++ b/recipes/azure-c-shared-utility/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "azure-c-shared-utility" %}
+{% set version = "2020.01.22" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/Azure/azure-c-shared-utility/archive/{{ version.replace('.', '-') }}.tar.gz
+    sha256: 643f3b84ac511b301e481c35278e6a4deacb9e945ad1e36dc3ff4b5f45300b39
+
+build:
+  number: 0
+  skip: true  # [not win64]
+  run_exports:
+    - {{ pin_subpackage(name, exact=True) }}
+
+requirements:
+  build:
+    - vs2017_win-64          # [win64]
+    - cmake
+    - ninja
+  host:
+    - azure-macro-utils-c
+    - umock-c
+  run:
+    - azure-macro-utils-c
+    - umock-c
+
+test:
+  commands:
+    - if not exist %PREFIX%\\Library\\bin\\aziotsharedutil.dll exit 1  # [win]
+
+about:
+  home: https://github.com/Azure/azure-c-shared-utility
+  license: MIT
+  license_file: LICENSE
+  summary: |
+    Azure C Shared Utility
+
+extra:
+  recipe-maintainers:
+    - seanyen

--- a/recipes/azure-macro-utils-c/bld.bat
+++ b/recipes/azure-macro-utils-c/bld.bat
@@ -1,0 +1,20 @@
+:: MSVC is preferred.
+set CC=cl.exe
+set CXX=cl.exe
+
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -Duse_installed_dependencies=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/azure-macro-utils-c/meta.yaml
+++ b/recipes/azure-macro-utils-c/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  - git_url: https://github.com/Azure/azure-macro-utils-c.git
-    git_rev: 59313d7ec9fa4b423e1bd0a24fdba792bfb29262
+  - url: https://github.com/Azure/azure-macro-utils-c/archive/59313d7ec9fa4b423e1bd0a24fdba792bfb29262.zip
+    sha256: 17fd40a533bff252fa8c6be015eb45ed62e61335afbab0239c18f97a9bd2d8fc
 
 build:
   number: 0

--- a/recipes/azure-macro-utils-c/meta.yaml
+++ b/recipes/azure-macro-utils-c/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "azure-macro-utils-c" %}
+{% set version = "2020.03.23" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - git_url: https://github.com/Azure/azure-macro-utils-c.git
+    git_rev: 59313d7ec9fa4b423e1bd0a24fdba792bfb29262
+
+build:
+  number: 0
+  skip: true  # [not win64]
+  run_exports:
+    - {{ pin_subpackage(name, exact=True) }}
+
+requirements:
+  build:
+    - vs2017_win-64          # [win64]
+    - cmake
+    - ninja
+
+test:
+  commands:
+    - if not exist %LIBRARY_PREFIX%\\include\\azure_macro_utils\\macro_utils.h exit 1
+
+about:
+  home: https://github.com/Azure/azure-macro-utils-c
+  license: MIT
+  license_file: LICENSE
+  summary: |
+    Microsoft Azure IoT SDKs - macro utils for C
+
+extra:
+  recipe-maintainers:
+    - seanyen

--- a/recipes/umock-c/bld.bat
+++ b/recipes/umock-c/bld.bat
@@ -1,0 +1,21 @@
+:: MSVC is preferred.
+set CC=cl.exe
+set CXX=cl.exe
+
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -Duse_installed_dependencies=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/umock-c/meta.yaml
+++ b/recipes/umock-c/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "umock-c" %}
+{% set version = "2020.03.27" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/Azure/umock-c/archive/1f0e52e3f54bdeeb138d400ea11701a1f7dc5e5c.zip
+    sha256: 8be1cbfa2259ca1140d186154d2561d1ed76ab0b5ce4efef1db1371fd3d92343
+
+build:
+  number: 0
+  skip: true  # [not win64]
+  run_exports:
+    - {{ pin_subpackage(name, exact=True) }}
+
+requirements:
+  build:
+    - vs2017_win-64          # [win64]
+    - cmake
+    - ninja
+  host:
+    - azure-macro-utils-c
+  run:
+    - azure-macro-utils-c
+
+test:
+  commands:
+    - if not exist %PREFIX%\\Library\\include\\umock_c\\umock_c.h exit 1  # [win]
+
+about:
+  home: https://github.com/Azure/umock-c
+  license: MIT
+  license_file: LICENSE
+  summary: |
+    A pure C mocking library
+
+extra:
+  recipe-maintainers:
+    - seanyen


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
