### PR TITLE
Adding onnxconverter-common

### DIFF
--- a/recipes/onnxconverter-common/meta.yaml
+++ b/recipes/onnxconverter-common/meta.yaml
@@ -15,7 +15,6 @@ build:
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
-  build:
   host:
     - python
     - pip
@@ -27,7 +26,7 @@ requirements:
 
 test:
   imports:
-    - unittest
+    - onnxconverter-common
     
 about:
   home: https://github.com/microsoft/onnxconverter-common

--- a/recipes/onnxconverter-common/meta.yaml
+++ b/recipes/onnxconverter-common/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "onnxconverter-common" %}
+{% set version = "1.7.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/microsoft/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: d3b468b19e4318983635e4cda95985c11a554c2e5704240c513ff0c7d9e361bf
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - protobuf
+    - onnx
+
+test:
+  imports:
+    - unittest
+    
+about:
+  home: https://github.com/microsoft/onnxconverter-common
+  license: MIT
+  license_file: LICENSE
+  summary: 'Common utilities for ONNX converters.'
+  description: |
+    The onnxconverter-common package provides common functions and utilities for use in converters from various AI frameworks to ONNX.
+    It also enables the different converters to work together to convert a model from mixed frameworks, like a scikit-learn pipeline embedding a xgboost model.
+
+extra:
+  recipe-maintainers:
+    - DavidKatz-il
+    - sephib

--- a/recipes/onnxconverter-common/meta.yaml
+++ b/recipes/onnxconverter-common/meta.yaml
@@ -26,7 +26,7 @@ requirements:
 
 test:
   imports:
-    - onnxconverter-common
+    - onnxconverter_common
     
 about:
   home: https://github.com/microsoft/onnxconverter-common


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
