### PR TITLE
macports-legacy-support: add recipe for v0.12

### DIFF
--- a/recipes/macports-legacy-support/meta.yaml
+++ b/recipes/macports-legacy-support/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "macports-legacy-support" %}
+{% set version = "0.12" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/macports/macports-legacy-support/archive/v{{ version }}.tar.gz
+  sha256: bb68d5d553eaa41768ee818c41e2cd5f5d35b51c465de9730aff9f536b931240
+
+build:
+  number: 0
+  skip: True  # [not osx]
+  script: make PREFIX=$PREFIX CFLAGS="$CPPFLAGS $CFLAGS" LDFLAGS="$LDFLAGS" install
+  run_exports:
+    # Let's trust them.
+    # xref: https://ports.macports.org/port/legacy-support/summary
+    - {{ pin_subpackage('macports-legacy-support') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/LegacySupport/time.h
+    - test -f ${PREFIX}/lib/libMacportsLegacySupport${SHLIB_EXT}
+
+about:
+  home: https://github.com/macports/macports-legacy-support
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Installs wrapper headers to add missing functionality to legacy OSX versions.'
+
+extra:
+  recipe-maintainers:
+    - nwani


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
