### PR TITLE
Adding ptmcmcsampler recipe

### DIFF
--- a/recipes/ptmcmcsampler/LICENSE
+++ b/recipes/ptmcmcsampler/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Justin Ellis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/ptmcmcsampler/meta.yaml
+++ b/recipes/ptmcmcsampler/meta.yaml
@@ -13,7 +13,6 @@ source:
 build:
   number: 0
   noarch: python
-  skip: true  # [win]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipes/ptmcmcsampler/meta.yaml
+++ b/recipes/ptmcmcsampler/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "ptmcmcsampler" %}
+{% set version = "2.0.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ptmcmcsampler-{{ version }}.tar.gz
+  sha256: 1f96ea651a3c3964a7e37ca3c3924aff83a552d0b278bfcc991af265d8739ae3
+
+build:
+  number: 0
+  noarch: python
+  skip: true  # [win]
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - numpy >=1.16.3
+    - python >=3.6
+    - scipy >=1.2.0
+    - mpi4py >=3.0.3
+
+test:
+  imports:
+    - PTMCMCSampler
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/jellis18/PTMCMCSampler
+  summary: Parallel tempering MCMC sampler written in Python
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - jellis18

--- a/recipes/ptmcmcsampler/meta.yaml
+++ b/recipes/ptmcmcsampler/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - numpy >=1.16.3
     - python >=3.6
     - scipy >=1.2.0
-    - mpi4py >=3.0.3
 
 test:
   imports:
@@ -33,6 +32,8 @@ test:
   requires:
     - pip
 
+# NOTE: licence file can be removed from recipe in next release
+# as it will be packaged in source dist
 about:
   home: https://github.com/jellis18/PTMCMCSampler
   summary: Parallel tempering MCMC sampler written in Python


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
