### PR TITLE
Adding recipe for gridtest

### DIFF
--- a/recipes/gridtest/meta.yaml
+++ b/recipes/gridtest/meta.yaml
@@ -1,0 +1,76 @@
+{% set name = "gridtest" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b0ab118ba07232270760ac96aa530e4b45291f501c18299ca7918605b047d3d9
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - gridtest=gridtest.client:main
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+
+requirements:
+  host:
+    - pip
+    - python >=3
+    - pytest-runner
+  run:
+    - python >=3
+    - pyaml
+
+test:
+  imports:
+    - gridtest
+    - gridtest.decorators
+    - gridtest.func
+    - gridtest.defaults
+    - gridtest.templates
+    - gridtest.utils
+    - gridtest.version
+    - gridtest.client
+    - gridtest.client.check
+    - gridtest.client.test
+    - gridtest.client.update
+    - gridtest.client.shell
+    - gridtest.client.generate
+    - gridtest.main
+    - gridtest.main.check
+    - gridtest.main.generate
+    - gridtest.main.helpers
+    - gridtest.main.substitute
+    - gridtest.main.test
+    - gridtest.main.update
+    - gridtest.main.workers
+    - gridtest.logger
+    - gridtest.logger.message
+    - gridtest.logger.namer
+    - gridtest.logger.progress
+    - gridtest.logger.spinner
+  commands:
+    - gridtest --help
+
+
+about:
+  home: https://github.com/vsoch/gridtest
+  license: MPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'generate grid testing for Python modules and functions'
+  description: |
+    GridTest is a small python library that will read in one or more python
+    scripts or modules, and generate a testing file that can be used to run grid
+    tests. A "gridtest" is one that is run over a grid of parameter
+    settings. For each gridtest, you can also measure one or more metrics.
+  doc_url: https://vsoch.github.io/gridtest
+  dev_url: https://github.com/vsoch/gridtest
+
+extra:
+  recipe-maintainers:
+    - vsoch


### PR DESCRIPTION
Signed-off-by: vsoch <vsochat@stanford.edu>
This pull request will add a conda forge library for [gridtest](https://vsoch.github.io/gridtest).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
