### PR TITLE
PROD move to 3.X for ci setup

### DIFF
--- a/.circleci/build_steps.sh
+++ b/.circleci/build_steps.sh
@@ -42,7 +42,7 @@ export CONDA_NPY='19'
 # Make sure build_artifacts is a valid channel
 conda index /home/conda/staged-recipes/build_artifacts
 
-conda install --yes --quiet "conda>4.7.12" conda-forge-ci-setup=2.* conda-forge-pinning networkx=2.3 "conda-build>=3.16"
+conda install --yes --quiet "conda>4.7.12" conda-forge-ci-setup=3.* conda-forge-pinning networkx=2.3 "conda-build>=3.16"
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/staged-recipes}"
 export CI_SUPPORT="/home/conda/.ci_support"
 setup_conda_rc "${FEEDSTOCK_ROOT}" "/home/conda/conda-recipes" "${CI_SUPPORT}/${CONFIG}.yaml"


### PR DESCRIPTION
This PR moves staged recipes to the latest ci setup scripts

cc @conda-forge/staged-recipes @conda-forge/core 