### PR TITLE
Add alsa-plugins

### DIFF
--- a/recipes/alsa-plugins/build.sh
+++ b/recipes/alsa-plugins/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+libtoolize --force --copy --automake
+aclocal
+autoheader
+automake --foreign --copy --add-missing
+autoconf
+./configure --prefix=$PREFIX --build=$BUILD --host=$HOST
+make -j${CPU_COUNT}
+make check
+make install

--- a/recipes/alsa-plugins/meta.yaml
+++ b/recipes/alsa-plugins/meta.yaml
@@ -1,0 +1,77 @@
+{% set name = "alsa-plugins" %}
+{% set version = "1.1.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: ftp://ftp.alsa-project.org/pub/plugins/{{ name }}-{{ version }}.tar.bz2
+  sha256: 797da5f8f53379fbea28817bc466de16affd2c07849e84f1af8d5e22f7bb7f1c
+
+build:
+  number: 0
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - autoconf
+    - automake
+    - libtool
+    - make
+    - pkg-config
+  host:
+    - alsa-lib >=1.0.11
+    # until alsa-plugins 1.1.7, ffmpeg with av_resample functions in avcodec needed
+    - ffmpeg <4
+    - jack >=0.98
+    - pulseaudio >=0.9.11
+  run:
+    # newer ffmpeg have a run_exports
+    - {{ pin_compatible('ffmpeg', max_pin='x.x') }}
+    - {{ pin_compatible('jack', max_pin='x.x.x') }}
+
+test:
+  commands:
+    {% set mods = [
+        "conf_pulse",
+        "ctl_arcam_av",
+        "ctl_oss",
+        "ctl_pulse",
+        "pcm_a52",
+        "pcm_jack",
+        "pcm_oss",
+        "pcm_pulse",
+        "pcm_upmix",
+        "pcm_usb_stream",
+        "pcm_vdownmix",
+        "rate_lavcrate",
+        "rate_lavcrate_fast",
+        "rate_lavcrate_faster",
+        "rate_lavcrate_high",
+        "rate_lavcrate_higher",
+        "rate_speexrate",
+        "rate_speexrate_best",
+        "rate_speexrate_medium",
+    ] %}
+    {% for mod in mods %}
+    - test -f $PREFIX/lib/alsa-lib/libasound_module_{{ mod }}$SHLIB_EXT
+    {% endfor %}
+
+about:
+  home: http://www.alsa-project.org/main/index.php/Main_Page
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  license_family: LGPL
+  license_file:
+    - COPYING
+    - COPYING.GPL
+  summary: 'The Advanced Linux Sound Architecture (ALSA) - plugins'
+  description: |
+    Plugins for the ALSA library, including play or capture via JACK or Pulse Audio and
+    stream conversions.
+  dev_url: https://github.com/alsa-project/alsa-plugins
+
+extra:
+  recipe-maintainers:
+    - ryanvolz


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

This adds a package for `alsa-plugins` that works with the current `alsa-libs` package but necessitates using an older `ffmpeg` build. Perhaps post-merge these can both be updated.

Initially, this pull request also includes a change to the Azure pipeline yaml files in order to test publishing artifacts.