### PR TITLE
add eventemitter recipe.

### DIFF
--- a/recipes/eventemitter/meta.yaml
+++ b/recipes/eventemitter/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "eventemitter" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0147a0d6fc8b03641997b337b8c755e89608bd0784335a4fec50bde1e31f8d6f
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+about:
+  home: https://github.com/asyncdef/eventemitter
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Tools for working with async events.'
+  
+  description: |
+    EventEmitter, The EventEmitter class can be used directly or as a mix-in to provide the ability to publish and subscribe to events.
+    Listener functions can be defined using def or async def. All listeners are executed in a deferred way. The coro that calls emit must yield for the event to propagate.
+    EventIterable, If the callback-style model of listening for events is undesirable, an async iterable is provided to offer a second model for handling events.
+    The EventIterable implements the async iterable interface and can be used in conjunction with any of the tools in aitertools.
+  doc_url: https://pypi.org/project/eventemitter/#description
+  dev_url: https://github.com/asyncdef/eventemitter
+
+extra:
+  recipe-maintainers:
+    - wiphoo

--- a/recipes/eventemitter/meta.yaml
+++ b/recipes/eventemitter/meta.yaml
@@ -21,6 +21,10 @@ requirements:
   run:
     - python
 
+test:
+  imports:
+    - eventemitter
+
 about:
   home: https://github.com/asyncdef/eventemitter
   license: Apache-2.0


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
