### PR TITLE
Fix github archive url

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -16,7 +16,7 @@ source:
   # uncomment the line below, and modify as needed. Use releases if available:
   # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
   # and otherwise fall back to archive: 
-  # url: https://github.com/simplejson/simplejson/archive/{{ version }}.tar.gz
+  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
   sha256: d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
   # sha256 is the preferred checksum -- you can get it for a file with:
   #  `openssl sha256 <file name>`.


### PR DESCRIPTION
The example URL for a github archive returns a `404` error. It's missing a `v` before the version number. This PR corrects the url, which is fine in the current docs (see **tip** at bottom of https://conda-forge.org/docs/maintainer/adding_pkgs.html?highlight=archive#step-by-step-instructions and elsewhere on that page).