### PR TITLE
Fix mkdir error for azure windows when dir exists

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,11 +18,14 @@ jobs:
     displayName: Install dependencies
 
   - script: |
-      export CI=azure
-      .circleci/run_docker_build.sh
+      set -e
 
       # make sure there is a package directory so that artifact publishing works
       mkdir -p build_artifacts/linux-64/
+
+      export CI=azure
+      .circleci/run_docker_build.sh
+
     displayName: Run docker build
   - publish: build_artifacts/linux-64/
     artifact: conda_pkgs_linux

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -48,6 +48,11 @@ jobs:
     displayName: Configure conda and conda-build
 
   - script: |
+      set -e
+
+      # make sure there is a package directory so that artifact publishing works
+      mkdir -p /usr/local/miniconda/conda-bld/osx-64/
+
       # Find the recipes from master in this PR and remove them.
       source activate base
 
@@ -62,7 +67,5 @@ jobs:
       # We just want to build all of the recipes.
       python .ci_support/build_all.py ./recipes
 
-      # make sure there is a package directory so that artifact publishing works
-      mkdir -p /usr/local/miniconda/conda-bld/osx-64/
   - publish: /usr/local/miniconda/conda-bld/osx-64/
     artifact: conda_pkgs_osx

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -76,14 +76,17 @@ jobs:
         for /f "tokens=*" %%a in ('git ls-tree --name-only master -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
         cd ..
 
+    - script: |
+        REM make sure there is a package directory so that artifact publishing works
+        setlocal enableextensions
+        if not exist C:\\Miniconda\\conda-bld\\win-64\\ mkdir C:\\Miniconda\\conda-bld\\win-64\\
+      displayName: Make artifact dir    
+
     # Special cased version setting some more things!
     - script: |
         git fetch --force origin master:master
         python .ci_support\build_all.py recipes --arch 64
 
-        REM make sure there is a package directory so that artifact publishing works
-        setlocal enableextensions
-        if not exist C:\\Miniconda\\conda-bld\\win-64\\ mkdir C:\\Miniconda\\conda-bld\\win-64\\
       displayName: Build recipe (maybe vs2008)
       env: {
         VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -83,7 +83,7 @@ jobs:
 
         REM make sure there is a package directory so that artifact publishing works
         setlocal enableextensions
-        mkdir C:\\Miniconda\\conda-bld\\win-64\\
+        if not exist C:\\Miniconda\\conda-bld\\win-64\\ mkdir C:\\Miniconda\\conda-bld\\win-64\\
       displayName: Build recipe (maybe vs2008)
       env: {
         VS90COMNTOOLS: "C:\\Program Files (x86)\\Common Files\\Microsoft\\Visual C++ for Python\\9.0\\VC\\bin",


### PR DESCRIPTION
Fixes error for windows build on azure when directory already exists:

https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=171315&view=logs&jobId=240f1fee-52bc-5498-a14a-8361bde76ba0&j=240f1fee-52bc-5498-a14a-8361bde76ba0&t=78a0099b-3f13-5ae9-c1f0-24f71d1eac20

@beckermr 