### PR TITLE
adding jupyterlab_email

### DIFF
--- a/recipes/jupyterlab_email/meta.yaml
+++ b/recipes/jupyterlab_email/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - jupyter-packaging
   run:
     - python >=3.7
-    - bs4 >=0.0.1
+    - beautifulsoup4 >=4.9.1
     - emails >=0.5.15
     - ipython >=7.2.0
     - jupyterlab >=1.0.0

--- a/recipes/jupyterlab_email/meta.yaml
+++ b/recipes/jupyterlab_email/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "jupyterlab_email" %}
+{% set version = "0.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 748f53b95ca6b2a4c4cd2d1782686f7b53d9601bcb78fa12e846cc5f036721e7
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+    - nodejs
+    - jupyter-packaging
+  run:
+    - python >=3.7
+    - bs4 >=0.0.1
+    - emails >=0.5.15
+    - ipython >=7.2.0
+    - jupyterlab >=1.0.0
+    - pandas >=0.23.4
+    - python-magic >=0.4.15
+
+test:
+  imports:
+    - jupyterlab_email
+
+about:
+  home: http://github.com/timkpaine/jupyterlab_email
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Sending emails from JupyterLab'
+
+  description: |
+    Sending emails from JupyterLab
+  dev_url: https://github.com/timkpaine/jupyterlab_email
+
+extra:
+  recipe-maintainers:
+    - timkpaine


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
