### PR TITLE
Add recipe for docs-versions-menu

### DIFF
--- a/recipes/docs_versions_menu/meta.yaml
+++ b/recipes/docs_versions_menu/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "docs-versions-menu" %}
+{% set version = "0.5.0rc1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/docs_versions_menu-{{ version }}.tar.gz
+  sha256: 404d720f28cac80791244021713807a2593ad94c14116acf6247eed788624091
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry_points:
+    - docs-versions-menu = docs_versions_menu.cli:main
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools
+
+  run:
+    - python >=3.6
+    - jinja2
+    - click >=6.7
+    - packaging
+    - pyparsing >=2.0.2
+    - sphinx
+
+test:
+  imports:
+    - docs_versions_menu
+
+  commands:
+    - docs-versions-menu --help
+
+about:
+  home: https://github.com/goerz/docs_versions_menu
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A versions-menu for Sphinx-based documentation.'
+  doc_url: https://goerz.github.io/docs_versions_menu
+  dev_url: https://github.com/goerz/docs_versions_menu
+
+extra:
+  recipe-maintainers:
+    - hhslepicka
+    - goerz

--- a/recipes/docs_versions_menu/meta.yaml
+++ b/recipes/docs_versions_menu/meta.yaml
@@ -33,9 +33,11 @@ requirements:
 test:
   imports:
     - docs_versions_menu
-
+  requires:
+    - pip
   commands:
     - docs-versions-menu --help
+    - pip check
 
 about:
   home: https://github.com/goerz/docs_versions_menu


### PR DESCRIPTION
@conda-forge/help-python This PR creates a *new* feedstock for the [docs-versions-menu](https://pypi.org/project/docs-versions-menu/) project, which was recently renamed from [doctr-versions-menu](https://pypi.org/project/doctr-versions-menu/).

The old project has an active feedstock at https://github.com/conda-forge/doctr-versions-menu-feedstock maintained by @hhslepicka and myself (@goerz); I'm adding both of us as maintainers for the new package as well. Note that I would like to keep the old feedstock active (just like the PyPI entry) for the possibility of making bugfix releases to the old package. 

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
