### PR TITLE
Package box2d-py (dependency for gym)

### DIFF
--- a/recipes/box2d-py/LICENSE
+++ b/recipes/box2d-py/LICENSE
@@ -1,0 +1,21 @@
+This software is covered under the zlib license.
+
+C++ version Copyright (c) 2006-2011 Erin Catto http://www.box2d.org
+Python version Copyright (c) 2008-2011 Ken Lauer / sirkne at gmail dot com
+
+Implemented using the pybox2d SWIG interface for Box2D (pybox2d.googlecode.com)
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+

--- a/recipes/box2d-py/meta.yaml
+++ b/recipes/box2d-py/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "2.3.8" %}
+
+package:
+  name: box2d-py
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/b/box2d-py/box2d-py-{{ version }}.tar.gz
+  sha256: bdacfbbc56079bb317548efe49d3d5a86646885cc27f4a2ee97e4b2960921ab7
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - pip
+    - swig
+  run:
+    - python
+
+test:
+  imports:
+    - Box2D
+
+about:
+  home: https://github.com/openai/box2d-py
+  license: Zlib
+  license_file: LICENSE
+  summary: 'A repackaged version of https://github.com/pybox2d/pybox2d'
+
+  description: 'A repackaged version of https://github.com/pybox2d/pybox2d'
+  dev_url: https://github.com/openai/box2d-py
+
+extra:
+  recipe-maintainers:
+    - h-vetinari


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Working towards #11162 (since the solver doesn't get the dependency build order correctly there). Curiously, there has been a surprising amount of progress on the dependencies in the few days that I haven't touched this, see #11195 for `atari-py`. Also see #11152, although the [repo](https://github.com/openai/box2d-py) of the dependency that's needed for gym says:
> This is a repackaged version of [pybox2d](https://github.com/pybox2d/pybox2d). For all information, see that repo. 

Maybe @christopherhesse can provide some more information on how compatible these packages are. Also, you're welcome to help/contribute in the recipe maintainership, if you're interested.