### PR TITLE
Inclusion of pypi desert for marshmallow and dataclasses integration to be hosted in conda-forge

### DIFF
--- a/recipes/desert/meta.yaml
+++ b/recipes/desert/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "desert" %}
+{% set version = "2020.11.18" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/desert-{{ version }}.tar.gz
+  sha256: d7b7fb521dc84eec955a766ed7e37349f998cf047f37fd9596cb09737d63c62d
+
+build:
+  number: 0
+  skip: true   # [py2k]
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - attrs
+    - dataclasses  # [py<37]
+    - marshmallow >=3.0
+    - python
+    - typing_inspect
+
+test:
+  imports:
+    - desert
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/python-desert/desert
+  summary: Deserialize to objects while staying DRY
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ndroo

--- a/recipes/desert/meta.yaml
+++ b/recipes/desert/meta.yaml
@@ -42,4 +42,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - ndroo
+    - andrew-mcgrath


### PR DESCRIPTION
Recipe was created with greyskull and no red flags appeared when generating the package details.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
