### PR TITLE
Add sbpy to conda-forge

### DIFF
--- a/recipes/sbpy/meta.yaml
+++ b/recipes/sbpy/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "sbpy" %}
+{% set version = "0.2.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 07fe29c0c46af723043f78aa00914cffba1dceb01b90bc6f934810f982a8e76f
+  patches:
+    - setup.cfg.patch
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy >=1.13.0
+    - astropy >=3.0
+    - matplotlib
+    - ads
+    - synphot
+    - astroquery >=0.4.1.dev0
+
+test:
+  imports:
+    - sbpy
+    - sbpy.units
+    - sbpy.obsutil
+    - sbpy.photometry
+
+about:
+  home: https://sbpy.org/
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.rst
+  summary: 'sbpy is a Python package for small-body planetary astronomy.'
+  description: |
+    sbpy is a community effort to build a Python package for small-body
+    planetary astronomy in the form of an Astropy affiliated package. The
+    goal is to collect and implement well-tested and well-documented code
+    for the scientific study of asteroids and comets, including (but not
+    limited to) observation planning, photometric models, spectroscopic
+    analysis, asteroid thermal models, lightcurve and shape tools, and
+    access tools for relevant databases.
+  doc_url: https://sbpy.readthedocs.io/
+  dev_url: https://github.com/NASA-Planetary-Science/sbpy
+
+extra:
+  recipe-maintainers:
+    - mwcraig

--- a/recipes/sbpy/meta.yaml
+++ b/recipes/sbpy/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - numpy >=1.13.0
     - astropy >=3.0
-    - matplotlib
+    - matplotlib-base
     - ads
     - synphot
     - astroquery >=0.4.1

--- a/recipes/sbpy/meta.yaml
+++ b/recipes/sbpy/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - matplotlib
     - ads
     - synphot
-    - astroquery >=0.4.1.dev0
+    - astroquery >=0.4.1
 
 test:
   imports:

--- a/recipes/sbpy/setup.cfg.patch
+++ b/recipes/sbpy/setup.cfg.patch
@@ -1,12 +1,27 @@
 diff --git a/setup.cfg b/setup.cfg
-index 1065384..fc3f6b5 100644
+index 1065384..6a49338 100644
 --- a/setup.cfg
 +++ b/setup.cfg
-@@ -21,6 +21,7 @@ remote_data_strict = True
+@@ -21,11 +21,12 @@ remote_data_strict = True
  
  [ah_bootstrap]
  auto_use = True
-+auto_upgrade = False
++offline = True
  
  [metadata]
  package_name = sbpy
+ description = A Python Module for Small-Body Planetary Astronomy
+-long_description = 
++long_description =
+ author = sbpy team
+ author_email = msk@astro.umd.edu
+ license = BSD 3-Clause
+@@ -62,8 +63,3 @@ ignore = E402,E741,E226,E501
+ # Excluding files that are directly copied from the package template or
+ # generated
+ exclude = _astropy_init.py,version.py,ah_bootstrap.py
+-
+-
+-[entry_points]
+-
+-astropy-package-template-example = packagename.example_mod:main

--- a/recipes/sbpy/setup.cfg.patch
+++ b/recipes/sbpy/setup.cfg.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.cfg b/setup.cfg
+index 1065384..fc3f6b5 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -21,6 +21,7 @@ remote_data_strict = True
+ 
+ [ah_bootstrap]
+ auto_use = True
++auto_upgrade = False
+ 
+ [metadata]
+ package_name = sbpy


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

The patch is necessary to prevent `astropy-helpers` from trying to auto-update during the build.