### PR TITLE
add jedi-language-server 0.21.0

### DIFF
--- a/recipes/jedi-language-server/meta.yaml
+++ b/recipes/jedi-language-server/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "jedi-language-server" %}
+{% set version = "0.21.0" %}
+
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jedi-language-server-{{ version }}.tar.gz
+  sha256: bb9d5e5c0aadf69cc441263685c83c12e67b6ed6f546dbd92dbed417123d8a47
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - jedi-language-server = jedi_language_server.cli:cli
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+
+requirements:
+  host:
+    - pip
+    - poetry
+    - python >=3.6
+  run:
+    - cached-property >=1.5.1
+    - click >=7.0
+    - jedi ==0.17.2
+    - pygls >=0.9.1,<0.10.0
+    - python >=3.6
+
+test:
+  imports:
+    - jedi_language_server
+  commands:
+    - pip check
+    - jedi-language-server --version
+    - jedi-language-server --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pappasam/jedi-language-server
+  summary: A language server for Jedi!
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml"
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example)
- [x] Source is from official source
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details)
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Notes
- Pretty straight `grayskull` job
- the upstream only requires `cached-property` on 3.6/3.7, but it doesn't appear to harm anything testing with 3.9
- the hard `jedi` pin is rough, but given the issues we've had elsewhere in this area, I guess I'll take it!