### PR TITLE
add gzip

### DIFF
--- a/recipes/gzip/build.sh
+++ b/recipes/gzip/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+./configure --prefix=$PREFIX
+make -j${CPU_COUNT}
+make install

--- a/recipes/gzip/meta.yaml
+++ b/recipes/gzip/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "gzip" %}
+{% set version = "1.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://ftp.gnu.org/gnu/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c91f74430bf7bc20402e1f657d0b252cb80aa66ba333a25704512af346633c68
+
+build:
+  number: 0
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+
+test:
+  commands:
+    - gzip --version
+
+about:
+  home: https://www.gnu.org/software/gzip/
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: COPYING
+  summary: 'The GNU zip complession utility'
+  description: |
+    gzip (GNU zip) is a compression utility designed to be a replacement
+    for 'compress'. Its main advantages over compress are much better
+    compression and freedom from patented algorithms.  The GNU Project
+    uses it as the standard compression program for its system.
+  doc_url: https://www.gnu.org/software/gzip/manual/gzip.html
+  dev_url: https://savannah.gnu.org/projects/gzip/
+
+extra:
+  recipe-maintainers:
+    - saraedum


### PR DESCRIPTION
The build for Windows fails due to:
```
.\utime.h:541:19: error: conflicting types for 'utime'
_GL_FUNCDECL_SYS (utime, int, (const char *filename, const struct utimbuf *ts)
                  ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt\sys/utime.h:149:43: note: previous definition is here
            static __inline int __CRTDECL utime(char const* const _FileName, struct utimbuf* const _Time)
```

I don't know if that's something that can be fixed easily. But maybe it's not that important for a first version.