### PR TITLE
Add rio tiler

### DIFF
--- a/recipes/rio-mucho/LICENSE
+++ b/recipes/rio-mucho/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Mapbox
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/recipes/rio-mucho/meta.yaml
+++ b/recipes/rio-mucho/meta.yaml
@@ -41,3 +41,4 @@ about:
 extra:
   recipe-maintainers:
     - lsetiawan
+    - nrweir

--- a/recipes/rio-mucho/meta.yaml
+++ b/recipes/rio-mucho/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "rio-mucho" %}
+{% set version = "1.0.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 606f662e4cc0c7efb98dd7a1eb4df9d93022a305d187b6c02574c4542593b590
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - numpy
+    - python
+    - rasterio ~=1.0
+
+test:
+  imports:
+    - riomucho
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/mapbox/rio-mucho
+  summary: Windowed multiprocessing wrapper for rasterio
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - lsetiawan

--- a/recipes/rio-mucho/meta.yaml
+++ b/recipes/rio-mucho/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - numpy
     - python
-    - rasterio ~= 1.0
+    - rasterio ~=1.0
 
 test:
   imports:

--- a/recipes/rio-mucho/meta.yaml
+++ b/recipes/rio-mucho/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - numpy
     - python
-    - rasterio ~=1.0
+    - rasterio ~= 1.0
 
 test:
   imports:

--- a/recipes/rio-tiler/LICENSE.txt
+++ b/recipes/rio-tiler/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Mapbox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/rio-tiler/meta.yaml
+++ b/recipes/rio-tiler/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - numexpr
     - numpy
     - python
-    - rasterio >= 1.1
+    - rasterio >=1.1
     - rio-toa
 
 test:

--- a/recipes/rio-tiler/meta.yaml
+++ b/recipes/rio-tiler/meta.yaml
@@ -46,3 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - lsetiawan
+    - nrweir

--- a/recipes/rio-tiler/meta.yaml
+++ b/recipes/rio-tiler/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "rio-tiler" %}
+{% set version = "1.4.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5ecfd828a72e4674669172f9baf4b6cf387d25119bc8dce603c77656d05b3f82
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - boto3
+    - mercantile
+    - numexpr
+    - numpy
+    - python
+    - rasterio>=1.1
+    - rio-toa
+
+test:
+  imports:
+    - rio_tiler
+    - rio_tiler.cmap
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/cogeotiff/rio-tiler
+  summary: Get mercator tile from CloudOptimized GeoTIFF and other cloud hosted raster such as CBERS-4, Sentinel-2, Sentinel-1 and Landsat-8 AWS PDS
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - lsetiawan

--- a/recipes/rio-tiler/meta.yaml
+++ b/recipes/rio-tiler/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - numexpr
     - numpy
     - python
-    - rasterio>=1.1
+    - rasterio >= 1.1
     - rio-toa
 
 test:

--- a/recipes/rio-toa/LICENSE.txt
+++ b/recipes/rio-toa/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2016, Mapbox
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/rio-toa/meta.yaml
+++ b/recipes/rio-toa/meta.yaml
@@ -43,3 +43,4 @@ about:
 extra:
   recipe-maintainers:
     - lsetiawan
+    - nrweir

--- a/recipes/rio-toa/meta.yaml
+++ b/recipes/rio-toa/meta.yaml
@@ -37,8 +37,8 @@ test:
 about:
   home: https://github.com/mapbox/rio-toa
   summary: Top Of Atmosphere (TOA) calculations for Landsat 8
-  license: BSD-1-Clause
-  license_file: PLEASE_ADD_LICENSE_FILE
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:

--- a/recipes/rio-toa/meta.yaml
+++ b/recipes/rio-toa/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "rio-toa" %}
+{% set version = "0.3.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2b905432d1b68addd0a27966b52a075d62845fb4232758ce767559dfa67b7e22
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - click
+    - python
+    - rasterio
+    - rio-mucho
+
+test:
+  imports:
+    - rio_toa
+    - rio_toa.scripts
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/mapbox/rio-toa
+  summary: Top Of Atmosphere (TOA) calculations for Landsat 8
+  license: BSD-1-Clause
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - lsetiawan


### PR DESCRIPTION
## Overview

This PR adds [rio-tiler](https://github.com/cogeotiff/rio-tiler/) to conda, resolving https://github.com/cogeotiff/rio-tiler/issues/112. Additionally, dependencies for rio-tiler that are not in conda already, are also added in such as [rio-toa](https://github.com/mapbox/rio-toa) and [rio-mucho](https://github.com/mapbox/rio-mucho).

## Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
