### PR TITLE
Add recipe for filemagic

### DIFF
--- a/recipes/filemagic/meta.yaml
+++ b/recipes/filemagic/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [not linux]
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:

--- a/recipes/filemagic/meta.yaml
+++ b/recipes/filemagic/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [not linux]
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:
@@ -19,6 +19,7 @@ requirements:
     - pip
     - python
   run:
+    - libmagic
     - python
 
 test:

--- a/recipes/filemagic/meta.yaml
+++ b/recipes/filemagic/meta.yaml
@@ -21,6 +21,10 @@ requirements:
   run:
     - python
 
+test:
+  imports:
+    - magic
+
 about:
   home: "http://filemagic.readthedocs.org"
   license: Apache-2.0

--- a/recipes/filemagic/meta.yaml
+++ b/recipes/filemagic/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "filemagic" %}
+{% set version = "1.6" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "e684359ef40820fe406f0ebc5bf8a78f89717bdb7fed688af68082d991d6dbf3"
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+about:
+  home: "http://filemagic.readthedocs.org"
+  license: Apache Software License v2
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "A Python API for libmagic, the library behind the Unix file command"
+  doc_url: https://filemagic.readthedocs.io/en/latest/
+  dev_url: https://github.com/aliles/filemagic
+
+extra:
+  recipe-maintainers:
+    - fcollonval

--- a/recipes/filemagic/meta.yaml
+++ b/recipes/filemagic/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 
 about:
   home: "http://filemagic.readthedocs.org"
-  license: Apache Software License v2
+  license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE
   summary: "A Python API for libmagic, the library behind the Unix file command"


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
