### PR TITLE
Adding backoff 1.10.0

### DIFF
--- a/recipes/backoff/meta.yaml
+++ b/recipes/backoff/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - poetry >= 0.12
+    - poetry >=0.12
   run:
     - python
 

--- a/recipes/backoff/meta.yaml
+++ b/recipes/backoff/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "backoff" %}
+{% set version = "1.10.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/litl/backoff/archive/{{ version }}.tar.gz
+  sha256: b8fba021fac74055ac05eb7c7bfce4723aedde6cd0a504e5326bcb0bdd6d19a4
+
+build:
+  noarch: python
+  number: 0
+  script: "poetry build"
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - poetry >= 0.12
+  run:
+    - python
+
+test:
+  imports:
+    - backoff
+
+about:
+  home: https://github.com/litl/backoff
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Function decoration for backoff and retry.'
+
+  description: |
+    This module provides function decorators which can be used to wrap
+    a function such that it will be retried until some condition is met.
+    It is meant to be of use when accessing unreliable resources with
+    the potential for intermittent failures i.e. network resources and
+    external APIs. Somewhat more generally, it may also be of use for
+    dynamically polling resources for externally generated content.
+  doc_url: https://github.com/litl/backoff
+  dev_url: https://github.com/litl/backoff
+
+extra:
+  recipe-maintainers:
+    - deeplook


### PR DESCRIPTION
I hope the poetry build is correct as I'm not familiar with poetry. Maybe someone in @conda-forge/help-python is? 

I'm not the author of `backoff` but I need 1.10.0 for my own package in conda-forge as 1.8.0 lacks some features.