### PR TITLE
added deeptime package (rename of scikit-time)

### DIFF
--- a/recipes/deeptime/meta.yaml
+++ b/recipes/deeptime/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "deeptime" %}
+{% set version = "0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/{{ name }}-ml/{{name}}/archive/v{{ version }}.tar.gz
+  sha256: 7a2f1cb653c5b862822c0ed2de8195b1c414737ca1cf977e1a029ab75f474305
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: True  # [py<36]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+  host:
+    - python
+    - cython
+    - pip
+    - numpy
+    - scipy
+
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - scipy
+    - scikit-learn
+
+test:
+  imports:
+    - deeptime
+
+about:
+  home: https://github.com/deeptime-ml/deeptime
+  license: LGPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE.txt
+  summary: 'Python library for analysis of time series data including dimensionality reduction, clustering, and Markov model estimation.'
+
+  description: |
+    Deeptime is a Python library for analysis for time series data. 
+    In particular, methods for dimensionality reduction, clustering, 
+    and Markov model estimation are implemented. It is available for Python 3.6+.
+  doc_url: https://deeptime-ml.github.io/
+  dev_url: https://github.com/deeptime-ml/deeptime
+
+extra:
+  recipe-maintainers:
+    - clonker
+    - marscher
+

--- a/recipes/deeptime/meta.yaml
+++ b/recipes/deeptime/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - pip
     - numpy
     - scipy
+    - pybind11
 
   run:
     - python

--- a/recipes/deeptime/meta.yaml
+++ b/recipes/deeptime/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "deeptime" %}
-{% set version = "0.2" %}
+{% set version = "0.2.1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/deeptime/meta.yaml
+++ b/recipes/deeptime/meta.yaml
@@ -26,12 +26,16 @@ requirements:
     - numpy
     - scipy
     - pybind11
+    - intel-openmp  # [osx]
+    - llvm-openmp  # [osx]
+    - libgomp  # [linux]
 
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - scipy
     - scikit-learn
+    - intel-openmp  # [osx]
 
 test:
   imports:

--- a/recipes/deeptime/meta.yaml
+++ b/recipes/deeptime/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}-ml/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 7a2f1cb653c5b862822c0ed2de8195b1c414737ca1cf977e1a029ab75f474305
+  sha256: ce190140e9cced27f50a0873bef13901af666568abfc65123efa676d6bb35a0c
 
 build:
   number: 0

--- a/recipes/deeptime/meta.yaml
+++ b/recipes/deeptime/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/{{ name }}-ml/{{name}}/archive/v{{ version }}.tar.gz
+  url: https://github.com/{{ name }}-ml/{{ name }}/archive/v{{ version }}.tar.gz
   sha256: 7a2f1cb653c5b862822c0ed2de8195b1c414737ca1cf977e1a029ab75f474305
 
 build:
@@ -54,4 +54,3 @@ extra:
   recipe-maintainers:
     - clonker
     - marscher
-


### PR DESCRIPTION
@conda-forge/help-python - The existing package "scikit-time" has been renamed to "deeptime". The github organization as well as repositories have been renamed and there has not been a full release yet, so the [scikit-time-feedstock](https://github.com/conda-forge/scikit-time-feedstock) can be archived. This is mainly a copy of the existing feedstock with some updates and modifications (urls, hashes, maintainers).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
