### PR TITLE
Adding schemaorg python module

### DIFF
--- a/recipes/schemaorg/meta.yaml
+++ b/recipes/schemaorg/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "schemaorg" %}
+{% set version = "0.0.23" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d8cf37ac540bc48753aaa0953668aeddbac9e7bf01f297788e5c400fda11cf71
+
+build:
+  number: 0
+  noarch: python
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+
+requirements:
+  host:
+    - pip
+    - python >=3
+    - pytest-runner
+  run:
+    - python >=3
+    - pyaml
+    - lxml
+
+test:
+  imports:
+    - schemaorg
+    - schemaorg.version
+    - schemaorg.utils
+    - schemaorg.defaults
+    - schemaorg.data
+    - schemaorg.logger
+    - schemaorg.main
+    - schemaorg.main.parse
+    - schemaorg.main.parse.base
+    - schemaorg.main.parse.validate
+    - schemaorg.main.parse.recipe
+    - schemaorg.templates
+    - schemaorg.templates.google
+    - schemaorg.templates.metadata
+
+
+about:
+  home: https://github.com/openschemas/schemaorg
+  license: AGPL-3.0-or-later
+  license_family: AGPL
+  license_file: LICENSE
+  summary: "Python functions for applied use of schema.org"
+  description: "Python functions for instantiating and validating schemas."
+  doc_url: https://openschemas.github.io/schemaorg
+  dev_url: https://github.com/openschemas/schemaorg
+
+extra:
+  recipe-maintainers:
+    - vsoch


### PR DESCRIPTION
This PR will add the [schemaorg](https://openschemas.github.io/schemaorg/) python module to conda cloud. 

Signed-off-by: vsoch <vsochat@stanford.edu>

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

I confirm that I am willing to be maintainer.
