### PR TITLE
Add tracywidom

### DIFF
--- a/recipes/tracywidom/meta.yaml
+++ b/recipes/tracywidom/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/tracywidom/meta.yaml
+++ b/recipes/tracywidom/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "TracyWidom" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1425fe9ad5764280ada7825037f30b5928f71a13265e32cea6c0d7c27cbc0a10
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - numpy >=1.7.0
+    - scipy >=0.13.0
+
+test:
+  imports:
+    - TracyWidom
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/yymao/TracyWidom
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Generate Tracy-Widom distribution functions (beta=1,2,4) in Python
+  doc_url: https://github.com/yymao/TracyWidom/blob/main/README.md
+  dev_url: https://github.com/yymao/TracyWidom
+
+extra:
+  recipe-maintainers:
+    - yymao


### PR DESCRIPTION
`tracywidom` is a Python package that generates the Tracy-Widom distribution functions.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.