### PR TITLE
add pytest-nunit 0.5.3

### DIFF
--- a/recipes/pytest-nunit/meta.yaml
+++ b/recipes/pytest-nunit/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "pytest-nunit" %}
+{% set version = "0.5.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 3c298627b57debbd4bfe9d47604129f84f19ecdb7db36c63110af0ab4b9c13e7
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - attrs
+    - pytest >=3.5.0
+    - python
+
+test:
+  imports:
+    - pytest_nunit
+    - pytest_nunit.models
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pytest-dev/pytest-nunit
+  summary: A pytest plugin for generating NUnit3 test result XML output
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there


Notes:
- quick grayskull job, minor adjustments
  - removed the py27 stuff, made noarch
- this is an up-coming dependency of @conda-forge/pytest-azurepipelines 1.0, but already appears to work without that release