### PR TITLE
add r-bsts 0.9.5 package from CRAN

### DIFF
--- a/recipes/r-bsts/bld.bat
+++ b/recipes/r-bsts/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-bsts/build.sh
+++ b/recipes/r-bsts/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -o errexit -o pipefail
+if [[ ${target_platform} =~ linux.* ]] || [[ ${target_platform} == win-32 ]] || [[ ${target_platform} == win-64 ]] || [[ ${target_platform} == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  ${R} CMD INSTALL --build .
+else
+  mkdir -p "${PREFIX}"/lib/R/library/bsts
+  mv ./* "${PREFIX}"/lib/R/library/bsts
+  if [[ ${target_platform} == osx-64 ]]; then
+    pushd "${PREFIX}"
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd "${libdir}" || exit 1
+          while IFS= read -r -d '' SHARED_LIB
+          do
+            echo "fixing SHARED_LIB ${SHARED_LIB}"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "${PREFIX}"/lib/libomp.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "${PREFIX}"/lib/libgfortran.3.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "${PREFIX}"/lib/libquadmath.0.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "${PREFIX}"/lib/libquadmath.0.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "${PREFIX}"/lib/libgfortran.3.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "${PREFIX}"/lib/libgcc_s.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "${PREFIX}"/sysroot/usr/lib/libiconv.2.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "${PREFIX}"/sysroot/usr/lib/libncurses.5.4.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "${PREFIX}"/sysroot/usr/lib/libicucore.A.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "${PREFIX}"/lib/libexpat.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "${PREFIX}"/lib/libcurl.4.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "${PREFIX}"/lib/libc++.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "${PREFIX}"/lib/libc++.1.dylib "${SHARED_LIB}" || true
+          done <   <(find . \( -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R" \) -print0)
+        popd
+      done
+    popd
+  fi
+fi

--- a/recipes/r-bsts/meta.yaml
+++ b/recipes/r-bsts/meta.yaml
@@ -1,0 +1,82 @@
+{% set version = '0.9.5' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-bsts
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/bsts_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/bsts/bsts_{{ version }}.tar.gz
+  sha256: b85371e62f116b63e50bbcdbf32c363f2244e97ced906f008defbf7e8a13089f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+  host:
+    - r-base
+    - r-boom >=0.9.6
+    - r-boomspikeslab >=1.2.3
+    - r-xts
+    - r-zoo >=1.8
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-boom >=0.9.6
+    - r-boomspikeslab >=1.2.3
+    - r-xts
+    - r-zoo >=1.8
+
+test:
+  commands:
+    - $R -e "library('bsts')"           # [not win]
+    - "\"%R%\" -e \"library('bsts')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=bsts
+  license: LGPL-2.1
+  summary: Time series regression using dynamic linear models fit using MCMC. See Scott and Varian
+    (2014) <DOI:10.1504/IJMMNO.2014.059942>, among many other sources.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - Yue-Li-atBain
+
+# Package: bsts
+# Version: 0.9.5
+# Date: 2020-04-29
+# Title: Bayesian Structural Time Series
+# Author: Steven L. Scott <steve.the.bayesian@gmail.com>
+# Maintainer: Steven L. Scott <steve.the.bayesian@gmail.com>
+# Description: Time series regression using dynamic linear models fit using MCMC. See Scott and Varian (2014) <DOI:10.1504/IJMMNO.2014.059942>, among many other sources.
+# Depends: BoomSpikeSlab (>= 1.2.3), zoo (>= 1.8), xts, Boom (>= 0.9.6), R(>= 3.4.0)
+# Suggests: testthat
+# LinkingTo: Boom (>= 0.9.6)
+# License: LGPL-2.1 | file LICENSE
+# Encoding: UTF-8
+# NeedsCompilation: yes
+# Packaged: 2020-05-01 14:24:35 UTC; steve
+# Repository: CRAN
+# Date/Publication: 2020-05-02 15:00:02 UTC

--- a/recipes/r-bsts/meta.yaml
+++ b/recipes/r-bsts/meta.yaml
@@ -51,7 +51,7 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=bsts
-  license: LGPL-2.1
+  license: LGPL-2.1-only
   summary: Time series regression using dynamic linear models fit using MCMC. See Scott and Varian
     (2014) <DOI:10.1504/IJMMNO.2014.059942>, among many other sources.
   license_family: LGPL


### PR DESCRIPTION
Adding the latest version of r bsts package from CRAN to conda-forge.
I have used the Conda r skeleton helpers script to create the recipes.


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
