### PR TITLE
Add recipe for distlib

### DIFF
--- a/distlib/meta.yaml
+++ b/distlib/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "distlib" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
+  sha256: 2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - distlib
+    - distlib._backport
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/distlib/
+  summary: Distribution utilities
+  doc_url: https://pythonhosted.org/distlib/
+  license: Apache-2.0
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
This library (at >=0.3) is required to build virtualenv 20.x:

conda-forge/virtualenv-feedstock#32
