### PR TITLE
Add `azure-keyvault-secrets`

### DIFF
--- a/recipes/azure-keyvault-secrets/LICENSE.txt
+++ b/recipes/azure-keyvault-secrets/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/azure-keyvault-secrets/meta.yaml
+++ b/recipes/azure-keyvault-secrets/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "azure-keyvault-secrets" %}
+{% set version = "4.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1083ab900da5ec63c518ffef49d9fdca02c81ddffdf80c52c03cd9da479e021f
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - azure-core >=1.7.0,<2.0.0
+    - msrest >=0.6.0
+    - azure-common ~=1.1
+
+test:
+  imports:
+    - azure.keyvault.secrets
+    - azure.keyvault.secrets.aio
+
+about:
+  home: https://docs.microsoft.com/en-au/azure/key-vault/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'Azure Key Vault Secret client library for Python'
+  doc_url: https://azuresdkdocs.blob.core.windows.net/$web/python/azure-keyvault-secrets/latest/index.html
+  dev_url: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/keyvault/azure-keyvault-secrets
+
+extra:
+  recipe-maintainers:
+    - dhirschfeld

--- a/recipes/azure-keyvault-secrets/meta.yaml
+++ b/recipes/azure-keyvault-secrets/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.zip
   sha256: 1083ab900da5ec63c518ffef49d9fdca02c81ddffdf80c52c03cd9da479e021f
 
 build:

--- a/recipes/azure-keyvault-secrets/meta.yaml
+++ b/recipes/azure-keyvault-secrets/meta.yaml
@@ -13,7 +13,7 @@ build:
   noarch: python
   number: 0
   script: |
-    cd {{ SRC_DIR }}/sdk/keyvault/azure-keyvault-secrets
+    cd ./sdk/keyvault/azure-keyvault-secrets
     {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipes/azure-keyvault-secrets/meta.yaml
+++ b/recipes/azure-keyvault-secrets/meta.yaml
@@ -12,7 +12,9 @@ source:
 build:
   noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: |
+    cd {{ SRC_DIR }}/sdk/keyvault/azure-keyvault-secrets
+    {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:

--- a/recipes/azure-keyvault-secrets/meta.yaml
+++ b/recipes/azure-keyvault-secrets/meta.yaml
@@ -12,9 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: |
-    cd ./sdk/keyvault/azure-keyvault-secrets
-    {{ PYTHON }} -m pip install . -vv
+  script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
