### PR TITLE
added country_converter recipe

### DIFF
--- a/recipes/country_converter/meta.yaml
+++ b/recipes/country_converter/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "country_converter" %}
+{% set version = "0.7.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/country_converter-{{ version }}.tar.gz
+  sha256: 27ff7e07fedbbbab612f435aca069339d26092d9bd992b284482213839d787ae
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - coco = country_converter.country_converter:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - pandas >=0.17.0
+    - python
+
+test:
+  imports:
+    - country_converter
+  commands:
+    - pip check
+    - coco --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/konstantinstadler/country_converter
+  summary: The country converter (coco) - a Python package for converting country names between different classifications schemes.
+  license: GPL-3.0
+  license_file: LICENSE
+  description: |
+    The country converter (coco) is a Python package to convert and match 
+    country names between different classifications and between different 
+    naming versions. Internally it uses regular expressions to match country 
+    names. Coco can also be used to build aggregation concordance matrices 
+    between different classification schemes.
+  doc_url: https://github.com/konstantinstadler/country_converter
+  dev_url: https://github.com/konstantinstadler/country_converter/blob/master/CONTRIBUTING.rst
+
+
+extra:
+  recipe-maintainers:
+    - konstantinstadler

--- a/recipes/country_converter/meta.yaml
+++ b/recipes/country_converter/meta.yaml
@@ -37,7 +37,7 @@ test:
 about:
   home: https://github.com/konstantinstadler/country_converter
   summary: The country converter (coco) - a Python package for converting country names between different classifications schemes.
-  license: GPL-3.0
+  license: GPL-3.0-or-later
   license_file: LICENSE
   description: |
     The country converter (coco) is a Python package to convert and match 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
