### PR TITLE
Added heaptrack

### DIFF
--- a/recipes/heaptrack/build.sh
+++ b/recipes/heaptrack/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+mkdir build && cd build
+
+cmake -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    ../source
+
+cmake --build . --target install -j${CPU_COUNT}

--- a/recipes/heaptrack/meta.yaml
+++ b/recipes/heaptrack/meta.yaml
@@ -1,0 +1,68 @@
+
+{% set name = "heaptrack" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/KDE/heaptrack/archive/v{{ version }}.tar.gz
+  sha256: f299a4846b80e607a412f439e17cddae13f0529701ffdb05eaa7ba878865717e
+  folder: source
+  # sha256 is the preferred checksum -- you can get it for a file with:
+  #  `openssl sha256 <file name>`.
+  # You may need the openssl package, available on conda-forge:
+  #  `conda install openssl -c conda-forge``
+  patches:
+    - stdc_format.patch
+
+build:
+  number: 0
+  skip: true  # [win]
+  ignore_run_exports:
+    - elfutils
+  
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+
+  host:
+    - boost-cpp
+    - libunwind
+    - elfutils
+
+  run:
+    - boost-cpp
+    - libunwind
+    - elfutils
+
+test:
+  commands:
+    - heaptrack_print --help
+
+about:
+  home: https://github.com/KDE/heaptrack
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
+  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
+  # See https://spdx.org/licenses/
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  license_file: COPYING
+  summary: 'heaptrack - a heap memory profiler for Linux'
+  description: |
+    Heaptrack traces all memory allocations and annotates these events with stack traces. Dedicated analysis tools then allow you to interpret the heap memory profile to:
+      find hotspots that need to be optimized to reduce the memory footprint of your application
+      find memory leaks, i.e. locations that allocate memory which is never deallocated
+      find allocation hotspots, i.e. code locations that trigger a lot of memory allocation calls
+      find temporary allocations, which are allocations that are directly followed by their deallocation
+  doc_url: https://userbase.kde.org/Heaptrack
+  dev_url: https://github.com/KDE/heaptrack
+
+extra:
+  recipe-maintainers:
+    - bcouturi
+    

--- a/recipes/heaptrack/meta.yaml
+++ b/recipes/heaptrack/meta.yaml
@@ -19,7 +19,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  skip: true  # [not linux]
   ignore_run_exports:
     - elfutils
   

--- a/recipes/heaptrack/meta.yaml
+++ b/recipes/heaptrack/meta.yaml
@@ -10,10 +10,6 @@ source:
   url: https://github.com/KDE/heaptrack/archive/v{{ version }}.tar.gz
   sha256: f299a4846b80e607a412f439e17cddae13f0529701ffdb05eaa7ba878865717e
   folder: source
-  # sha256 is the preferred checksum -- you can get it for a file with:
-  #  `openssl sha256 <file name>`.
-  # You may need the openssl package, available on conda-forge:
-  #  `conda install openssl -c conda-forge``
   patches:
     - stdc_format.patch
 
@@ -46,11 +42,7 @@ test:
 
 about:
   home: https://github.com/KDE/heaptrack
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
-  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
-  # See https://spdx.org/licenses/
   license: LGPL-2.1-or-later
-  license_family: LGPL
   license_file: source/COPYING
   summary: 'heaptrack - a heap memory profiler for Linux'
   description: |
@@ -65,4 +57,5 @@ about:
 extra:
   recipe-maintainers:
     - bcouturi
+    - chrisburr
     

--- a/recipes/heaptrack/meta.yaml
+++ b/recipes/heaptrack/meta.yaml
@@ -51,7 +51,7 @@ about:
   # See https://spdx.org/licenses/
   license: LGPL-2.1-or-later
   license_family: LGPL
-  license_file: COPYING
+  license_file: source/COPYING
   summary: 'heaptrack - a heap memory profiler for Linux'
   description: |
     Heaptrack traces all memory allocations and annotates these events with stack traces. Dedicated analysis tools then allow you to interpret the heap memory profile to:

--- a/recipes/heaptrack/stdc_format.patch
+++ b/recipes/heaptrack/stdc_format.patch
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2020-12-01 11:42:02.093529379 +0100
++++ CMakeLists.txt	2020-12-01 11:42:35.482271906 +0100
+@@ -92,6 +92,8 @@
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wpedantic")
+ endif()
+ 
++add_definitions(-D__STDC_FORMAT_MACROS)
++
+ include (CheckCXXSourceCompiles)
+ check_cxx_source_compiles(
+     "#include <unordered_map>


### PR DESCRIPTION
Added the recipe to package the command line part of heaptrack (https://github.com/KDE/heaptrack)

- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [X] Source is from official source
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
