### PR TITLE
Add google-crc32c

### DIFF
--- a/recipes/google-crc32c/meta.yaml
+++ b/recipes/google-crc32c/meta.yaml
@@ -8,11 +8,6 @@ package:
 source:
   url: https://github.com/googleapis/python-crc32c/archive/v{{ version }}.tar.gz
   sha256: 83144943a727beaffea6d133a1f9e425b46c95d8940ea429091c1c965d9c7ac7
-  # sha256 is the preferred checksum -- you can get it for a file with:
-  #  `openssl sha256 <file name>`.
-  # You may need the openssl package, available on conda-forge:
-  #  `conda install openssl -c conda-forge``
-
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"

--- a/recipes/google-crc32c/meta.yaml
+++ b/recipes/google-crc32c/meta.yaml
@@ -13,7 +13,7 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
-  build:
+  host:
     - python
     - pip
     - libcrc32c

--- a/recipes/google-crc32c/meta.yaml
+++ b/recipes/google-crc32c/meta.yaml
@@ -13,6 +13,8 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
+  build:
+   - {{ compiler('c') }}
   host:
     - python
     - pip

--- a/recipes/google-crc32c/meta.yaml
+++ b/recipes/google-crc32c/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "google-crc32c" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/googleapis/python-crc32c/archive/v{{ version }}.tar.gz
+  sha256: 83144943a727beaffea6d133a1f9e425b46c95d8940ea429091c1c965d9c7ac7
+  # sha256 is the preferred checksum -- you can get it for a file with:
+  #  `openssl sha256 <file name>`.
+  # You may need the openssl package, available on conda-forge:
+  #  `conda install openssl -c conda-forge``
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - python
+    - pip
+    - libcrc32c
+    - cffi >=1.0.0
+  run:
+    - python
+    - libcrc32c
+    - cffi >=1.0.0
+
+test:
+  requires:
+    - python
+    - pip
+  imports:
+    - crc32c
+    - crc32c.cffi
+  commands:
+    - python -m pip check
+
+
+about:
+  home: https://github.com/googleapis/python-crc32c
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Python wrapper for a hardware-based implementation of the CRC32C hashing algorithm'
+
+  description: |
+    google-crc32c wraps the libcrc32c
+    <https://github.com/google/crc32c> package, which is a hardware-based
+    implementation of the CRC32C hashing algorithm.
+  doc_url: https://github.com/googleapis/python-crc32c
+  dev_url: https://github.com/googleapis/python-crc32c
+
+extra:
+  recipe-maintainers:
+    - tswast

--- a/recipes/google-crc32c/meta.yaml
+++ b/recipes/google-crc32c/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - cffi >=1.0.0
   run:
     - python
-    - libcrc32c
     - cffi >=1.0.0
 
 test:


### PR DESCRIPTION
Upstream: https://github.com/googleapis/python-crc32c

python/c hybrid `@conda-forge/help-python-c`

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] N/A, depending on `libcrc32c` for dynamic linking ~If static libraries are linked in, the license of the static library is packaged.~ 
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

@xhochy Would you like to be added as a maintainer here? I see you're the lone maintainer of libcrc32c at the moment (I'd be glad to help out over on that repo)

Closes #12173 