### PR TITLE
Adding DoWhy python package

### DIFF
--- a/recipes/dowhy/meta.yaml
+++ b/recipes/dowhy/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pip
     - python >=3.5
   run:
-    - matplotlib
+    - matplotlib-base
     - networkx >=2.0
     - numpy >=1.15
     - pandas >=0.24

--- a/recipes/dowhy/meta.yaml
+++ b/recipes/dowhy/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "dowhy" %}
+{% set version = "0.4" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 2e59e4f2cb864c73cd87a84988bbda73fdc0aad19075306e383d520d4f8cbed4 
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python >=3.5
+  run:
+    - matplotlib
+    - networkx >=2.0
+    - numpy >=1.15
+    - pandas >=0.24
+    - pydot >=1.4
+    - python >=3.5
+    - scikit-learn
+    - scipy
+    - statsmodels
+    - sympy >=1.4
+
+test:
+  imports:
+    - dowhy
+    - dowhy.api
+    - dowhy.causal_estimators
+    - dowhy.causal_refuters
+    - dowhy.do_samplers
+
+about:
+  home: "https://github.com/microsoft/dowhy"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE  # LICENSE file is in the root folder of the archive
+  summary: "DoWhy is a Python library for causal inference that supports explicit modeling and testing of causal assumptions."
+  doc_url: "https://microsoft.github.io/dowhy/" 
+  dev_url: https://github.com/microsoft/dowhy
+
+extra:
+  recipe-maintainers:
+    - amit-sharma


### PR DESCRIPTION
Hello, 
This is a PR for adding my package DoWhy to conda-forge.
The package has MIT license and it is already included in the tar archive's root folder. Therefore, following the instructions [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#about), I have added the path to my LICENSE file in meta.yaml.

Let me know if there are any further changes that need to be made. Thanks!

@conda-forge-admin, please ping team

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [ ] Source is from official source
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there