### PR TITLE
Add recipe for aws-c-common

### DIFF
--- a/recipes/aws-c-common/bld.bat
+++ b/recipes/aws-c-common/bld.bat
@@ -1,0 +1,13 @@
+mkdir "%SRC_DIR%"\build
+pushd "%SRC_DIR%"\build
+
+cmake -G "Ninja" ^
+      -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+      -DCMAKE_INSTALL_LIBDIR=lib ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DBUILD_SHARED_LIBS=ON ^
+      ..
+if errorlevel 1 exit 1
+
+ninja install
+if errorlevel 1 exit 1

--- a/recipes/aws-c-common/build.sh
+++ b/recipes/aws-c-common/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+mkdir build
+pushd build
+cmake ${CMAKE_ARGS} -GNinja \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_SHARED_LIBS=ON \
+  ..
+ninja install
+popd

--- a/recipes/aws-c-common/meta.yaml
+++ b/recipes/aws-c-common/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "aws-c-common" %}
+{% set version = "0.4.56" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 14742af19a24956e7f01dab82bcf966eee689da2bc3a01d63cabc5fba0668599
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("aws-c-common", max_pin="x.x.x") }}
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - ninja
+
+test:
+  commands:
+    - test -f $PREFIX/lib/libaws-c-common${SHLIB_EXT}  # [unix]
+    - test -f $PREFIX/include/aws/common/config.h  # [unix]
+    - test -f $PREFIX/lib/cmake/AwsCFlags.cmake  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\aws-c-common.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\include\\aws\\common\\config.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\AwsCFlags.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/awslabs/aws-c-common
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Core c99 package for AWS SDK for C. Includes cross-platform primitives, configuration, data structures, and error handling.
+
+extra:
+  recipe-maintainers:
+    - xhochy


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
