### PR TITLE
Adding cliche (based on pypi package)

### DIFF
--- a/recipes/cliche/license.txt
+++ b/recipes/cliche/license.txt
@@ -1,0 +1,7 @@
+Copyright 2020 Pascal van Kooten <pascal@vks.ai>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/cliche/meta.yaml
+++ b/recipes/cliche/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cliche" %}
-{% set version = "0.5.26" %}
+{% set version = "0.5.27" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cliche-{{ version }}.tar.gz
-  sha256: 744a82f42202d668a0b0af7df8a4e5d2c4e704509b53936020c4430385d8353e
+  sha256: 48bbe64bdd9675db28e1cd0c47abfc4d66542907798ed626ac3c9dcab6fbe905
 
 build:
   number: 0
@@ -38,8 +38,8 @@ about:
   home: https://github.com/kootenpv/cliche
   summary: A minimalistic CLI wrapper out to be the best
   license: MIT
-  license_file: PLEASE_ADD_LICENSE_FILE
+  license_file: license.txt
 
 extra:
   recipe-maintainers:
-    - pascal
+    - kootenpv

--- a/recipes/cliche/meta.yaml
+++ b/recipes/cliche/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "cliche" %}
 {% set version = "0.5.27" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cliche-{{ version }}.tar.gz
-  sha256: 48bbe64bdd9675db28e1cd0c47abfc4d66542907798ed626ac3c9dcab6fbe905
+  sha256: 58d8053a36997f6f9f14eca43962f39ea02d37db96fc43245c7b27ef809c37c3
 
 build:
   number: 0

--- a/recipes/cliche/meta.yaml
+++ b/recipes/cliche/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - pip
     - python
   run:
-    - argparse >=1.4.0
     - python
 
 test:

--- a/recipes/cliche/meta.yaml
+++ b/recipes/cliche/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cliche" %}
-{% set version = "0.5.27" %}
+{% set version = "0.5.28" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/cliche/meta.yaml
+++ b/recipes/cliche/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "cliche" %}
+{% set version = "0.5.26" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cliche-{{ version }}.tar.gz
+  sha256: 744a82f42202d668a0b0af7df8a4e5d2c4e704509b53936020c4430385d8353e
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - cliche = cliche.__init__:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - argparse >=1.4.0
+    - python
+
+test:
+  imports:
+    - cliche
+  commands:
+    - pip check
+    - cliche --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/kootenpv/cliche
+  summary: A minimalistic CLI wrapper out to be the best
+  license: MIT
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - pascal


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
