### PR TITLE
start of nvtop feedstock

### DIFF
--- a/recipes/nvtop/build.sh
+++ b/recipes/nvtop/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p nvtop/build && cd nvtop/build
+cmake ..
+
+make
+make check
+make install
+

--- a/recipes/nvtop/meta.yaml
+++ b/recipes/nvtop/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "nvtop" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/syllo/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: de3d7b6a889f886f3bc28c15c3c34cfb6fcb7cb7ebc9a0cc36c3c77d837029b1
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - automake
+    - libtool
+    - cmake
+    - make
+    - cudatoolkit-dev
+    - {{ compiler('c') }}
+  host:
+    - ncurses
+    - cudatoolkit-dev
+
+  run:
+    - ncurses
+    - cudatoolkit-dev
+
+test:
+  commands:
+    - nvtop --version
+
+about:
+  home: https://github.com/syllo/nvtop/
+  license: GPL-3.0
+  license_file: COPYING
+  summary: Nvtop stands for NVidia TOP, a (h)top like task monitor for NVIDIA GPUs. It can handle multiple GPUs and print information about them in a htop familiar way.
+
+extra:
+  recipe-maintainers:
+    - andrewannex
+

--- a/recipes/nvtop/meta.yaml
+++ b/recipes/nvtop/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: https://github.com/syllo/nvtop/
-  license: GPL-3.0
+  license: GPL-3.0-only
   license_file: COPYING
   summary: Nvtop stands for NVidia TOP, a (h)top like task monitor for NVIDIA GPUs. It can handle multiple GPUs and print information about them in a htop familiar way.
 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
