### PR TITLE
Add recipe for OpenXR-SDK

### DIFF
--- a/recipes/openxr-sdk/bld.bat
+++ b/recipes/openxr-sdk/bld.bat
@@ -1,0 +1,25 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_LIBDIR=lib ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -DVulkan_FOUND=OFF ^
+    -DVULKAN_INCOMPATIBLE=ON ^
+    -DDYNAMIC_LOADER=ON ^
+    -DFALLBACK_CONFIG_DIRS=%LIBRARY_PREFIX%\etc\xdg ^
+    -DFALLBACK_DATA_DIRS=%LIBRARY_PREFIX%\share ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/openxr-sdk/build.sh
+++ b/recipes/openxr-sdk/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+mkdir build && cd build
+
+cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DBUILD_SHARED_LIBS=ON \
+      -DVulkan_FOUND=OFF \
+      -DVULKAN_INCOMPATIBLE=ON \
+      -DDYNAMIC_LOADER=ON \
+      -DFALLBACK_CONFIG_DIRS=$PREFIX/etc/xdg \
+      -DFALLBACK_DATA_DIRS=$PREFIX/share \
+      -DHAVE_FILESYSTEM_WITHOUT_LIB=OFF \
+      $SRC_DIR
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/openxr-sdk/meta.yaml
+++ b/recipes/openxr-sdk/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "openxr-sdk" %}
+{% set version = "1.0.14" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+    url: https://github.com/KhronosGroup/OpenXR-SDK/archive/release-{{ version }}.tar.gz
+    sha256: 06384c5af646f9a84881ead336caa1430fa668635470e4153373b50649dfe78b
+
+build:
+  number: 0
+  skip: true  # [osx]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - make                               # [not win]
+    - cmake
+    - pkg-config
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxxf86vm') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
+  host:
+    - jsoncpp
+    - xorg-libxfixes  # [linux]
+
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/openxr/openxr.h  # [not win]
+    - test -f ${PREFIX}/lib/libopenxr_loader.so  # [linux]
+    - test -f ${PREFIX}/lib/cmake/openxr/OpenXRConfig.cmake  # [not win]
+    - if exist %PREFIX%\\Library\\include\\openxr\\openxr.h (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\lib\\openxr_loader.lib (exit 0) else (exit 1)  # [win]
+    - if exist $PREFIX$\\Library\\bin\\openxr_loader.dll (exit 0) else (exit 1)  # [win]
+    - if exist %PREFIX%\\Library\\cmake\\OpenXRConfig.cmake (exit 0) else (exit 1)  # [win]
+
+about:
+  home: https://github.com/KhronosGroup/OpenXR-SDK
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: OpenXR headers and loader.
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
The [OpenXR-SDK](https://github.com/KhronosGroup/OpenXR-SDK) contains the headers and the loader for runtimes based on the OpenXR standard. OpenXR is a royalty-free, open standard that provides high-performance access to Augmented Reality (AR) and Virtual Reality (VR)—collectively known as XR—platforms and devices.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
