### PR TITLE
Add two new napari subpackages, napari-plugin-engine and napari-svg

### DIFF
--- a/recipes/napari-plugin-engine/meta.yaml
+++ b/recipes/napari-plugin-engine/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5c5b0460d7043072cad3c79910d2054a0a916245b4fb2d641d1c391a9cd88040
+  sha256: 60da74d55be0c115c689d37f2ac4143bc1529e0810362e0f22149f3aeb39dba2
 
 build:
   noarch: python

--- a/recipes/napari-plugin-engine/meta.yaml
+++ b/recipes/napari-plugin-engine/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "napari-plugin-engine" %}
+{% set version = "0.1.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5c5b0460d7043072cad3c79910d2054a0a916245b4fb2d641d1c391a9cd88040
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools_scm
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - napari_plugin_engine
+
+about:
+  home: https://github.com/napari/napari-plugin-engine
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A fork of pluggy - plugin management package'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    A fork of pluggy - plugin management package.
+  doc_url: https://napari-plugin-engine.readthedocs.io/
+  dev_url: https://github.com/napari/napari-plugin-engine
+
+extra:
+  recipe-maintainers:
+    - tlambert03
+    - jni
+    - sofroniewn

--- a/recipes/napari-svg/meta.yaml
+++ b/recipes/napari-svg/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "napari-svg" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c36ccabc1b07dd7e185e0c2a62198bee2d0e1e9673fcfe407c55fb0f2be8854e
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools_scm
+  run:
+    - imageio
+    - numpy
+    - napari-plugin-engine
+    - vispy
+    - python >=3.6
+
+test:
+  imports:
+    - napari_svg
+
+about:
+  home: https://github.com/napari/napari-svg
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'An io plugin for reading and writing svg files with napari'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    An io plugin for reading and writing svg files with napari
+  doc_url: https://github.com/napari/napari-svg
+  dev_url: https://github.com/napari/napari-svg
+
+extra:
+  recipe-maintainers:
+    - sofroniewn
+    - tlambert03
+    - jni


### PR DESCRIPTION
The latest napari release (0.3.0) depends on these two packages, which
are not yet available on conda-forge. See:

https://github.com/conda-forge/napari-feedstock/pull/1

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
