### PR TITLE
add PyTurboJPEG

### DIFF
--- a/recipes/pyturbojpeg/LICENSE
+++ b/recipes/pyturbojpeg/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018-2020 Lilo Huang <kuso.cc@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pyturbojpeg/meta.yaml
+++ b/recipes/pyturbojpeg/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "PyTurboJPEG" %}
+{% set version = "1.4.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 09688a93331281e566569b4d313e1d1a058ca32ccae1a2473847a10e4ca2f2a7
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - libjpeg-turbo
+
+test:
+  imports:
+    - turbojpeg
+
+about:
+  home: https://github.com/lilohuang/PyTurboJPEG/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A Python wrapper of libjpeg-turbo for decoding and encoding JPEG image.'
+  doc_url: https://github.com/lilohuang/PyTurboJPEG/
+  dev_url: https://github.com/lilohuang/PyTurboJPEG/
+
+extra:
+  recipe-maintainers:
+    - carlodri

--- a/recipes/pyturbojpeg/meta.yaml
+++ b/recipes/pyturbojpeg/meta.yaml
@@ -24,10 +24,10 @@ requirements:
     - libjpeg-turbo
 
 test:
-  imports:
-    - turbojpeg
+  requires:
+    - requests
 
-about:
+    about:
   home: https://github.com/lilohuang/PyTurboJPEG/
   license: MIT
   license_family: MIT

--- a/recipes/pyturbojpeg/meta.yaml
+++ b/recipes/pyturbojpeg/meta.yaml
@@ -27,7 +27,7 @@ test:
   requires:
     - requests
 
-    about:
+about:
   home: https://github.com/lilohuang/PyTurboJPEG/
   license: MIT
   license_family: MIT

--- a/recipes/pyturbojpeg/run_test.py
+++ b/recipes/pyturbojpeg/run_test.py
@@ -1,0 +1,16 @@
+from turbojpeg import TurboJPEG
+import requests
+
+url = "https://upload.wikimedia.org/wikipedia/commons/9/98/03-bryone-dioique.jpg"
+r = requests.get(url, allow_redirects=True)
+
+jpeg = TurboJPEG()
+
+with open("03-bryone-dioique.jpg", "wb") as test_file:
+    test_file.write(r.content)
+
+with open("03-bryone-dioique.jpg", "rb") as in_file:
+    bgr_array = jpeg.decode(in_file.read())
+
+with open("output.jpg", "wb") as out_file:
+    out_file.write(jpeg.encode(bgr_array))


### PR DESCRIPTION
https://github.com/lilohuang/PyTurboJPEG/

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
