### PR TITLE
[wip] add mouseinfo, pygetwindow, rubicon-objc, pyrect for pyautogui

### DIFF
--- a/recipes/mouseinfo/000-python-xlib.patch
+++ b/recipes/mouseinfo/000-python-xlib.patch
@@ -1,11 +1,9 @@
-diff --git a/setup.py b/setup.py
-index deff8c5..971c39f 100644
---- a/setup.py
-+++ b/setup.py
-@@ -32,8 +32,7 @@ setup(
+--- setup.py	2020-03-27 15:08:49.000000000 -0400
++++ setup.py	2020-12-08 20:10:07.747733010 -0500
+@@ -31,8 +31,7 @@
+     test_suite='tests',
      # NOTE: Update the python_version info for Pillow as Pillow supports later versions of Python.
-     install_requires=['pyobjc-core;platform_system=="Darwin"',
-                       'pyobjc;platform_system=="Darwin"',
+     install_requires=['rubicon-objc;platform_system=="Darwin"',
 -                      'python3-Xlib;platform_system=="Linux" and python_version>="3.0"',
 -                      'Xlib;platform_system=="Linux" and python_version<"3.0"',
 +                      'python-Xlib;platform_system=="Linux"',

--- a/recipes/mouseinfo/000-python-xlib.patch
+++ b/recipes/mouseinfo/000-python-xlib.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.py b/setup.py
+index deff8c5..971c39f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -32,8 +32,7 @@ setup(
+     # NOTE: Update the python_version info for Pillow as Pillow supports later versions of Python.
+     install_requires=['pyobjc-core;platform_system=="Darwin"',
+                       'pyobjc;platform_system=="Darwin"',
+-                      'python3-Xlib;platform_system=="Linux" and python_version>="3.0"',
+-                      'Xlib;platform_system=="Linux" and python_version<"3.0"',
++                      'python-Xlib;platform_system=="Linux"',
+                       'pyperclip',
+                       'Pillow >= 5.2.0; python_version == "3.7"',
+                       'Pillow >= 4.0.0; python_version == "3.6"',

--- a/recipes/mouseinfo/meta.yaml
+++ b/recipes/mouseinfo/meta.yaml
@@ -37,7 +37,7 @@ test:
     - mouseinfo  # [not linux]
   commands:
     - pip check
-    - xvfb-run --server-args=":99 -screen 0 1024x768x24 -ac +extension GLX -noreset" python -c "import mouseinfo"
+    - xvfb-run --server-args=":99 -screen 0 1024x768x24 -ac +extension GLX -noreset" python -c "import mouseinfo"  # [linux]
   requires:
     - pip
 

--- a/recipes/mouseinfo/meta.yaml
+++ b/recipes/mouseinfo/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "mouseinfo" %}
+{% set version = "0.1.3" %}
+
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/MouseInfo-{{ version }}.tar.gz
+    sha256: 2c62fb8885062b8e520a3cce0a297c657adcc08c60952eb05bc8256ef6f7f6e7
+    patches:
+      # TODO: remove if/when upstream PR is merged
+      - 000-python-xlib.patch  # [linux]
+  # TODO: remove if/when upstream PR is merged
+  - url: https://raw.githubusercontent.com/asweigart/mouseinfo/master/LICENSE.txt
+    sha256: 8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - pillow
+    - pyperclip
+    - python
+    - python-xlib  # [linux]
+    - rubicon-objc  # [osx]
+
+test:
+  imports:
+    - mouseinfo
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/asweigart/mouseinfo
+  summary: An application to display XY position and RGB color information for the pixel currently under the mouse. Works on Python 2 and 3.
+  license: GPL-3.0-or-later
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/mouseinfo/meta.yaml
+++ b/recipes/mouseinfo/meta.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 2c62fb8885062b8e520a3cce0a297c657adcc08c60952eb05bc8256ef6f7f6e7
     patches:
       # TODO: remove if/when upstream PR is merged
-      - 000-python-xlib.patch  # [linux]
+      - 000-python-xlib.patch
   # TODO: remove if/when upstream PR is merged
   - url: https://raw.githubusercontent.com/asweigart/mouseinfo/master/LICENSE.txt
     sha256: 8ceb4b9ee5adedde47b31e975c1d90c73ad27b6b165a1dcd80c7c545eb65b903

--- a/recipes/mouseinfo/meta.yaml
+++ b/recipes/mouseinfo/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - python
   run:
     - pillow
+    - pyobjc-core  # [osx]
     - pyperclip
     - python
     - python-xlib  # [linux]

--- a/recipes/mouseinfo/meta.yaml
+++ b/recipes/mouseinfo/meta.yaml
@@ -34,9 +34,10 @@ requirements:
 
 test:
   imports:
-    - mouseinfo
+    - mouseinfo  # [not linux]
   commands:
     - pip check
+    - xvfb-run --server-args=":99 -screen 0 1024x768x24 -ac +extension GLX -noreset" python -c "import mouseinfo"
   requires:
     - pip
 

--- a/recipes/mouseinfo/yum_requirements.txt
+++ b/recipes/mouseinfo/yum_requirements.txt
@@ -1,0 +1,1 @@
+xorg-x11-server-Xvfb

--- a/recipes/pygetwindow/meta.yaml
+++ b/recipes/pygetwindow/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "pygetwindow" %}
+{% set version = "0.0.9" %}
+
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyGetWindow-{{ version }}.tar.gz
+    sha256: 17894355e7d2b305cd832d717708384017c1698a90ce24f6f7fbf0242dd0a688
+  # TODO: remove if/when upstream PR is merged
+  - url: https://raw.githubusercontent.com/asweigart/PyGetWindow/master/LICENSE.txt
+    sha256: f8c2193c7e92df1a8335548a69653fa56b0ea3536586d93932f8c79c206df9fd
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - pyrect
+    - python
+
+test:
+  imports:
+    - pygetwindow
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/asweigart/pygetwindow
+  summary: A simple, cross-platform module for obtaining GUI information on application's windows.
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/pygetwindow/meta.yaml
+++ b/recipes/pygetwindow/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
-  skip: true  # [not win]
+  skip: true  # [linux]
 
 requirements:
   host:
@@ -25,6 +25,7 @@ requirements:
   run:
     - pyrect
     - python
+    - pyobjc-framework-quartz  # [osx]
 
 test:
   imports:

--- a/recipes/pygetwindow/meta.yaml
+++ b/recipes/pygetwindow/meta.yaml
@@ -15,8 +15,8 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps
+  skip: true  # [not win]
 
 requirements:
   host:

--- a/recipes/pyrect/meta.yaml
+++ b/recipes/pyrect/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pyrect" %}
+{% set version = "0.1.4" %}
+
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyRect-{{ version }}.tar.gz
+    sha256: 3b2fa7353ce32a11aa6b0a15495968d2a763423c8947ae248b92c037def4e202
+  # TODO: remove when/if upstream PR is merged
+  - url: https://raw.githubusercontent.com/asweigart/PyRect/master/LICENSE.txt
+    sha256: acd22ce944f31780b1e3ffc67cea696421a7a582ad6abe5ef4d46ee9bb68aec9
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - python >=2.7
+  run:
+    - python >=2.7
+
+test:
+  imports:
+    - pyrect
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/asweigart/pyrect
+  summary: PyRect is a simple module with a Rect class for Pygame-like rectangular areas.
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/rubicon-objc/meta.yaml
+++ b/recipes/rubicon-objc/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps
-  skip: true  # [osx]
+  skip: true  # [not osx]
 
 requirements:
   host:

--- a/recipes/rubicon-objc/meta.yaml
+++ b/recipes/rubicon-objc/meta.yaml
@@ -12,15 +12,15 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps
+  skip: true  # [osx]
 
 requirements:
   host:
     - pip
-    - python >=3.5
+    - python
   run:
-    - python >=3.5
+    - python
 
 test:
   imports:

--- a/recipes/rubicon-objc/meta.yaml
+++ b/recipes/rubicon-objc/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "rubicon-objc" %}
+{% set version = "0.4.0" %}
+
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/rubicon-objc-{{ version }}.tar.gz
+  sha256: a54be431be212c95106b3f9dbb3903fd96683caca926613ba7dd8b4605cb87cc
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - python >=3.5
+  run:
+    - python >=3.5
+
+test:
+  imports:
+    - rubicon
+    - rubicon.objc
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://beeware.org/rubicon
+  summary: A bridge between an Objective C runtime environment and Python.
+  dev_url: https://github.com/beeware/rubicon-objc
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Notes:
- can split this up into smaller PRs, but wanted a quick look at CI
- all of the upstream license/dependency PRs have been made
- not sure what to make of rubicon-objc yet, very probably is OSX-only

Refs:
- hopefully resolves dependency issues from https://github.com/conda-forge/pyautogui-feedstock/issues/24
- maybe blocked by https://github.com/conda-forge/pyobjc-framework-cocoa-feedstock/pull/23