### PR TITLE
add docstring-parser 0.7.1

### DIFF
--- a/recipes/docstring-parser/meta.yaml
+++ b/recipes/docstring-parser/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "docstring_parser" %}
+{% set version = "0.7.1" %}
+
+package:
+  name: {{ name.replace("_", "-") }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7f91d48ea2e4ad04a101f3aa24767f8475545acc93af1b3b14c617733d40c086
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+
+test:
+  requires:
+    - pip
+    - pytest
+    - pytest-cov
+  imports:
+    - docstring_parser
+  commands:
+    - python -m pip check
+    - pytest --pyargs {{ name }} --cov {{ name }} --cov-fail-under 97
+
+about:
+  home: https://github.com/rr-/docstring_parser
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: 'Parse Python docstrings. Currently support ReST, Google, and Numpydoc-style docstrings.'
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there


Notes:
- tried to grayskull, but ran into some issues, so this is hand-built
- this is for docstring-parser 0.7.1, while 0.7.2 has already been released
  - this is needed to unblock  https://github.com/conda-forge/dagster-feedstock/pull/60 due to a hard pin, will add 0.7.2 after merge