### PR TITLE
add grpcio-health-checking 1.33.2

### DIFF
--- a/recipes/grpcio-health-checking/meta.yaml
+++ b/recipes/grpcio-health-checking/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "grpcio-health-checking" %}
 {% set version = "1.33.2" %}
-# appears to have matched since 1.0.0, but...
-{% set grpc_version = version %}
 
 package:
   name: {{ name|lower }}
@@ -21,7 +19,7 @@ requirements:
     - pip
     - python >=3.5
   run:
-    - grpcio >={{ grpc_version }}
+    - grpcio >={{ version }}
     - protobuf >=3.6.0
     - python >=3.5
 
@@ -33,7 +31,6 @@ test:
     - grpc_health.v1
   commands:
     - pip check
-    - python -c 'from grpc_version import VERSION; print(VERSION); assert VERSION == "{{ grpc_version }}"'
   requires:
     - pip
 

--- a/recipes/grpcio-health-checking/meta.yaml
+++ b/recipes/grpcio-health-checking/meta.yaml
@@ -19,11 +19,11 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.5
   run:
     - grpcio >={{ grpc_version }}
     - protobuf >=3.6.0
-    - python
+    - python >=3.5
 
 test:
   source_files:

--- a/recipes/grpcio-health-checking/meta.yaml
+++ b/recipes/grpcio-health-checking/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "grpcio-health-checking" %}
+{% set version = "1.33.2" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/grpcio-health-checking-{{ version }}.tar.gz
+  sha256: 35f8bce59f5e3b16ac524f954597dc54195e3277b1d600c96f54fc64780ebdf6
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - grpcio >=1.33.2
+    - protobuf >=3.6.0
+    - python
+
+test:
+  imports:
+    - grpc_health
+    - grpc_health.v1
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://grpc.io
+  summary: Standard Health Checking Service for gRPC
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/grpcio-health-checking/meta.yaml
+++ b/recipes/grpcio-health-checking/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "grpcio-health-checking" %}
 {% set version = "1.33.2" %}
-
+# appears to have matched since 1.0.0, but...
+{% set grpc_version = version %}
 
 package:
   name: {{ name|lower }}
@@ -20,16 +21,19 @@ requirements:
     - pip
     - python
   run:
-    - grpcio >=1.33.2
+    - grpcio >={{ grpc_version }}
     - protobuf >=3.6.0
     - python
 
 test:
+  source_files:
+    - grpc_version.py
   imports:
     - grpc_health
     - grpc_health.v1
   commands:
     - pip check
+    - python -c 'from grpc_version import VERSION; print(VERSION); assert VERSION == "{{ grpc_version }}"'
   requires:
     - pip
 

--- a/recipes/grpcio-health-checking/meta.yaml
+++ b/recipes/grpcio-health-checking/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/grpcio-health-checking-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 35f8bce59f5e3b16ac524f954597dc54195e3277b1d600c96f54fc64780ebdf6
 
 build:

--- a/recipes/grpcio-health-checking/run_test.py
+++ b/recipes/grpcio-health-checking/run_test.py
@@ -1,0 +1,23 @@
+""" grpc_version.py is generated during the build, capturing the version of grpcio
+    used to generate code from the protocol buffer definitions.
+
+    Historically, the grpc_version.VERSION has always matched PKG_VERSION.
+"""
+import os
+import grpc_version
+import sys
+
+PKG_VERSION = os.environ["PKG_VERSION"]
+GRPC_VERSION = grpc_version.VERSION
+
+print("""
+Checking grpc versions:
+  - recipe:           {pkg}
+  - grpc_version.py:  {grpc}
+""".format(pkg=PKG_VERSION, grpc=GRPC_VERSION))
+
+if PKG_VERSION != GRPC_VERSION:
+    print("... grpc_version.py does not match package version")
+    sys.exit(1)
+
+print("... versions match")


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there

- will (eventually) block https://github.com/conda-forge/dagster-feedstock/issues/76