### PR TITLE
Add recipe for libignition-utils1 

### DIFF
--- a/recipes/libignition-utils1/19.patch
+++ b/recipes/libignition-utils1/19.patch
@@ -1,0 +1,461 @@
+From 33a04fc7db005bbbdacb9f5c91d13effb9b326cc Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio.traversaro@iit.it>
+Date: Wed, 31 Mar 2021 18:32:40 +0200
+Subject: [PATCH] Add IGN_UTILS_VENDOR_CLI11 to optionally use external CLI11
+
+Signed-off-by: Silvio Traversaro <silvio.traversaro@iit.it>
+---
+ CMakeLists.txt                                 | 16 +++++++++++++---
+ .../include/ignition/utils/CMakeLists.txt      |  1 +
+ .../include/ignition/utils/cli/App.hpp         | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/CLI.hpp         | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Config.hpp      | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/ConfigFwd.hpp   | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Error.hpp       | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Formatter.hpp   | 18 ++++++++++++++++++
+ .../ignition/utils/cli/FormatterFwd.hpp        | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Macros.hpp      | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Option.hpp      | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Split.hpp       | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/StringTools.hpp | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Timer.hpp       | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/TypeTools.hpp   | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Validators.hpp  | 18 ++++++++++++++++++
+ .../include/ignition/utils/cli/Version.hpp     | 18 ++++++++++++++++++
+ external-cli/src/CMakeLists.txt                |  7 +++++++
+ 18 files changed, 291 insertions(+), 3 deletions(-)
+ create mode 100644 external-cli/include/ignition/utils/CMakeLists.txt
+ create mode 100644 external-cli/include/ignition/utils/cli/App.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/CLI.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Config.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/ConfigFwd.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Error.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Formatter.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/FormatterFwd.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Macros.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Option.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Split.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/StringTools.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Timer.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/TypeTools.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Validators.hpp
+ create mode 100644 external-cli/include/ignition/utils/cli/Version.hpp
+ create mode 100644 external-cli/src/CMakeLists.txt
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 67958a7..b5ab0ae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -21,19 +21,29 @@ ign_configure_project(VERSION_SUFFIX)
+ # Set project-specific options
+ #============================================================================
+ 
+-# ignition-utils currently has no options that are unique to it
++option(
++  IGN_UTILS_VENDOR_CLI11
++  "If true, use the vendored version of CLI11, otherwise use an external one"
++  true)
+ 
+ #============================================================================
+ # Search for project-specific dependencies
+ #============================================================================
+ 
+-# ignition-utils shouldn't have any dependencies besides ign-cmake
++if(IGN_UTILS_VENDOR_CLI11)
++  set(IGN_UTILS_COMPONENTS "cli")
++else()
++  # PKGCONFIG_IGNORE can be removed once pkg-config support in CLI11 (see
++  # https://github.com/CLIUtils/CLI11/pull/523) is released
++  ign_find_package(CLI11 REQUIRED_BY cli PKGCONFIG_IGNORE)
++  set(IGN_UTILS_COMPONENTS "external-cli")
++endif()
+ 
+ #============================================================================
+ # Configure the build
+ #============================================================================
+ ign_configure_build(QUIT_IF_BUILD_ERRORS
+-  COMPONENTS cli)
++  COMPONENTS ${IGN_UTILS_COMPONENTS})
+ 
+ #============================================================================
+ # Create package information
+diff --git a/external-cli/include/ignition/utils/CMakeLists.txt b/external-cli/include/ignition/utils/CMakeLists.txt
+new file mode 100644
+index 0000000..12c13b8
+--- /dev/null
++++ b/external-cli/include/ignition/utils/CMakeLists.txt
+@@ -0,0 +1 @@
++ign_install_all_headers(COMPONENT cli)
+diff --git a/external-cli/include/ignition/utils/cli/App.hpp b/external-cli/include/ignition/utils/cli/App.hpp
+new file mode 100644
+index 0000000..dce0aa8
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/App.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/App.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/CLI.hpp b/external-cli/include/ignition/utils/cli/CLI.hpp
+new file mode 100644
+index 0000000..03d4cde
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/CLI.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/CLI.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Config.hpp b/external-cli/include/ignition/utils/cli/Config.hpp
+new file mode 100644
+index 0000000..41133fa
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Config.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Config.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/ConfigFwd.hpp b/external-cli/include/ignition/utils/cli/ConfigFwd.hpp
+new file mode 100644
+index 0000000..a97570e
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/ConfigFwd.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/ConfigFwd.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Error.hpp b/external-cli/include/ignition/utils/cli/Error.hpp
+new file mode 100644
+index 0000000..4f5bebf
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Error.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Error.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Formatter.hpp b/external-cli/include/ignition/utils/cli/Formatter.hpp
+new file mode 100644
+index 0000000..2cabea5
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Formatter.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Formatter.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/FormatterFwd.hpp b/external-cli/include/ignition/utils/cli/FormatterFwd.hpp
+new file mode 100644
+index 0000000..ec407b3
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/FormatterFwd.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/FormatterFwd.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Macros.hpp b/external-cli/include/ignition/utils/cli/Macros.hpp
+new file mode 100644
+index 0000000..9af7813
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Macros.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Macros.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Option.hpp b/external-cli/include/ignition/utils/cli/Option.hpp
+new file mode 100644
+index 0000000..7f8379b
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Option.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Option.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Split.hpp b/external-cli/include/ignition/utils/cli/Split.hpp
+new file mode 100644
+index 0000000..6995e99
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Split.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Split.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/StringTools.hpp b/external-cli/include/ignition/utils/cli/StringTools.hpp
+new file mode 100644
+index 0000000..f3d996d
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/StringTools.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/StringTools.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Timer.hpp b/external-cli/include/ignition/utils/cli/Timer.hpp
+new file mode 100644
+index 0000000..63758f6
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Timer.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Timer.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/TypeTools.hpp b/external-cli/include/ignition/utils/cli/TypeTools.hpp
+new file mode 100644
+index 0000000..979a7e8
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/TypeTools.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/TypeTools.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Validators.hpp b/external-cli/include/ignition/utils/cli/Validators.hpp
+new file mode 100644
+index 0000000..219bc51
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Validators.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Validators.hpp>
+diff --git a/external-cli/include/ignition/utils/cli/Version.hpp b/external-cli/include/ignition/utils/cli/Version.hpp
+new file mode 100644
+index 0000000..0b4772b
+--- /dev/null
++++ b/external-cli/include/ignition/utils/cli/Version.hpp
+@@ -0,0 +1,18 @@
++/*
++ * Copyright (C) 2021 Open Source Robotics Foundation
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ *
++ */
++
++#include <CLI/Version.hpp>
+diff --git a/external-cli/src/CMakeLists.txt b/external-cli/src/CMakeLists.txt
+new file mode 100644
+index 0000000..b81f671
+--- /dev/null
++++ b/external-cli/src/CMakeLists.txt
+@@ -0,0 +1,7 @@
++ign_add_component(
++  cli
++  INTERFACE
++  INDEPENDENT_FROM_PROJECT_LIB
++  GET_TARGET_NAME component)
++
++target_link_libraries(${component} INTERFACE CLI11::CLI11)

--- a/recipes/libignition-utils1/bld.bat
+++ b/recipes/libignition-utils1/bld.bat
@@ -7,6 +7,7 @@ cmake ^
     -DCMAKE_BUILD_TYPE=Release ^
     -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
     -DBUILD_TESTING=ON ^
+    -DIGN_UTILS_VENDOR_CLI11=OFF ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipes/libignition-utils1/bld.bat
+++ b/recipes/libignition-utils1/bld.bat
@@ -1,0 +1,23 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "NMake Makefiles" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DBUILD_TESTING=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test
+ctest --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipes/libignition-utils1/build.sh
+++ b/recipes/libignition-utils1/build.sh
@@ -10,7 +10,8 @@ cmake ${CMAKE_ARGS} \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
       -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_TESTING=OFF \
+      -DBUILD_TESTING=ON \
+      -DIGN_UTILS_VENDOR_CLI11=OFF \
       ..
 
 cmake --build . --config Release --parallel ${CPU_COUNT}

--- a/recipes/libignition-utils1/build.sh
+++ b/recipes/libignition-utils1/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_TESTING=OFF \
+      ..
+
+cmake --build . --config Release --parallel ${CPU_COUNT}
+cmake --build . --config Release --parallel ${CPU_COUNT} --target install
+ctest --output-on-failure -C Release

--- a/recipes/libignition-utils1/meta.yaml
+++ b/recipes/libignition-utils1/meta.yaml
@@ -1,0 +1,56 @@
+{% set component_name = "utils" %}
+{% set base_name = "libignition-" + component_name %}
+{% set version = "1.0.0" %}
+{% set major_version = version.split('.')[0] %}
+{% set name = base_name + major_version %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
+    sha256: 7a9664baacaeaba781d94cddec03534115c00cfe803ec64d89a04faa2e15a4b1
+    patches:
+      - 19.patch
+
+build:
+  number: 0
+  skip: true  # [not linux]
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - make  # [not win]
+    - cmake
+    - pkg-config
+  host:
+    - cli11
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/ignition/{{ component_name }}{{ major_version }}/ignition/{{ component_name }}.hh  # [not win]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.so  # [linux]
+    - test -f ${PREFIX}/lib/libignition-{{ component_name }}{{ major_version }}.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/ignition-{{ component_name }}{{ major_version }}/ignition-{{ component_name }}{{ major_version }}-config.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\ignition\\{{ component_name }}{{ major_version }}\\ignition\\{{ component_name }}.hh exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\ignition-{{ component_name }}{{ major_version }}.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\ignition-{{ component_name }}{{ major_version }}.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\ignition-{{ component_name }}{{ major_version }}\\ignition-{{ component_name }}{{ major_version }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/ignitionrobotics/ign-{{ component_name }}
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Classes and functions for robot applications.
+
+extra:
+  feedstock-name: {{ base_name }}
+  recipe-maintainers:
+    - wolfv
+    - traversaro
+    - Tobias-Fischer

--- a/recipes/libignition-utils1/meta.yaml
+++ b/recipes/libignition-utils1/meta.yaml
@@ -28,6 +28,7 @@ requirements:
     - cmake
     - pkg-config
   host:
+    - libignition-cmake2
     - cli11
 
 test:

--- a/recipes/libignition-utils1/meta.yaml
+++ b/recipes/libignition-utils1/meta.yaml
@@ -10,13 +10,12 @@ package:
 
 source:
   - url: https://github.com/ignitionrobotics/ign-{{ component_name }}/archive/ignition-{{ component_name }}{{ major_version }}_{{ version }}.tar.gz
-    sha256: 7a9664baacaeaba781d94cddec03534115c00cfe803ec64d89a04faa2e15a4b1
+    sha256: bd024164f12f66e125b544602ec481f6760d5a710aeb62d34a015fb598ee5a0a
     patches:
       - 19.patch
 
 build:
   number: 0
-  skip: true  # [not linux]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x') }}
 


### PR DESCRIPTION
Fix https://github.com/conda-forge/staged-recipes/issues/13551 . This adds the Ignition Utils library, the last maintained Ignition library that is missing  from conda-forge. This includes the change proposed upstream in https://github.com/ignitionrobotics/ign-utils/pull/19 to avoid vendoring cli11 .

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
