### PR TITLE
Adding circle-fit 0.1.3

### DIFF
--- a/recipes/circle-fit/LICENSE.txt
+++ b/recipes/circle-fit/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2019 Michael Klear
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/circle-fit/meta.yaml
+++ b/recipes/circle-fit/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "circle-fit" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: d4173696cca074c9e5a2791169854064730b0fa53836326c55634d947222d794
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - matplotlib
+    - numpy
+    - pip
+    - python
+    - scipy
+  run:
+    - matplotlib
+    - numpy
+    - python
+    - scipy
+
+test:
+  imports:
+    - circle_fit
+
+about:
+  home: "https://github.com/AlliedToasters/circle-fit"
+  license: MIT
+  summary: "Circle Fitting Library in Python"
+
+extra:
+  recipe-maintainers:
+    - seanyen

--- a/recipes/circle-fit/meta.yaml
+++ b/recipes/circle-fit/meta.yaml
@@ -33,6 +33,7 @@ test:
 about:
   home: "https://github.com/AlliedToasters/circle-fit"
   license: MIT
+  license_file: LICENSE.txt
   summary: "Circle Fitting Library in Python"
 
 extra:

--- a/recipes/circle-fit/meta.yaml
+++ b/recipes/circle-fit/meta.yaml
@@ -10,16 +10,14 @@ source:
   sha256: d4173696cca074c9e5a2791169854064730b0fa53836326c55634d947222d794
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - matplotlib
-    - numpy
     - pip
     - python
-    - scipy
   run:
     - matplotlib
     - numpy
@@ -32,6 +30,8 @@ test:
 
 about:
   home: "https://github.com/AlliedToasters/circle-fit"
+  # ticket for upstream to add LICENSE.txt in the next release
+  # https://github.com/AlliedToasters/circle-fit/issues/7
   license: MIT
   license_file: LICENSE.txt
   summary: "Circle Fitting Library in Python"


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
