### PR TITLE
adding socketIO-client-nexus

### DIFF
--- a/recipes/socketIO-client-nexus/meta.yaml
+++ b/recipes/socketIO-client-nexus/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "socketIO-client-nexus" %}
+{% set version = "0.7.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 41e6aaaff981f6729690f472eb2c7a5d1dda07349077e34444527b9700b0aea5
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+    - ipython >=7.0.1
+    - pandas >=0.22.0
+    - requests >=2.22.0
+    - selenium >=3.141.0
+    - ujson >=1.35
+
+test:
+  imports:
+    - socketIO_client_nexus
+
+about:
+  home: https://github.com/nexus-devs/socketIO-client-2.0.3
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A socket.io 2.x client library for Python'
+
+  description: |
+    A socket.io 2.x client library for Python
+  dev_url: https://github.com/nexus-devs/socketIO-client-2.0.3
+
+extra:
+  recipe-maintainers:
+    - timkpaine

--- a/recipes/socketIO-client-nexus/meta.yaml
+++ b/recipes/socketIO-client-nexus/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.6
     - pip
   run:
     - python >=3.6

--- a/recipes/socketIO-client-nexus/meta.yaml
+++ b/recipes/socketIO-client-nexus/meta.yaml
@@ -19,12 +19,10 @@ requirements:
     - python >=3.7
     - pip
   run:
-    - python >=3.7
-    - ipython >=7.0.1
-    - pandas >=0.22.0
-    - requests >=2.22.0
-    - selenium >=3.141.0
-    - ujson >=1.35
+    - python >=3.6
+    - requests >=2.7.0
+    - six
+    - websocket-client
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
