### PR TITLE
Adding pyfit-sne

### DIFF
--- a/recipes/pyfit-sne/meta.yaml
+++ b/recipes/pyfit-sne/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "pyFIt-SNE" %}
+{% set version = "1.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/KlugerLab/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 10746c4ca3ea0702ff042ac79a01b8fbbdd916162b47c48541d750cb3ef05097
+  
+build:
+  number: 0
+  skip: True  # [win or py27]
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+  host:
+    - python
+    - cython
+    - pip
+    - fftw
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - fitsne
+
+about:
+  home: https://github.com/KlugerLab/pyFIt-SNE
+  license: Multiple
+  license_file: LICENSE.txt
+  summary: 'Python wrapper for FFT-accelerated Interpolation-based t-SNE (FIt-SNE) package.'
+  dev_url: https://github.com/KlugerLab/FIt-SNE
+
+extra:
+  recipe-maintainers:
+    - yihming
+    - bli25broad


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel](https://gitter.im/conda-forge/conda-forge.github.io)
or on our [Keybase chat](https://keybase.io/team/condaforge.chat)
if your recipe isn't reviewed promptly.
-->

This recipe includes a python wrapper of FIt-SNE package. There is already a similar recipe `fit-sne` on conda-forge, but since it only includes the CPP binding and cannot be directly used in Python, we decide to submit this recipe. The python wrapper is also from FIt-SNE team's official source.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
