### PR TITLE
Add densmap-learn recipe

### DIFF
--- a/recipes/densmap-learn/LICENSE
+++ b/recipes/densmap-learn/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright © 2020 <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/densmap-learn/LICENSE
+++ b/recipes/densmap-learn/LICENSE
@@ -1,9 +1,0 @@
-The MIT License (MIT)
-
-Copyright © 2020 <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
+  noarch: python
 
 requirements:
   host:

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -16,13 +16,10 @@ build:
 
 requirements:
   host:
-    - numba ==0.48.0
-    - numpy >=1.13
     - pip
     - python
-    - scikit-learn >=0.16
-    - scipy >=0.19
   run:
+    - setuptools
     - numba ==0.48.0
     - numpy >=1.13
     - python
@@ -32,8 +29,6 @@ requirements:
 test:
   imports:
     - densmap
-  requires:
-    - nose
 
 about:
   home: "http://github.com/hhcho/densvis"

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "densmap-learn" %}
+{% set version = "0.2.1" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: 6e9d8a2286335633b924fbb631a0f4fbbb1b6c07714feaae86ec3fc0e9124716
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - numba ==0.48.0
+    - numpy >=1.13
+    - pip
+    - python
+    - scikit-learn >=0.16
+    - scipy >=0.19
+  run:
+    - numba ==0.48.0
+    - numpy >=1.13
+    - python
+    - scikit-learn >=0.16
+    - scipy >=0.19
+
+test:
+  imports:
+    - densmap
+  requires:
+    - nose
+
+about:
+  home: "http://github.com/hhcho/densvis"
+  license: MIT
+  license_family: MIT
+  license_file: 
+  summary: "Density-preserving data visualization tool densMAP"
+  doc_url: 
+  dev_url: 
+
+extra:
+  recipe-maintainers:
+    - Alanocallaghan

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -38,7 +38,7 @@ about:
   home: "http://github.com/hhcho/densvis"
   license: MIT
   license_family: MIT
-  license_file: 
+  license_file: LICENSE
   summary: "Density-preserving data visualization tool densMAP"
   doc_url: 
   dev_url: 

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "densmap-learn" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: 6e9d8a2286335633b924fbb631a0f4fbbb1b6c07714feaae86ec3fc0e9124716
+  sha256: 004f66f0fbddfd5f36cdde29abdb0e59b83fc9d15ef9373114194fc3430a0800
 
 build:
   number: 0

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.7.8
   run:
     - setuptools
     - numba ==0.48.0

--- a/recipes/densmap-learn/meta.yaml
+++ b/recipes/densmap-learn/meta.yaml
@@ -36,8 +36,6 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: "Density-preserving data visualization tool densMAP"
-  doc_url: 
-  dev_url: 
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
