### PR TITLE
oslo.log: new recipe

### DIFF
--- a/recipes/oslo.log/meta.yaml
+++ b/recipes/oslo.log/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "oslo.log" %}
+{% set version = "4.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 22bf26492222de2a2ee346ab62701fd12cd01bba733fb14e6c070300c3f96da8
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - convert-json = oslo_log.cmds.convert_json:main
+
+requirements:
+  host:
+    - pbr >=3.1.1
+    - pip
+    - python
+  run:
+    - python
+    - pbr >=3.1.1
+    - oslo.config >=5.2.0
+    - oslo.context >=2.20.0
+    - oslo.i18n >=3.20.0
+    - oslo.utils >=3.36.0
+    - oslo.serialization >=2.25.0
+    - debtcollector >=1.19.0
+    - pyinotify >=0.9.6  # [linux]
+    - python-dateutil >=2.7.0
+
+test:
+  imports:
+    - oslo_log
+  commands:
+    - convert-json -h
+
+about:
+  home: https://docs.openstack.org/oslo.log/latest/
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: A library provides standardized configuration for all openstack projects
+  dev_url: https://bugs.launchpad.net/oslo.log
+
+extra:
+  recipe-maintainers:
+    - tschoonj


### PR DESCRIPTION
Can I add `noarch: python` in this case?


<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there