### PR TITLE
Add you-get to conda-forge 

### DIFF
--- a/recipes/you-get/meta.yaml
+++ b/recipes/you-get/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "you-get" %}
+{% set version = "0.4.1432" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 421b71ee644afc63581c2d57bf6785c0e65c51d9debe74b8449685c90fd56f44
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - you-get = you_get.__main__:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - you_get
+    - you_get.cli_wrapper
+    - you_get.cli_wrapper.downloader
+    - you_get.cli_wrapper.openssl
+    - you_get.cli_wrapper.player
+    - you_get.cli_wrapper.transcoder
+    - you_get.extractors
+    - you_get.processor
+    - you_get.util
+  commands:
+    - you-get --help
+
+about:
+  home: "https://you-get.org/"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: "Dumb downloader that scrapes the web"
+  description: |
+    Command line downloader for YouTube and many other online video/
+    audio sources.
+  doc_url: "https://you-get.org/"
+  dev_url: "https://github.com/soimort/you-get"
+
+extra:
+  recipe-maintainers:
+    - mwcraig


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
