### PR TITLE
adding jupyterlab_powerpoint

### DIFF
--- a/recipes/jupyterlab_powerpoint/meta.yaml
+++ b/recipes/jupyterlab_powerpoint/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python >=3.7
     - pip
     - nodejs
+    - jupyter-packaging
   run:
     - python >=3.7
     - jupyterlab >=1.0.0

--- a/recipes/jupyterlab_powerpoint/meta.yaml
+++ b/recipes/jupyterlab_powerpoint/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "jupyterlab_powerpoint" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 866391ef0a8d97de2aabebbc31ab6cb6b74399ba5a3d5879c8876e97534e9a83
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+    - nodejs
+  run:
+    - python >=3.7
+    - jupyterlab >=1.0.0
+    - nbconvert >=5.5.0
+    - nbformat >=4.4.0
+    - python-pptx >=0.6.0
+
+test:
+  imports:
+    - jupyterlab_powerpoint
+
+about:
+  home: http://github.com/timkpaine/jupyterlab_powerpoint
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Create powerpoints from jupyter notebooks'
+
+  description: |
+    Create powerpoints from jupyter notebooks
+  dev_url: https://github.com/timkpaine/jupyterlab_powerpoint
+
+extra:
+  recipe-maintainers:
+    - timkpaine


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
