### PR TITLE
Add recipe for rmf

### DIFF
--- a/recipes/rmf/bld.bat
+++ b/recipes/rmf/bld.bat
@@ -1,0 +1,22 @@
+mkdir build
+cd build
+
+:: We use conda's boost, which includes zlib support, but defining
+:: BOOST_ALL_DYN_LINK makes boost try to link against boost_zlib*.lib,
+:: which doesn't exist. Override this by explicitly naming the boost library
+:: to link against - since there isn't one, link against kernel32 instead
+:: (which pretty much everything links against, so this doesn't introduce
+:: an extra dependency)
+
+cmake -DCMAKE_BUILD_TYPE=Release ^
+      -G Ninja ^
+      -DCMAKE_PREFIX_PATH=%PREFIX:\=/% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX:\=/% ^
+      -DCMAKE_INSTALL_LIBDIR=bin ^
+      -DCMAKE_INSTALL_PYTHONDIR=%SP_DIR:\=/% ^
+      -DCMAKE_CXX_FLAGS="/DBOOST_ALL_DYN_LINK /EHsc /D_HDF5USEDLL_ /DH5_BUILT_AS_DYNAMIC_LIB /DWIN32 /bigobj /DBOOST_ZLIB_BINARY=kernel32" ^
+      ..
+if errorlevel 1 exit 1
+
+ninja install -j%CPU_COUNT%
+if errorlevel 1 exit 1

--- a/recipes/rmf/build.sh
+++ b/recipes/rmf/build.sh
@@ -5,6 +5,7 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -G Ninja \
       -DCMAKE_PREFIX_PATH=${PREFIX} \
       -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+      -DCMAKE_INSTALL_PYTHONDIR=${SP_DIR} \
       -DCMAKE_INSTALL_LIBDIR=lib \
       ..
 ninja install -j${CPU_COUNT}

--- a/recipes/rmf/build.sh
+++ b/recipes/rmf/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -G Ninja \
+      -DCMAKE_PREFIX_PATH=${PREFIX} \
+      -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      ..
+ninja install -j${CPU_COUNT}

--- a/recipes/rmf/build.sh
+++ b/recipes/rmf/build.sh
@@ -8,4 +8,4 @@ cmake -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_INSTALL_PYTHONDIR=${SP_DIR} \
       -DCMAKE_INSTALL_LIBDIR=lib \
       ..
-ninja install -j${CPU_COUNT}
+ninja install

--- a/recipes/rmf/build.sh
+++ b/recipes/rmf/build.sh
@@ -4,7 +4,7 @@ mkdir build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release \
       -G Ninja \
       -DCMAKE_PREFIX_PATH=${PREFIX} \
-      -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+      ${CMAKE_ARGS} \
       -DCMAKE_INSTALL_PYTHONDIR=${SP_DIR} \
       -DCMAKE_INSTALL_LIBDIR=lib \
       ..

--- a/recipes/rmf/meta.yaml
+++ b/recipes/rmf/meta.yaml
@@ -22,11 +22,11 @@ requirements:
     - ninja
   host:
     - python
-    - boost
+    - boost-cpp
     - hdf5
   run:
     - python
-    - boost
+    - boost-cpp
     - hdf5
 
 test:

--- a/recipes/rmf/meta.yaml
+++ b/recipes/rmf/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "rmf" %}
+{% set version = "1.3" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/salilab/rmf/archive/refs/tags/{{ version }}.tar.gz
+  sha256: d93f5939052f8edce62dab8e4e292962b5ceb36a2d5aa064f73abfa55db91f0e
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - swig
+    - cmake
+    - ninja
+  host:
+    - python
+    - boost
+    - hdf5
+  run:
+    - python
+    - boost
+    - hdf5
+
+test:
+  imports:
+    - RMF
+    - RMF_HDF5
+  commands:
+    - rmf3_dump --version
+
+about:
+  home: https://integrativemodeling.org/rmf/
+  summary: Library to support reading and writing of RMF files
+  license: Apache-2.0
+  license_file: COPYING
+  description: |
+    This library provides support for the RMF file format for storing
+    hierarchical molecular data (such as atomic or coarse grained
+    representations of proteins), along with markup, including geometry
+    and score data.
+  doc_url: https://integrativemodeling.org/rmf/
+  dev_url: https://github.com/salilab/rmf/
+
+extra:
+  recipe-maintainers:
+    - benmwebb

--- a/recipes/rmf/meta.yaml
+++ b/recipes/rmf/meta.yaml
@@ -9,6 +9,8 @@ package:
 source:
   url: https://github.com/salilab/rmf/archive/refs/tags/{{ version }}.tar.gz
   sha256: d93f5939052f8edce62dab8e4e292962b5ceb36a2d5aa064f73abfa55db91f0e
+  patches:
+    - swap-template.patch
 
 build:
   number: 0

--- a/recipes/rmf/run_test.py
+++ b/recipes/rmf/run_test.py
@@ -1,0 +1,15 @@
+import RMF
+import os
+
+# Make sure that we can read in an RMF file that we ourselves created
+# in both modern and old (HDF5) format
+for suffix in ('rmf', 'rmf-hdf5'):
+    r = RMF.create_rmf_file("test.%s" % suffix)
+    r.add_frame("root", RMF.FRAME)
+    del r
+
+    r = RMF.open_rmf_file_read_only("test.%s" % suffix)
+    r.set_current_frame(RMF.FrameID(0))
+    del r
+
+    os.unlink("test.%s" % suffix)

--- a/recipes/rmf/swap-template.patch
+++ b/recipes/rmf/swap-template.patch
@@ -1,0 +1,13 @@
+diff --git a/include/RMF/internal/SharedDataData.h b/include/RMF/internal/SharedDataData.h
+index 9586e380..0b6ee6cd 100644
+--- a/include/RMF/internal/SharedDataData.h
++++ b/include/RMF/internal/SharedDataData.h
+@@ -44,7 +44,7 @@ struct TypeData : RMF_SMALL_UNORDERED_MAP<ID<Traits>, KeyData<Traits> > {
+     P::operator=(o);
+     return *this;
+   }
+-  void swap(TypeData<Traits>& o) { std::swap<P>(*this, o); }
++  void swap(TypeData<Traits>& o) { P::swap(o); }
+ };
+ 
+ #define RMF_SHARED_DATA_TYPE_PARENT(Traits, UCName) , public TypeData<Traits>


### PR DESCRIPTION
Package the Rich Molecular Format (RMF) library for use with conda-forge.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
