### PR TITLE
Add inspiral-range

### DIFF
--- a/recipes/inspiral-range/meta.yaml
+++ b/recipes/inspiral-range/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "inspiral_range" %}
+{% set version = "0.3.0" %}
+
+
+package:
+  name: {{ name|lower|replace('_', '-') }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5cd901bb6c3a328dc048dc529a5499a0cdec9f4ed102e9835a80807cb330af9f
+
+build:
+  entry_points:
+    - inspiral-range = inspiral_range.__main__:main
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - astropy
+    - python
+    - scipy
+
+test:
+  imports:
+    - inspiral_range
+  commands:
+    - inspiral-range --help
+
+about:
+  home: https://git.ligo.org/gwinc/inspiral_range
+  dev_url: https://git.ligo.org/gwinc/inspiral_range
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file:
+    - COPYING
+    - COPYING-GPL-3
+  summary: GW detector inspiral range calculation tools
+  description: |
+    The inspiral_range package provides tools for calculating various binary
+    inspiral range measures useful as figures of merit for gravitational wave
+    detectors characterised by a strain noise spectral density.
+
+    It includes a command-line tool for calculating various inspiral ranges
+    from a supplied file of detector noise spectral density (either ASD or
+    PSD).
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod
+    - jrollins

--- a/recipes/inspiral-range/meta.yaml
+++ b/recipes/inspiral-range/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "inspiral_range" %}
-{% set version = "0.3.0" %}
-
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower|replace('_', '-') }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5cd901bb6c3a328dc048dc529a5499a0cdec9f4ed102e9835a80807cb330af9f
+  sha256: 503624248d3824266889a3343611ce412d50737591e31f62287265b25c7e9a0f
 
 build:
   entry_points:
@@ -27,12 +26,13 @@ requirements:
     - scipy
 
 test:
-  requires:
-    - python-lal  # [not win]
   imports:
     - inspiral_range
+  source_files:
+    - inspiral_range/test
   commands:
-    - inspiral-range --help
+    - inspiral-range --asd inspiral_range/test/O2.txt
+    - inspiral-range --asd inspiral_range/test/O3.txt m1=30 m2=30
 
 about:
   home: https://git.ligo.org/gwinc/inspiral_range

--- a/recipes/inspiral-range/meta.yaml
+++ b/recipes/inspiral-range/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - scipy
 
 test:
+  requires:
+    - python-lal  # [not win]
   imports:
     - inspiral_range
   commands:


### PR DESCRIPTION
This PR adds a recipe for the `inspiral-range` (`inspiral_range` on pypi) package, used in gravitational-wave astrophysics.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
