### PR TITLE
Add recipe for libignition-launch3

### DIFF
--- a/recipes/libignition-launch3/build.sh
+++ b/recipes/libignition-launch3/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      ..
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/libignition-launch3/meta.yaml
+++ b/recipes/libignition-launch3/meta.yaml
@@ -1,0 +1,71 @@
+{% set component_name = "launch" %}
+{% set base_name = "libignition-" + component_name %}
+{% set version = "3.1.1" %}
+{% set major_version = version.split('.')[0] %}
+{% set name = base_name + major_version %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
+    sha256: 7a9664baacaeaba781d94cddec03534115c00cfe803ec64d89a04faa2e15a4b1
+
+build:
+  number: 0
+  skip: true  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - make  # [not win]
+    - cmake
+    - pkg-config
+    - {{ cdt('mesa-libgl-devel') }}  # [linux]
+    - {{ cdt('mesa-dri-drivers') }}  # [linux]
+    - {{ cdt('libselinux') }}  # [linux]
+    - {{ cdt('libxdamage') }}  # [linux]
+    - {{ cdt('libxxf86vm') }}  # [linux]
+    - {{ cdt('libxext') }}     # [linux]
+  host:
+    - libignition-cmake2
+    - tinyxml2
+    - libignition-common3
+    - libignition-plugin1
+    - libignition-tools1 
+    - libignition-transport9
+    - libignition-msgs6
+    - libignition-math6
+    - libignition-gui4
+    - qt
+    - libignition-gazebo4
+    - libwebsockets
+    - xorg-libxfixes  # [linux]
+    
+test:
+  commands:
+    - test -f ${PREFIX}/include/ignition/{{ component_name }}{{ major_version }}/ignition/{{ component_name }}.hh  # [not win]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.so  # [linux]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/ignition-{{ component_name }}{{ major_version }}/ignition-{{ component_name }}{{ major_version }}-config.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\ignition\\{{ component_name }}{{ major_version }}\\ignition\\{{ component_name }}.hh exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\ignition-{{ component_name }}{{ major_version }}\\ignition-{{ component_name }}{{ major_version }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/ignitionrobotics/ign-{{ component_name }}
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Ignition Library to run and manage programs and plugins.
+
+extra:
+  feedstock-name: {{ base_name }}
+  recipe-maintainers:
+    - wolfv
+    - traversaro
+    - Tobias-Fischer

--- a/recipes/libignition-launch3/meta.yaml
+++ b/recipes/libignition-launch3/meta.yaml
@@ -44,6 +44,8 @@ requirements:
     - qt
     - libignition-gazebo4
     - libwebsockets
+    - libprotobuf
+    - libsdformat10
     - xorg-libxfixes  # [linux]
     
 test:

--- a/recipes/libignition-launch3/meta.yaml
+++ b/recipes/libignition-launch3/meta.yaml
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
-    sha256: 7a9664baacaeaba781d94cddec03534115c00cfe803ec64d89a04faa2e15a4b1
+    sha256: 9da81f6113839af88a14a5ddc6c853f002326b00cdaa18e913153dd38ce060a3
 
 build:
   number: 0


### PR DESCRIPTION
Related to https://github.com/conda-forge/staged-recipes/issues/13551 . This adds the Ignition Launch library.

Support for macOS and Windows is currently blocked by the following issues in dependent libraries:
* https://github.com/conda-forge/libignition-sensors-feedstock/pull/3
* https://github.com/conda-forge/libignition-physics-feedstock/pull/12

So for the time being only Linux is enabled, support for the other platforms will be added as soon as the dependencies are ready.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
