### PR TITLE
Add soapysdr-module-remote.

### DIFF
--- a/recipes/soapysdr-module-remote/bld.bat
+++ b/recipes/soapysdr-module-remote/bld.bat
@@ -1,0 +1,23 @@
+setlocal EnableDelayedExpansion
+@echo on
+
+:: Make a build folder and change to it
+mkdir build
+cd build
+
+:: configure
+cmake -G "Ninja" ^
+    -DCMAKE_BUILD_TYPE:STRING=Release ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+    -DLIB_SUFFIX:STRING="" ^
+    ..
+if errorlevel 1 exit 1
+
+:: build
+cmake --build . --config Release -- -j%CPU_COUNT%
+if errorlevel 1 exit 1
+
+:: install
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/soapysdr-module-remote/build.sh
+++ b/recipes/soapysdr-module-remote/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+mkdir build
+cd build
+
+cmake_config_args=(
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX=$PREFIX
+    -DLIB_SUFFIX=""
+)
+
+cmake .. "${cmake_config_args[@]}"
+cmake --build . --config Release -- -j${CPU_COUNT}
+cmake --build . --config Release --target install

--- a/recipes/soapysdr-module-remote/meta.yaml
+++ b/recipes/soapysdr-module-remote/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "soapysdr-module-remote" %}
+{% set version = "0.5.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: https://github.com/pothosware/SoapyRemote/archive/soapy-remote-{{ version }}.tar.gz
+  sha256: 66a372d85c984e7279b4fdc0a7f5b0d7ba340e390bc4b8bd626a6523cd3c3c76
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('soapysdr-module-remote', max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja  # [win]
+  host:
+    - soapysdr
+
+test:
+  commands:
+    # verify that libraries get installed
+    - test -f $PREFIX/lib/SoapySDR/modules0.7/libremoteSupport.so  # [not win]
+    - if not exist %PREFIX%\\Library\\lib\\SoapySDR\\modules0.7\\remoteSupport.dll exit 1  # [win]
+
+    # show info to see if module is detected
+    - SoapySDRUtil --info
+
+    # test that the remote server can run
+    - SoapySDRServer --help
+
+about:
+  home: https://github.com/pothosware/SoapyRemote/wiki
+  license: BSL-1.0
+  license_file: LICENSE_1_0.txt
+  summary: 'SoapySDR remote module, use any Soapy SDR remotely'
+  description: |
+    Use any SoapySDR supported device transparently over a local network link.
+    The remote support feature can turn any SDR into a network peripheral.
+  doc_url: https://github.com/pothosware/SoapyRemote/wiki
+  dev_url: https://github.com/pothosware/SoapyRemote
+
+extra:
+  recipe-maintainers:
+    - petrushy
+    - ryanvolz


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
