### PR TITLE
Add recipe for unfccc_di_api.

### DIFF
--- a/recipes/unfccc_di_api/meta.yaml
+++ b/recipes/unfccc_di_api/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "unfccc_di_api" %}
+{% set version = "2.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unfccc_di_api-{{ version }}.tar.gz
+  sha256: 093a085a8dedc8d4b54ef8a190cca382f7378b0c3b8e818259b896ec7838d760
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools-scm
+  run:
+    - pandas
+    - python >=3.6
+    - requests
+    - treelib
+
+test:
+  imports:
+    - unfccc_di_api
+  requires:
+    - pytest
+  commands:
+    - pytest --pyargs unfccc_di_api
+
+about:
+  home: https://github.com/pik-primap/unfccc_di_api
+  summary: Python wrapper around the Flexible Query API of the UNFCCC.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://unfccc-di-api.readthedocs.io/
+  dev_url: https://github.com/pik-primap/unfccc_di_api/
+
+extra:
+  recipe-maintainers:
+    - mikapfl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

@conda-forge-admin, please ping team

@conda-forge/help-python


I would like to include my package unfccc_di_api in conda-forge. It is a python wrapper for the UNFCCC flexible query API, and is used (optionally) by pyam-iamc. Because unfccc_di_api is at the moment not available on conda-forge, the conda-forge build of pyam-iamc can't use it, which is one reason why I would like to get unfccc_di_api into conda-forge.

This is the first time I try to add a conda-forge recipe. I tested it locally with docker, I hope everything is fine!

Thanks a lot + cheers,
Mika