### PR TITLE
Add jupyterhub idle culler 1.0

### DIFF
--- a/recipes/jupyterhub-idle-culler/COPYING.md
+++ b/recipes/jupyterhub-idle-culler/COPYING.md
@@ -1,0 +1,59 @@
+# The Jupyter multi-user notebook server licensing terms
+
+Jupyter multi-user notebook server is licensed under the terms of the Modified BSD License
+(also known as New or Revised or 3-Clause BSD), as follows:
+
+- Copyright (c) 2014-, Jupyter Development Team
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of the Jupyter Development Team nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+## About the Jupyter Development Team
+
+The Jupyter Development Team is the set of all contributors to the Jupyter project.
+This includes all of the Jupyter subprojects.
+
+The core team that coordinates development on GitHub can be found here:
+https://github.com/jupyter/.
+
+## Our Copyright Policy
+
+Jupyter uses a shared copyright model. Each contributor maintains copyright
+over their contributions to Jupyter. But, it is important to note that these
+contributions are typically only changes to the repositories. Thus, the Jupyter
+source code, in its entirety is not the copyright of any single person or
+institution.  Instead, it is the collective copyright of the entire Jupyter
+Development Team.  If individual contributors want to maintain a record of what
+changes/contributions they have specific copyright on, they should indicate
+their copyright in the commit message of the change, when they commit the
+change to one of the Jupyter repositories.
+
+With this in mind, the following banner should be used in any source code file
+to indicate the copyright and license terms:
+
+    # Copyright (c) Jupyter Development Team.
+    # Distributed under the terms of the Modified BSD License.

--- a/recipes/jupyterhub-idle-culler/meta.yaml
+++ b/recipes/jupyterhub-idle-culler/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: python
 
 requirements:
   host:

--- a/recipes/jupyterhub-idle-culler/meta.yaml
+++ b/recipes/jupyterhub-idle-culler/meta.yaml
@@ -32,7 +32,7 @@ about:
   license_family: BSD
   license_file: COPYING.md
   summary:
-  JupyterHub service to cull idle servers and users
+    JupyterHub service to cull idle servers and users
   description: |
     jupyterhub-idle-culler provides a JupyterHub service to cull and shut down
     idle notebook servers and users on a JupyterHub deployment.

--- a/recipes/jupyterhub-idle-culler/meta.yaml
+++ b/recipes/jupyterhub-idle-culler/meta.yaml
@@ -13,6 +13,9 @@ build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
   noarch: python
+  entry_points:
+    - cull_idle_servers.py = jupyterhub_idle_culler:main
+    - jupyterhub-idle-culler = jupyterhub_idle_culler:main
 
 requirements:
   host:
@@ -26,6 +29,9 @@ requirements:
 test:
   imports:
     - jupyterhub_idle_culler
+  commands:
+    - cull_idle_servers.py --help
+    - jupyterhub-idle-culler --help
 
 about:
   home: https://github.com/jupyterhub/jupyterhub-idle-culler

--- a/recipes/jupyterhub-idle-culler/meta.yaml
+++ b/recipes/jupyterhub-idle-culler/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "jupyterhub-idle-culler" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/jupyterhub-idle-culler/meta.yaml
+++ b/recipes/jupyterhub-idle-culler/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "jupyterhub-idle-culler" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d9e58baa48cba6a79b83c43d8dcab7b758a66c2c4a9bc8394f7b43e03d891621
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - tornado
+    - python-dateutil
+
+test:
+  imports:
+    - jupyterhub_idle_culler
+
+about:
+  home: https://github.com/jupyterhub/jupyterhub-idle-culler
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: COPYING.md
+  summary:
+  JupyterHub service to cull idle servers and users
+  description: |
+    jupyterhub-idle-culler provides a JupyterHub service to cull and shut down
+    idle notebook servers and users on a JupyterHub deployment.
+  doc_url: https://github.com/jupyterhub/jupyterhub-idle-culler/blob/master/README.rst
+  dev_url: https://github.com/jupyterhub/jupyterhub-idle-culler
+
+extra:
+  recipe-maintainers:
+    - ericdill

--- a/recipes/jupyterhub-idle-culler/meta.yaml
+++ b/recipes/jupyterhub-idle-culler/meta.yaml
@@ -30,6 +30,7 @@ about:
   home: https://github.com/jupyterhub/jupyterhub-idle-culler
   license: BSD-3-Clause
   license_family: BSD
+  # Opened license packaging PR upstream: https://github.com/jupyterhub/jupyterhub-idle-culler/pull/3
   license_file: COPYING.md
   summary:
     JupyterHub service to cull idle servers and users


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] N/A If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
