### PR TITLE
add component-contribution

### DIFF
--- a/recipes/component-contribution/meta.yaml
+++ b/recipes/component-contribution/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "component-contribution" %}
+{% set version = "0.4.0b4" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/component-contribution-{{ version }}.tar.gz
+  sha256: e678a86f6cdba36c6cf0cac220066569c6403409c88817fa83aa9dd6ce5b7dcd
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - appdirs ~=1.4
+    - diskcache ~=5.0
+    - equilibrator-cache ~=0.4.0b2
+    - httpx ~=0.16
+    - path ~=15.0
+    - periodictable ~=1.5
+    - python >=3.6
+    - pyzenodo3 ~=1.0
+    - tenacity ~=6.2
+    - uncertainties ~=3.1
+
+test:
+  imports:
+    - component_contribution
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://gitlab.com/equilibrator/component-contribution
+  summary: Standard reaction Gibbs energy estimation for biochemical reactions.
+  license: MIT
+  license_file: LICENSE
+  description: >
+    Standard reaction Gibbs energy estimation for biochemical reactions.  For more
+    information on the method behind component-contribution, please view our open
+    access paper:
+
+    Noor E, Haraldsdóttir HS, Milo R, Fleming RMT (2013)
+    Consistent Estimation of Gibbs Energy Using Component Contributions,
+    PLoS Comput Biol 9:e1003098, DOI: 10.1371/journal.pcbi.1003098
+
+    Please, cite this paper if you publish work that uses component-contribution.
+  dev_url: https://gitlab.com/equilibrator/component-contribution
+
+extra:
+  recipe-maintainers:
+    - eladnoor
+    - Midnighter


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
