### PR TITLE
WIP: Add opentimelineio 0.13.0 recipe

### DIFF
--- a/recipes/opentimelineio/meta.yaml
+++ b/recipes/opentimelineio/meta.yaml
@@ -43,7 +43,7 @@ test:
 
 about:
   home: https://github.com/PixarAnimationStudios/OpenTimelineIO
-  license: Modified Apache 2.0
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE.txt
   summary: Python API for interchange of editorial cut information

--- a/recipes/opentimelineio/meta.yaml
+++ b/recipes/opentimelineio/meta.yaml
@@ -24,14 +24,14 @@ requirements:
     - pip
     - pyaaf2
     - setuptools
-    - python >=2.7
+    - python
   run:
     - pip
     - pyaaf2
-    - python >=2.7
+    - python
 
 
-tests:
+test:
   imports:
     - opentimelineio
     - opentimelineio.opentime
@@ -43,7 +43,7 @@ tests:
 
 about:
   home: https://github.com/PixarAnimationStudios/OpenTimelineIO
-  license: Modified Apache 2.0 License
+  license: Modified Apache 2.0
   license_family: Apache
   license_file: LICENSE.txt
   summary: Python API for interchange of editorial cut information

--- a/recipes/opentimelineio/meta.yaml
+++ b/recipes/opentimelineio/meta.yaml
@@ -1,0 +1,54 @@
+
+{% set name = "opentimelineio" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  - url: https://github.com/PixarAnimationStudios/OpenTimelineIO/archive/refs/tags/v0.13.tar.gz
+    sha256: 33a63891b4656804242512e122b33ed12e35d4038fd78610ccb82b441b9506dd
+  - url: https://github.com/pybind/pybind11/archive/refs/tags/v2.6.2.tar.gz
+    sha256: 8ff2fff22df038f5cd02cea8af56622bc67f5b64534f1b83b9f133b8366acff2
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install --no-deps --ignore-installed . -vv"
+
+requirements:
+  build:
+    - "{{ compiler('cxx') }}"
+    - cmake
+  host:
+    - pip
+    - pyaaf2
+    - setuptools
+    - python >=2.7
+  run:
+    - pip
+    - pyaaf2
+    - python >=2.7
+
+
+tests:
+  imports:
+    - opentimelineio
+    - opentimelineio.opentime
+  commands:
+    - make test
+    - otioconvert --help
+    - otioviewer --help
+    - otioconvert --help
+
+about:
+  home: https://github.com/PixarAnimationStudios/OpenTimelineIO
+  license: Modified Apache 2.0 License
+  license_family: Apache
+  license_file: LICENSE.txt
+  summary: Python API for interchange of editorial cut information
+  doc_url: "https://opentimelineio.readthedocs.io"
+
+extra:
+  recipe-maintainers:
+    - vvzen


### PR DESCRIPTION
Hi all!

this is my second PR here, the first one was relatively simple since it's one a pure python package.

Now I'm trying something a bit more complex! OpenTimelineIO is a c++ package with python bindings generated using pybind11 . Unfortunately they're vendorizing some dependencies as git submodules in their repo, but the GitHub tarball doesn't take them into account (I found this issue discussing that: https://github.com/conda-forge/conda-forge.github.io/issues/619 ). So in the end I added pybind11 as an additional url in the `source` , otherwise cmake would fail with a `CMake Error at src/py-opentimelineio/opentime-bindings/CMakeLists.txt:1 (pybind11_add_module)` . I'm not sure this is the right approach, but once again, I'm still trying to wrap my head around conda-forge and packaging, so any suggestions are welcome!

Thanks!

Valerio