### PR TITLE
Add omero-py python package

### DIFF
--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -10,7 +10,9 @@ source:
   sha256: c636ee6141d7b64c17f37f13159d5f9672d1050ae7bd482d3909404e5ea1c568
 
 build:
-  noarch: python
+  # Can't use noarch because Windows requirements are different
+  # If we remove pywin32 from OMERO.py we could switch to noarch
+  # noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
   script_env:

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -25,13 +25,13 @@ build:
 requirements:
   host:
     - pip
-    - python =3
+    - python
   run:
     - appdirs
     - future
     - numpy
     - pillow
-    - python =3
+    - python
     - pywin32  # [win]
     - requests
     - pyyaml

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -20,7 +20,7 @@ build:
   entry_points:
     - omero = omero.main:main
   # zeroc-ice 3.6.5 is currently available for cpython 3.6, 3.7, 3.8
-  skip: true  # [py<36 or py>38 or python_impl=='pypy']
+  skip: True  # [py<36 or py>38 or python_impl=="pypy"]
 
 requirements:
   host:

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -59,7 +59,7 @@ test:
 
 about:
   home: https://www.openmicroscopy.org/
-  license: GNU General Public v2 or later (GPLv2+)
+  license: GPL-2.0-or-later
   license_family: GPL2
   license_file: LICENSE.txt
   summary: Python bindings to the OMERO.blitz server

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "omero-py" %}
-{% set version = "5.8.2" %}
+{% set version = "5.8.3" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c636ee6141d7b64c17f37f13159d5f9672d1050ae7bd482d3909404e5ea1c568
+  sha256: 3371d0a628c2cce9f7891306a65bc9c4b15613c2264a5f221bdc11fb9073883a
 
 build:
   # Can't use noarch because Windows requirements are different

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -19,8 +19,8 @@ build:
     - VERSION_SUFFIX
   entry_points:
     - omero = omero.main:main
-  # zeroc-ice 3.6.5 is currently available for Python 3.6, 3.7, 3.8
-  skip: true  # [py<36 or py>38]
+  # zeroc-ice 3.6.5 is currently available for cpython 3.6, 3.7, 3.8
+  skip: true  # [py<36 or py>38 or python_impl=='pypy']
 
 requirements:
   host:

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "omero-py" %}
-{% set version = "5.8.3" %}
+{% set version = "5.9.0" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3371d0a628c2cce9f7891306a65bc9c4b15613c2264a5f221bdc11fb9073883a
+  sha256: b53e04394a557675197adea2d6396ea9a0922ac1fa39a3d5c8460e9579a2b462
 
 build:
   # Can't use noarch because Windows requirements are different

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pywin32  # [win]
     - requests
     - pyyaml
-    - zeroc-ice36-python
+    - zeroc-ice =3.6
 
 test:
   commands:
@@ -61,10 +61,14 @@ about:
   home: https://www.openmicroscopy.org/
   license: GNU General Public v2 or later (GPLv2+)
   license_family: GPL2
+  license_file: LICENSE.txt
   summary: Python bindings to the OMERO.blitz server
   doc_url: https://docs.openmicroscopy.org/latest/omero/developers
   dev_url: https://github.com/ome/omero-py
 
 extra:
   recipe-maintainers:
-    - ome
+    - jburel
+    - joshmoore
+    - manics
+    - sbesson

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "omero-py" %}
+{% set version = "5.8.2" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}{{ environ.get('VERSION_SUFFIX', '') }}"
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c636ee6141d7b64c17f37f13159d5f9672d1050ae7bd482d3909404e5ea1c568
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
+  script_env:
+    - VERSION_SUFFIX
+  entry_points:
+    - omero = omero.main:main
+
+requirements:
+  host:
+    - pip
+    - python =3
+  run:
+    - appdirs
+    - future
+    - numpy
+    - pillow
+    - python =3
+    - pywin32  # [win]
+    - requests
+    - pyyaml
+    - zeroc-ice36-python
+
+test:
+  commands:
+    - omero --help
+    - omero version
+  imports:
+    - omero
+    - omero.api
+    - omero.clients
+    - omero.cmd
+    - omero.constants
+    - omero.fs
+    - omero.gateway
+    - omero.grid
+    - omero.install
+    - omero.metadatastore
+    - omero.model
+    - omero.plugins
+    - omero.romio
+    - omero.sys
+    - omero.util
+    - omero_ext
+
+about:
+  home: https://www.openmicroscopy.org/
+  license: GNU General Public v2 or later (GPLv2+)
+  license_family: GPL2
+  summary: Python bindings to the OMERO.blitz server
+  doc_url: https://docs.openmicroscopy.org/latest/omero/developers
+  dev_url: https://github.com/ome/omero-py
+
+extra:
+  recipe-maintainers:
+    - ome

--- a/recipes/omero-py/meta.yaml
+++ b/recipes/omero-py/meta.yaml
@@ -19,6 +19,8 @@ build:
     - VERSION_SUFFIX
   entry_points:
     - omero = omero.main:main
+  # zeroc-ice 3.6.5 is currently available for Python 3.6, 3.7, 3.8
+  skip: true  # [py<36 or py>38]
 
 requirements:
   host:


### PR DESCRIPTION
cc: @conda-forge/help-python (Resurrecting #13028)


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] ~If static libraries are linked in, the license of the static library is packaged.~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.

## Background

This package was originally in bioconda, but we're moving it to conda-forge to support other packages, and also for Windows support: bioconda/bioconda-recipes#15831 (comment)

The ome has been maintaining its own repository for this package due to problems with the bioconda package:

 * https://github.com/ome/conda-omero-py
 * https://anaconda.org/ome/omero-py

But now that the dependency zeroc-ice 3.6 is available in conda-forge we'd like to add omero-py here too.
