### PR TITLE
Add markdown-it-py recipe

### DIFF
--- a/recipes/markdown-it-py/meta.yaml
+++ b/recipes/markdown-it-py/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "markdown-it-py" %}
+{% set version = "0.4.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "925da55cba665cb9808ef851885993f856c678c8009077a59ab3134d7dac876f"
+
+build:
+  number: 0
+  entry_points:
+    - markdown-it = markdown_it.cli.parse:main
+    - markdown-it-bench = markdown_it.cli.benchmark:main
+  noarch: "python"
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - attrs >=19.3,<20
+    - python >=3.6
+
+test:
+  imports:
+    - markdown_it
+    - markdown_it.cli
+    - markdown_it.common
+    - markdown_it.extensions
+    - markdown_it.extensions.footnote
+    - markdown_it.extensions.front_matter
+    - markdown_it.extensions.myst_blocks
+    - markdown_it.extensions.myst_role
+    - markdown_it.extensions.texmath
+    - markdown_it.helpers
+    - markdown_it.presets
+    - markdown_it.rules_block
+    - markdown_it.rules_core
+    - markdown_it.rules_inline
+  commands:
+    - markdown-it --help
+    - markdown-it-bench --help
+
+about:
+  home: "https://github.com/ExecutableBookProject/markdown-it-py"
+  license: "MIT"
+  license_family: "MIT"
+  license_file: "LICENSE"
+  summary: "Python port of markdown-it. Markdown parsing, done right!"
+
+extra:
+  recipe-maintainers:
+    - chrisjsewell

--- a/recipes/markdown-it-py/meta.yaml
+++ b/recipes/markdown-it-py/meta.yaml
@@ -51,6 +51,8 @@ about:
   license_family: "MIT"
   license_file: "LICENSE"
   summary: "Python port of markdown-it. Markdown parsing, done right!"
+  doc_url: https://github.com/ExecutableBookProject/markdown-it-py/blob/master/README.md
+  dev_url: https://github.com/ExecutableBookProject/markdown-it-py
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
