### PR TITLE
Adding `spherical` package

### DIFF
--- a/recipes/spherical/meta.yaml
+++ b/recipes/spherical/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "spherical" %}
+{% set version = "0.0.1" %}
+{% set sha256 = "b2e44f1e18796d0928d4bec66253b37650aaba661ac9e66787779cca71dfbc11" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  noarch: python
+  number: 0
+  script: /bin/rm -f pyproject.toml && {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6
+    - pip >=20.0.2
+  run:
+    - python >=3.6
+    - numpy >=1.13
+    - scipy >=1.0
+    - numba >=0.50
+    - quaternionic >=0.1.15
+
+test:
+  imports:
+    - spherical
+
+about:
+  home: https://github.com/moble/spherical
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Evaluate and transform D matrices, 3-j symbols, and (scalar or spin-weighted) spherical harmonics
+  description: |
+    This package provides efficient, accurate, and numerically stable code to compute various
+    spherical functions and related quantities.  The code is written in pure python, but is
+    automatically compiled with numba for greater efficiency.
+  doc_url: https://spherical.readthedocs.io/
+  dev_url: https://github.com/moble/spherical
+
+extra:
+  recipe-maintainers:
+    - moble


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
