### PR TITLE
Added feedstock for trampoline

### DIFF
--- a/recipes/trampoline/meta.yaml
+++ b/recipes/trampoline/meta.yaml
@@ -15,10 +15,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:

--- a/recipes/trampoline/meta.yaml
+++ b/recipes/trampoline/meta.yaml
@@ -39,4 +39,4 @@ about:
 extra:
   recipe-maintainers:
     - krisevans
-    - dhirschf
+    - dhirschfeld

--- a/recipes/trampoline/meta.yaml
+++ b/recipes/trampoline/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "trampoline" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://gitlab.com/ferreum/trampoline/-/archive/1d98f39c3015594e2ac8ed48dccc2f393b4dd82b/trampoline-1d98f39c3015594e2ac8ed48dccc2f393b4dd82b.tar.gz
+  sha256: 4e026488a57a7a49b3c4a809a93ace8fcccae5b66a7ef9b1b9581755c38ae15f
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - trampoline
+
+about:
+  home: https://gitlab.com/ferreum/trampoline
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'Simple and tiny yield-based trampoline implementation'
+
+  description: |
+    Simple and tiny yield-based trampoline implementation.
+  doc_url: https://gitlab.com/ferreum/trampoline
+  dev_url: https://gitlab.com/ferreum/trampoline
+
+extra:
+  recipe-maintainers:
+    - krisevans
+    - dhirschf


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
