### PR TITLE
Adding recipe for qme (pronounced "Queue Me")

### DIFF
--- a/recipes/qme/meta.yaml
+++ b/recipes/qme/meta.yaml
@@ -1,0 +1,90 @@
+{% set name = "qme" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cd99b7e5b78d71cc3010f4b225c842720e7c1436fb7cae8414165c8f2df55f2c
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - qme=qme.client:main
+  script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+
+requirements:
+  host:
+    - pip
+    - python >=3
+    - pytest-runner
+  run:
+    - python >=3
+    - sqlalchemy
+    - flask
+    - flask-restful
+    - flask-socketio
+    - gevent-websocket
+
+test:
+  imports:
+    - qme
+    - qme.defaults
+    - qme.version
+    - qme.app
+    - qme.app.server
+    - qme.client
+    - qme.client.config
+    - qme.client.get
+    - qme.client.listing
+    - qme.client.run
+    - qme.client.start
+    - qme.client.clear
+    - qme.client.generate
+    - qme.client.search
+    - qme.logger
+    - qme.logger.message
+    - qme.logger.namer
+    - qme.logger.progress
+    - qme.logger.spinner
+    - qme.main
+    - qme.main.executor
+    - qme.main.executor.base
+    - qme.main.executor.shell
+    - qme.main.executor.slurm
+    - qme.main.config
+    - qme.main.database
+    - qme.main.database.base
+    - qme.main.database.models
+    - qme.main.database.sqlite
+    - qme.main.database.relational
+    - qme.main.database.filesystem
+    - qme.utils
+    - qme.utils.command
+    - qme.utils.file
+    - qme.utils.prompt
+    - qme.utils.regex
+  commands:
+    - qme --help
+
+
+about:
+  home: https://github.com/vsoch/qme
+  license: MPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'reproducible job submission and dashboard library'
+  description: |
+    "Queue-me" is a jobs queue and dashboard generation tool that can be used
+    to specify executors (entities that run jobs) and actions for them. You can
+    use qme only on the command line, or if desired, via an interactive web dashboard.
+    The dashboard (and it's dependencies) are not required for using the base library.
+  doc_url: https://vsoch.github.io/qme
+  dev_url: https://github.com/vsoch/qme
+
+extra:
+  recipe-maintainers:
+    - vsoch

--- a/recipes/qme/meta.yaml
+++ b/recipes/qme/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qme" %}
-{% set version = "0.0.1" %}
+{% set version = "0.0.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cd99b7e5b78d71cc3010f4b225c842720e7c1436fb7cae8414165c8f2df55f2c
+  sha256: eddfe5a12559a85c7a60d5dd3ee8299aa994ca1be6a95ee5a0e2d46a8548f158
 
 build:
   number: 0


### PR DESCRIPTION
This will add a conda recipe for the qme (pronounced Queue Me) library, which is a dashboard and task management tool in Python. 

Signed-off-by: vsoch <vsochat@stanford.edu>

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
