### PR TITLE
add datefinder python package

### DIFF
--- a/recipes/datefinder/meta.yaml
+++ b/recipes/datefinder/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://github.com/akoumjian/datefinder/archive/v0.7.1.tar.gz"
+  url: "https://github.com/akoumjian/datefinder/archive/v{{ version}}.tar.gz"
   sha256: acab2bebfdb09fdc9e9d512b280bf676a9a03f286c666234d50cfe65a5da7f7d
 
 build:
@@ -17,9 +17,7 @@ build:
 requirements:
   host:
     - python
-    - regex >=2017.02.08
-    - python-dateutil >=2.4.2
-    - pytz
+    - pip
 
   run:
     - python

--- a/recipes/datefinder/meta.yaml
+++ b/recipes/datefinder/meta.yaml
@@ -17,16 +17,15 @@ build:
 requirements:
   host:
     - python
-    - regex>=2017.02.08 
-    - python-dateutil>=2.4.2
+    - regex >=2017.02.08
+    - python-dateutil >=2.4.2
     - pytz
 
   run:
     - python
-    - regex>=2017.02.08 
-    - python-dateutil>=2.4.2
+    - regex >=2017.02.08
+    - python-dateutil >=2.4.2
     - pytz
-
 
 test:
   imports:

--- a/recipes/datefinder/meta.yaml
+++ b/recipes/datefinder/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://github.com/akoumjian/datefinder/archive/v{{ version}}.tar.gz"
+  url: "https://github.com/akoumjian/datefinder/archive/v{{ version }}.tar.gz"
   sha256: acab2bebfdb09fdc9e9d512b280bf676a9a03f286c666234d50cfe65a5da7f7d
 
 build:

--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "datefinder" %}
+{% set version = "0.7.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://github.com/akoumjian/datefinder/archive/v0.7.1.tar.gz"
+  sha256: acab2bebfdb09fdc9e9d512b280bf676a9a03f286c666234d50cfe65a5da7f7d
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: python
+
+requirements:
+  host:
+    - python
+    - regex>=2017.02.08 
+    - python-dateutil>=2.4.2
+    - pytz
+
+  run:
+    - python
+    - regex>=2017.02.08 
+    - python-dateutil>=2.4.2
+    - pytz
+
+
+test:
+  imports:
+    - datefinder
+
+about:
+  home: "https://github.com/akoumjian/datefinder"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "A python module for locating dates inside text."
+  doc_url: https://github.com/akoumjian/datefinder
+  dev_url: https://github.com/akoumjian/datefinder
+
+extra:
+  recipe-maintainers:
+    - melonhead901


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
