### PR TITLE
[wip] Add go-ipfs 0.7.0

### DIFF
--- a/recipes/go-ipfs/bld.bat
+++ b/recipes/go-ipfs/bld.bat
@@ -1,0 +1,14 @@
+copy "%RECIPE_DIR%\build.sh" .
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+set PREFIX=%PREFIX:\=/%
+set SRC_DIR=%SRC_DIR:\=/%
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
+
+
+bash -lc "./build.sh"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+exit /b 0

--- a/recipes/go-ipfs/bld.bat
+++ b/recipes/go-ipfs/bld.bat
@@ -1,4 +1,4 @@
-copy "%RECIPE_DIR%\build.sh" .
+copy "%RECIPE_DIR%\build_win.sh" .
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 set PREFIX=%PREFIX:\=/%
@@ -8,7 +8,7 @@ set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1
 
 
-bash -lc "./build.sh"
+bash -lc "./build_win.sh"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 exit /b 0

--- a/recipes/go-ipfs/build.sh
+++ b/recipes/go-ipfs/build.sh
@@ -6,10 +6,9 @@ export CGO_ENABLED=1
 
 module='github.com/ipfs/go-ipfs'
 
-make build GOTAGS=openssl
-mkdir -p $PREFIX/bin
-cp cmd/ipfs/ipfs $PREFIX/bin/ipfs
-
+make -C "src/${module}" \
+  install \
+  GOTAGS=openssl
 
 gather_licenses() {
   # shellcheck disable=SC2039  # Allow widely supported non-POSIX local keyword.
@@ -47,4 +46,4 @@ cat "${2}"
   rm -r "${acc_dir}" "${tmp_dir}"
 }
 
-gather_licenses ./third-party-licenses.txt "${module}/cmd/ipfs/ipfs"
+# gather_licenses ./third-party-licenses.txt "${module}/cmd/ipfs"

--- a/recipes/go-ipfs/build.sh
+++ b/recipes/go-ipfs/build.sh
@@ -46,4 +46,24 @@ cat "${2}"
   rm -r "${acc_dir}" "${tmp_dir}"
 }
 
+# TODO: figure out what to do with
+#
 # gather_licenses ./third-party-licenses.txt "${module}/cmd/ipfs"
+#
+# fails with
+# F0206 15:06:39.374624  156753 main.go:43] one or more libraries have an incompatible/unknown license:
+# map["unknown":[
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/bbloom"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-cidutil"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-cidutil/cidenc"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-ipld-git"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-verifcid"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipld/go-car"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/ipld/go-car/util"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/libp2p/go-libp2p-asn-util"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/libp2p/go-libp2p-noise"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/libp2p/go-libp2p-noise/pb"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/multiformats/go-base36"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/whyrusleeping/base32"
+#     "github.com/ipfs/go-ipfs/vendor/github.com/whyrusleeping/cbor-gen"
+#]]

--- a/recipes/go-ipfs/build.sh
+++ b/recipes/go-ipfs/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eux
+
+export GOPATH="$( pwd )"
+export CGO_ENABLED=1
+
+module='github.com/ipfs/go-ipfs'
+
+make build GOTAGS=openssl
+mkdir -p $PREFIX/bin
+cp cmd/ipfs/ipfs $PREFIX/bin/ipfs
+
+
+gather_licenses() {
+  # shellcheck disable=SC2039  # Allow widely supported non-POSIX local keyword.
+  local module output tmp_dir acc_dir
+  output="${1}"
+  shift
+  tmp_dir="$(pwd)/gather-licenses-tmp"
+  acc_dir="$(pwd)/gather-licenses-acc"
+  mkdir "${acc_dir}"
+  cat > "${output}" <<'EOF'
+--------------------------------------------------------------------------------
+The output below is generated with `go-licenses csv` and `go-licenses save`.
+================================================================================
+EOF
+  for module ; do
+    cat >> "${output}" <<EOF
+go-licenses csv ${module}
+================================================================================
+EOF
+    go get -d "${module}"
+    chmod -R +rw "$( go env GOPATH )"
+    go-licenses csv "${module}" | sort >> "${output}"
+    go-licenses save "${module}" --force --save_path="${tmp_dir}"
+    cp -r "${tmp_dir}"/* "${acc_dir}"/
+  done
+  # shellcheck disable=SC2016  # Not expanding $ in single quotes intentional.
+  find "${acc_dir}" -type f | sort | xargs -L1 sh -c '
+cat <<EOF
+--------------------------------------------------------------------------------
+${2#${1%/}/}
+================================================================================
+EOF
+cat "${2}"
+' -- "${acc_dir}" >> "${output}"
+  rm -r "${acc_dir}" "${tmp_dir}"
+}
+
+gather_licenses ./third-party-licenses.txt "${module}/cmd/ipfs/ipfs"

--- a/recipes/go-ipfs/build_win.sh
+++ b/recipes/go-ipfs/build_win.sh
@@ -2,10 +2,9 @@
 set -eux
 
 export GOPATH="$( pwd )"
-export CGO_ENABLED=1
+export CGO_ENABLED=0
 
 module='github.com/ipfs/go-ipfs'
 
 make -C "src/${module}" \
-  install \
-  GOTAGS=openssl
+  install

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -7,6 +7,7 @@ package:
 source:
   url: https://github.com/ipfs/go-ipfs/releases/download/v{{ version }}/go-ipfs-source.tar.gz
   sha256: c349802561a61c1efeade4e3e681723b76e9192edacc5a955cf5f68e49e57fba
+  folder: src/github.com/ipfs/go-ipfs
 
 build:
   number: 0
@@ -16,6 +17,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - go-cgo >=1.14.4
+    - go-licenses
     - make
   host:
     - openssl
@@ -30,8 +32,8 @@ about:
   home: https://ipfs.io
   license: Apache-2.0 or MIT
   license_file:
-    - LICENSE-APACHE
-    - LICENSE-MIT
+    - src/github.com/ipfs/go-ipfs/LICENSE-APACHE
+    - src/github.com/ipfs/go-ipfs/LICENSE-MIT
 
   summary: 'IPFS implementation in Go'
 

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -31,7 +31,7 @@ test:
     - posix  # [win]
   commands:
     - ipfs --version
-    - bash test_ipfs.sh
+    - bash -lc "./test_ipfs.sh"
 
 about:
   home: https://ipfs.io

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -65,7 +65,6 @@ about:
 
   summary: 'IPFS implementation in Go'
 
-  # The remaining entries in this section are optional, but recommended.
   description: |
     IPFS is a global, versioned, peer-to-peer filesystem. It combines good ideas
     from previous systems such as Git, BitTorrent, Kademlia, SFS, and the Web.

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -11,17 +11,16 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  skip: true  # [osx]
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('go-cgo') }}
+    - posix  # [win]
     - go-licenses
-    - make
+    - make  # [unix]
   host:
-    - openssl
-  run:
     - openssl
 
 test:

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -16,19 +16,22 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('go-cgo') }}
+    - {{ compiler('go-cgo') }}  # [unix]
+    - {{ compiler('go') }}  # [win]
     - posix  # [win]
     - go-licenses
     - make  # [unix]
   host:
-    - openssl
+    - openssl  # [unix]
 
 test:
+  files:
+    - test_ipfs.sh
+  requires:
+    - posix  # [win]
   commands:
     - ipfs --version
-    - export IPFS_PATH=$(pwd)/.ipfs-repo
-    - ipfs init
-    - ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | grep Hello
+    - bash test_ipfs.sh
 
 about:
   home: https://ipfs.io
@@ -38,6 +41,27 @@ about:
     - src/github.com/ipfs/go-ipfs/LICENSE-MIT
     # TODO: on linux, about 10 upstreams fail (many are ipfs/ipld first-party)
     # - third-party-licenses.txt
+    #
+    #   gather_licenses ./third-party-licenses.txt "${module}/cmd/ipfs"
+    #
+    # fails with
+    #
+    #   F0206 15:06:39.374624  156753 main.go:43] one or more libraries have an incompatible/unknown license:
+    #   map["unknown":[
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/bbloom"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-cidutil"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-cidutil/cidenc"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-ipld-git"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipfs/go-verifcid"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipld/go-car"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/ipld/go-car/util"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/libp2p/go-libp2p-asn-util"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/libp2p/go-libp2p-noise"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/libp2p/go-libp2p-noise/pb"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/multiformats/go-base36"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/whyrusleeping/base32"
+    #       "github.com/ipfs/go-ipfs/vendor/github.com/whyrusleeping/cbor-gen"
+    #   ]]
 
   summary: 'IPFS implementation in Go'
 

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "0.7.0" %}
+
+package:
+  name: go-ipfs
+  version: {{ version }}
+
+source:
+  url: https://github.com/ipfs/go-ipfs/releases/download/v{{ version }}/go-ipfs-source.tar.gz
+  sha256: c349802561a61c1efeade4e3e681723b76e9192edacc5a955cf5f68e49e57fba
+
+build:
+  number: 0
+  detect_binary_files_with_prefix: False
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - go-cgo >=1.14.4
+    - make
+  host:
+    - openssl
+  run:
+    - openssl
+
+test:
+  commands:
+    - ipfs --version
+
+about:
+  home: https://ipfs.io
+  license: Apache-2.0 or MIT
+  license_file:
+    - LICENSE-APACHE
+    - LICENSE-MIT
+
+  summary: 'IPFS implementation in Go'
+
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    IPFS is a global, versioned, peer-to-peer filesystem. It combines good ideas
+    from previous systems such as Git, BitTorrent, Kademlia, SFS, and the Web.
+    It is like a single BitTorrent swarm, exchanging git objects. IPFS provides
+    an interface as simple as the HTTP web, but with permanence built-in. You
+    can also mount the world at /ipfs.
+  doc_url: https://docs.ipfs.io
+  dev_url: https://github.com/ipfs/go-ipfs
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -11,12 +11,12 @@ source:
 
 build:
   number: 0
-  detect_binary_files_with_prefix: False
+  skip: true  # [win]
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - go-cgo >=1.14.4
+    - {{ compiler('go-cgo') }}
     - go-licenses
     - make
   host:
@@ -27,6 +27,9 @@ requirements:
 test:
   commands:
     - ipfs --version
+    - export IPFS_PATH=$(pwd)/.ipfs-repo
+    - ipfs init
+    - ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | grep Hello
 
 about:
   home: https://ipfs.io
@@ -34,6 +37,8 @@ about:
   license_file:
     - src/github.com/ipfs/go-ipfs/LICENSE-APACHE
     - src/github.com/ipfs/go-ipfs/LICENSE-MIT
+    # TODO: on linux, about 10 upstreams fail (many are ipfs/ipld first-party)
+    # - third-party-licenses.txt
 
   summary: 'IPFS implementation in Go'
 

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -24,13 +24,21 @@ requirements:
   host:
     - openssl  # [unix]
 
+{% set cid = "/ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc" %}
+{% set ipfs_args = "-c ./.ipfs-repo --debug" %}
+
 test:
   commands:
     - ipfs --version
-    - ipfs -c ./.ipfs-repo --debug init
-    - ipfs -c ./.ipfs-repo --debug cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme
-    - echo 'hello world' > hello
-    - ipfs -c ./.ipfs-repo --debug add hello
+    - ipfs --help
+    - ipfs commands
+    - ipfs {{ ipfs_args }} init
+    - ipfs {{ ipfs_args }} ls {{ cid }}
+    - ipfs {{ ipfs_args }} refs {{ cid }}
+    - ipfs {{ ipfs_args }} cat {{ cid }}/readme
+    - ipfs {{ ipfs_args }} get {{ cid }}
+    - echo 'hello world' > hello.txt
+    - ipfs {{ ipfs_args }} add hello.txt
 
 about:
   home: https://ipfs.io

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -31,7 +31,7 @@ test:
     - posix  # [win]
   commands:
     - ipfs --version
-    - bash -lc "./test_ipfs.sh"
+    - bash test_ipfs.sh
 
 about:
   home: https://ipfs.io

--- a/recipes/go-ipfs/meta.yaml
+++ b/recipes/go-ipfs/meta.yaml
@@ -25,13 +25,12 @@ requirements:
     - openssl  # [unix]
 
 test:
-  files:
-    - test_ipfs.sh
-  requires:
-    - posix  # [win]
   commands:
     - ipfs --version
-    - bash test_ipfs.sh
+    - ipfs -c ./.ipfs-repo --debug init
+    - ipfs -c ./.ipfs-repo --debug cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme
+    - echo 'hello world' > hello
+    - ipfs -c ./.ipfs-repo --debug add hello
 
 about:
   home: https://ipfs.io

--- a/recipes/go-ipfs/test_ipfs.sh
+++ b/recipes/go-ipfs/test_ipfs.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
+set -eux
 export IPFS_PATH=$(pwd)/.ipfs-repo
+
 ipfs init
 ls -lathr $IPFS_PATH
-ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme \
-  | grep Hello
+
+ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | tee readme
+cat readme | grep Hello
+
+ipfs add readme

--- a/recipes/go-ipfs/test_ipfs.sh
+++ b/recipes/go-ipfs/test_ipfs.sh
@@ -2,10 +2,13 @@
 set -eux
 export IPFS_PATH=$(pwd)/.ipfs-repo
 
+echo "does it init"
 ipfs init
 ls -lathr $IPFS_PATH
 
+echo "does it fetch"
 ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | tee readme
 cat readme | grep Hello
 
+echo "does it add"
 ipfs add readme

--- a/recipes/go-ipfs/test_ipfs.sh
+++ b/recipes/go-ipfs/test_ipfs.sh
@@ -3,13 +3,13 @@ set -eux
 export IPFS_PATH=$(pwd)/.ipfs-repo
 
 echo "does it init"
-ipfs init
+ipfs --debug init
 ls -lathr $IPFS_PATH
 
 echo "does it fetch"
-ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | tee readme
+ipfs --debug cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | tee readme
 cat readme | grep Hello
 
 echo "does it add"
-ipfs add readme | tee added.txt
+ipfs --debug add readme | tee added.txt
 cat added.txt | grep QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB

--- a/recipes/go-ipfs/test_ipfs.sh
+++ b/recipes/go-ipfs/test_ipfs.sh
@@ -11,4 +11,5 @@ ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme | tee readm
 cat readme | grep Hello
 
 echo "does it add"
-ipfs add readme
+ipfs add readme | tee added.txt
+cat added.txt | grep QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB

--- a/recipes/go-ipfs/test_ipfs.sh
+++ b/recipes/go-ipfs/test_ipfs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+export IPFS_PATH=$(pwd)/.ipfs-repo
+ipfs init
+ls -lathr $IPFS_PATH
+ipfs cat /ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc/readme \
+  | grep Hello


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
  - [ ] the `go-licenses` approach currently fails as about 10 packages don't have licenses discoverable by `go-licenses`
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


notes:
- fixes #13577

<details>
<summary>licenses not found by <code>go-licenses</code></summary>
<pre>
github.com/ipfs/go-verifcid            # has LICENSE-MIT LICENSE-APACHE COPYRIGHT
github.com/ipfs/bbloom                 # has LICENSE
github.com/multiformats/go-base36      # has LICENSE.md
github.com/whyrusleeping/base32        # has LICENSE
github.com/whyrusleeping/cbor-gen      # has LICENSE
github.com/ipld/go-car                 # opened PR for MIT LICENSE
github.com/ipfs/go-cidutil             # opened PR for MIT LICENSE
github.com/ipfs/go-ipld-git            # opened PR for MIT LICENSE
github.com/libp2p/go-libp2p-asn-util   # opened PR for MIT LICENSE
github.com/libp2p/go-libp2p-noise      # opened PR for MIT LICENSE
</pre>
</details>
