### PR TITLE
add pytest-github-actions-annotate-failures 0.1.0

### DIFF
--- a/recipes/pytest-github-actions-annotate-failures/LICENSE
+++ b/recipes/pytest-github-actions-annotate-failures/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 utagawa kiki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pytest-github-actions-annotate-failures/meta.yaml
+++ b/recipes/pytest-github-actions-annotate-failures/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pytest-github-actions-annotate-failures" %}
+{% set version = "0.1.0" %}
+
+# TODO:
+# - version >0.1.0 (unreleased) includes LICENSE in sdist, remove from feedstock
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-github-actions-annotate-failures-{{ version }}.tar.gz
+  sha256: 568cf8338d99e53a747fb3fd1b007978721f542ce0ba5992b67f2d27effe1487
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - pytest >=4.0.0
+    - python
+
+test:
+  imports:
+    - pytest_github_actions_annotate_failures
+  commands:
+    - python -m pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/utgwkk/pytest-github-actions-annotate-failures
+  summary: pytest plugin to annotate failed tests with a workflow command for GitHub Actions
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
  - upstream `master` already includes LICENSE, added TODO
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
