### PR TITLE
PR: Add jupyterlab-translate package

### DIFF
--- a/recipes/jupyterlab-translate/meta.yaml
+++ b/recipes/jupyterlab-translate/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "jupyterlab-translate" %}
+{% set version = "0.1.1" %}
+{% set hash = "bbd8b50d02397a179e14192bff410983e9012e6f6ceb455cb002e1eea26b448c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: {{ hash }}
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - jupyterlab-translate = jupyterlab_translate.cli:main
+    - gettext-extract = jupyterlab_translate.gettext_extract:main
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - babel
+    - click
+    - cookiecutter
+    - nodejs
+    - polib
+    - python
+
+test:
+  commands:
+    - gettext-extract --help
+    - jupyterlab-translate --help
+  imports:
+    - jupyterlab_translate
+
+about:
+  home: https://github.com/jupyterlab/jupyterlab-translate
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Jupyterlab Language Pack Translations Helper'
+  description: |
+    Jupyter Translate provides functionality to extract localizable strings
+    from Jupyterlab extensions. Extensions can update the `jupyterlab-
+    language-packs` repository or provide localization files in the extension
+    package.
+  doc_url: https://github.com/jupyterlab/jupyterlab-translate
+  dev_url: https://github.com/jupyterlab/jupyterlab-translate
+
+extra:
+  recipe-maintainers:
+    - goanpeca


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
