### PR TITLE
Add compas_mobile_robot_reloc (rename, hyphens changed to underscores)

### DIFF
--- a/recipes/compas_mobile_robot_reloc/meta.yaml
+++ b/recipes/compas_mobile_robot_reloc/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "compas_mobile_robot_reloc" %}
+{% set version = "1.0.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 36457668c737c621394cdfdb50f1d5d299b9ad1935380a80e4f8c7da1545d891
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vvv
+
+requirements:
+  host:
+    - pep517
+    - pip
+    - python >=3.7
+    - setuptools-scm
+    - wheel
+  run:
+    - compas >=0.19.3,<1.0
+    - python >=3.7
+
+test:
+  imports:
+    - compas_mobile_robot_reloc
+    - compas_mobile_robot_reloc.utils
+    - compas_mobile_robot_reloc.xforms
+
+about:
+  home: https://gramaziokohler.github.io/compas_mobile_robot_reloc
+  summary: Robot localization using external measuring device (total station).
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - tetov


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Renaming of [compas-mobile-robot-reloc](https://anaconda.org/conda-forge/compas-mobile-robot-reloc) to compas-mobile-robot-reloc to not diverge from internal package name and docs.
