### PR TITLE
jupyter_to_medium package - first upload to conda forge

### DIFF
--- a/recipes/jupyter_to_medium/meta.yaml
+++ b/recipes/jupyter_to_medium/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "jupyter_to_medium" %}
+{% set version = "0.1.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5b864634bac1caf610a30a6e757179beddc54ae5c06a6434e807d1eccfdb7f66
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - jupyter_to_medium=jupyter_to_medium._command_line:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - nbconvert
+    - python >=3.6
+    - requests
+
+test:
+  imports:
+    - jupyter_to_medium
+  commands:
+    - pip check
+    - jupyter_to_medium --help
+  requires:
+    - pip
+
+about:
+  home: https://dexplo.org/jupyter_to_medium
+  summary: Publish a Jupyter Notebook as a Medium blogpost
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://dexplo.org/jupyter_to_medium
+  dev_url: https://github.com/dexplo/jupyter_to_medium
+
+extra:
+  recipe-maintainers:
+    - tdpetrou


### PR DESCRIPTION
I used grayskull adding just the doc_url and dev_url lines on my own.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
