### PR TITLE
Add recipe for django-ipware

### DIFF
--- a/recipes/django-ipware/meta.yaml
+++ b/recipes/django-ipware/meta.yaml
@@ -1,0 +1,34 @@
+{% set name = "django-ipware" %}
+{% set version = "3.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 73a640a5bff00aa7503a35e92e462001cfabb07d73d649c262f117423beee953
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - django
+
+about:
+  home: https://pypi.org/project/django-axes/
+  summary: django-ipware, application to retrieve client's IP address.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - swainn
+    - gagelarsen

--- a/recipes/django-ipware/run_test.py
+++ b/recipes/django-ipware/run_test.py
@@ -1,0 +1,4 @@
+import django
+from django.conf import settings
+settings.configure(INSTALLED_APPS=['ipware'])
+django.setup()


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
