### PR TITLE
Adding rsconnect-python

### DIFF
--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:

--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rstudio/rsconnect-python/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 709D584CA256FB13AE6F53F9B2B5AA96E71F151DD94A83249B7F82D671EE37D5
+  sha256: 709d584ca256fb13ae6f53f9b2b5aa96e71f151dd94a83249b7f82d671ee37d5
 
 build:
   noarch: python

--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -18,7 +18,10 @@ requirements:
     - python >=3.6
     - pip
   run:
-    - python >=3.6
+    - python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+    - six >=1.14.0
+    - click >=7.0.0
+    - pip >=10.0.0  # rsconnect-python invokes pip as a subprocess
 
 test:
   imports:

--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 709d584ca256fb13ae6f53f9b2b5aa96e71f151dd94a83249b7f82d671ee37d5
 
 build:
-  noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -23,7 +23,7 @@ requirements:
 
 test:
   imports:
-    - rsconnect-python
+    - rsconnect
 
 about:
   home: https://github.com/rstudio/rsconnect-python

--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -10,8 +10,11 @@ source:
   sha256: 709d584ca256fb13ae6f53f9b2b5aa96e71f151dd94a83249b7f82d671ee37d5
 
 build:
+  noarch: python
+  entry_points:
+    - rsconnect = rsconnect.main:cli
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:
   host:

--- a/recipes/rsconnect-python/meta.yaml
+++ b/recipes/rsconnect-python/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "rsconnect-python" %}
+{% set version = "1.5.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/rstudio/rsconnect-python/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 709D584CA256FB13AE6F53F9B2B5AA96E71F151DD94A83249B7F82D671EE37D5
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - rsconnect-python
+
+about:
+  home: https://github.com/rstudio/rsconnect-python
+  license: GPL-2.0-only
+  license_family: GPL
+  license_file: LICENSE.md
+  summary: 'The rsconnect-python CLI and library'
+
+extra:
+  recipe-maintainers:
+    - bcwu


### PR DESCRIPTION
This PR adds rsconnect-python as a conda-forge feedstock

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
