### PR TITLE
Adding kaleido-core

### DIFF
--- a/recipes/kaleido-core/bld.bat
+++ b/recipes/kaleido-core/bld.bat
@@ -1,0 +1,11 @@
+set APP_DIR=%PREFIX%\Library\bin\KaleidoApp
+set LAUNCH_SCRIPT=%PREFIX%\Library\bin\kaleido.cmd
+set BIN_LOCATION=%APP_DIR%/kaleido.cmd
+
+mkdir -p $APP_DIR
+copy * $APP_DIR
+
+(
+echo @echo off
+echo %BIN_LOCATION% %*
+)>"%LAUNCH_SCRIPT%"

--- a/recipes/kaleido-core/bld.bat
+++ b/recipes/kaleido-core/bld.bat
@@ -2,8 +2,8 @@ set APP_DIR=%PREFIX%\Library\bin\KaleidoApp
 set LAUNCH_SCRIPT=%PREFIX%\Library\bin\kaleido.cmd
 set BIN_LOCATION=%APP_DIR%/kaleido.cmd
 
-mkdir -p $APP_DIR
-copy * $APP_DIR
+mkdir %APP_DIR%
+copy * %APP_DIR%
 
 (
 echo @echo off

--- a/recipes/kaleido-core/bld.bat
+++ b/recipes/kaleido-core/bld.bat
@@ -4,6 +4,7 @@ set BIN_LOCATION=%APP_DIR%/kaleido.cmd
 
 mkdir %APP_DIR%
 xcopy * %APP_DIR% /E/H
+if errorlevel 1 exit 1
 
 (
 echo @echo off

--- a/recipes/kaleido-core/bld.bat
+++ b/recipes/kaleido-core/bld.bat
@@ -3,9 +3,9 @@ set LAUNCH_SCRIPT=%PREFIX%\Library\bin\kaleido.cmd
 set BIN_LOCATION=%APP_DIR%/kaleido.cmd
 
 mkdir %APP_DIR%
-copy * %APP_DIR%
+xcopy * %APP_DIR% /E/H
 
 (
 echo @echo off
-echo %BIN_LOCATION% %*
+echo %BIN_LOCATION% %%*
 )>"%LAUNCH_SCRIPT%"

--- a/recipes/kaleido-core/build.sh
+++ b/recipes/kaleido-core/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eux
+
+APP_DIR=$PREFIX/bin/KaleidoApp
+LAUNCH_SCRIPT=$PREFIX/bin/kaleido
+BIN_LOCATION=$APP_DIR/kaleido
+mkdir -p $APP_DIR
+
+# Copy everything to app directory
+cp -r ./* $APP_DIR
+
+# Clean up conda build files
+rm -rf $APP_DIR/build_env_setup.sh
+rm -rf $APP_DIR/conda_build.sh
+
+# Write launch script and make executable
+cat <<EOF >$LAUNCH_SCRIPT
+#!/bin/bash
+export FONTCONFIG_PATH=$PREFIX/etc/fonts
+$BIN_LOCATION "\$@"
+EOF
+chmod +x $LAUNCH_SCRIPT

--- a/recipes/kaleido-core/build.sh
+++ b/recipes/kaleido-core/build.sh
@@ -19,4 +19,5 @@ cat <<EOF >$LAUNCH_SCRIPT
 export FONTCONFIG_PATH=$PREFIX/etc/fonts
 $BIN_LOCATION "\$@"
 EOF
+
 chmod +x $LAUNCH_SCRIPT

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -1,0 +1,61 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+# Using the name variable with the URL in line 14 is convenient
+# when copying and pasting from another recipe, but not really needed.
+{% set name = "kaleido-core" %}
+{% set version = "0.1.0a1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip
+  sha256: 99efdea7d0617ea7ce0a243481de77df50dadb14726610da575f30dc74f88dc4
+
+build:
+  number: 0
+  ignore_run_exports:
+    - sqlite  # Chromium loads sqlite dynamically
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - sysroot_linux-64 2.17  # [linux64]
+  host:
+    - expat
+    - nspr
+    - nss
+    - sqlite
+  run:
+    - expat
+    - nspr
+    - nss
+    - sqlite
+    - fontconfig
+    - fonts-conda-forge
+
+#test:
+#  # Some packages might need a `test/commands` key to check CLI.
+#  # List all the packages/modules that `run_test.py` imports.
+#  imports:
+#    - simplejson
+#    - simplejson.tests
+
+about:
+  home: https://github.com/plotly/Kaleido
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'Fast static image export for web-based visualization libraries'
+  description: |
+    Kaleido is a cross-platform library for generating static images
+    (e.g. png, svg, pdf, etc.) for web-based visualization libraries, with a
+    particular focus on eliminating external dependencies.
+  doc_url: https://github.com/plotly/Kaleido
+  dev_url: https://github.com/plotly/Kaleido
+
+extra:
+  recipe-maintainers:
+    - jonmmease

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -24,7 +24,9 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - sysroot_linux-64 2.17  # [linux64]
+    # Uncomment after feedstock creation to specify minimum GLIBC version and change
+    # docker image to condaforge/linux-anvil-cos7-x86_64
+    # - sysroot_linux-64 2.17  # [linux64]
   host:
     - expat   # [linux64]
     - nspr    # [linux64]

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip  # [linux64]
-  sha256: 0aa7dde3e767b4b8c1b9aa84de204186442b061fdbeb1ff0c3e486ed7074d7fb  # [linux64]
+  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip  # [linux]
+  sha256: 0aa7dde3e767b4b8c1b9aa84de204186442b061fdbeb1ff0c3e486ed7074d7fb  # [linux]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_mac.zip  # [osx]
   sha256: 694b7f29a38b7dbc9b262a03a579e56b2ca34ce64ea58ad264b8ef5ae32904cf  # [osx]
@@ -19,7 +19,7 @@ build:
   number: 0
   ignore_run_exports:
     # Chromium loads sqlite dynamically
-    - sqlite  # [linux64]
+    - sqlite  # [linux]
   missing_dso_whitelist:
     - /usr/lib/*  # [osx]
     - /System/Library/Frameworks/*  # [osx]
@@ -29,19 +29,19 @@ requirements:
     - {{ compiler('c') }}
     # Uncomment after feedstock creation to specify minimum GLIBC version and change
     # docker image to condaforge/linux-anvil-cos7-x86_64
-    # - sysroot_linux-64 2.17  # [linux64]
+    # - sysroot_linux-64 2.17  # [linux]
   host:
-    - expat   # [linux64]
-    - nspr    # [linux64]
-    - nss     # [linux64]
-    - sqlite  # [linux64]
+    - expat   # [linux]
+    - nspr    # [linux]
+    - nss     # [linux]
+    - sqlite  # [linux]
   run:
-    - expat   # [linux64]
-    - nspr    # [linux64]
-    - nss     # [linux64]
-    - sqlite  # [linux64]
-    - fontconfig         # [linux64]
-    - fonts-conda-forge  # [linux64]
+    - expat   # [linux]
+    - nspr    # [linux]
+    - nss     # [linux]
+    - sqlite  # [linux]
+    - fontconfig         # [linux]
+    - fonts-conda-forge  # [linux]
 
 test:
   requires:

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -1,40 +1,48 @@
 {% set name = "kaleido-core" %}
-{% set version = "0.1.0a1" %}
+{% set version = "0.1.0a2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip
-  sha256: 99efdea7d0617ea7ce0a243481de77df50dadb14726610da575f30dc74f88dc4
+  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip  # [linux64]
+  sha256: 0aa7dde3e767b4b8c1b9aa84de204186442b061fdbeb1ff0c3e486ed7074d7fb  # [linux64]
+
+  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_mac.zip  # [osx]
+  sha256: 694b7f29a38b7dbc9b262a03a579e56b2ca34ce64ea58ad264b8ef5ae32904cf  # [osx]
+
+  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_win_x64.zip  # [win64]
+  sha256: b9c80478d684ec25bbece8744c3cd032a7058726c720015479bf5cce7fcfebbf  # [win64]
 
 build:
   number: 0
   ignore_run_exports:
-    - sqlite  # Chromium loads sqlite dynamically
+    # Chromium loads sqlite dynamically
+    - sqlite  # [linux64]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - sysroot_linux-64 2.17  # [linux64]
   host:
-    - expat
-    - nspr
-    - nss
-    - sqlite
+    - expat   # [linux64]
+    - nspr    # [linux64]
+    - nss     # [linux64]
+    - sqlite  # [linux64]
   run:
-    - expat
-    - nspr
-    - nss
-    - sqlite
-    - fontconfig
-    - fonts-conda-forge
+    - expat   # [linux64]
+    - nspr    # [linux64]
+    - nss     # [linux64]
+    - sqlite  # [linux64]
+    - fontconfig         # [linux64]
+    - fonts-conda-forge  # [linux64]
 
 test:
   commands:
     - |  # Check for presence of png image prefix in output
-      echo '{"data": {"data": []}, "format": "png"}' | kaleido plotly | grep iVBORw
+      echo '{"data": {"data": []}, "format": "png"}' | kaleido plotly | grep iVBORw  # [not win64]
+      echo '{"data": {"data": []}, "format": "png"}' | kaleido plotly | findstr iVBORw  # [win64]
 
 about:
   home: https://github.com/plotly/Kaleido

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -44,10 +44,8 @@ requirements:
     - fonts-conda-forge  # [linux64]
 
 test:
-  commands:
-    - |  # Check for presence of png image prefix in output
-      echo '{"data": {"data": []}, "format": "png"}' | kaleido plotly | grep iVBORw  # [not win64]
-      echo '{"data": {"data": []}, "format": "png"}' | kaleido plotly | findstr iVBORw  # [win64]
+  requires:
+    - python
 
 about:
   home: https://github.com/plotly/Kaleido

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kaleido-core" %}
-{% set version = "0.1.0a2" %}
+{% set version = "0.1.0a3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip  # [linux]
-  sha256: 0aa7dde3e767b4b8c1b9aa84de204186442b061fdbeb1ff0c3e486ed7074d7fb  # [linux]
+  sha256: 523fce13fca1fac2770273f2f19b3bac20d7a47e78ef9caa58590e98500535d8  # [linux]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_mac.zip  # [osx]
-  sha256: 694b7f29a38b7dbc9b262a03a579e56b2ca34ce64ea58ad264b8ef5ae32904cf  # [osx]
+  sha256: 785b7a38ded6b5f525911f856eabf91cdc137550e224055b01707a73568aa508  # [osx]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_win_x64.zip  # [win64]
-  sha256: b9c80478d684ec25bbece8744c3cd032a7058726c720015479bf5cce7fcfebbf  # [win64]
+  sha256: 2bf0cea17642322aa8681c41f465550f2338afc68a03c4b241b88d823fefecd8  # [win64]
 
 build:
   number: 0

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -20,6 +20,9 @@ build:
   ignore_run_exports:
     # Chromium loads sqlite dynamically
     - sqlite  # [linux64]
+  missing_dso_whitelist:
+    - /usr/lib/*  # [osx]
+    - /System/Library/Frameworks/*  # [osx]
 
 requirements:
   build:

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -27,7 +27,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
     # Uncomment after feedstock creation to specify minimum GLIBC version and change
     # docker image to condaforge/linux-anvil-cos7-x86_64
     # - sysroot_linux-64 2.17  # [linux64]

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -1,8 +1,3 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
-# Using the name variable with the URL in line 14 is convenient
-# when copying and pasting from another recipe, but not really needed.
 {% set name = "kaleido-core" %}
 {% set version = "0.1.0a1" %}
 
@@ -36,12 +31,10 @@ requirements:
     - fontconfig
     - fonts-conda-forge
 
-#test:
-#  # Some packages might need a `test/commands` key to check CLI.
-#  # List all the packages/modules that `run_test.py` imports.
-#  imports:
-#    - simplejson
-#    - simplejson.tests
+test:
+  commands:
+    - |  # Check for presence of png image prefix in output
+      echo '{"data": {"data": []}, "format": "png"}' | kaleido plotly | grep iVBORw
 
 about:
   home: https://github.com/plotly/Kaleido

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -24,6 +24,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     # Uncomment after feedstock creation to specify minimum GLIBC version and change
     # docker image to condaforge/linux-anvil-cos7-x86_64
     # - sysroot_linux-64 2.17  # [linux64]

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -45,6 +45,7 @@ requirements:
     - sqlite  # [linux]
     - fontconfig         # [linux]
     - fonts-conda-forge  # [linux]
+    - __osx >=10.10      # [osx]
 
 test:
   requires:

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -51,7 +51,9 @@ about:
   home: https://github.com/plotly/Kaleido
   license: MIT
   license_family: MIT
-  license_file: LICENSE.txt
+  license_file:
+    - LICENSE.txt
+    - repos/CREDITS.html
   summary: 'Fast static image export for web-based visualization libraries'
   description: |
     Kaleido is a cross-platform library for generating static images

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kaleido-core" %}
-{% set version = "0.1.0a3" %}
+{% set version = "0.1.0a4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip  # [linux]
-  sha256: 523fce13fca1fac2770273f2f19b3bac20d7a47e78ef9caa58590e98500535d8  # [linux]
+  sha256: 578bf8c9806553d27a61ddb41d710664bebc099bb77bfb95c76277f7ee093a7b  # [linux]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_mac.zip  # [osx]
-  sha256: 785b7a38ded6b5f525911f856eabf91cdc137550e224055b01707a73568aa508  # [osx]
+  sha256: 01b2bdb0a343df88857d562139d1c96d72b41ff8fd53b5be62379d9f41e29dea  # [osx]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_win_x64.zip  # [win64]
-  sha256: 2bf0cea17642322aa8681c41f465550f2338afc68a03c4b241b88d823fefecd8  # [win64]
+  sha256: c8c17c91920833882213dd54ab4a1952966ef8ec0046dfe047671070e35ec2a6  # [win64]
 
 build:
   number: 0
@@ -57,8 +57,7 @@ about:
   license_family: MIT
   license_file:
     - LICENSE.txt
-    - CREDITS.html        # [linux]
-    - repos/CREDITS.html  # [not linux]
+    - CREDITS.html
   summary: 'Fast static image export for web-based visualization libraries'
   description: |
     Kaleido is a cross-platform library for generating static images

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -12,8 +12,8 @@ source:
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_mac.zip  # [osx]
   sha256: 815e77d5858c97921e31d524c172df6a12a7a7f9518548ddb237a23840dc2738  # [osx]
 
-  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_win_x64.zip  # [win64]
-  sha256: 13f9776a9e87cc327ca6804d310d0c7515f176f9a951ad5bcf9eb77a9c8c6297  # [win64]
+  url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_win_x64.zip  # [win]
+  sha256: 13f9776a9e87cc327ca6804d310d0c7515f176f9a951ad5bcf9eb77a9c8c6297  # [win]
 
 build:
   number: 0

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -57,7 +57,8 @@ about:
   license_family: MIT
   license_file:
     - LICENSE.txt
-    - CREDITS.html
+    - CREDITS.html        # [linux]
+    - repos/CREDITS.html  # [not linux]
   summary: 'Fast static image export for web-based visualization libraries'
   description: |
     Kaleido is a cross-platform library for generating static images

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kaleido-core" %}
-{% set version = "0.1.0a4" %}
+{% set version = "0.1.0a5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_minimal_linux_x64.zip  # [linux]
-  sha256: 578bf8c9806553d27a61ddb41d710664bebc099bb77bfb95c76277f7ee093a7b  # [linux]
+  sha256: 4544791929b7e98cd1049f8e9f994dd9397a5bcefcaf0fb49bd63b6bc7f81459  # [linux]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_mac.zip  # [osx]
-  sha256: 01b2bdb0a343df88857d562139d1c96d72b41ff8fd53b5be62379d9f41e29dea  # [osx]
+  sha256: 815e77d5858c97921e31d524c172df6a12a7a7f9518548ddb237a23840dc2738  # [osx]
 
   url: https://github.com/plotly/Kaleido/releases/download/v{{ version }}/kaleido_win_x64.zip  # [win64]
-  sha256: c8c17c91920833882213dd54ab4a1952966ef8ec0046dfe047671070e35ec2a6  # [win64]
+  sha256: 13f9776a9e87cc327ca6804d310d0c7515f176f9a951ad5bcf9eb77a9c8c6297  # [win64]
 
 build:
   number: 0

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -17,6 +17,9 @@ source:
 
 build:
   number: 0
+  # Remove skip after feedstock creation and sysroot_linux-64 2.17 dependency can be
+  # added
+  skip: True  # [linux]
   ignore_run_exports:
     # Chromium loads sqlite dynamically
     - sqlite  # [linux]

--- a/recipes/kaleido-core/meta.yaml
+++ b/recipes/kaleido-core/meta.yaml
@@ -56,7 +56,7 @@ about:
   license_family: MIT
   license_file:
     - LICENSE.txt
-    - repos/CREDITS.html
+    - CREDITS.html
   summary: 'Fast static image export for web-based visualization libraries'
   description: |
     Kaleido is a cross-platform library for generating static images

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -11,7 +11,7 @@ if platform.system == "Linux":
 if platform.system == "Windows":
     ext = ".cmd"
 else:
-    ext = ".sh"
+    ext = ""
 
 p = Popen(
     ['kaleido' + ext, "plotly", "--disable-gpu"],

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -4,11 +4,11 @@ import platform
 
 # Remove "sys.exit" after feedstock creation when running
 # on linux-anvil-cos7-x86_64 image
-if platform.system == "Linux":
+if platform.system() == "Linux":
     import sys
     sys.exit(0)
 
-if platform.system == "Windows":
+if platform.system() == "Windows":
     ext = ".cmd"
 else:
     ext = ""
@@ -22,4 +22,4 @@ p = Popen(
 stdout_data = p.communicate(
     input=json.dumps({"data": {"data": []}, "format": "png"})
 )[0]
-assert "iVBORw" in stdout_data
+assert "iVBOrw" in stdout_data

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -22,4 +22,4 @@ p = Popen(
 stdout_data = p.communicate(
     input=json.dumps({"data": {"data": []}, "format": "png"})
 )[0]
-assert "iVBOrw" in stdout_data
+assert "iVBORw" in stdout_data

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -11,7 +11,7 @@ if platform.system == "Linux":
 if platform.system == "Windows":
     ext = ".cmd"
 else:
-    ext = ".cmd"
+    ext = ".sh"
 
 p = Popen(
     ['kaleido' + ext, "plotly", "--disable-gpu"],

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -1,7 +1,20 @@
 from subprocess import Popen, PIPE
 import json
+import platform
+
+# Remove "sys.exit" after feedstock creation when running
+# on linux-anvil-cos7-x86_64 image
+if platform.system == "Linux":
+    import sys
+    sys.exit(0)
+
+if platform.system == "Windows":
+    ext = ".cmd"
+else:
+    ext = ".cmd"
+
 p = Popen(
-    ['kaleido', "plotly", "--disable-gpu"],
+    ['kaleido' + ext, "plotly", "--disable-gpu"],
     stdout=PIPE, stdin=PIPE, stderr=PIPE,
     text=True
 )

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -1,0 +1,12 @@
+from subprocess import Popen, PIPE
+import json
+p = Popen(
+    ['kaleido', "plotly", "--disable-gpu"],
+    stdout=PIPE, stdin=PIPE, stderr=PIPE,
+    text=True
+)
+
+stdout_data = p.communicate(
+    input=json.dumps({"data": {"data": []}, "format": "png"})
+)[0]
+assert "iVBORw" in stdout_data

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -2,12 +2,6 @@ from subprocess import Popen, PIPE
 import json
 import platform
 
-# Remove "sys.exit" after feedstock creation when running
-# on linux-anvil-cos7-x86_64 image
-if platform.system() == "Linux":
-    import sys
-    sys.exit(0)
-
 if platform.system() == "Windows":
     ext = ".cmd"
 else:

--- a/recipes/kaleido-core/run_test.py
+++ b/recipes/kaleido-core/run_test.py
@@ -14,7 +14,7 @@ else:
     ext = ""
 
 p = Popen(
-    ['kaleido' + ext, "plotly", "--disable-gpu"],
+    ['kaleido' + ext, "plotly", "--disable-gpu", "--no-sandbox", "--disable-breakpad"],
     stdout=PIPE, stdin=PIPE, stderr=PIPE,
     text=True
 )


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] ~Source~ Binary is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] ~If static libraries are linked in, the license of the static library is packaged.~
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

This PR is a WIP implementation of the updates discussed in https://github.com/conda-forge/staged-recipes/pull/12093#issuecomment-697415943 with @ericdill, @wolfv, and @mbargull (Thanks again for your time on this!).  This PR contains the recipe for the non-Python `kaleido-core` package.  I've only tested the Linux build locally so far but, overall, I think just about everything worked out as we discussed:
 - Minimal builds of kaleido core, with no vendored shared libraries or fonts, are now published as release artifacts in the kaleido repo, along with their sha256 hashes (See `kaleido_minimal_linux_arm64.zip` and `kaleido_minimal_linux_arm64.zip.sha256` from  https://github.com/plotly/Kaleido/releases/tag/v0.1.0a2).
 - Everything works properly when referencing the conda-forge builds of `expat`, `nspr`, `nss`, and `sqlite`.
 - Font loading works properly when depending on `fontconfig` and `fonts-conda-forge`, as long as the `FONTCONFIG_PATH` environment variable is set in the `kaleido` launch script.
 - The licenses for all of Chromium's bundled dependencies are included in the `CREDITS.html` file. This file is generated by the chromium build system, and I reference it from the main LICENSE.txt file.
 - A `kaleido` entry point bash script is placed in the `bin` directory on installation. The Python library is going to be updated to search the `PATH` if it doesn't find the kaleido binary vendored in the Python package.

I'll still need to do some work on macos and win64 builds. Thanks

