### PR TITLE
Adding neutronics_material_maker

### DIFF
--- a/recipes/neutronics-material-maker/LICENSE.txt
+++ b/recipes/neutronics-material-maker/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 UKAEA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/neutronics-material-maker/meta.yaml
+++ b/recipes/neutronics-material-maker/meta.yaml
@@ -1,0 +1,47 @@
+
+{% set name = "neutronics_material_maker" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 841959e2af03213c135dc961ba90d5a0187ede7d72e0cbfd8ecf64242281c36d
+
+build:
+  number: 0
+  skip: true  # [win]
+  skip: true  # [py<35]
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - openmc
+    - CoolProp
+
+test:
+  imports:
+    - neutronics_material_maker
+
+about:
+  home: https://github.com/ukaea/neutronics_material_maker
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'A tool for making parametric material cards for use in neutronics codes.'
+
+  description: |
+    The aim of this project is to facilitate the creation of materials
+    for use in neutronics codes such as OpenMC, Serpent, MCNP and Fispact.
+  doc_url: neutronics-material-maker.readthedocs.io/
+  dev_url: https://github.com/ukaea/neutronics_material_maker
+
+extra:
+  recipe-maintainers:
+    - shimwell

--- a/recipes/neutronics-material-maker/meta.yaml
+++ b/recipes/neutronics-material-maker/meta.yaml
@@ -17,10 +17,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
     - openmc
     - CoolProp
 

--- a/recipes/neutronics-material-maker/meta.yaml
+++ b/recipes/neutronics-material-maker/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "neutronics_material_maker" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 841959e2af03213c135dc961ba90d5a0187ede7d72e0cbfd8ecf64242281c36d
+  sha256: 43f89bc94ca76bd45fe26cb59b1a17c801ccf0db1578d304589f050175070def
 
 build:
   number: 0

--- a/recipes/neutronics-material-maker/meta.yaml
+++ b/recipes/neutronics-material-maker/meta.yaml
@@ -12,8 +12,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
-  skip: true  # [py<35]
+  noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/neutronics-material-maker/meta.yaml
+++ b/recipes/neutronics-material-maker/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.6
     - openmc
-    - CoolProp
+    - coolprop
 
 test:
   imports:


### PR DESCRIPTION
Hi this is my first attempt at a PR for a python package I've been working on. It is basically a collection of materials combined with the ability to export these materials in a variety of neutronics codes. Would appreciate any feed back particular from @scopatz as PyNe materials were an inspiration for some of this work

I have tested it locally with the ```CONFIG=linux64 ./.scripts/run_docker_build.sh``` command and it appears to build and import the package

I confirm that I look forward to maintaining this package should it be accepted

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
