### PR TITLE
Add lsstdesc-gcr-catalogs

### DIFF
--- a/recipes/lsstdesc-gcr-catalogs/meta.yaml
+++ b/recipes/lsstdesc-gcr-catalogs/meta.yaml
@@ -56,3 +56,5 @@ about:
 extra:
   recipe-maintainers:
     - yymao
+    - JoanneBogart
+    - heather999

--- a/recipes/lsstdesc-gcr-catalogs/meta.yaml
+++ b/recipes/lsstdesc-gcr-catalogs/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "lsstdesc-gcr-catalogs" %}
+{% set version = "1.0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/LSSTDESC/gcr-catalogs/archive/v{{ version }}.tar.gz
+  sha256: 6e45d9d21ba40e5c69cd0fcb20be37495b82bc6b8b2695f92d0b9a0578dda9b0
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - requests
+    - pyyaml
+    - numpy
+    - astropy
+    - GCR >=0.8.8
+    - h5py
+    - healpy
+    - pandas
+    - pyarrow
+
+test:
+  imports:
+    - GCRCatalogs
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/LSSTDESC/gcr-catalogs
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'A repository of data catalogs for the LSST Dark Energy Science Collaboration (DESC)'
+  description: |
+      GCRCatalogs is a Python package that serves as a catalog repository for 
+      the Rubin LSST Dark Energy Science Collaboration (DESC). 
+      It provides a unified user interface to access all catalogs by using 
+      the Generic Catalog Reader (GCR) base class.
+  doc_url: https://github.com/LSSTDESC/gcr-catalogs/blob/master/README.md
+  dev_url: https://github.com/LSSTDESC/gcr-catalogs
+
+extra:
+  recipe-maintainers:
+    - yymao

--- a/recipes/lsstdesc-gcr-catalogs/meta.yaml
+++ b/recipes/lsstdesc-gcr-catalogs/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - pyyaml
     - numpy
     - astropy
-    - GCR >=0.8.8
+    - gcr >=0.8.8
     - h5py
     - healpy
     - pandas

--- a/recipes/lsstdesc-gcr-catalogs/meta.yaml
+++ b/recipes/lsstdesc-gcr-catalogs/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lsstdesc-gcr-catalogs" %}
-{% set version = "1.0.3" %}
+{% set version = "1.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/LSSTDESC/gcr-catalogs/archive/v{{ version }}.tar.gz
-  sha256: 6e45d9d21ba40e5c69cd0fcb20be37495b82bc6b8b2695f92d0b9a0578dda9b0
+  sha256: feffb3d42b33c64530009127cb3ffe02659bfb18ac109dcf0a6756a16885c113
 
 build:
   number: 0

--- a/recipes/lsstdesc-gcr-catalogs/meta.yaml
+++ b/recipes/lsstdesc-gcr-catalogs/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - healpy
     - pandas
     - pyarrow
+    - pytables
 
 test:
   imports:


### PR DESCRIPTION
Add `lsstdesc-gcr-catalogs`, a python package that hosts catalogs for the Rubin LSST Dark Energy Science Collaboration (LSST DESC). [cc DESC member @beckermr]

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
