### PR TITLE
Only skip the exact example recipe

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -45,7 +45,7 @@ def list_recipes():
     for recipe_dir in recipes:
         # We don't list the "example" feedstock. It is an example, and is there
         # to be helpful.
-        if recipe_dir.startswith('example'):
+        if recipe_dir == 'example':
             continue
         path = os.path.abspath(os.path.join(recipe_directory_name, recipe_dir))
         yield path, get_feedstock_name_from_meta(MetaData(path))


### PR DESCRIPTION
Recipes whose directories began with `example` are incorrectly skipped. Only match the actual `example` recipe.