### PR TITLE
Add astroalign to conda-forge

### DIFF
--- a/recipes/astroalign/meta.yaml
+++ b/recipes/astroalign/meta.yaml
@@ -25,6 +25,10 @@ requirements:
     - scipy >=0.15
     - sep
 
+test:
+  imports:
+    - astroalign
+
 about:
   home: https://astroalign.readthedocs.io/
   license: MIT

--- a/recipes/astroalign/meta.yaml
+++ b/recipes/astroalign/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "astroalign" %}
+{% set version = "2.0.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: f88b47f6383309840c6d4c7f7d47b61111b51bf9d55162a11de1595264139ee0
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - numpy >=1.6.2
+    - python
+    - scikit-image
+    - scipy >=0.15
+    - sep
+
+about:
+  home: https://astroalign.readthedocs.io/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: "A tool to align astronomical images based on asterism matching"
+  description: |
+    ASTROALIGN is a python module that will try to align two stellar
+    astronomical images, especially when there is no WCS information available.
+
+    It does so by finding similar 3-point asterisms (triangles) in both images
+    and deducing the affine transformation between them.
+  doc_url: https://astroalign.readthedocs.io/
+  dev_url: https://github.com/toros-astro/astroalign
+
+extra:
+  recipe-maintainers:
+    - mwcraig


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
