### PR TITLE
Add physical_validation recipe

### DIFF
--- a/recipes/physical_validation/meta.yaml
+++ b/recipes/physical_validation/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "physical_validation" %}
+{% set version = "1.0rc4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/shirtsgroup/physical_validation/archive/{{ version }}.tar.gz
+  sha256: 8b7b80bbe22e555a290283e0eaa1edd6a20440f7f5e5f96887d7a51ac3c64dc5
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: True  # [py<35]
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - scipy
+    - pymbar
+
+#test:
+#  # Some packages might need a `test/commands` key to check CLI.
+#  # List all the packages/modules that `run_test.py` imports.
+#  imports:
+#    - simplejson
+#    - simplejson.tests
+
+about:
+  home: https://github.com/shirtsgroup/physical_validation
+  license: LGPL-2.1
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'Physical validation of molecular simulation results'
+
+  description: |
+    Physical validation of molecular simulation results
+  doc_url: https://physical-validation.readthedocs.io/
+  dev_url: https://github.com/shirtsgroup/physical_validation
+
+extra:
+  recipe-maintainers:
+    - ptmerz
+    - mrshirts
+    - mattwthompson


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
