### PR TITLE
Adding pdb2pqr_htmd_propka30

### DIFF
--- a/recipes/pdb2pqr_htmd_propka30/meta.yaml
+++ b/recipes/pdb2pqr_htmd_propka30/meta.yaml
@@ -31,7 +31,7 @@ test:
     - pdb2pqr.propka30.Source
     - pdb2pqr.src
   commands:
-    - pdb2pqr_cli  --ff CHARMM --ffout CHARMM --chain --ph-calc-method=propka $SP_DIR/pdb2pqr/test/1rxz.pdb  tmp.pdb
+    - pdb2pqr -h
 
 about:
   home: "http://www.poissonboltzmann.org/"

--- a/recipes/pdb2pqr_htmd_propka30/meta.yaml
+++ b/recipes/pdb2pqr_htmd_propka30/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pdb2pqr_htmd_propka30" %}
+{% set version = "0.0.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 11038a630e31c823ea3cfe3d9f878e18edd4517b6a8916cb3e0127e1fa96035e
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: python
+  entry_points:
+    - pdb2pqr_cli = pdb2pqr.main:main
+
+requirements:
+  host:
+    - pip
+    - python >=3.5
+  run:
+    - python >=3.5
+
+test:
+  imports:
+    - pdb2pqr
+    - pdb2pqr.extensions
+    - pdb2pqr.propka30
+    - pdb2pqr.propka30.Source
+    - pdb2pqr.src
+  commands:
+    - pdb2pqr_cli  --ff CHARMM --ffout CHARMM --chain --ph-calc-method=propka $SP_DIR/pdb2pqr/test/1rxz.pdb  tmp.pdb
+
+about:
+  home: "http://www.poissonboltzmann.org/"
+  license: BSD-3-Clause
+  license_file: pdb2pqr/COPYING
+  summary: "PDB2PQR: an automated pipeline for the setup of Poisson-Boltzmann electrostatics calculations. This version is from the htmd-fixups branch with few fixes to use propka30 with python3"
+
+extra:
+  recipe-maintainers:
+    - samuelmurail

--- a/recipes/pdb2pqr_htmd_propka30/meta.yaml
+++ b/recipes/pdb2pqr_htmd_propka30/meta.yaml
@@ -31,7 +31,7 @@ test:
     - pdb2pqr.propka30.Source
     - pdb2pqr.src
   commands:
-    - pdb2pqr -h
+    - pdb2pqr_cli -h
 
 about:
   home: "http://www.poissonboltzmann.org/"


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
