### PR TITLE
Adding tiny-process-library

### DIFF
--- a/recipes/tiny-process-library/bld.bat
+++ b/recipes/tiny-process-library/bld.bat
@@ -1,0 +1,20 @@
+mkdir build
+cd build
+
+cmake ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_LIBDIR=lib ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --install . --config Release
+if errorlevel 1 exit 1

--- a/recipes/tiny-process-library/build.sh
+++ b/recipes/tiny-process-library/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+mkdir build && cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DBUILD_SHARED_LIBS=ON \
+      $SRC_DIR
+
+cmake --build . --config Release
+cmake --install . --config Release

--- a/recipes/tiny-process-library/meta.yaml
+++ b/recipes/tiny-process-library/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "tiny-process-library" %}
+{% set version = "2.0.4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://gitlab.com/eidheim/{{ name }}/-/archive/v{{ version }}/{{ name }}-v{{ version }}.tar.gz
+    sha256: b99dcb51461323b8284a7762ad105c159b88cdcce0c2cc183e4f474f80ef1f1a
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make                               # [not win]
+    - cmake
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/process.hpp  # [not win]
+    - test -f ${PREFIX}/lib/libtiny-process-library.so  # [linux]
+    - test -f ${PREFIX}/lib/libtiny-process-library.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/tiny-process-library/tiny-process-library-config.cmake  # [not win]
+    - if exist %PREFIX%\\Library\\include\\process.hpp (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\lib\\tiny-process-library.lib (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\bin\\tiny-process-library.dll (exit 0) else (exit 1)  # [win]
+    - if exist %PREFIX%\\Library\\lib\\cmake\\tiny-process-library\\tiny-process-library-config.cmake (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://gitlab.com/eidheim/tiny-process-library
+  license: MIT
+  license_file: LICENSE
+  summary: A small platform independent library making it simple to create and stop new processes in C++.
+
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
The tiny-process-library ( )  is a small C++ library to launch processes, and it will be a dependency on Windows of the next release of the Gazebo robotic simulator (https://github.com/conda-forge/gazebo-feedstock, https://github.com/osrf/gazebo/pull/2864).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
