### PR TITLE
Add doctr-versions-menu

### DIFF
--- a/recipes/doctr-versions-menu/0001-no_unicode.patch
+++ b/recipes/doctr-versions-menu/0001-no_unicode.patch
@@ -1,0 +1,26 @@
+diff --git a/docs/command.rst b/docs/command.rst
+index c61993a..2d7cc0a 100644
+--- a/docs/command.rst
++++ b/docs/command.rst
+@@ -182,7 +182,7 @@ variable "folder" for rendering. For example,
+ 
+     doctr-versions-menu --label '<releases>'  "{{ folder | replace('v', '', 1) }}" --label master '{{ folder }} (latest dev branch)'
+ 
+-drops the initial "v" from the folder name of released versions (``v1.0.0`` →
++drops the initial "v" from the folder name of released versions (``v1.0.0`` ->
+ ``1.0.0``) and appends a label " (latest dev branch)" to the label for the
+ ``master`` folder.
+ 
+diff --git a/src/doctr_versions_menu/cli.py b/src/doctr_versions_menu/cli.py
+index 75c3fec..cb0d3e7 100644
+--- a/src/doctr_versions_menu/cli.py
++++ b/src/doctr_versions_menu/cli.py
+@@ -222,7 +222,7 @@ def main(
+     file (``doctr-versions-menu.conf`` in the ``gh-pages`` root)
+     instead of via command line flags. Every long-form-flag has a corresponding
+     config file variable, obtained by replacing hyphens with underscores
+-    (``--write-index-html`` → ``write_index_html``).
++    (``--write-index-html`` -> ``write_index_html``).
+     """
+     logging.basicConfig(level=logging.WARNING)
+     logger = logging.getLogger(__name__)

--- a/recipes/doctr-versions-menu/meta.yaml
+++ b/recipes/doctr-versions-menu/meta.yaml
@@ -7,7 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/doctr_versions_menu-{{ version }}.tar.gz
-  sha256: 2713d6923639c9a8e96894b340d5e0780c2c923c3d785ec94a2c6196e9d4fe45 
+  sha256: 2713d6923639c9a8e96894b340d5e0780c2c923c3d785ec94a2c6196e9d4fe45
+  patches:
+    - 00001-no_unicode.patch
 
 build:
   noarch: python

--- a/recipes/doctr-versions-menu/meta.yaml
+++ b/recipes/doctr-versions-menu/meta.yaml
@@ -18,12 +18,12 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.5
     - pip
     - setuptools
 
   run:
-    - python
+    - python >=3.5
     - click >=6.7
     - configobj >=5.0.6
     - doctr
@@ -49,4 +49,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - hhslepicka 
+    - hhslepicka

--- a/recipes/doctr-versions-menu/meta.yaml
+++ b/recipes/doctr-versions-menu/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/doctr_versions_menu-{{ version }}.tar.gz
   sha256: 2713d6923639c9a8e96894b340d5e0780c2c923c3d785ec94a2c6196e9d4fe45 
 
 build:
@@ -44,8 +44,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: 'Sphinx extension and command to add a versions menu to Doctr-deployed documentation'
-  doc_url: https://simplejson.readthedocs.io/
-  dev_url: https://goerz.github.io/doctr_versions_menu
+  doc_url: https://goerz.github.io/doctr_versions_menu
+  dev_url: https://github.com/goerz/doctr_versions_menu
 
 extra:
   recipe-maintainers:

--- a/recipes/doctr-versions-menu/meta.yaml
+++ b/recipes/doctr-versions-menu/meta.yaml
@@ -9,7 +9,7 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/doctr_versions_menu-{{ version }}.tar.gz
   sha256: 2713d6923639c9a8e96894b340d5e0780c2c923c3d785ec94a2c6196e9d4fe45
   patches:
-    - 00001-no_unicode.patch
+    - 0001-no_unicode.patch
 
 build:
   noarch: python

--- a/recipes/doctr-versions-menu/meta.yaml
+++ b/recipes/doctr-versions-menu/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/doctr_versions_menu-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/doctr_versions_menu-{{ version }}.tar.gz
   sha256: 2713d6923639c9a8e96894b340d5e0780c2c923c3d785ec94a2c6196e9d4fe45 
 
 build:

--- a/recipes/doctr-versions-menu/meta.yaml
+++ b/recipes/doctr-versions-menu/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "doctr-versions-menu" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 2713d6923639c9a8e96894b340d5e0780c2c923c3d785ec94a2c6196e9d4fe45 
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - doctr-versions-menu = doctr_versions_menu.cli:main
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+
+  run:
+    - python
+    - click >=6.7
+    - configobj >=5.0.6
+    - doctr
+    - packaging
+    - pyparsing
+    - sphinx
+
+test:
+  imports:
+    - doctr_versions_menu
+
+  commands:
+    - doctr-versions-menu --help
+
+about:
+  home: https://github.com/goerz/doctr_versions_menu
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Sphinx extension and command to add a versions menu to Doctr-deployed documentation'
+  doc_url: https://simplejson.readthedocs.io/
+  dev_url: https://goerz.github.io/doctr_versions_menu
+
+extra:
+  recipe-maintainers:
+    - hhslepicka 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

Attn. @goerz would you like to be added as maintainer of this feedstock as well?