### PR TITLE
Remove section about legacy compilers from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,26 +148,3 @@ All apologies in advance if your recipe PR does not recieve prompt attention.
 This is a high volume repository and issues can easily be missed. We are always
 looking for more staged-recipe reviewers. If you are interested in volunteering,
 please contact a member of @conda-forge/core. We'd love to have the help!
-
-### 13. How to build with old compilers (GCC v4) on staged-recipes?
-
-First, don't. Second, please don't.
-
-Add a `conda_build_config.yaml` file inside the recipe folder with the contents
-
-```yaml
-channel_sources:
-- conda-forge/label/cf201901,defaults   # [unix]
-- conda-forge,defaults                  # [win]
-channel_targets:
-- conda-forge cf201901                  # [unix]
-- conda-forge main                      # [win]
-c_compiler:                             # [unix]
-- gcc                                   # [linux]
-- clang                                 # [osx]
-cxx_compiler:                           # [unix]
-- gxx                                   # [linux]
-- clangxx                               # [osx]
-fortran_compiler:                       # [unix]
-- gfortran                              # [unix]
-```


### PR DESCRIPTION
@conda-forge/core I haven't see anyone try to use the legacy compilers in a very long time and I don't think there are any valid use cases left. Shall we just remove this section from the staged-recipes README?