### PR TITLE
libcst: add recipe for v0.3.4

### DIFF
--- a/recipes/libcst/meta.yaml
+++ b/recipes/libcst/meta.yaml
@@ -1,0 +1,74 @@
+{% set name = "libcst" %}
+{% set version = "0.3.4" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 449bf67813e4ced937edb9811355e2734ac709b4f36416889c6e169a03b96362
+
+build:
+  number: 0
+  skip: True  # [py < 36]
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - dataclasses   # [py < 37]
+    - pip
+    - python
+    - pyyaml >=5.2
+    - typing_extensions >=3.7.2
+    - typing_inspect >=0.4.0
+  run:
+    - dataclasses   # [py < 37]
+    - python
+    - pyyaml >=5.2
+    - typing_extensions >=3.7.2
+    - typing_inspect >=0.4.0
+
+test:
+  imports:
+    - libcst
+    - libcst._nodes
+    - libcst._nodes.tests
+    - libcst._parser
+    - libcst._parser.conversions
+    - libcst._parser.parso
+    - libcst._parser.parso.pgen2
+    - libcst._parser.parso.python
+    - libcst._parser.parso.tests
+    - libcst._parser.tests
+    - libcst._parser.types
+    - libcst._parser.types.tests
+    - libcst.codegen
+    - libcst.codegen.tests
+    - libcst.codemod
+    - libcst.codemod.commands
+    - libcst.codemod.commands.tests
+    - libcst.codemod.tests
+    - libcst.codemod.visitors
+    - libcst.codemod.visitors.tests
+    - libcst.helpers
+    - libcst.helpers.tests
+    - libcst.matchers
+    - libcst.matchers.tests
+    - libcst.metadata
+    - libcst.metadata.tests
+    - libcst.testing
+    - libcst.tests
+
+about:
+  home: "https://github.com/Instagram/LibCST"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "A concrete syntax tree with AST-like properties for Python 3.5, 3.6, 3.7 and 3.8 programs."
+  doc_url: https://libcst.readthedocs.io/
+  dev_url: https://github.com/Instagram/LibCST
+
+extra:
+  recipe-maintainers:
+    - nwani

--- a/recipes/libcst/meta.yaml
+++ b/recipes/libcst/meta.yaml
@@ -72,3 +72,4 @@ about:
 extra:
   recipe-maintainers:
     - nwani
+    - bollwyvl

--- a/recipes/libcst/meta.yaml
+++ b/recipes/libcst/meta.yaml
@@ -71,5 +71,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - nwani
+    - nehaljwani
     - bollwyvl


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
