### PR TITLE
Add recipe for pytest-split

### DIFF
--- a/recipes/pytest-split/meta.yaml
+++ b/recipes/pytest-split/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "pytest-split" %}
+{% set version = "0.1.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bf0163aafe5686e917a7f043567af96c50fabfe1ba0aa3be0f1b65556e09aa3c
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6,<4
+    - setuptools-scm
+    - pip
+  run:
+    - python >=3.6,<4
+    - pytest >=5.4
+
+test:
+  requires:
+    - pip
+  commands:
+    - pip check
+    - pytest --traceconfig | grep pytest-pycodestyle-{{ version }}
+
+about:
+  home: https://github.com/henry0312/pytest-pycodestyle
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: pytest plugin to split tests based on execution time.
+  description: pytest plugin which splits the test suite to equally sized "sub suites" based on test execution time.
+
+  doc_url: https://github.com/jerry-git/pytest-split
+  dev_url: https://github.com/jerry-git/pytest-split
+
+extra:
+  recipe-maintainers:
+    - ma-sadeghi

--- a/recipes/pytest-split/meta.yaml
+++ b/recipes/pytest-split/meta.yaml
@@ -28,13 +28,13 @@ test:
     - pip
   commands:
     - pip check
-    - pytest --traceconfig | grep pytest-pycodestyle-{{ version }}
+    - pytest --traceconfig | grep pytest-split-{{ version }}
 
 about:
   home: https://github.com/henry0312/pytest-pycodestyle
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  license_file: LICENCE
   summary: pytest plugin to split tests based on execution time.
   description: pytest plugin which splits the test suite to equally sized "sub suites" based on test execution time.
 

--- a/recipes/pytest-split/meta.yaml
+++ b/recipes/pytest-split/meta.yaml
@@ -31,7 +31,7 @@ test:
     - pytest --traceconfig | grep pytest-split-{{ version }}
 
 about:
-  home: https://github.com/henry0312/pytest-pycodestyle
+  home: https://github.com/jerry-git/pytest-split
   license: MIT
   license_family: MIT
   license_file: LICENCE


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
