### PR TITLE
Add pytest-filter-subpackage

### DIFF
--- a/recipes/pytest-filter-subpackage/meta.yaml
+++ b/recipes/pytest-filter-subpackage/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pytest-filter-subpackage" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: b7d8fc3a42989b652032e6b0998a87dd00d43bf2b013ba5d2e86f930da149ae8
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - setuptools_scm
+    - python >=3.6
+  run:
+    - python >=3.6
+    - pytest >=3.0
+
+test:
+  requires:
+    - pytest
+    - pytest-doctestplus
+    - pytest-cov
+  imports:
+    - pytest_filter_subpackage
+
+about:
+  home: https://github.com/astropy/pytest-filter-subpackage
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.rst
+  summary: "Pytest plugin for filtering based on sub-packages"
+  description: |
+    This package contains a simple plugin for the pytest framework that
+    provides a shortcut to testing all code and documentation for a given
+    sub-package.
+  doc_url: https://github.com/astropy/pytest-filter-subpackage/blob/master/README.rst
+  dev_url: https://github.com/astropy/pytest-filter-subpackage
+
+extra:
+  recipe-maintainers:
+    - mwcraig
+    - astrofrog-conda-forge


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
