### PR TITLE
Add recipe for xcube-cds

### DIFF
--- a/recipes/xcube-cds/meta.yaml
+++ b/recipes/xcube-cds/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "xcube-cds" %}
+{% set version = "0.5.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/dcs4cop/xcube-cds/archive/v{{ version }}.tar.gz
+  sha256: 24e9c75e0ff3820f6b2aa998425094cc88ab4822a6e2c3b79ac0afa4d179e80e
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    # Python
+    - python >=3.6
+    # Required
+    - xcube >=0.5
+    - cdsapi >=0.2.7
+test:
+  imports:
+    - xcube_cds
+
+about:
+  summary: xcube plugin for the Climate Data Store (CDS) API
+  home: https://github.com/dcs4cop/xcube-cds
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  description: xcube-cds is an xcube plugin which can generate data cubes from the Copernicus Climate Data Store (CDS) API.
+  doc_url: https://github.com/dcs4cop/xcube-cds/blob/master/README.md
+  dev_url: https://github.com/dcs4cop/xcube-cds
+
+extra:
+  recipe-maintainers:
+    - pont-us


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
 (I am the only user listed in the maintainer section, and I hereby confirm that I am willing to be listed there.)
