### PR TITLE
add sphinxext-rediraffe 0.2.5

### DIFF
--- a/recipes/sphinxext-rediraffe/meta.yaml
+++ b/recipes/sphinxext-rediraffe/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "sphinxext-rediraffe" %}
+{% set version = "0.2.5" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+    sha256: a17287cdee7763341b91762879e042b33a4916d6a2fc6d2f97a18107325bd2cc
+  # TODO: remove if/when merged upstream
+  - url: https://raw.githubusercontent.com/wpilibsuite/{{ name }}/v{{ version }}/LICENSE.md
+    sha256: 7dba86b73b12fc0d05e6f66799d3950a8f3952e69909ffe6372eb6b817e27ac9
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - python >=3.6
+    - sphinx >=2.0
+
+test:
+  imports:
+    - sphinxext.rediraffe
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/wpilibsuite/sphinxext-rediraffe
+  summary: Sphinx Extension that redirects non-existent pages to working pages.
+  license: MIT
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
  - [x] [upstream PR](https://github.com/wpilibsuite/sphinxext-rediraffe/pull/44)
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
