### PR TITLE
Add igwn-cmake

### DIFF
--- a/recipes/igwn-cmake/bld.bat
+++ b/recipes/igwn-cmake/bld.bat
@@ -1,0 +1,21 @@
+mkdir _build
+cd _build
+
+:: configure
+cmake "%SRC_DIR%" ^
+	-G "NMake Makefiles" ^
+	-DCMAKE_BUILD_TYPE:STRING=Release ^
+	-DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%"
+if errorlevel 1 exit 1
+
+:: build
+cmake --build . --parallel "%CPU_COUNT%" --verbose
+if errorlevel 1 exit 1
+
+:: test
+ctest -V
+if errorlevel 1 exit 1
+
+:: install
+cmake --build . --parallel "%CPU_COUNT%" --verbose --target install
+if errorlevel 1 exit 1

--- a/recipes/igwn-cmake/build.sh
+++ b/recipes/igwn-cmake/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+mkdir -p _build
+pushd _build
+
+# configure
+cmake \
+	-DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+	-DCMAKE_INSTALL_PREFIX:PATH=${PREFIX} \
+	${SRC_DIR} \
+;
+
+# build
+cmake --build . --parallel ${CPU_COUNT}
+
+# test
+ctest -V
+
+# install
+cmake --build . --parallel ${CPU_COUNT} --target install

--- a/recipes/igwn-cmake/meta.yaml
+++ b/recipes/igwn-cmake/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "igwn-cmake" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
+  sha256: 7c145e5f6c6eb4950b24bdddce689a592908146b07fb2223778e8425b9b6f5d6
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - pkg-config
+
+test:
+  requires:
+    - pkg-config
+  commands:
+    - pkg-config --print-errors --modversion igwncmake
+
+about:
+  home: https://git.ligo.org/ldastools/igwn-cmake
+  license: GPL-2.0-or-later
+  license_family: GPL
+  license_file: COPYING
+  summary: This is a collection of CMake functions used as a replacement for autoconf macros
+  description: |
+    This is a collection of macros and scripts that were developed to aid
+    in the process of converting Autotools based projects into CMake.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - emaros

--- a/recipes/igwn-cmake/meta.yaml
+++ b/recipes/igwn-cmake/meta.yaml
@@ -1,16 +1,15 @@
 {% set name = "igwn-cmake" %}
-{% set version = "1.2.0" %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: http://software.igwn.org/lscsoft/source/{{ name }}-{{ version }}.tar.gz
-  sha256: 7c145e5f6c6eb4950b24bdddce689a592908146b07fb2223778e8425b9b6f5d6
+  url: http://software.igwn.org/sources/source/{{ name }}-{{ version }}.tar.gz
+  sha256: c86ac84e53cbb141aaa58087de5e442bdb122db5af4c119dc7c89129f261da21
 
 build:
-  noarch: generic
   number: 0
 
 requirements:

--- a/recipes/igwn-cmake/meta.yaml
+++ b/recipes/igwn-cmake/meta.yaml
@@ -15,6 +15,7 @@ build:
 requirements:
   build:
     - cmake
+    - make  # [not win]
     - pkg-config
 
 test:


### PR DESCRIPTION
This PR adds a recipe for `igwn-cmake` a cmake modules library.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
