### PR TITLE
Add LAGraph C library, which builds upon GraphBLAS

### DIFF
--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -4,6 +4,7 @@
 export INSTALL="${PREFIX}"
 export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release"
 
+rm -f ${PREFIX}/lib/libgraphblas.a
 # make LAGraph
 pushd build
 cmake .. $CMAKE_OPTIONS

--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# make sure CMake install goes in the right place
+export INSTALL="${PREFIX}"
+export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
+
+# make LAGraph
+pushd build
+cmake .. $CMAKE_OPTIONS
+make lagraph lagraph_static VERBOSE=1
+make install VERBOSE=1
+popd

--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -2,7 +2,7 @@
 
 # make sure CMake install goes in the right place
 export INSTALL="${PREFIX}"
-export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib"
+export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release"
 
 # make LAGraph
 pushd build

--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -7,6 +7,6 @@ export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=li
 # make LAGraph
 pushd build
 cmake .. $CMAKE_OPTIONS
-make lagraph lagraph_static VERBOSE=1
+make lagraph VERBOSE=1
 make install VERBOSE=1
 popd

--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -4,7 +4,6 @@
 export INSTALL="${PREFIX}"
 export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release"
 
-rm -f ${PREFIX}/lib/libgraphblas.a
 # make LAGraph
 pushd build
 cmake .. $CMAKE_OPTIONS

--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -9,4 +9,5 @@ pushd build
 cmake .. $CMAKE_OPTIONS
 make lagraph VERBOSE=1
 make install VERBOSE=1
+rm -f ${PREFIX}/lib/liblagraph.a
 popd

--- a/recipes/lagraph/build.sh
+++ b/recipes/lagraph/build.sh
@@ -9,5 +9,6 @@ pushd build
 cmake .. $CMAKE_OPTIONS
 make lagraph VERBOSE=1
 make install VERBOSE=1
+# forcibly remove the static library
 rm -f ${PREFIX}/lib/liblagraph.a
 popd

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -19,7 +19,8 @@ requirements:
     - cmake
     - make
     - m4
-    - libgomp
+    - openmp  # [linux]
+    - llvm-openmp  # [osx]
   host:
     - graphblas
   run:

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -21,8 +21,12 @@ requirements:
     - m4
   host:
     - graphblas
+    - openmp  # [linux]
+    - llvm-openmp  # [osx]
   run:
     - graphblas
+    - openmp  # [linux]
+    - llvm-openmp  # [osx]
 
 test:
   commands:

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -19,8 +19,7 @@ requirements:
     - cmake
     - make
     - m4
-    - openmp  # [linux]
-    - llvm-openmp  # [osx]
+    - libgomp  # [linux]
   host:
     - graphblas
   run:

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/LAGraph.h
     - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
-    - [[ ! -f ${PREFIX}/lib/liblagraph.a ]]
+    - [ ! -f ${PREFIX}/lib/liblagraph.a ]
 
 about:
   home: https://github.com/GraphBLAS/LAGraph

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/LAGraph.h
     - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
-    - [ ! -f ${PREFIX}/lib/liblagraph.a ]
+    - test ! -f ${PREFIX}/lib/liblagraph.a
 
 about:
   home: https://github.com/GraphBLAS/LAGraph

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -1,11 +1,9 @@
-{% set version = "8Aug2020" %}
-
 package:
   name: lagraph
-  version: {{ version }}
+  version: 2020.08.08
 
 source:
-  url: https://github.com/GraphBLAS/LAGraph/archive/{{ version }}.tar.gz
+  url: https://github.com/GraphBLAS/LAGraph/archive/8Aug2020.tar.gz
   sha256: e7a05decd21d2f209ca24046447bff7a9eefe54b071eca5f9fedf6d468bda58c
 
 build:

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "8Aug2020" %}
+
+package:
+  name: lagraph
+  version: {{ version }}
+
+source:
+  url: https://github.com/GraphBLAS/LAGraph/archive/{{ version }}.tar.gz
+  sha256: e7a05decd21d2f209ca24046447bff7a9eefe54b071eca5f9fedf6d468bda58c
+
+build:
+  skip: true  # [win]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+    - m4
+  host:
+    - graphblas
+  run:
+    - graphblas
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/LAGraph.h
+    - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
+    - test -f ${PREFIX}/lib/liblagraph.a
+
+about:
+  home: https://github.com/GraphBLAS/LAGraph
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: This is a library plus a test harness for collecting algorithms that use the GraphBLAS
+
+extra:
+  recipe-maintainers:
+    - jim22k
+    - eriknw

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/LAGraph.h
     - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
-    - test -f ${PREFIX}/lib/liblagraph.a
+    - ! test -f ${PREFIX}/lib/liblagraph.a
 
 about:
   home: https://github.com/GraphBLAS/LAGraph

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/LAGraph.h
     - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
-    - ! test -f ${PREFIX}/lib/liblagraph.a
+    - test -f ${PREFIX}/lib/liblagraph.a
 
 about:
   home: https://github.com/GraphBLAS/LAGraph

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/LAGraph.h
     - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
-    - test -f ${PREFIX}/lib/liblagraph.a
+    - [[ ! -f ${PREFIX}/lib/liblagraph.a ]]
 
 about:
   home: https://github.com/GraphBLAS/LAGraph

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -30,7 +30,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/LAGraph.h
     - test -f ${PREFIX}/lib/liblagraph${SHLIB_EXT}
-    - test ! -f ${PREFIX}/lib/liblagraph.a
+    - test ! -e ${PREFIX}/lib/liblagraph.a
 
 about:
   home: https://github.com/GraphBLAS/LAGraph

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -19,14 +19,11 @@ requirements:
     - cmake
     - make
     - m4
+    - libgomp
   host:
     - graphblas
-    - openmp  # [linux]
-    - llvm-openmp  # [osx]
   run:
     - graphblas
-    - openmp  # [linux]
-    - llvm-openmp  # [osx]
 
 test:
   commands:

--- a/recipes/lagraph/meta.yaml
+++ b/recipes/lagraph/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - make
     - m4
     - libgomp  # [linux]
+    - llvm-openmp  # [osx]
   host:
     - graphblas
   run:


### PR DESCRIPTION
The version number, `"8Aug2020"`, is currently rather informal and uncommon, and I don't know if this will cause any difficulties (is it preferred that version numbers sort nicely?).

It might be nice to run one of the (very quick) tests for sanity, such as `cd Test/SSSP ; make`, but I don't know the best way to do this.  What directory are we in when we run the test commands?  Can we instead run this test in the build script?

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there