### PR TITLE
Add coverage-fixpaths recipe

### DIFF
--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   noarch: python
   number: 0
+  skip: true  # [win]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:

--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -10,18 +10,18 @@ source:
   sha256: 18880405439c1a6329e5448b104c2b03de248fa4f54a7ec2f123fd226a2a573b
 
 build:
+  noarch: python
   number: 0
-  skip: true  # [win or py<36]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   entry_points:
     - coverage-fixpaths = coveragefixpaths.__main__:main
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:

--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -26,6 +26,8 @@ requirements:
 test:
   imports:
     - coveragefixpaths
+  commands:
+    - coverage-fixpaths --help
 
 about:
   home: https://github.com/omegacen/coverage-fixpaths

--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -27,7 +27,7 @@ test:
 
 about:
   home: https://github.com/omegacen/coverage-fixpaths
-  license: LGPL-3.0
+  license: LGPL-3.0-or-later
   license_file: LICENSE
   summary: 'A small CLI tool that automatically fixes paths in Cobertura coverage reports'
 

--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -10,17 +10,16 @@ source:
   sha256: 18880405439c1a6329e5448b104c2b03de248fa4f54a7ec2f123fd226a2a573b
 
 build:
-  noarch: python
   number: 0
-  skip: true  # [win]
+  skip: true  # [win or py<36]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:

--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "coverage-fixpaths" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 18880405439c1a6329e5448b104c2b03de248fa4f54a7ec2f123fd226a2a573b
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - coveragefixpaths
+
+about:
+  home: https://github.com/omegacen/coverage-fixpaths
+  license: LGPL-3.0
+  license_file: LICENSE
+  summary: 'A small CLI tool that automatically fixes paths in Cobertura coverage reports'
+
+extra:
+  recipe-maintainers:
+    - teake

--- a/recipes/coverage-fixpaths/meta.yaml
+++ b/recipes/coverage-fixpaths/meta.yaml
@@ -13,6 +13,8 @@ build:
   number: 0
   skip: true  # [win or py<36]
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  entry_points:
+    - coverage-fixpaths = coveragefixpaths.__main__:main
 
 requirements:
   host:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
