### PR TITLE
Added vedo (rename of vtkplotter)

### DIFF
--- a/recipes/vedo/LICENSE.txt
+++ b/recipes/vedo/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Marco Musy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/vedo/meta.yaml
+++ b/recipes/vedo/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "vedo" %}
+{% set version = "2020.3.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c6fa05769313a2794aaa064c8d40da67d161b8bdc38b23827dbe7832f830fd62
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - vtk
+    - numpy
+
+test:
+  imports:
+    - vtkplotter
+
+about:
+  home: https://github.com/marcomusy/vtkplotter
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: A python module for scientific visualization, analysis and animation of 3D objects and point clouds based on VTK.
+  doc_url: https://vtkplotter.embl.es/
+  dev_url: https://github.com/marcomusy/vtkplotter
+
+extra:
+  recipe-maintainers:
+    - RubendeBruin
+    - marcomusy

--- a/recipes/vedo/meta.yaml
+++ b/recipes/vedo/meta.yaml
@@ -28,13 +28,13 @@ test:
     - vtkplotter
 
 about:
-  home: https://github.com/marcomusy/vtkplotter
+  home: https://github.com/marcomusy/vedo/
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: A python module for scientific visualization, analysis and animation of 3D objects and point clouds based on VTK.
-  doc_url: https://vtkplotter.embl.es/
-  dev_url: https://github.com/marcomusy/vtkplotter
+  doc_url: https://github.com/marcomusy/vedo/
+  dev_url: https://github.com/marcomusy/vedo/
 
 extra:
   recipe-maintainers:

--- a/recipes/vedo/meta.yaml
+++ b/recipes/vedo/meta.yaml
@@ -25,7 +25,7 @@ requirements:
 
 test:
   imports:
-    - vtkplotter
+    - vedo
 
 about:
   home: https://github.com/marcomusy/vedo/

--- a/recipes/vedo/yum_requirements.txt
+++ b/recipes/vedo/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGL-devel


### PR DESCRIPTION
@conda-forge/help-python , the existing package "vtkplotter" has been renamed to "vedo".

For the moment we think it is good to have the old vtkplotter and new vedo packages next to eachoter. The vtkplotter package is deprecated and will be removed in due time.

This is a copy of the existing vtk plotter feedstock with only the names and sha updated. Everything else (maintainers, license) remains unchanged.


Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

