### PR TITLE
Package quantized-mesh-encoder

### DIFF
--- a/recipes/quantized-mesh-encoder/meta.yaml
+++ b/recipes/quantized-mesh-encoder/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.3.0" %}
+{% set name = "quantized-mesh-encoder" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fa72fe5288c3f2f16697cbd13ce8a3071b60476f04a4bfb29ac9fd63accaf4f1
+
+build:
+  number: 0
+  skip: true  # [py<36]
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - python
+    - numpy
+    - cython
+    - pip
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - quantized_mesh_encoder
+
+about:
+  home: https://github.com/kylebarron/quantized-mesh-encoder
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A fast Python Quantized Mesh encoder
+  description: |
+    A fast Python Quantized Mesh encoder. Encodes a mesh with 100k coordinates and 180k triangles in 20ms.
+  doc_url: https://github.com/kylebarron/quantized-mesh-encoder
+  dev_url: https://github.com/kylebarron/quantized-mesh-encoder
+
+extra:
+  recipe-maintainers:
+    - davidbrochart
+    - kylebarron

--- a/recipes/quantized-mesh-encoder/meta.yaml
+++ b/recipes/quantized-mesh-encoder/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.0" %}
+{% set version = "0.3.1" %}
 {% set name = "quantized-mesh-encoder" %}
 
 package:
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: fa72fe5288c3f2f16697cbd13ce8a3071b60476f04a4bfb29ac9fd63accaf4f1
+  sha256: 606bcbfcf99e45476412a3797754cbc979383dfa5d45ab4bfb9c3206e17ee7c9
 
 build:
   number: 0
-  skip: true  # [py<36 and py>38]
+  skip: true  # [py<36]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/quantized-mesh-encoder/meta.yaml
+++ b/recipes/quantized-mesh-encoder/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<36 and py>38]
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
