### PR TITLE
Add email-validator

### DIFF
--- a/recipes/email-validator/meta.yaml
+++ b/recipes/email-validator/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "email-validator" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/JoshData/python-email-validator/archive/v{{ version }}.tar.gz
+  sha256: 4970d17437d3bb1a5318f1fcd22b1117858d9d6e12657501279e862d98339a1d
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - email_validator=email_validator:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - dnspython >=1.15.0
+    - idna >=2.0.0
+    - pip
+    - python
+  run:
+    - dnspython >=1.15.0
+    - idna >=2.0.0
+    - python
+
+test:
+  source_files:
+    - tests
+  requires:
+    - coverage
+    - docutils
+    - flake8
+    - pytest
+    - pytest-cov
+  imports:
+    - email_validator
+  commands:
+    - email_validator --help
+    - pytest --cov=email_validator
+
+about:
+  home: https://github.com/JoshData/python-email-validator
+  license: CC0-1.0
+  license_family: CC
+  license_file: LICENSE
+  summary: A robust email syntax and deliverability validation library for Python 2.x/3.x.
+  doc_url: https://github.com/JoshData/python-email-validator
+  dev_url: https://github.com/JoshData/python-email-validator
+
+extra:
+  recipe-maintainers:
+    - xylar


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
