### PR TITLE
Add rust-nightly recipe

### DIFF
--- a/recipes/rust-nightly/bld.bat
+++ b/recipes/rust-nightly/bld.bat
@@ -1,0 +1,3 @@
+FOR /F "delims=" %%i in ('cygpath.exe -u "%PREFIX%"') DO set "pfx=%%i"
+bash install.sh --prefix=%pfx%/Library
+if errorlevel 1 exit 1

--- a/recipes/rust-nightly/build.sh
+++ b/recipes/rust-nightly/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+./install.sh --prefix=$PREFIX
+
+# Fun times -- by default, Rust/Cargo tries to link executables on Linux by
+# invoking `cc`. An executable of this name is not necessarily available. By
+# setting a magic environment variable, we can override this default.
+
+if [ "$c_compiler" = gcc ] ; then
+    case "$BUILD" in
+        x86_64-*) rust_env_arch=X86_64_UNKNOWN_LINUX_GNU ;;
+        aarch64-*) rust_env_arch=AARCH64_UNKNOWN_LINUX_GNU ;;
+        powerpc64le-*) rust_env_arch=POWERPC64LE_UNKNOWN_LINUX_GNU ;;
+        *) echo "unknown BUILD $BUILD" ; exit 1 ;;
+    esac
+
+    mkdir -p $PREFIX/etc/conda/activate.d $PREFIX/etc/conda/deactivate.d
+
+    cat <<EOF >$PREFIX/etc/conda/activate.d/rust.sh
+export CARGO_TARGET_${rust_env_arch}_LINKER=\$CC
+EOF
+
+    cat <<EOF >$PREFIX/etc/conda/deactivate.d/rust.sh
+unset CARGO_TARGET_${rust_env_arch}_LINKER
+EOF
+fi

--- a/recipes/rust-nightly/forge_test.sh
+++ b/recipes/rust-nightly/forge_test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e -x
+
+## TODO: remove the following `unset` lines, once the following issue in `conda-build` is resolved:
+##       <https://github.com/conda/conda-build/issues/2255>
+
+unset REQUESTS_CA_BUNDLE
+unset SSL_CERT_FILE
+
+rustc --help
+rustdoc --help
+cargo --help
+cargo install --force xsv

--- a/recipes/rust-nightly/meta.yaml
+++ b/recipes/rust-nightly/meta.yaml
@@ -1,15 +1,16 @@
-{% set version = "2020-06-09" %}
+{% set version = "2020.06.09" %}
+{% set url_version | replace(".", "-") %}{{ version }}{% endset %}
 
 package:
   name: rust-nightly
   version: {{ version }}
 
 source:
-  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
-  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
-  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
-  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-x86_64-apple-darwin.tar.gz  # [osx]
-  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-x86_64-pc-windows-msvc.tar.gz  # [win64]
+  url: https://static.rust-lang.org/dist/{{ url_version }}/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
+  url: https://static.rust-lang.org/dist/{{ url_version }}/rust-nightly-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
+  url: https://static.rust-lang.org/dist/{{ url_version }}/rust-nightly-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
+  url: https://static.rust-lang.org/dist/{{ url_version }}/rust-nightly-x86_64-apple-darwin.tar.gz  # [osx]
+  url: https://static.rust-lang.org/dist/{{ url_version }}/rust-nightly-x86_64-pc-windows-msvc.tar.gz  # [win64]
   sha256: 2e59f105bbe2f5a20920734c73c544175ad282e0490ea307bf93b1f9724b85aa  # [linux and x86_64]
   sha256: 71473dc5853430e3174b8f847508fa0b18a83af141d2c58f7bd9290cc5fe557c  # [aarch64]
   sha256: 3e545bdd66ff32220178226e820150c6b57e9b198af2bc38fb922092cfa25621  # [ppc64le]

--- a/recipes/rust-nightly/meta.yaml
+++ b/recipes/rust-nightly/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = "2020-06-09" %}
+
+package:
+  name: rust-nightly
+  version: {{ version }}
+
+source:
+  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-x86_64-unknown-linux-gnu.tar.gz  # [linux and x86_64]
+  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-aarch64-unknown-linux-gnu.tar.gz  # [aarch64]
+  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-powerpc64le-unknown-linux-gnu.tar.gz  # [ppc64le]
+  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-x86_64-apple-darwin.tar.gz  # [osx]
+  url: https://static.rust-lang.org/dist/{{ version }}/rust-nightly-x86_64-pc-windows-msvc.tar.gz  # [win64]
+  sha256: 2e59f105bbe2f5a20920734c73c544175ad282e0490ea307bf93b1f9724b85aa  # [linux and x86_64]
+  sha256: 71473dc5853430e3174b8f847508fa0b18a83af141d2c58f7bd9290cc5fe557c  # [aarch64]
+  sha256: 3e545bdd66ff32220178226e820150c6b57e9b198af2bc38fb922092cfa25621  # [ppc64le]
+  sha256: 039a822c4652638c0ed27cdf3440b5c5b0fff8eb41902c17e255899b93a13ac2  # [osx]
+  sha256: 7e8f97be7eb32b6f59e40a75e63bc2438a0573092e8312b1be2b52f28f1cc851  # [win64]
+
+build:
+  number: 0
+  # the distributed binaries are already relocatable
+  binary_relocation: false
+
+requirements:
+  build:
+    - posix  # [win]
+  run:
+    - {{ compiler('c') }}  # [linux] -- rustc needs a toolchain to link executables on Linux
+
+test:
+  files:
+    - forge_test.sh
+  commands:
+    - time bash ./forge_test.sh  # [not win]
+    - bash forge_test.sh  # [win]
+
+about:
+  home: https://www.rust-lang.org
+  license: MIT
+  license_file:
+    - LICENSE-APACHE
+    - LICENSE-MIT
+  summary: |
+    Rust is a systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.
+    This package provides the compiler (rustc) and the documentation utilities rustdoc.
+  dev_url: https://doc.rust-lang.org/std/
+  doc_url: https://www.rust-lang.org/en-US/documentation.html
+
+extra:
+  recipe-maintainers:
+    - synapticarbors

--- a/recipes/rust-nightly/meta.yaml
+++ b/recipes/rust-nightly/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   number: 0
   # the distributed binaries are already relocatable
-  binary_relocation: false
+  binary_relocation: False
 
 requirements:
   build:


### PR DESCRIPTION
This recipe largely follows the main `rust-feedstock`. I'm not sure how the regro-bot is going to handle this since there will be an update every day and we don't necessarily want to have an update for each one. I was thinking once a month or every two weeks would be sufficient. 

This PR was prompted by the `orjson-feedstock` that depends on nightly, but is pulling it in directly in its build. 