### PR TITLE
Add abc classroom to Conda Forge

### DIFF
--- a/recipes/abc-classroom/meta.yaml
+++ b/recipes/abc-classroom/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "abc-classroom" %}
+{% set version = "0.0.15" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d4495b34d8e57e0e5cc4fd9ab1d9a703cd7d15b201f40cef0891feffc8672abb
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+    - nbclean
+    - jinja2
+    - nbformat
+    - ruamel.yaml
+    - github3.py
+test:
+  imports:
+    - # What would we wnat to test for abc-classroom - importing a few things perhaps or running something at the cli?
+
+about:
+  home: http://github.com/earthlab/abc-classroom
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'A package for managing student assignment repos in Github Classroom.'
+
+  description: |
+    A set of command line commands that create template repos, push new content 
+    to GitHub, collect student assignment repos and returns feedback. This package is maintained
+    by Earth Lab.
+  doc_url: http://abc-classroom.readthedocs.io/
+  dev_url: https://github.com/earthlab/abc-classroom
+
+extra:
+  recipe-maintainers:
+    - lwasser

--- a/recipes/abc-classroom/meta.yaml
+++ b/recipes/abc-classroom/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - github3.py
 test:
   imports:
-    - abc-classroom
+    - abcclassroom
 
 about:
   home: http://github.com/earthlab/abc-classroom

--- a/recipes/abc-classroom/meta.yaml
+++ b/recipes/abc-classroom/meta.yaml
@@ -27,13 +27,13 @@ requirements:
     - github3.py
 test:
   imports:
-    - # What would we wnat to test for abc-classroom - importing a few things perhaps or running something at the cli?
+    - abc-classroom
 
 about:
   home: http://github.com/earthlab/abc-classroom
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE
+  license_file: LICENSE.rst
   summary: 'A package for managing student assignment repos in Github Classroom.'
 
   description: |


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
