### PR TITLE
feat: add recipe for COBRApy

### DIFF
--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -43,7 +43,7 @@ test:
 about:
   home: https://opencobra.github.io/cobrapy
   summary: COBRApy is a package for constraints-based modeling of metabolic networks.
-  license: LGPL-2.1
+  license: LGPL-2.0-or-later OR GPL-2.0-or-later
   license_family: GPL
   license_file: LICENSE
   description: >

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -20,13 +20,19 @@ requirements:
     - pip
     - python >=3.6
   run:
+    - appdirs
     - depinfo
+    - diskcache
     - future
+    - httpx
+    - importlib_resources
     - numpy >=1.13
     - optlang >=1.4.2,<1.4.6
     - pandas >=1.0
+    - pydantic
     - python >=3.6
     - python-libsbml-experimental ==5.18.3
+    - rich
     - ruamel.yaml >=0.16
     - six
     - swiglpk

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - pydantic
     - python >=3.6
     - python-libsbml-experimental ==5.18.3
-    - rich
+    - rich <7.0
     - ruamel.yaml >=0.16
     - six
     - swiglpk

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -59,4 +59,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - cdiener
     - Midnighter

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cobra" %}
-{% set version = "0.18.1" %}
+{% set version = "0.20.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cobra-{{ version }}.tar.gz
-  sha256: c1ba04b4eff13f83692cbbbe99c3240fa079d89cb41d50b08b597141a7c91eeb
+  sha256: db3d8df2eab62b2aa2db75e8e85811c83b248071abf208c765f8f455cfaa88e2
 
 build:
   number: 0
@@ -23,10 +23,10 @@ requirements:
     - depinfo
     - future
     - numpy >=1.13
-    - optlang >=1.4.2
+    - optlang >=1.4.2,<1.4.6
     - pandas >=1.0
     - python >=3.6
-    - python-libsbml-experimental >=5.18.3
+    - python-libsbml-experimental ==5.18.3
     - ruamel.yaml >=0.16
     - six
     - swiglpk

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "cobra" %}
+{% set version = "0.18.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cobra-{{ version }}.tar.gz
+  sha256: c1ba04b4eff13f83692cbbbe99c3240fa079d89cb41d50b08b597141a7c91eeb
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - depinfo
+    - future
+    - numpy >=1.13
+    - optlang >=1.4.2
+    - pandas >=1.0
+    - python >=3.6
+    - python-libsbml-experimental >=5.18.3
+    - ruamel.yaml >=0.16
+    - six
+    - swiglpk
+
+test:
+  imports:
+    - cobra
+    - cobra.flux_analysis
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://opencobra.github.io/cobrapy
+  summary: COBRApy is a package for constraints-based modeling of metabolic networks.
+  license: LGPL-2.1
+  license_family: GPL
+  license_file: LICENSE
+  description: >
+    Constraint-based reconstruction and analysis (COBRA) methods are widely used
+    for genome-scale modeling of metabolic networks in both prokaryotes and
+    eukaryotes. COBRApy is a constraint-based modeling package that is
+    designed to accommodate the biological complexity of the next generation of
+    COBRA models and provides access to commonly used COBRA methods, such as
+    flux-balance analysis, flux variability analysis, and gene deletion
+    analyses.
+  doc_url: https://cobrapy.readthedocs.io
+  dev_url: https://github.com/opencobra/cobrapy
+
+extra:
+  recipe-maintainers:
+    - Midnighter

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - pandas >=1.0
     - pydantic
     - python >=3.6
-    - python-libsbml-experimental ==5.19.0
+    - python-libsbml ==5.19.0
     - rich <7.0
     - ruamel.yaml >=0.16
     - six

--- a/recipes/cobra/meta.yaml
+++ b/recipes/cobra/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cobra" %}
-{% set version = "0.20.0" %}
+{% set version = "0.21.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cobra-{{ version }}.tar.gz
-  sha256: db3d8df2eab62b2aa2db75e8e85811c83b248071abf208c765f8f455cfaa88e2
+  sha256: 4a0a95012bf97f5b196c1155d4db666006718f31f82be552ddb62d0721ae0182
 
 build:
   number: 0
@@ -31,7 +31,7 @@ requirements:
     - pandas >=1.0
     - pydantic
     - python >=3.6
-    - python-libsbml-experimental ==5.18.3
+    - python-libsbml-experimental ==5.19.0
     - rich <7.0
     - ruamel.yaml >=0.16
     - six


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
