### PR TITLE
Add coin or split packages

### DIFF
--- a/recipes/Cbc/build.sh
+++ b/recipes/Cbc/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+UNAME="$(uname)"
+export CFLAGS="${CFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
+
+# Use only 1 thread with OpenBLAS to avoid timeouts on CIs.
+# This should have no other affect on the build. A user
+# should still be able to set this (or not) to a different
+# value at run-time to get the expected amount of parallelism.
+export OPENBLAS_NUM_THREADS=1
+
+WITH_BLAS_LIB="-L${PREFIX}/lib -lblas"
+WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
+
+./configure --prefix="${PREFIX}" --exec-prefix="${PREFIX}" \
+  --with-blas-lib="${WITH_BLAS_LIB}" \
+  --with-lapack-lib="${WITH_LAPACK_LIB}" \
+  --enable-cbc-parallel \
+  --enable-gnu-packages \
+  || { echo "PRINTING CONFIG.LOG"; cat config.log; echo "PRINTING CoinUtils/CONFIG.LOG"; cat CoinUtils/config.log; exit 1; }
+make -j "${CPU_COUNT}"
+
+# if [ "${UNAME}" == "Linux" ]; then
+#   make test
+# fi
+make install

--- a/recipes/Cbc/build.sh
+++ b/recipes/Cbc/build.sh
@@ -23,7 +23,4 @@ WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
   || { echo "PRINTING CONFIG.LOG"; cat config.log; echo "PRINTING CoinUtils/CONFIG.LOG"; cat CoinUtils/config.log; exit 1; }
 make -j "${CPU_COUNT}"
 
-# if [ "${UNAME}" == "Linux" ]; then
-#   make test
-# fi
 make install

--- a/recipes/Cbc/meta.yaml
+++ b/recipes/Cbc/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "coin-or-cbc" %}
+{% set version = "2.10.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/coin-or/Cbc/archive/releases/{{ version }}.tar.gz
+    sha256: 601a7084e75955f98ccf1ef982d272cbe7f34558c527dadc661d49e6f0fc58a3
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config
+    - make  # [unix]
+  host:
+    - coin-or-utils
+    - coin-or-cgl
+    - coin-or-clp
+    - coin-or-osi
+    - libblas
+    - libcblas
+    - liblapack
+    - readline  # [unix]
+    - zlib
+    - bzip2
+    # - mumps
+    # - nauty
+    - ncurses
+    # TODO upstream should link with blas, not openblas
+    - openblas
+  run:
+    - ncurses
+    - openblas
+  run_constrained:
+    - coincbc * metapackage
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libCbc${SHLIB_EXT}
+    - test -f $PREFIX/include/coin/CbcConfig.h
+    - test -f $PREFIX/lib/libCbcSolver${SHLIB_EXT}
+    - test -f $PREFIX/lib/libOsiCbc${SHLIB_EXT}
+
+about:
+  home: https://projects.coin-or.org/Cbc
+  dev_url: https://github.com/coin-or/Cbc
+  license: EPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'COIN-OR branch and cut (Cbc)'
+  description: |
+    Cbc (Coin-or branch and cut) is an open-source mixed integer linear
+    programming solver written in C++. It can be used as a callable library or
+    using a stand-alone executable. It can be called through AIMMS (through the
+    AIMMSlinks project), AMPL (natively), CMPL, GAMS (through the GAMSlinks
+    project), JuMP, Mathematica, MiniZinc, MPL (through the CoinMP project), PuLP,
+    Python (e.g., cbcpy), and OpenSolver for Excel, among others.
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - tkralphs

--- a/recipes/Cbc/meta.yaml
+++ b/recipes/Cbc/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - ncurses
     - openblas
   run_constrained:
-    - coincbc * metapackage
+    - coincbc * *_metapackage
 
 test:
   commands:

--- a/recipes/Cbc/meta.yaml
+++ b/recipes/Cbc/meta.yaml
@@ -50,6 +50,7 @@ test:
     - test -f $PREFIX/include/coin/CbcConfig.h
     - test -f $PREFIX/lib/libCbcSolver${SHLIB_EXT}
     - test -f $PREFIX/lib/libOsiCbc${SHLIB_EXT}
+    - echo ? | cbc
 
 about:
   home: https://projects.coin-or.org/Cbc

--- a/recipes/Cbc/meta.yaml
+++ b/recipes/Cbc/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - readline  # [unix]
     - zlib
     - bzip2
+    # mumps and nauty are optional deps. currently outdated, leading to solver issues on osx
     # - mumps
     # - nauty
     - ncurses

--- a/recipes/Cgl/build.sh
+++ b/recipes/Cgl/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+UNAME="$(uname)"
+export CFLAGS="${CFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
+
+if [ "${UNAME}" == "Linux" ]; then
+	export FLIBS="-lgcc_s -lgcc -lstdc++ -lm"
+fi
+
+# Use only 1 thread with OpenBLAS to avoid timeouts on CIs.
+# This should have no other affect on the build. A user
+# should still be able to set this (or not) to a different
+# value at run-time to get the expected amount of parallelism.
+export OPENBLAS_NUM_THREADS=1
+
+./configure \
+    --prefix="${PREFIX}" \
+    --exec-prefix="${PREFIX}" \
+    --enable-gnu-packages
+
+make -j "${CPU_COUNT}"
+# if [ "${UNAME}" == "Linux" ]; then
+#   make test
+# fi
+make install

--- a/recipes/Cgl/build.sh
+++ b/recipes/Cgl/build.sh
@@ -22,7 +22,4 @@ export OPENBLAS_NUM_THREADS=1
     --enable-gnu-packages
 
 make -j "${CPU_COUNT}"
-# if [ "${UNAME}" == "Linux" ]; then
-#   make test
-# fi
 make install

--- a/recipes/Cgl/meta.yaml
+++ b/recipes/Cgl/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "coin-or-cgl" %}
+{% set version = "0.60.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/coin-or/Cgl/archive/releases/{{ version }}.tar.gz
+    sha256: cfeeedd68feab7c0ce377eb9c7b61715120478f12c4dd0064b05ad640e20f3fb
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config
+    - make  # [unix]
+  host:
+    - coin-or-utils
+    - coin-or-osi
+    - coin-or-clp
+    - libblas
+    - libcblas
+    - liblapack
+    - zlib
+    - bzip2
+    - ncurses
+    - readline
+  run:
+    - ncurses
+    - readline
+  run_constrained:
+    - coincbc * metapackage
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libCgl${SHLIB_EXT}
+    - test -f $PREFIX/include/coin/CglAllDifferent.hpp
+
+about:
+  home: https://projects.coin-or.org/Cgl
+  dev_url: https://github.com/coin-or/Cgl
+  license: EPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'COIN-OR Cut Generation Library (Cgl)'
+  description: |
+    The COIN-OR Cut Generation Library (Cgl) is a collection of cut generators
+    that can be used with other COIN-OR packages that make use of cuts, such as,
+    among others, the linear solver Clp or the mixed integer linear programming
+    solvers Cbc or BCP. Cgl uses the abstract class OsiSolverInterface (see Osi)
+    to use or communicate with a solver. It does not directly call a solver.
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - tkralphs

--- a/recipes/Cgl/meta.yaml
+++ b/recipes/Cgl/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - ncurses
     - readline
   run_constrained:
-    - coincbc * metapackage
+    - coincbc * *_metapackage
 
 test:
   commands:

--- a/recipes/Clp/build.sh
+++ b/recipes/Clp/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+UNAME="$(uname)"
+export CFLAGS="${CFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
+
+if [ "${UNAME}" == "Linux" ]; then
+    export FLIBS="-lgcc_s -lgcc -lstdc++ -lm"
+fi
+
+# Use only 1 thread with OpenBLAS to avoid timeouts on CIs.
+# This should have no other affect on the build. A user
+# should still be able to set this (or not) to a different
+# value at run-time to get the expected amount of parallelism.
+export OPENBLAS_NUM_THREADS=1
+
+WITH_BLAS_LIB="-L${PREFIX}/lib -lblas"
+WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
+
+./configure \
+    --prefix="${PREFIX}" \
+    --exec-prefix="${PREFIX}" \
+    --with-blas-lib="${WITH_BLAS_LIB}" \
+    --with-lapack-lib="${WITH_LAPACK_LIB}" \
+    --enable-gnu-packages
+
+make -j "${CPU_COUNT}"
+# if [ "${UNAME}" == "Linux" ]; then
+#   make test
+# fi
+make install

--- a/recipes/Clp/build.sh
+++ b/recipes/Clp/build.sh
@@ -27,7 +27,4 @@ WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
     --enable-gnu-packages
 
 make -j "${CPU_COUNT}"
-# if [ "${UNAME}" == "Linux" ]; then
-#   make test
-# fi
 make install

--- a/recipes/Clp/meta.yaml
+++ b/recipes/Clp/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "coin-or-clp" %}
+{% set version = "1.17.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/coin-or/Clp/archive/releases/{{ version }}.tar.gz
+    sha256: ef412cde00cb1313d9041115a700d8d59d4b8b8b5e4dde43e9deb5108fcfbea8
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - pkg-config
+    - make  # [unix]
+  host:
+    - coin-or-utils
+    - coin-or-osi
+    - libblas
+    - libcblas
+    - liblapack
+    - readline  # [unix]
+    - zlib
+    - bzip2
+    - ncurses
+  run:
+    - ncurses
+  run_constrained:
+    - coincbc * metapackage
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libClp${SHLIB_EXT}
+    - test -f $PREFIX/lib/libOsiClp${SHLIB_EXT}
+    - test -f $PREFIX/include/coin/ClpGubDynamicMatrix.hpp
+    - test -f $PREFIX/include/coin/OsiClpSolverInterface.hpp
+
+about:
+  home: https://projects.coin-or.org/Clp
+  dev_url: https://github.com/coin-or/Clp
+  license: EPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'COIN-OR linear programming (Clp)'
+  description: |
+    Clp (Coin-or linear programming) is an open-source linear programming solver.
+    It is primarily meant to be used as a callable library, but a basic,
+    stand-alone executable version is also available. It is designed to find
+    solutions of mathematical optimization problems of the form
+
+    minimize c'x such that lhs ≤ Ax ≤ rhs and lb ≤ x ≤ ub
+
+    CLP includes primal and dual Simplex solvers. Both dual and primal algorithms can use matrix storage methods provided by the user (0-1 and network matrices are already supported in addition to the default sparse matrix). The dual algorithm has Dantzig and Steepest edge row pivot choices; new ones may be provided by the user. The same is true for the column pivot choice of the primal algorithm. The primal can also use a non linear cost which should work for piecewise linear convex functions. CLP also includes a barrier method for solving LPs.
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - tkralphs

--- a/recipes/Clp/meta.yaml
+++ b/recipes/Clp/meta.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - ncurses
   run_constrained:
-    - coincbc * metapackage
+    - coincbc * *_metapackage
 
 test:
   commands:

--- a/recipes/Clp/meta.yaml
+++ b/recipes/Clp/meta.yaml
@@ -43,6 +43,7 @@ test:
     - test -f $PREFIX/lib/libOsiClp${SHLIB_EXT}
     - test -f $PREFIX/include/coin/ClpGubDynamicMatrix.hpp
     - test -f $PREFIX/include/coin/OsiClpSolverInterface.hpp
+    - echo ? | clp
 
 about:
   home: https://projects.coin-or.org/Clp

--- a/recipes/CoinUtils/build.sh
+++ b/recipes/CoinUtils/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+UNAME="$(uname)"
+export CFLAGS="${CFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
+
+if [ "${UNAME}" == "Linux" ]; then
+    export FLIBS="-lgcc_s -lgcc -lstdc++ -lm"
+fi
+
+# Use only 1 thread with OpenBLAS to avoid timeouts on CIs.
+# This should have no other affect on the build. A user
+# should still be able to set this (or not) to a different
+# value at run-time to get the expected amount of parallelism.
+export OPENBLAS_NUM_THREADS=1
+
+WITH_BLAS_LIB="-L${PREFIX}/lib -lblas"
+WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
+
+./configure \
+    --prefix="${PREFIX}" \
+    --exec-prefix="${PREFIX}" \
+    --with-blas-lib="${WITH_BLAS_LIB}" \
+    --with-lapack-lib="${WITH_LAPACK_LIB}" \
+
+make -j "${CPU_COUNT}"
+# if [ "${UNAME}" == "Linux" ]; then
+#   make test
+# fi
+make install

--- a/recipes/CoinUtils/build.sh
+++ b/recipes/CoinUtils/build.sh
@@ -26,7 +26,4 @@ WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
     --with-lapack-lib="${WITH_LAPACK_LIB}" \
 
 make -j "${CPU_COUNT}"
-# if [ "${UNAME}" == "Linux" ]; then
-#   make test
-# fi
 make install

--- a/recipes/CoinUtils/meta.yaml
+++ b/recipes/CoinUtils/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "coin-or-utils" %}
+{% set version = "2.11.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/coin-or/CoinUtils/archive/releases/{{ version }}.tar.gz
+    sha256: d4effff4452e73356eed9f889efd9c44fe9cd68bd37b608a5ebb2c58bd45ef81
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - pkg-config
+    - make  # [unix]
+  host:
+    - zlib
+    - bzip2
+    - libblas
+    - libcblas
+    - liblapack
+    - liblapacke
+  run_constrained:
+    - coincbc * metapackage
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libCoinUtils${SHLIB_EXT}
+    - test -f $PREFIX/include/coin/CoinSort.hpp
+
+about:
+  home: https://projects.coin-or.org/CoinUtils
+  dev_url: https://github.com/coin-or/CoinUtils
+  license: EPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'COIN-OR Utilities (CoinUtils)'
+  description: |
+    CoinUtils (Coin-OR Utilities) is an open-source collection of classes and
+    functions that are generally useful to more than one COIN-OR project. These
+    utilities include:
+
+      - classes for storing and manipulating sparse matrices and vectors,
+      - performing matrix factorization,
+      - parsing input files in standard formats, e.g. MPS,
+      - building representations of mathematical programs,
+      - performing simple presolve operations,
+      - warm starting algorithms for mathematical programs, and
+      - comparing floating point numbers with a tolerance, among others.
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - tkralphs

--- a/recipes/CoinUtils/meta.yaml
+++ b/recipes/CoinUtils/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - liblapack
     - liblapacke
   run_constrained:
-    - coincbc * metapackage
+    - coincbc * *_metapackage
 
 test:
   commands:

--- a/recipes/Osi/build.sh
+++ b/recipes/Osi/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+UNAME="$(uname)"
+export CFLAGS="${CFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS} -O3"
+export CXXFLAGS="${CXXFLAGS//-std=c++17/-std=c++11}"
+
+if [ "${UNAME}" == "Linux" ]; then
+    export FLIBS="-lgcc_s -lgcc -lstdc++ -lm"
+fi
+
+# Use only 1 thread with OpenBLAS to avoid timeouts on CIs.
+# This should have no other affect on the build. A user
+# should still be able to set this (or not) to a different
+# value at run-time to get the expected amount of parallelism.
+export OPENBLAS_NUM_THREADS=1
+
+WITH_BLAS_LIB="-L${PREFIX}/lib -lblas"
+WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
+
+./configure \
+    --prefix="${PREFIX}" \
+    --exec-prefix="${PREFIX}" \
+    --with-blas-lib="${WITH_BLAS_LIB}" \
+    --with-lapack-lib="${WITH_LAPACK_LIB}" \
+
+make -j "${CPU_COUNT}"
+# if [ "${UNAME}" == "Linux" ]; then
+#   make test
+# fi
+make install

--- a/recipes/Osi/build.sh
+++ b/recipes/Osi/build.sh
@@ -26,7 +26,4 @@ WITH_LAPACK_LIB="-L${PREFIX}/lib -llapack"
     --with-lapack-lib="${WITH_LAPACK_LIB}" \
 
 make -j "${CPU_COUNT}"
-# if [ "${UNAME}" == "Linux" ]; then
-#   make test
-# fi
 make install

--- a/recipes/Osi/meta.yaml
+++ b/recipes/Osi/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "coin-or-osi" %}
+{% set version = "0.108.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/coin-or/Osi/archive/releases/{{ version }}.tar.gz
+    sha256: 984a5886825e2da9bf44d8a665f4b92812f0700e451c12baf9883eaa2315fad5
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - pkg-config
+    - make  # [unix]
+  host:
+    - coin-or-utils
+    - zlib
+    - bzip2
+    - libblas
+    - libcblas
+    - liblapack
+  run_constrained:
+    - coincbc * metapackage
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libOsi${SHLIB_EXT}
+    - test -f $PREFIX/include/coin/OsiConfig.h
+
+about:
+  home: https://github.com/coin-or/Osi
+  dev_url: https://github.com/coin-or/Osi
+  license: EPL-2.0
+  license_family: OTHER
+  license_file: LICENSE
+  summary: 'Coin OR Open Solver Interface (OSI)'
+  description: |
+    Osi (Open Solver Interface) provides an abstract base class to a generic
+    linear programming (LP) solver, along with derived classes for specific
+    solvers. Many applications may be able to use the Osi to insulate themselves
+    from a specific LP solver. That is, programs written to the OSI standard may
+    be linked to any solver with an OSI interface and should produce correct
+    results. The OSI has been significantly extended compared to its first
+    incarnation. Currently, the OSI supports linear programming solvers and has
+    rudimentary support for integer programming. Among others the following
+    operations are supported:
+
+      - creating the LP formulation;
+      - directly modifying the formulation by adding rows/columns;
+      - modifying the formulation by adding cutting planes provided by CGL;
+      - solving the formulation (and resolving after modifications);
+      - extracting solution information;
+      - invoking the underlying solver's branch-and-bound component.
+
+extra:
+  recipe-maintainers:
+    - wolfv
+    - tkralphs

--- a/recipes/Osi/meta.yaml
+++ b/recipes/Osi/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - libcblas
     - liblapack
   run_constrained:
-    - coincbc * metapackage
+    - coincbc * *_metapackage
 
 test:
   commands:


### PR DESCRIPTION
Coincbc is currently available on conda-forge, but that package vendors quite some individual libraries. 

This is an attempt to split those up.

ping @scopatz @tkralphs @isuruf 

Those are the libraries that I built back in the days to support Google ortools, which I am still very interested in having on conda-forge because it's awesome. cc @mizux @lperron