### PR TITLE
Add recipe for typer-cli

### DIFF
--- a/recipes/typer-cli/meta.yaml
+++ b/recipes/typer-cli/meta.yaml
@@ -22,8 +22,8 @@ requirements:
     - poetry
     - python
   run:
-    - python ~=3.6
-    - importlib_metadata ~=1.5
+    - python >=3.6,<4
+    - importlib_metadata >=1.5,<2
     - typer >=0.2.1,<0.3.0
     - colorama >=0.4.3,<0.5.0
     - shellingham >=1.3.2,<2.0.0

--- a/recipes/typer-cli/meta.yaml
+++ b/recipes/typer-cli/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "typer-cli" %}
+{% set version = "0.0.9" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name | replace('_', '-') }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 55b9794f347311e9c2fb1ce4b10a66945cd95f2f30e2452b1bf96c3ab3163632
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+  entry_point:
+    - typer = typer_cli.main:main
+
+requirements:
+  host:
+    - pip
+    - poetry
+    - python
+  run:
+    - python ~=3.6
+    - importlib_metadata ~=1.5
+    - typer >=0.2.1,<0.3.0
+    - colorama >=0.4.3,<0.5.0
+    - shellingham >=1.3.2,<2.0.0
+
+test:
+  imports:
+    - typer_cli
+
+about:
+  home: https://github.com/tiangolo/typer-cli
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Run Typer scripts with completion, without having to create a package, using Typer CLI.
+  doc_url: https://typer.tiangolo.com/typer-cli/
+
+extra:
+  recipe-maintainers:
+    - fcollonval

--- a/recipes/typer-cli/meta.yaml
+++ b/recipes/typer-cli/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
-  entry_point:
+  entry_points:
     - typer = typer_cli.main:main
 
 requirements:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
