### PR TITLE
Add recipe for libignition-gazebo4

### DIFF
--- a/recipes/libignition-gazebo4/build.sh
+++ b/recipes/libignition-gazebo4/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      ..
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - make  # [not win]
     - cmake
     - pkg-config
+    # da
     #- {{ cdt('mesa-libgl-devel') }}  # [linux]
     #- {{ cdt('mesa-dri-drivers') }}  # [linux]
     #- {{ cdt('libselinux') }}  # [linux]

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -47,6 +47,7 @@ requirements:
     - libignition-math6
     - libignition-tools1
     - libprotobuf
+    - qt
     - xorg-libxfixes  # [linux]
 
 test:

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -18,6 +18,7 @@ build:
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 
+
 requirements:
   build:
     - {{ compiler('cxx') }}

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -1,0 +1,75 @@
+{% set component_name = "gazebo" %}
+{% set base_name = "libignition-" + component_name %}
+{% set version = "4.6.0" %}
+{% set major_version = version.split('.')[0] %}
+{% set name = base_name + major_version %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
+    sha256: bcb86e8f539e80a97347b5de0d718e428bf000660f92dd43b3b19640e14fc4a5
+
+build:
+  number: 0
+  skip: true # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - make  # [not win]
+    - cmake
+    - pkg-config
+    #- {{ cdt('mesa-libgl-devel') }}  # [linux]
+    #- {{ cdt('mesa-dri-drivers') }}  # [linux]
+    #- {{ cdt('libselinux') }}  # [linux]
+    #- {{ cdt('libxdamage') }}  # [linux]
+    #- {{ cdt('libxxf86vm') }}  # [linux]
+    #- {{ cdt('libxext') }}     # [linux]
+  host:
+    - libignition-cmake2
+    - sdformat10
+    - libignition-plugin1
+    - libignition-transport9
+    - libignition-msgs6
+    - libignition-common3
+    - libignition-fuel-tools5
+    - libignition-gui4
+    - libignition-physics3
+    - libignition-sensors4
+    - libignition-rendering4
+    - libignition-math6
+    - libignition-tools1
+    - libprotobuf
+    #- qt
+    #- xorg-libxfixes  # [linux]
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/ignition/{{ component_name }}{{ major_version }}/ignition/{{ component_name }}.hh  # [not win]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.so  # [linux]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/ignition-{{ component_name }}{{ major_version }}/ignition-{{ component_name }}{{ major_version }}-config.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\ignition\\{{ component_name }}{{ major_version }}\\ignition\\{{ component_name }}.hh exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\ignition-{{ component_name }}{{ major_version }}\\ignition-{{ component_name }}{{ major_version }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/ignitionrobotics/ign-{{ component_name }}
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Open source robotics simulator. Through Ignition Gazebo users have access to high fidelity physics, rendering, and sensor models. Additionally, users and developers have multiple points of entry to simulation including a graphical user interface, plugins, and asynchronous message passing and services. 
+
+extra:
+  feedstock-name: {{ base_name }}
+  recipe-maintainers:
+    - wolfv
+    - traversaro
+    - Tobias-Fischer
+    - j-rivero

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - libignition-tools1
     - libprotobuf
     - qt
+    - tinyxml2
     - xorg-libxfixes  # [linux]
 
 test:

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -8,7 +8,6 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
     sha256: 7a9664baacaeaba781d94cddec03534115c00cfe803ec64d89a04faa2e15a4b1
@@ -26,13 +25,12 @@ requirements:
     - make  # [not win]
     - cmake
     - pkg-config
-    # da
-    #- {{ cdt('mesa-libgl-devel') }}  # [linux]
-    #- {{ cdt('mesa-dri-drivers') }}  # [linux]
-    #- {{ cdt('libselinux') }}  # [linux]
-    #- {{ cdt('libxdamage') }}  # [linux]
-    #- {{ cdt('libxxf86vm') }}  # [linux]
-    #- {{ cdt('libxext') }}     # [linux]
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxxf86vm') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
   host:
     - libignition-cmake2
     - libsdformat10
@@ -48,8 +46,7 @@ requirements:
     - libignition-math6
     - libignition-tools1
     - libprotobuf
-    #- qt
-    #- xorg-libxfixes  # [linux]
+    - xorg-libxfixes  # [linux]
 
 test:
   commands:

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -8,6 +8,7 @@ package:
   name: {{ name }}
   version: {{ version }}
 
+
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
     sha256: bcb86e8f539e80a97347b5de0d718e428bf000660f92dd43b3b19640e14fc4a5

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true # [not linux]
+  skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     #- {{ cdt('libxext') }}     # [linux]
   host:
     - libignition-cmake2
-    - sdformat10
+    - libsdformat10
     - libignition-plugin1
     - libignition-transport9
     - libignition-msgs6

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
-    sha256: bcb86e8f539e80a97347b5de0d718e428bf000660f92dd43b3b19640e14fc4a5
+    sha256: 7a9664baacaeaba781d94cddec03534115c00cfe803ec64d89a04faa2e15a4b1
 
 build:
   number: 0

--- a/recipes/libignition-gazebo4/meta.yaml
+++ b/recipes/libignition-gazebo4/meta.yaml
@@ -74,4 +74,3 @@ extra:
     - wolfv
     - traversaro
     - Tobias-Fischer
-    - j-rivero


### PR DESCRIPTION
Related to https://github.com/conda-forge/staged-recipes/issues/13551 . This adds the Ignition Gazebo simulator, the successor of the widely used Gazebo robotics simulator (http://gazebosim.org/). Ignition Gazebo is part of the ignition robotics libraries (see https://ignitionrobotics.org/).

Support for macOS and Windows is currently blocked by the following issues in dependent libraries:
* https://github.com/conda-forge/libignition-sensors-feedstock/pull/3
* https://github.com/conda-forge/libignition-physics-feedstock/pull/12

So for the time being only Linux is enabled, support for the other platforms will be added as soon as the dependencies are ready.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
