### PR TITLE
Add authenticatorpy package

### DIFF
--- a/recipes/authenticatorpy/meta.yaml
+++ b/recipes/authenticatorpy/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "authenticatorpy" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/abdullahselek/authenticatorpy/archive/{{ version }}.tar.gz
+  sha256: 2ca01ac22c1df5fec93ff450d6c6ba1468f4f2fb4ce8147d450b678b10a66f8f
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+
+test:
+  imports:
+    - authenticatorpy
+
+about:
+  home: https://github.com/abdullahselek/authenticatorpy
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A Python library that provide unique keys for 2FA with given secret.'
+  description: |
+    A Python library that provide unique keys for 2FA with given secret.
+  doc_url: https://authenticatorpy.abdullahselek.com/
+  dev_url: https://github.com/abdullahselek/authenticatorpy
+
+extra:
+  recipe-maintainers:
+    - abdullahselek


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
