### PR TITLE
Add coverage-badge recipe

### DIFF
--- a/recipes/coverage-badge/LICENSE.txt
+++ b/recipes/coverage-badge/LICENSE.txt
@@ -1,0 +1,19 @@
+Copyright (C) 2015-2020 Danilo Bargen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/coverage-badge/meta.yaml
+++ b/recipes/coverage-badge/meta.yaml
@@ -34,7 +34,7 @@ about:
   home: "https://github.com/dbrgn/coverage-badge"
   license: MIT
   license_family: MIT
-  license_file:
+  license_file: LICENSE.txt
   summary: "Generate coverage badges for Coverage.py."
   doc_url:
   dev_url: "https://github.com/dbrgn/coverage-badge"

--- a/recipes/coverage-badge/meta.yaml
+++ b/recipes/coverage-badge/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - python
   run:
     - python
+    - setuptools
 
 test:
   imports:

--- a/recipes/coverage-badge/meta.yaml
+++ b/recipes/coverage-badge/meta.yaml
@@ -36,7 +36,6 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: "Generate coverage badges for Coverage.py."
-  doc_url:
   dev_url: "https://github.com/dbrgn/coverage-badge"
 
 extra:

--- a/recipes/coverage-badge/meta.yaml
+++ b/recipes/coverage-badge/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "coverage-badge" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 142fd121f3bd14956aff3c45bff6f8bc37bd74c6350626a950ebb6accb24276e
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - coverage-badge = coverage_badge.__main__:main
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - coverage_badge
+  commands:
+    - coverage-badge --help
+
+about:
+  home: "https://github.com/dbrgn/coverage-badge"
+  license: MIT
+  license_family: MIT
+  license_file:
+  summary: "Generate coverage badges for Coverage.py."
+  doc_url:
+  dev_url: "https://github.com/dbrgn/coverage-badge"
+
+extra:
+  recipe-maintainers:
+    - Hoxbro

--- a/recipes/coverage-badge/meta.yaml
+++ b/recipes/coverage-badge/meta.yaml
@@ -23,6 +23,7 @@ requirements:
   run:
     - python
     - setuptools
+    - coverage
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
