### PR TITLE
Parse feedstock name from recipe correctly when creating feedstocks

### DIFF
--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -38,7 +38,7 @@ source ~/miniconda/bin/activate root
 
 conda install --yes --quiet \
   conda-forge-ci-setup=2.* \
-  conda-smithy=3.* \
+  "conda-smithy>=3.7.1<4.0.0a0" \
   conda-forge-pinning \
   git=2.12.2 \
   "conda-build>=3.16" \

--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -13,6 +13,7 @@ Such as:
 from __future__ import print_function
 
 from conda_build.metadata import MetaData
+from conda_smithy.utils import get_feedstock_name_from_meta
 from contextlib import contextmanager
 from datetime import datetime
 from github import Github, GithubException
@@ -44,7 +45,7 @@ def list_recipes():
         if recipe_dir.startswith('example'):
             continue
         path = os.path.abspath(os.path.join(recipe_directory_name, recipe_dir))
-        yield path, MetaData(path).name()
+        yield path, get_feedstock_name_from_meta(MetaData(path))
 
 
 @contextmanager


### PR DESCRIPTION
This PR patches `create_feedstocks.py` to correctly parse the feedstock name from the recipe, now that there are a few different ways to handle that. The logic is deferred to `conda_smithy`, who's version is now pinned to `>=3.7.1` in the environment creation.

Fixes #11669