### PR TITLE
Adding law

### DIFF
--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "law" %}
-{% set version = "0.0.40" %}
+{% set version = "0.0.41" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 338c528f7f91545eab0b6990bbb84768c608773e2bc40b7f08e134cc603540ca
+  sha256: 3b6e457bb99da69ddab03e91a80057958ee9477dba7bb6f8823059b2cbce19b3
 
 build:
   number: 0
@@ -19,13 +19,13 @@ requirements:
     - python
     - pip
     - six >=1.10
-    - luigi>=2.8.2,<3 # [py<=27]
-    - luigi>=2.8.2 # [py>30]
+    - luigi >=2.8.2,<3  # [py<=27]
+    - luigi >=2.8.2  # [py>30]
   run:
     - python
     - six >=1.10
-    - luigi>=2.8.2,<3 # [py<=27]
-    - luigi>=2.8.2 # [py>30]
+    - luigi >=2.8.2,<3  # [py<=27]
+    - luigi >=2.8.2  # [py>30]
 
 test:
   requires:
@@ -80,7 +80,8 @@ about:
 
     Key features:
     - CLI with auto-completion and interactive status and dependency inspection.
-    - Remote targets with automatic retries and local caching: WebDAV, HTTP, Dropbox, SFTP, all WLCG protocols (srm, xrootd, rfio, dcap, gsiftp, ...)
+    - Remote targets with automatic retries and local caching: WebDAV, HTTP, Dropbox, SFTP, all WLCG
+      protocols (srm, xrootd, rfio, dcap, gsiftp, ...)
     - Automatic submission to batch systems from within tasks: HTCondor, LSF, gLite, ARC
     - Environment sandboxing, configurable on task level: Docker, Singularity, Sub-Shells
   doc_url: https://law.readthedocs.io

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "law" %}
-{% set version = "0.0.39" %}
+{% set version = "0.0.40" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 17bdde1e6c8251881bb695950304cf3ef7d23a3ece34718714ce3d17b81302eb
+  sha256: 338c528f7f91545eab0b6990bbb84768c608773e2bc40b7f08e134cc603540ca
 
 build:
   number: 0
@@ -65,19 +65,23 @@ test:
      - law --help
 
 about:
-  home: "https://github.com/riga/law"
+  home: https://github.com/riga/law
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'Use law to build complex and large-scale task workflows.'
+  summary: "Use law to build complex and large-scale task workflows."
   description: |
-    Use law to build complex and large-scale task workflows. It is build on top of luigi and adds abstractions for run locations, storage locations and software environments. Law strictly disentangles these building blocks and ensures they remain interchangeable and resource-opportunistic.
+    Use law to build complex and large-scale task workflows. It is build on top of luigi and adds
+    abstractions for run locations, storage locations and software environments. Law strictly
+    disentangles these building blocks and ensures they remain interchangeable and
+    resource-opportunistic.
+
     Key features:
     - CLI with auto-completion and interactive status and dependency inspection.
     - Remote targets with automatic retries and local caching: WebDAV, HTTP, Dropbox, SFTP, all WLCG protocols (srm, xrootd, rfio, dcap, gsiftp, ...)
     - Automatic submission to batch systems from within tasks: HTCondor, LSF, gLite, ARC
     - Environment sandboxing, configurable on task level: Docker, Singularity, Sub-Shells
-  doc_url: https://law.readthedocs.io/en/latest/
+  doc_url: https://law.readthedocs.io
   dev_url: https://github.com/riga/law
 
 extra:

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -48,6 +48,7 @@ test:
     - law.contrib.matplotlib
     - law.contrib.mercurial
     - law.contrib.numpy
+    - law.contrib.profiling
     - law.contrib.rich
     - law.contrib.root
     - law.contrib.singularity

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 3b6e457bb99da69ddab03e91a80057958ee9477dba7bb6f8823059b2cbce19b3
 
 build:
-  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [win]
 
 requirements:
   host:

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
+  skip: true  # [win]
 
 requirements:
   host:

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 3b6e457bb99da69ddab03e91a80057958ee9477dba7bb6f8823059b2cbce19b3
 
 build:
+  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: true  # [win]
 
 requirements:
   host:

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -1,0 +1,83 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+# Using the name variable with the URL in line 14 is convenient
+# when copying and pasting from another recipe, but not really needed.
+{% set name = "simplejson" %}
+{% set version = "3.8.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # If getting the source from GitHub, remove the line above,
+  # uncomment the line below, and modify as needed. Use releases if available:
+  # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
+  # and otherwise fall back to archive: 
+  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
+  sha256: d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
+  # sha256 is the preferred checksum -- you can get it for a file with:
+  #  `openssl sha256 <file name>`.
+  # You may need the openssl package, available on conda-forge:
+  #  `conda install openssl -c conda-forge``
+
+build:
+  # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
+  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
+  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
+  # noarch: python
+  number: 0
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    # If your project compiles code (such as a C extension) then add the required compilers as separate entries here.
+    # Compilers are named 'c', 'cxx' and 'fortran'.
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  # Some packages might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - simplejson
+    - simplejson.tests
+
+about:
+  home: https://github.com/simplejson/simplejson
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
+  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
+  # See https://opensource.org/licenses/alphabetical
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
+  license_family: MIT
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
+  license_file: LICENSE.txt
+  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    simplejson is a simple, fast, complete, correct and extensible
+    JSON <https://json.org> encoder and decoder for Python 2.5+ and
+    Python 3.3+. It is pure Python code with no dependencies, but includes
+    an optional C extension for a serious speed boost.
+  doc_url: https://simplejson.readthedocs.io/
+  dev_url: https://github.com/simplejson/simplejson
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - LisaSimpson
+    - LandoCalrissian

--- a/recipes/law/meta.yaml
+++ b/recipes/law/meta.yaml
@@ -1,83 +1,85 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
-# Using the name variable with the URL in line 14 is convenient
-# when copying and pasting from another recipe, but not really needed.
-{% set name = "simplejson" %}
-{% set version = "3.8.2" %}
+{% set name = "law" %}
+{% set version = "0.0.39" %}
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # If getting the source from GitHub, remove the line above,
-  # uncomment the line below, and modify as needed. Use releases if available:
-  # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
-  # and otherwise fall back to archive: 
-  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
-  sha256: d58439c548433adcda98e695be53e526ba940a4b9c44fb9a05d92cd495cdd47f
-  # sha256 is the preferred checksum -- you can get it for a file with:
-  #  `openssl sha256 <file name>`.
-  # You may need the openssl package, available on conda-forge:
-  #  `conda install openssl -c conda-forge``
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 17bdde1e6c8251881bb695950304cf3ef7d23a3ece34718714ce3d17b81302eb
 
 build:
-  # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
-  # noarch: python
   number: 0
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
-  build:
-    # If your project compiles code (such as a C extension) then add the required compilers as separate entries here.
-    # Compilers are named 'c', 'cxx' and 'fortran'.
-    - {{ compiler('c') }}
   host:
     - python
     - pip
+    - six >=1.10
+    - luigi>=2.8.2,<3 # [py<=27]
+    - luigi>=2.8.2 # [py>30]
   run:
     - python
+    - six >=1.10
+    - luigi>=2.8.2,<3 # [py<=27]
+    - luigi>=2.8.2 # [py>30]
 
 test:
-  # Some packages might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
+  requires:
+    - ipython
   imports:
-    - simplejson
-    - simplejson.tests
+    - law
+    - law.cli
+    - law.contrib
+    - law.contrib.arc
+    - law.contrib.cms
+    - law.contrib.coffea
+    - law.contrib.docker
+    - law.contrib.dropbox
+    - law.contrib.git
+    - law.contrib.glite
+    - law.contrib.hdf5
+    - law.contrib.htcondor
+    - law.contrib.ipython
+    - law.contrib.keras
+    - law.contrib.lsf
+    - law.contrib.matplotlib
+    - law.contrib.mercurial
+    - law.contrib.numpy
+    - law.contrib.rich
+    - law.contrib.root
+    - law.contrib.singularity
+    - law.contrib.slack
+    - law.contrib.tasks
+    - law.contrib.telegram
+    - law.contrib.tensorflow
+    - law.contrib.wlcg
+    - law.job
+    - law.sandbox
+    - law.target
+    - law.task
+    - law.workflow
+  commands:
+     - law --help
 
 about:
-  home: https://github.com/simplejson/simplejson
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
-  # Prefer the short version, e.g: GPL-2.0 instead of GNU General Public License version 2.0
-  # See https://opensource.org/licenses/alphabetical
-  license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". (optional)
-  license_family: MIT
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
-  license_file: LICENSE.txt
-  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
-
-  # The remaining entries in this section are optional, but recommended.
+  home: "https://github.com/riga/law"
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'Use law to build complex and large-scale task workflows.'
   description: |
-    simplejson is a simple, fast, complete, correct and extensible
-    JSON <https://json.org> encoder and decoder for Python 2.5+ and
-    Python 3.3+. It is pure Python code with no dependencies, but includes
-    an optional C extension for a serious speed boost.
-  doc_url: https://simplejson.readthedocs.io/
-  dev_url: https://github.com/simplejson/simplejson
+    Use law to build complex and large-scale task workflows. It is build on top of luigi and adds abstractions for run locations, storage locations and software environments. Law strictly disentangles these building blocks and ensures they remain interchangeable and resource-opportunistic.
+    Key features:
+    - CLI with auto-completion and interactive status and dependency inspection.
+    - Remote targets with automatic retries and local caching: WebDAV, HTTP, Dropbox, SFTP, all WLCG protocols (srm, xrootd, rfio, dcap, gsiftp, ...)
+    - Automatic submission to batch systems from within tasks: HTCondor, LSF, gLite, ARC
+    - Environment sandboxing, configurable on task level: Docker, Singularity, Sub-Shells
+  doc_url: https://law.readthedocs.io/en/latest/
+  dev_url: https://github.com/riga/law
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
-    - LisaSimpson
-    - LandoCalrissian
+    - riga


### PR DESCRIPTION
This PR adds the law (luigi analysis workflows) package, starting from version 0.0.41, to the index.

- [GitHub](https://github.com/riga/law)
- [PyPI](https://pypi.org/project/law/)

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] ~If static libraries are linked in, the license of the static library is packaged.~ Does not apply.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
