### PR TITLE
Rename Theano-PyMC to Aesara

### DIFF
--- a/recipes/aesara/meta.yaml
+++ b/recipes/aesara/meta.yaml
@@ -1,0 +1,52 @@
+{% set version = "2.0.0" %}
+
+package:
+  name: aesara
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/a/aesara/aesara-{{ version }}.tar.gz
+  sha256: 030498ec15411f0ac8fadc2120f483892bffdf3d9824d37cff967ca7b0987247
+  patches:
+
+build:
+  number: 0
+  entry_points:
+    - aesara-cache = bin.aesara_cache:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - python
+    - setuptools
+    - six >=1.9.0
+    - numpy >=1.9.1
+    - scipy >=0.14
+    - pygpu >=0.7.0,<0.8
+    - jax  # [py>=37 and not win]
+    - filelock
+
+test:
+  imports:
+    - aesara
+  commands:
+    - aesara-cache help
+
+about:
+  home: https://github.com/pymc-devs/aesara
+  license: BSD-3-Clause
+  summary: An optimizing compiler for evaluating mathematical expressions. Aesara is a fork of the Theano library maintained by the PyMC developers.
+  license_file: LICENSE.txt
+  dev_url: https://github.com/pymc-devs/aesara/
+  doc_url: https://aesara.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - twiecki
+    - ericmjl
+    - brandonwillard


### PR DESCRIPTION
We've changed the name of our project, [Theano-PyMC](https://github.com/conda-forge/theano-pymc-feedstock), to Aesara.