### PR TITLE
add r-boomspikeslab 1.2.3 from CRAN [review ready]

### DIFF
--- a/recipes/r-boomspikeslab/bld.bat
+++ b/recipes/r-boomspikeslab/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build .
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-boomspikeslab/build.sh
+++ b/recipes/r-boomspikeslab/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -o errexit -o pipefail
+if [[ ${target_platform} =~ linux.* ]] || [[ ${target_platform} == win-32 ]] || [[ ${target_platform} == win-64 ]] || [[ ${target_platform} == osx-64 ]]; then
+  export DISABLE_AUTOBREW=1
+  ${R} CMD INSTALL --build .
+else
+  mkdir -p "${PREFIX}"/lib/R/library/BoomSpikeSlab
+  mv ./* "${PREFIX}"/lib/R/library/BoomSpikeSlab
+  if [[ ${target_platform} == osx-64 ]]; then
+    pushd "${PREFIX}"
+      for libdir in lib/R/lib lib/R/modules lib/R/library lib/R/bin/exec sysroot/usr/lib; do
+        pushd "${libdir}" || exit 1
+          while IFS= read -r -d '' SHARED_LIB
+          do
+            echo "fixing SHARED_LIB ${SHARED_LIB}"
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5.0-MRO/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libR.dylib "${PREFIX}"/lib/R/lib/libR.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/clang4/lib/libomp.dylib "${PREFIX}"/lib/libomp.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libgfortran.3.dylib "${PREFIX}"/lib/libgfortran.3.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libquadmath.0.dylib "${PREFIX}"/lib/libquadmath.0.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/local/gfortran/lib/libquadmath.0.dylib "${PREFIX}"/lib/libquadmath.0.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libgfortran.3.dylib "${PREFIX}"/lib/libgfortran.3.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libgcc_s.1.dylib "${PREFIX}"/lib/libgcc_s.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libiconv.2.dylib "${PREFIX}"/sysroot/usr/lib/libiconv.2.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libncurses.5.4.dylib "${PREFIX}"/sysroot/usr/lib/libncurses.5.4.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libicucore.A.dylib "${PREFIX}"/sysroot/usr/lib/libicucore.A.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libexpat.1.dylib "${PREFIX}"/lib/libexpat.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libcurl.4.dylib "${PREFIX}"/lib/libcurl.4.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /usr/lib/libc++.1.dylib "${PREFIX}"/lib/libc++.1.dylib "${SHARED_LIB}" || true
+            install_name_tool -change /Library/Frameworks/R.framework/Versions/3.5/Resources/lib/libc++.1.dylib "${PREFIX}"/lib/libc++.1.dylib "${SHARED_LIB}" || true
+          done <   <(find . \( -type f -iname "*.dylib" -or -iname "*.so" -or -iname "R" \) -print0)
+        popd
+      done
+    popd
+  fi
+fi

--- a/recipes/r-boomspikeslab/meta.yaml
+++ b/recipes/r-boomspikeslab/meta.yaml
@@ -45,7 +45,7 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=BoomSpikeSlab
-  license: LGPL-2.1
+  license: LGPL-2.1-only
   summary: Spike and slab regression with a variety of residual error distributions corresponding
     to Gaussian, Student T, probit, logit, SVM, and a few others.  Spike and slab regression
     is Bayesian regression with prior distributions containing a point mass at zero.  The

--- a/recipes/r-boomspikeslab/meta.yaml
+++ b/recipes/r-boomspikeslab/meta.yaml
@@ -1,0 +1,82 @@
+{% set version = '1.2.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-boomspikeslab
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/BoomSpikeSlab_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/BoomSpikeSlab/BoomSpikeSlab_{{ version }}.tar.gz
+  sha256: 393e696ed7f1288b5e86db9e712c5636b8036949baeee063c02117157c896945
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+  host:
+    - r-base
+    - r-boom >=0.9.6
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-boom >=0.9.6
+
+test:
+  commands:
+    - $R -e "library('BoomSpikeSlab')"           # [not win]
+    - "\"%R%\" -e \"library('BoomSpikeSlab')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=BoomSpikeSlab
+  license: LGPL-2.1
+  summary: Spike and slab regression with a variety of residual error distributions corresponding
+    to Gaussian, Student T, probit, logit, SVM, and a few others.  Spike and slab regression
+    is Bayesian regression with prior distributions containing a point mass at zero.  The
+    posterior updates the amount of mass on this point, leading to a posterior distribution
+    that is actually sparse, in the sense that if you sample from it many coefficients
+    are actually zeros.  Sampling from this posterior distribution is an elegant way
+    to handle Bayesian variable selection and model averaging.  See <DOI:10.1504/IJMMNO.2014.059942>
+    for an explanation of the Gaussian case.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - Yue-Li-atBain
+
+# Package: BoomSpikeSlab
+# Version: 1.2.3
+# Date: 2020-04-29
+# Title: MCMC for Spike and Slab Regression
+# Author: Steven L. Scott <steve.the.bayesian@gmail.com>
+# Maintainer: Steven L. Scott <steve.the.bayesian@gmail.com>
+# Description: Spike and slab regression with a variety of residual error distributions corresponding to Gaussian, Student T, probit, logit, SVM, and a few others.  Spike and slab regression is Bayesian regression with prior distributions containing a point mass at zero.  The posterior updates the amount of mass on this point, leading to a posterior distribution that is actually sparse, in the sense that if you sample from it many coefficients are actually zeros.  Sampling from this posterior distribution is an elegant way to handle Bayesian variable selection and model averaging.  See <DOI:10.1504/IJMMNO.2014.059942> for an explanation of the Gaussian case.
+# License: LGPL-2.1 | file LICENSE
+# Depends: Boom (>= 0.9.6) , R (>= 3.5.0)
+# LinkingTo: Boom(>= 0.9.6)
+# Suggests: MASS, testthat, mlbench, igraph
+# Encoding: UTF-8
+# NeedsCompilation: yes
+# Packaged: 2020-04-30 22:57:12 UTC; steve
+# Repository: CRAN
+# Date/Publication: 2020-05-01 06:50:33 UTC


### PR DESCRIPTION
Adding the latest version of r bookspikeslab package from CRAN to conda-forge.
I have used the Conda r skeleton helpers script to create the recipes.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
