### PR TITLE
Add mecab, mecab-python3 and unidic-lite recipes

### DIFF
--- a/recipes/mecab-python3/meta.yaml
+++ b/recipes/mecab-python3/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "mecab-python3" %}
+{% set version = "1.0.3" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/mecab-python3-{{ version }}.tar.gz
+  sha256: 62abe28a1155398325372291483608427bc82681fef80e7d132904415f9fd42e
+
+build:
+  number: 0
+  entry_points:
+    - mecab-py = MeCab.cli:parse
+    - mecab-py-info = MeCab.cli:info
+  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - pip
+    - python
+    - setuptools_scm
+    - mecab
+  run:
+    - python
+    - mecab
+
+test:
+  imports:
+    - MeCab
+  commands:
+    - pip check
+    - mecab-py-info
+  requires:
+    - pip
+    - unidic-lite
+
+about:
+  home: https://github.com/SamuraiT/mecab-python3
+  summary: Python wrapper for the MeCab morphological analyzer for Japanese
+  license: GPL-2.0-only OR LGPL-2.1-only OR BSD-3-Clause
+  license_file:
+    - COPYING
+    - GPL
+    - LGPL
+    - BSD
+
+extra:
+  recipe-maintainers:
+    - rynorris
+    - henry-thompson

--- a/recipes/mecab/build.sh
+++ b/recipes/mecab/build.sh
@@ -4,3 +4,4 @@ cd mecab
 ./configure --prefix=$PREFIX --with-charset=utf8
 make -j${CPU_COUNT}
 make install
+make check

--- a/recipes/mecab/build.sh
+++ b/recipes/mecab/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+cd mecab
+./configure --prefix=$PREFIX --with-charset=utf8
+make -j${CPU_COUNT}
+make install

--- a/recipes/mecab/build.sh
+++ b/recipes/mecab/build.sh
@@ -3,5 +3,5 @@
 cd mecab
 ./configure --prefix=$PREFIX --with-charset=utf8
 make -j${CPU_COUNT}
-make install
 make check
+make install

--- a/recipes/mecab/meta.yaml
+++ b/recipes/mecab/meta.yaml
@@ -1,0 +1,33 @@
+{% set name = "mecab" %}
+{% set version = "0.996" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/rynorris/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 4608b499e6e13f81c5d1423379541da69ab9e92eabeaccec02d3eca3ae14cb7e
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+
+about:
+  home: https://github.com/rynorris/mecab
+  license: GPL-2.0-only OR LGPL-2.1-only OR BSD-3-Clause
+  license_file:
+    - mecab/COPYING
+    - mecab/GPL
+    - mecab/LGPL
+    - mecab/BSD
+  summary: 'MeCab: Yet Another Part-of-Speech and Morphological Analyzer'
+
+extra:
+  recipe-maintainers:
+    - rynorris
+    - henry-thompson

--- a/recipes/mecab/meta.yaml
+++ b/recipes/mecab/meta.yaml
@@ -17,6 +17,10 @@ requirements:
   build:
     - {{ compiler('cxx') }}
 
+test:
+  commands:
+    - mecab --help | grep MeCab
+
 about:
   home: https://github.com/rynorris/mecab
   license: GPL-2.0-only OR LGPL-2.1-only OR BSD-3-Clause

--- a/recipes/unidic-lite/meta.yaml
+++ b/recipes/unidic-lite/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "unidic-lite" %}
+{% set version = "1.0.8" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unidic-lite-{{ version }}.tar.gz
+  sha256: db9d4572d9fdd4d00a97949d4b0741ec480ee05a7e7e2e32f547500dae27b245
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - unidic_lite
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/polm/unidic-lite
+  summary: A small version of UniDic packaged for Python
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - rynorris
+    - henry-thompson


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

This PR adds 3 recipes providing support for using the MeCab Japanese morphological analyzer.
  - mecab: packages up the mecab C library itself
  - mecab-python3: python bindings for the C library (generated with grayskull)
  - unidic-lite: a dictionary, required for using mecab (generated with grayskull)

I have tested building and installing these 3 packages into a local conda-env, and it works as expected.

Note:  I've excluded Windows for now because I'm not familiar enough with the build infrastructure to get MeCab to build there.

Note: The MeCab source comes from my fork (which is, and will remain, an identical copy of the official repo), since the official maintainer doesn't tag releases on the repo, meaning there's no consistent place to pull a source archive.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [ ] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
