### PR TITLE
Package memestra

### DIFF
--- a/recipes/memestra/meta.yaml
+++ b/recipes/memestra/meta.yaml
@@ -32,6 +32,8 @@ requirements:
 test:
   imports:
     - memestra
+  commands:
+    - memestra --help
 
 about:
   home: https://github.com/QuantStack/memestra

--- a/recipes/memestra/meta.yaml
+++ b/recipes/memestra/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.0.1" %}
+{% set build = 0 %}
+
+package:
+  name: memestra
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/m/memestra/memestra-{{ version }}.tar.gz
+  sha256: 055961e37a8211cc937b5571c373021e2e4c14e4cd051c88b738511d211fb1c4
+
+build:
+  number: {{ build }}
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.4.0
+    - pip
+  run:
+    - python
+    - gast
+    - beniget
+    - nbformat
+    - nbconvert
+    - pyyaml
+
+test:
+  imports:
+    - memestra
+
+about:
+  home: https://github.com/QuantStack/memestra
+  license: BSD-3-Clause
+  license_family: BSD
+  summary: Python checker for places where deprecated functions are called.
+  description: |
+    Memestra checks code for places where deprecated functions are called.
+  doc_url: https://github.com/QuantStack/memestra
+  dev_url: https://github.com/QuantStack/memestra
+
+extra:
+  recipe-maintainers:
+    - davidbrochart

--- a/recipes/memestra/meta.yaml
+++ b/recipes/memestra/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.2" %}
+{% set version = "0.0.3" %}
 {% set build = 0 %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/m/memestra/memestra-{{ version }}.tar.gz
-  sha256: 83e56251b5dc4828473d4e6f9c233579598f90ab306db2c359b22fd8dba6b270
+  sha256: 0cf015bdd9ddcc4ddcb5c6e72191ce9314df31d2006ebe61f10c3bb2e9fcb273
 
 build:
   number: {{ build }}

--- a/recipes/memestra/meta.yaml
+++ b/recipes/memestra/meta.yaml
@@ -13,6 +13,9 @@ build:
   number: {{ build }}
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - memestra = memestra.memestra:run
+    - memestra-cache = memestra.caching:run
 
 requirements:
   host:

--- a/recipes/memestra/meta.yaml
+++ b/recipes/memestra/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 {% set build = 0 %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/m/memestra/memestra-{{ version }}.tar.gz
-  sha256: 055961e37a8211cc937b5571c373021e2e4c14e4cd051c88b738511d211fb1c4
+  sha256: 83e56251b5dc4828473d4e6f9c233579598f90ab306db2c359b22fd8dba6b270
 
 build:
   number: {{ build }}
@@ -34,6 +34,7 @@ about:
   home: https://github.com/QuantStack/memestra
   license: BSD-3-Clause
   license_family: BSD
+  license_file: LICENSE
   summary: Python checker for places where deprecated functions are called.
   description: |
     Memestra checks code for places where deprecated functions are called.
@@ -43,3 +44,5 @@ about:
 extra:
   recipe-maintainers:
     - davidbrochart
+    - SylvainCorlay
+    - marimeireles


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
