### PR TITLE
Add recipe for ignition-gui4

### DIFF
--- a/recipes/libignition-gui4/bld.bat
+++ b/recipes/libignition-gui4/bld.bat
@@ -1,0 +1,26 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DCMAKE_INSTALL_LIBDIR=lib ^
+    -DBUILD_SHARED_LIBS=ON ^
+    -DBUILD_TESTING=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest -C Release
+if errorlevel 1 exit 1

--- a/recipes/libignition-gui4/build.sh
+++ b/recipes/libignition-gui4/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=ON \
+      ..
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/libignition-gui4/build.sh
+++ b/recipes/libignition-gui4/build.sh
@@ -10,7 +10,7 @@ cmake ${CMAKE_ARGS} \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
       -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_TESTING=ON \
+      -DBUILD_TESTING=OFF \
       ..
 
 cmake --build . --config Release

--- a/recipes/libignition-gui4/meta.yaml
+++ b/recipes/libignition-gui4/meta.yaml
@@ -24,6 +24,12 @@ requirements:
     - make  # [not win]
     - cmake
     - pkg-config
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxxf86vm') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
   host:
     - libignition-cmake2
     - libprotobuf
@@ -36,6 +42,7 @@ requirements:
     - libignition-msgs6
     - libignition-tools1
     - qt
+    - xorg-libxfixes  # [linux]
 
 test:
   commands:

--- a/recipes/libignition-gui4/meta.yaml
+++ b/recipes/libignition-gui4/meta.yaml
@@ -1,0 +1,62 @@
+{% set component_name = "gui" %}
+{% set base_name = "libignition-" + component_name %}
+{% set version = "4.3.0" %}
+{% set major_version = version.split('.')[0] %}
+{% set name = base_name + major_version %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
+    sha256: d3a3ae2d635323c0757a6d1bb17c5ccbd990ab491aa5136ad4934dbbeab6bebe
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - make  # [not win]
+    - cmake
+    - pkg-config
+  host:
+    - libignition-cmake2
+    - libprotobuf
+    - tinyxml2
+    - libignition-math6
+    - libignition-common3
+    - libignition-plugin1
+    - libignition-transport9
+    - libignition-rendering4
+    - libignition-msgs6
+    - libignition-tools1
+    - qt
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/ignition/{{ component_name }}{{ major_version }}/ignition/{{ component_name }}.hh  # [not win]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.so  # [linux]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/ignition-{{ component_name }}{{ major_version }}/ignition-{{ component_name }}{{ major_version }}-config.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\ignition\\{{ component_name }}{{ major_version }}\\ignition\\{{ component_name }}.hh exit 1  # [win]
+    - if not exist $PREFIX$\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib (exit 0) exit 1  # [win]
+    - if not exist $PREFIX$\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll (exit 0) exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\ignition-{{ component_name }}{{ major_version }}\\ignition-{{ component_name }}{{ major_version }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/ignitionrobotics/ign-{{ component_name }}
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Ignition Robotics library that builds on top of Qt to provide widgets which are useful when developing robotics applications, such as a 3D view, plots, dashboard.
+extra:
+  feedstock-name: {{ base_name }}
+  recipe-maintainers:
+    - wolfv
+    - traversaro
+    - Tobias-Fischer
+    - j-rivero

--- a/recipes/libignition-gui4/meta.yaml
+++ b/recipes/libignition-gui4/meta.yaml
@@ -51,8 +51,8 @@ test:
     - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.dylib  # [osx]
     - test -f ${PREFIX}/lib/cmake/ignition-{{ component_name }}{{ major_version }}/ignition-{{ component_name }}{{ major_version }}-config.cmake  # [not win]
     - if not exist %PREFIX%\\Library\\include\\ignition\\{{ component_name }}{{ major_version }}\\ignition\\{{ component_name }}.hh exit 1  # [win]
-    - if not exist $PREFIX$\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib exit 1  # [win]
-    - if not exist $PREFIX$\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\cmake\\ignition-{{ component_name }}{{ major_version }}\\ignition-{{ component_name }}{{ major_version }}-config.cmake exit 1  # [win]
 
 about:

--- a/recipes/libignition-gui4/meta.yaml
+++ b/recipes/libignition-gui4/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
-    sha256: d3a3ae2d635323c0757a6d1bb17c5ccbd990ab491aa5136ad4934dbbeab6bebe
+    sha256: bcb86e8f539e80a97347b5de0d718e428bf000660f92dd43b3b19640e14fc4a5
 
 build:
   number: 0
@@ -44,8 +44,8 @@ test:
     - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.dylib  # [osx]
     - test -f ${PREFIX}/lib/cmake/ignition-{{ component_name }}{{ major_version }}/ignition-{{ component_name }}{{ major_version }}-config.cmake  # [not win]
     - if not exist %PREFIX%\\Library\\include\\ignition\\{{ component_name }}{{ major_version }}\\ignition\\{{ component_name }}.hh exit 1  # [win]
-    - if not exist $PREFIX$\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib (exit 0) exit 1  # [win]
-    - if not exist $PREFIX$\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll (exit 0) exit 1  # [win]
+    - if not exist $PREFIX$\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib exit 1  # [win]
+    - if not exist $PREFIX$\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\cmake\\ignition-{{ component_name }}{{ major_version }}\\ignition-{{ component_name }}{{ major_version }}-config.cmake exit 1  # [win]
 
 about:

--- a/recipes/libignition-gui4/yum_requirements.txt
+++ b/recipes/libignition-gui4/yum_requirements.txt
@@ -1,0 +1,6 @@
+mesa-libGL
+mesa-dri-drivers
+libselinux
+libXdamage
+libXxf86vm
+libXext


### PR DESCRIPTION
Related to https://github.com/conda-forge/staged-recipes/issues/13551 . This adds a new missing library out of the ignition robotics libraries (see https://ignitionrobotics.org/).


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
