### PR TITLE
Adding rwa-python and tramway

### DIFF
--- a/recipes/polytope/meta.yaml
+++ b/recipes/polytope/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "0.2.3" %}
+
+package:
+  name: polytope
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/project/polytope/{{ version }}/.tar.gz
+  sha256: b459aa618526bc54091aa97b4f9ac34bf6e1e8c9c00721a9781544056e7e7e2a
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install ."
+
+requirements:
+  host:
+    - pip
+    - python >=2.7
+  run:
+    - networkx >=1.6
+    - numpy >=1.10.0
+    - python >=2.7
+    - scipy >=0.18.0
+
+test:
+  imports:
+    - polytope
+  requires:
+    - nose
+    - matplotlib >=2.0.0
+  commands:
+    - nose tests/
+  source_files:
+    - tests/*_test.py
+
+about:
+  home: https://pypi.org/project/polytope/
+  license: BSD
+  license_file: LICENSE
+  summary: "a toolbox for geometric operations on polytopes in any dimension"
+  doc_url: https://tulip-control.github.io/polytope/

--- a/recipes/polytope/meta.yaml
+++ b/recipes/polytope/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - numpy >=1.10.0
     - python >=2.7
     - scipy >=0.18.0
+    - cvxopt >=1.2.5
 
 test:
   imports:
@@ -30,7 +31,7 @@ test:
     - nose
     - matplotlib-base >=2.0.0
   commands:
-    - "{{ PYTHON }} -m nose tests/"
+    - python -m nose tests/
   source_files:
     - tests/*_test.py
 

--- a/recipes/polytope/meta.yaml
+++ b/recipes/polytope/meta.yaml
@@ -30,13 +30,17 @@ test:
     - nose
     - matplotlib-base >=2.0.0
   commands:
-    - nose tests/
+    - "{{ PYTHON }} -m nose tests/"
   source_files:
     - tests/*_test.py
 
 about:
   home: https://pypi.org/project/polytope/
-  license: BSD
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: "a toolbox for geometric operations on polytopes in any dimension"
   doc_url: https://tulip-control.github.io/polytope/
+
+extra:
+  recipe-maintainers:
+    - DecBayComp

--- a/recipes/polytope/meta.yaml
+++ b/recipes/polytope/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/project/polytope/{{ version }}/.tar.gz
+  url: https://pypi.io/packages/source/p/polytope/polytope-{{ version }}.tar.gz
   sha256: b459aa618526bc54091aa97b4f9ac34bf6e1e8c9c00721a9781544056e7e7e2a
 
 build:
@@ -28,7 +28,7 @@ test:
     - polytope
   requires:
     - nose
-    - matplotlib >=2.0.0
+    - matplotlib-base >=2.0.0
   commands:
     - nose tests/
   source_files:

--- a/recipes/rwa-python/meta.yaml
+++ b/recipes/rwa-python/meta.yaml
@@ -1,0 +1,49 @@
+{% set version = "0.8.5" %}
+
+package:
+  name: rwa-python
+  version: {{ version }}
+
+source:
+  url: https://github.com/DecBayComp/RWA-python/archive/v{{ version }}.tar.gz
+  sha256: 9bcc928ccfb22d1353d59a95c98062ef2b6543c56044ee92cf52ded32cb6d262
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install ."
+
+requirements:
+  host:
+    - pip
+    - python >=2.7
+  run:
+    - hdf5
+    - h5py
+    - numpy
+    - pandas
+    - python >=2.7
+    - scipy
+    - six
+
+test:
+  imports:
+    - rwa
+  requires:
+    - pytest
+  commands:
+    - pytest tests/
+  source_files:
+    - tests/test_*.py
+
+about:
+  home: https://github.com/DecBayComp/RWA-python
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: "HDF5-based serialization library for Python datatypes"
+  doc_url: https://rwa-python.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - DecBayComp

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "tramway" %}
-{% set version = "0.5" %}
+{% set version = "0.6" %}
 
 package:
   name: {{ name }}
@@ -8,13 +8,13 @@ package:
 
 source:
   url: https://github.com/DecBayComp/TRamWAy/archive/v{{ version }}.tar.gz
-  sha256: 6e26acc4280dfb6d93f1d5009009927dd1fa2e63f18a2c4e160b9a1e40534bc6
+  sha256: 3a6bb7359ee58a247bf8b4b8bb7efb29a99599c2ce8aea78a6f269f3818bbe41
 
 build:
   skip: True  # [py<36]
   number: 0
   # remove polytope as soon as the package is available in some conda channel, if it ever is
-  script: "{{ PYTHON }} -m pip install --no-deps https://pypi.io/packages/source/p/polytope/polytope-0.2.3.tar.gz . -vv"
+  script: "{{ PYTHON }} -m pip install --no-deps . -vv"
 
 requirements:
   host:
@@ -26,6 +26,7 @@ requirements:
     - rwa-python
     - matplotlib
     - cvxopt
+    - polytope
     - tqdm
     - scikit-image
     - stopit  # [not win]
@@ -59,3 +60,4 @@ about:
 extra:
   recipe-maintainers:
     - DecBayComp
+    - francoislaurent

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - hdf5
     - python
     - rwa-python
-    - matplotlib
+    - matplotlib-base
     - cvxopt
     - polytope
     - tqdm
@@ -60,4 +60,3 @@ about:
 extra:
   recipe-maintainers:
     - DecBayComp
-    - francoislaurent

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -44,10 +44,11 @@ test:
          tests/test_core.py
          tests/test_analyzer.py::TestSptDataAccess
          tests/test_analyzer.py::TestTesseller
-         tests/test_analyzer.py::TestMapper # [not win]
          tests/test_analyzer.py::TestIndexer
          tests/test_analyzer.py::TestAssignment
          tests/test_analyzer.py::TestSideEffects
+    - pytest
+         tests/test_analyzer.py::TestMapper
          tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost # [not win]
 
 about:

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: 6e26acc4280dfb6d93f1d5009009927dd1fa2e63f18a2c4e160b9a1e40534bc6
 
 build:
+  noarch: python
   number: 0
   # remove polytope as soon as the package is available in some conda channel, if it ever is
   script: "{{ PYTHON }} -m pip install --no-deps https://pypi.io/packages/source/p/polytope/polytope-0.2.3.tar.gz . -vv"

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -1,0 +1,58 @@
+
+{% set name = "tramway" %}
+{% set version = "0.5" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/DecBayComp/TRamWAy/archive/v{{ version }}.tar.gz
+  sha256: 6e26acc4280dfb6d93f1d5009009927dd1fa2e63f18a2c4e160b9a1e40534bc6
+
+build:
+  noarch: python
+  number: 0
+  # remove polytope as soon as the package is available in some conda channel, if it ever is
+  script: "{{ PYTHON }} -m pip install --no-deps https://pypi.io/packages/source/p/polytope/polytope-0.2.3.tar.gz . -vv"
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - hdf5
+    - python >=3.6
+    - rwa-python
+    - matplotlib
+    - cvxopt
+    - tqdm
+    - scikit-image
+    - stopit
+
+test:
+  imports:
+    - tramway
+  source_files:
+    - tests/test_core.py
+    - tests/test_analyzer.py
+    - tests/test_analyzer_pipeline.py
+  requires:
+    - pytest
+  commands:
+    - pytest
+         tests/test_core.py
+         tests/test_analyzer.py
+         tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost
+
+about:
+  home: https://github.com/DecBayComp/TRamWAy
+  license: CECILL-2.1
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'The RAndom Walk AnalYzer: analysis toolbox for localization microscopy data'
+  doc_url: https://tramway.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - DecBayComp

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - cvxopt
     - tqdm
     - scikit-image
-    - stopit
+    - stopit # [not win]
 
 test:
   imports:
@@ -42,8 +42,13 @@ test:
   commands:
     - pytest
          tests/test_core.py
-         tests/test_analyzer.py
-         tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost
+         tests/test_analyzer.py::TestSptDataAccess
+         tests/test_analyzer.py::TestTesseller
+         tests/test_analyzer.py::TestMapper # [not win]
+         tests/test_analyzer.py::TestIndexer
+         tests/test_analyzer.py::TestAssignment
+         tests/test_analyzer.py::TestSideEffects
+         tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost # [not win]
 
 about:
   home: https://github.com/DecBayComp/TRamWAy

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -47,8 +47,8 @@ test:
          tests/test_analyzer.py::TestIndexer
          tests/test_analyzer.py::TestAssignment
          tests/test_analyzer.py::TestSideEffects
-    - pytest  # [not win]
-         tests/test_analyzer.py::TestMapper  # [not win]
+    - pytest
+         tests/test_analyzer.py::TestMapper
          tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost  # [not win]
 
 about:

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -47,9 +47,6 @@ test:
          tests/test_analyzer.py::TestIndexer
          tests/test_analyzer.py::TestAssignment
          tests/test_analyzer.py::TestSideEffects
-    - pytest
-         tests/test_analyzer.py::TestMapper
-         tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost  # [not win]
 
 about:
   home: https://github.com/DecBayComp/TRamWAy

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 6e26acc4280dfb6d93f1d5009009927dd1fa2e63f18a2c4e160b9a1e40534bc6
 
 build:
-  noarch: python
+  skip: True  # [py<36]
   number: 0
   # remove polytope as soon as the package is available in some conda channel, if it ever is
   script: "{{ PYTHON }} -m pip install --no-deps https://pypi.io/packages/source/p/polytope/polytope-0.2.3.tar.gz . -vv"
@@ -19,10 +19,10 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
     - hdf5
-    - python >=3.6
+    - python
     - rwa-python
     - matplotlib
     - cvxopt
@@ -47,8 +47,7 @@ test:
          tests/test_analyzer.py::TestIndexer
          tests/test_analyzer.py::TestAssignment
          tests/test_analyzer.py::TestSideEffects
-    - pytest
-         tests/test_analyzer.py::TestMapper
+         tests/test_analyzer.py::TestMapper  # [not win]
          tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost  # [not win]
 
 about:

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -47,6 +47,7 @@ test:
          tests/test_analyzer.py::TestIndexer
          tests/test_analyzer.py::TestAssignment
          tests/test_analyzer.py::TestSideEffects
+    - pytest  # [not win]
          tests/test_analyzer.py::TestMapper  # [not win]
          tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost  # [not win]
 

--- a/recipes/tramway/meta.yaml
+++ b/recipes/tramway/meta.yaml
@@ -11,7 +11,6 @@ source:
   sha256: 6e26acc4280dfb6d93f1d5009009927dd1fa2e63f18a2c4e160b9a1e40534bc6
 
 build:
-  noarch: python
   number: 0
   # remove polytope as soon as the package is available in some conda channel, if it ever is
   script: "{{ PYTHON }} -m pip install --no-deps https://pypi.io/packages/source/p/polytope/polytope-0.2.3.tar.gz . -vv"
@@ -28,7 +27,7 @@ requirements:
     - cvxopt
     - tqdm
     - scikit-image
-    - stopit # [not win]
+    - stopit  # [not win]
 
 test:
   imports:
@@ -49,7 +48,7 @@ test:
          tests/test_analyzer.py::TestSideEffects
     - pytest
          tests/test_analyzer.py::TestMapper
-         tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost # [not win]
+         tests/test_analyzer_pipeline.py::TestPipeline::test_LocalHost  # [not win]
 
 about:
   home: https://github.com/DecBayComp/TRamWAy


### PR DESCRIPTION
The tramway package optionally depends on the [polytope](https://pypi.org/project/polytope/) package that is not available in conda, but on pypi instead.

The meta.yaml recipe cheats and installs this dependency with pip. As a consequence, we expect this PR to be rejected...

Can we ourselves add a feedstock for this package, and maintain it?

Thanks!