### PR TITLE
Adding ipyfilechooser v0.3.5

### DIFF
--- a/recipes/ipyfilechooser/meta.yaml
+++ b/recipes/ipyfilechooser/meta.yaml
@@ -1,0 +1,38 @@
+{% set name = "ipyfilechooser" %}
+{% set version = "0.3.5" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 4f50aac15f36b941d04d51d1d5729c7cf6018dbd7c4554e32fa303d0f9743075
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - ipywidgets
+    - python
+
+test:
+  imports:
+    - ipyfilechooser
+
+about:
+  home: "https://github.com/crahan/ipyfilechooser"
+  license: MIT
+  license_family: MIT
+  summary: "Python file chooser widget for use in Jupyter/IPython in conjunction with ipywidgets"
+  dev_url: https://github.com/crahan/ipyfilechooser
+
+extra:
+  recipe-maintainers:
+    - crahan

--- a/recipes/ipyfilechooser/meta.yaml
+++ b/recipes/ipyfilechooser/meta.yaml
@@ -30,6 +30,7 @@ about:
   home: "https://github.com/crahan/ipyfilechooser"
   license: MIT
   license_family: MIT
+  license_file: LICENSE
   summary: "Python file chooser widget for use in Jupyter/IPython in conjunction with ipywidgets"
   dev_url: https://github.com/crahan/ipyfilechooser
 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
