### PR TITLE
Added recipe for pyramid_debugtoolbar and pyramid_mako

### DIFF
--- a/recipes/pyramid_debugtoolbar/meta.yaml
+++ b/recipes/pyramid_debugtoolbar/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "pyramid_debugtoolbar" %}
+{% set version = "4.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5a1fd20bad4b8a1172f0ef4d22191ba382181206d0e566ffcf03d066b88429d7
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=2.7
+    - setuptools
+  run:
+    - python >=2.7
+    - pyramid
+
+test:
+  imports:
+    - pyramid_debugtoolbar
+
+about:
+  home: https://trypyramid.com
+  license: BSD-derived
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: The Pyramid Web Framework, a Pylons project
+  doc_url: https://docs.pylonsproject.org/projects/pyramid_mako/en/latest/
+  dev_url: https://github.com/Pylons/pyramid_mako
+
+extra:
+  recipe-maintainers:
+    - ChrisBarker-NOAA
+    - JamesMakela-NOAA

--- a/recipes/pyramid_debugtoolbar/meta.yaml
+++ b/recipes/pyramid_debugtoolbar/meta.yaml
@@ -29,7 +29,7 @@ test:
 
 about:
   home: https://trypyramid.com
-  license: BSD-derived
+  license: LicenseRef-Pylons
   license_family: BSD
   license_file: LICENSE.txt
   summary: The Pyramid Web Framework, a Pylons project

--- a/recipes/pyramid_mako/meta.yaml
+++ b/recipes/pyramid_mako/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "pyramid_mako" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0066c863441f1c3ddea60cee1ccc50d00a91a317a8052ca44131da1a12a840e2
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=2.7
+    - setuptools
+  run:
+    - python >=2.7
+    - mako >=1.1.0
+    - pyramid
+
+test:
+  imports:
+    - pyramid_mako
+  # requires:
+  #   - webtest >=1.3.1
+
+about:
+  home: https://trypyramid.com
+  license: BSD-derived
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: The Pyramid Web Framework, a Pylons project
+  doc_url: https://docs.pylonsproject.org/projects/pyramid_mako/en/latest/
+  dev_url: https://github.com/Pylons/pyramid_mako
+
+extra:
+  recipe-maintainers:
+    - ChrisBarker-NOAA
+    - JamesMakela-NOAA
+

--- a/recipes/pyramid_mako/meta.yaml
+++ b/recipes/pyramid_mako/meta.yaml
@@ -43,4 +43,3 @@ extra:
   recipe-maintainers:
     - ChrisBarker-NOAA
     - JamesMakela-NOAA
-

--- a/recipes/pyramid_mako/meta.yaml
+++ b/recipes/pyramid_mako/meta.yaml
@@ -27,12 +27,10 @@ requirements:
 test:
   imports:
     - pyramid_mako
-  # requires:
-  #   - webtest >=1.3.1
 
 about:
   home: https://trypyramid.com
-  license: BSD-derived
+  license: LicenseRef-Pylons
   license_family: BSD
   license_file: LICENSE.txt
   summary: The Pyramid Web Framework, a Pylons project


### PR DESCRIPTION
@conda-forge/help-python: this is because defaults hasn't updated since py3.8

And I've made the a noarch package now.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.

@JamesMakela-NOAA: please post a comment indicating willingness to maintain.
