### PR TITLE
Conda-forge recipe to add pydrift 0.2.2 to the channel

### DIFF
--- a/recipes/pydrift/meta.yaml
+++ b/recipes/pydrift/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pydrift" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5b8df1d8780b8bf15a4756564bb01860244664f30e22da8cb92bf21f763c3818
+  sha256: 1132d0c3cebcc3b419a95cfcac5d002acaee67aa84a21e6b309cab03f30b6484
 
 build:
   noarch: python


### PR DESCRIPTION
New PR because of the new version of pydrift 0.2.2

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
