### PR TITLE
Add recipes for 4 Apache Airflow providers

### DIFF
--- a/recipes/apache-airflow-providers-ftp/meta.yaml
+++ b/recipes/apache-airflow-providers-ftp/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "apache-airflow-providers-ftp" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/apache-airflow-providers-ftp-{{ version }}.tar.gz
+  sha256: 861cfae5245dd18abd26ac1f8d27f672bafb23fd368fc754bcd8670cc6597d4f
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+    - wheel
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - airflow.providers.ftp
+    - airflow.providers.ftp.hooks
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://airflow.apache.org/
+  summary: Provider for File Transfer Protocol (FTP) for Apache Airflow
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  doc_url: https://airflow.apache.org/docs/apache-airflow-providers-ftp/stable/index.html
+  dev_url: https://github.com/apache/airflow/
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/recipes/apache-airflow-providers-http/meta.yaml
+++ b/recipes/apache-airflow-providers-http/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "apache-airflow-providers-http" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/apache-airflow-providers-http-{{ version }}.tar.gz
+  sha256: 49f972eceddba9ce6a2cabcf6f227648114aef261552d55af4a7140ec1999155
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+    - wheel
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - airflow.providers.http
+    - airflow.providers.http.example_dags
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://airflow.apache.org/
+  summary: Provider for Hypertext Transfer Protocol (HTTP) for Apache Airflow
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  doc_url: https://airflow.apache.org/docs/apache-airflow-providers-http/stable/index.html
+  dev_url: https://github.com/apache/airflow/
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/recipes/apache-airflow-providers-imap/meta.yaml
+++ b/recipes/apache-airflow-providers-imap/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "apache-airflow-providers-imap" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/apache-airflow-providers-imap-{{ version }}.tar.gz
+  sha256: 9f614cd6c1bd48875c8e1079dfc6d8e587673f8b316b60472acbeb6c6368760b
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+    - wheel
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - airflow.providers.imap
+    - airflow.providers.imap.hooks
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://airflow.apache.org/
+  summary: Provider for Internet Message Access Protocol (IMAP) for Apache Airflow
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  doc_url: https://airflow.apache.org/docs/apache-airflow-providers-imap/stable/index.html
+  dev_url: https://github.com/apache/airflow/
+
+extra:
+  recipe-maintainers:
+    - xylar

--- a/recipes/apache-airflow-providers-sqlite/meta.yaml
+++ b/recipes/apache-airflow-providers-sqlite/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "apache-airflow-providers-sqlite" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/apache-airflow-providers-sqlite-{{ version }}.tar.gz
+  sha256: 0196e788f16221d081ade9fa490eb50a589232976731a036ef0cb3573efaddad
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+    - wheel
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - airflow.providers.sqlite
+    - airflow.providers.sqlite.example_dags
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://airflow.apache.org/
+  summary: Provider for SQLite for Apache Airflow
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  doc_url: https://airflow.apache.org/docs/apache-airflow-providers-sqlite/stable/index.html
+  dev_url: https://github.com/apache/airflow/
+
+extra:
+  recipe-maintainers:
+    - xylar


### PR DESCRIPTION
This merge adds recipes for the ftp, http, imap and sqlite providers for Apache Airflow.  These are dependencies of Apache Airflow 2.0.1, the latest release.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
