### PR TITLE
Add ghq to conda-forge

### DIFF
--- a/recipes/go-ghq/meta.yaml
+++ b/recipes/go-ghq/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "ghq" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: go-{{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/x-motemen/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: fbd40f1ba18ace399ea8625fb01da2d008a5c2b500b17979196577aaa827511b
+
+build:
+  number: 0
+  script: 
+    - go install -ldflags "-X main.revision={{ version }}" .
+
+requirements:
+  build:
+    - {{ compiler('go') }}
+
+test:
+  commands:
+    - ghq --help
+
+about:
+  home: https://github.com/x-motemen/ghq
+  license: MIT
+  license_file: LICENSE
+  summary: ghq provides a way to organize remote repository clones, like go get does.
+
+  dev_url: https://github.com/x-motemen/ghq
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there