### PR TITLE
Add remove-dagmc-tags package

### DIFF
--- a/recipes/remove-dagmc-tags/LICENSE
+++ b/recipes/remove-dagmc-tags/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Jonathan Shimwell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/remove-dagmc-tags/LICENSE
+++ b/recipes/remove-dagmc-tags/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Jonathan Shimwell
+Copyright (c) 2021 the DAGMC development team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -13,7 +13,6 @@ source:
 build:
   number: 0
   skip: true  # [win]
-  noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "remove_dagmc_tags" %}
-{% set version = "0.0.3" %}
+{% set version = "0.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a7e90a32806e86004cacc2f39843982ac547ce9a6adbd1dee3d2b6019f593b1b
+  sha256: b1fcddcba5103f5a32b59f3f48fe09f8f2112a3562d27543ba260b4f5ccf1e74
 
 build:
   number: 0
@@ -30,6 +30,7 @@ test:
   source_files:
     - tests/test_command_line_tool.py
     - tests/test_python_api.py
+    - tests/dagmc.h5m
   requires:
     - pytest
   commands:

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "remove_dagmc_tags" %}
-{% set version = "0.0.4" %}
+{% set version = "0.0.5" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b1fcddcba5103f5a32b59f3f48fe09f8f2112a3562d27543ba260b4f5ccf1e74
+  sha256: e3e16c6ad219c1764db5db4236d326b4a022b2d62c98475c9318a9e9faa82b72
 
 build:
   number: 0

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -1,0 +1,53 @@
+
+{% set name = "remove_dagmc_tags" %}
+{% set version = "0.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 8b14e7df90a943a11057eae787aac23ad238ae0119c39a00ca393d0ff692295d
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - moab
+    - numpy
+
+test:
+  requires:
+    - pytest
+  imports:
+    - remove_dagmc_tags
+  commands:
+    - pytest tests
+
+about:
+  home: https://github.com/svalinn/remove_dagmc_tags
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: 'A python package and command line tool for removing DAGMC tags such as graveyard and vacuum.'
+
+  description: |
+    This is a minimal Python package that provides both command line and API
+    interfaces for removing multiple tags from a DAGMC h5m file.
+    This is useful for preparing the h5m file for visulisation where it is
+    desirable to remove reflecting surfaces, vacuum materials and the
+    graveyard(s) region from the geometry before viewing the vtk file.
+  doc_url: https://github.com/svalinn/remove_dagmc_tags
+  dev_url: https://github.com/svalinn/remove_dagmc_tags
+
+extra:
+  recipe-maintainers:
+    - shimwell

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -12,6 +12,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win]
   noarch: python
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -17,10 +17,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
+    - python
     - moab
     - numpy
 

--- a/recipes/remove-dagmc-tags/meta.yaml
+++ b/recipes/remove-dagmc-tags/meta.yaml
@@ -1,6 +1,6 @@
 
 {% set name = "remove_dagmc_tags" %}
-{% set version = "0.0.2" %}
+{% set version = "0.0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8b14e7df90a943a11057eae787aac23ad238ae0119c39a00ca393d0ff692295d
+  sha256: a7e90a32806e86004cacc2f39843982ac547ce9a6adbd1dee3d2b6019f593b1b
 
 build:
   number: 0
@@ -25,10 +25,13 @@ requirements:
     - numpy
 
 test:
-  requires:
-    - pytest
   imports:
     - remove_dagmc_tags
+  source_files:
+    - tests/test_command_line_tool.py
+    - tests/test_python_api.py
+  requires:
+    - pytest
   commands:
     - pytest tests
 


### PR DESCRIPTION
Hi there Conda Forge

I am keen to add this package to the conda forge collection. It is a simple tool for DAGMC that allows users to remove parts of the geometry. It is great to have it on conda forge because it requires pymoab (part of Moab) which conda forge already distributes

I have tested it locally with the CONFIG=linux64 ./.scripts/run_docker_build.sh command and it appears to build, import the package and run some pytests

I confirm that I look forward to maintaining this package should it be accepted

Checklist

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
