### PR TITLE
Add recipe for tomlplusplus

### DIFF
--- a/recipes/tomlplusplus/102.patch
+++ b/recipes/tomlplusplus/102.patch
@@ -1,0 +1,238 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 960e2ab..1f63175 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,54 +1,44 @@
+-cmake_minimum_required(VERSION 3.13...3.19)
++cmake_minimum_required(VERSION 3.14)
++
++project(
++    tomlplusplus
++    VERSION 2.4.0
++    DESCRIPTION "Header-only TOML config file parser and serializer for C++17 (and later!)"
++    HOMEPAGE_URL "https://marzer.github.io/tomlplusplus/"
++    LANGUAGES CXX
++)
+ 
+-project(tomlplusplus LANGUAGES CXX VERSION 2.3.1)
++include(cmake/project-is-top-level.cmake)
++include(cmake/variables.cmake)
+ 
+-# Determine if this project is built as a subproject (using
+-# add_subdirectory) or if it is the master project.
+-set(MASTER_PROJECT OFF)
+-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+-    set(MASTER_PROJECT ON)
+-    message(STATUS "CMake version: ${CMAKE_VERSION}")
+-endif()
++# ---- Declare library ----
+ 
++add_library(tomlplusplus_tomlplusplus INTERFACE)
++add_library(tomlplusplus::tomlplusplus ALIAS tomlplusplus_tomlplusplus)
+ 
+-add_library(tomlplusplus INTERFACE)
+-add_library(tomlplusplus::tomlplusplus ALIAS tomlplusplus)
+-target_compile_features(tomlplusplus INTERFACE cxx_std_17)
+-target_include_directories(tomlplusplus INTERFACE
+-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-  $<INSTALL_INTERFACE:include>
++set_property(
++    TARGET tomlplusplus_tomlplusplus PROPERTY
++    EXPORT_NAME tomlplusplus
+ )
+ 
++target_include_directories(
++  tomlplusplus_tomlplusplus
++  ${tomlplusplus_warning_guard} # unquoted for list expansion
++  INTERFACE
++  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
++)
+ 
+-option(TOMLPP_BUILD_EXAMPLES "Build examples." ${MASTER_PROJECT})
+-if(TOMLPP_BUILD_EXAMPLES)
+-    add_subdirectory(examples)
+-endif()
+-
+-
+-option(TOMLPP_INSTALL "Generate the install target" ${MASTER_PROJECT})
+-if(TOMLPP_INSTALL)
+-    include(CMakePackageConfigHelpers)
+-    include(GNUInstallDirs)
+-    install(TARGETS tomlplusplus EXPORT ${PROJECT_NAME}Targets)
++target_compile_features(tomlplusplus_tomlplusplus INTERFACE cxx_std_17)
+ 
+-    install(DIRECTORY include/toml++ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++# ---- Install rules ----
+ 
+-    write_basic_package_version_file(
+-        ${PROJECT_NAME}ConfigVersion.cmake
+-        COMPATIBILITY SameMajorVersion
+-    )
++include(cmake/install-rules.cmake)
+ 
+-    install(
+-        FILES cmake/tomlplusplusConfig.cmake # ---------->
+-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+-    )
++# ---- Examples ----
+ 
+-    install(
+-        EXPORT ${PROJECT_NAME}Targets
+-        NAMESPACE ${PROJECT_NAME}::
+-        FILE ${PROJECT_NAME}Targets.cmake   # <----------
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+-    )
++if(PROJECT_IS_TOP_LEVEL)
++  option(BUILD_EXAMPLES "Build examples tree." OFF)
++  if(BUILD_EXAMPLES)
++    add_subdirectory(examples)
++  endif()
+ endif()
+diff --git a/cmake/install-rules.cmake b/cmake/install-rules.cmake
+new file mode 100644
+index 0000000..3e6dd2c
+--- /dev/null
++++ b/cmake/install-rules.cmake
+@@ -0,0 +1,46 @@
++include(CMakePackageConfigHelpers)
++include(GNUInstallDirs)
++
++install(
++    DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
++    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++    COMPONENT tomlplusplus_Development
++)
++
++install(
++    TARGETS tomlplusplus_tomlplusplus
++    EXPORT tomlplusplusTargets
++    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
++)
++
++write_basic_package_version_file(
++    tomlplusplusConfigVersion.cmake
++    COMPATIBILITY SameMajorVersion
++    ARCH_INDEPENDENT
++)
++
++set(
++    tomlplusplus_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/tomlplusplus"
++    CACHE STRING "CMake package config location relative to the install prefix"
++)
++
++mark_as_advanced(tomlplusplus_INSTALL_CMAKEDIR)
++
++install(
++    FILES
++    "${PROJECT_SOURCE_DIR}/cmake/tomlplusplusConfig.cmake"
++    "${PROJECT_BINARY_DIR}/tomlplusplusConfigVersion.cmake"
++    DESTINATION "${tomlplusplus_INSTALL_CMAKEDIR}"
++    COMPONENT tomlplusplus_Development
++)
++
++install(
++    EXPORT tomlplusplusTargets
++    NAMESPACE tomlplusplus::
++    DESTINATION "${tomlplusplus_INSTALL_CMAKEDIR}"
++    COMPONENT tomlplusplus_Development
++)
++
++if(PROJECT_IS_TOP_LEVEL)
++  include(CPack)
++endif()
+diff --git a/cmake/project-is-top-level.cmake b/cmake/project-is-top-level.cmake
+new file mode 100644
+index 0000000..3435fc0
+--- /dev/null
++++ b/cmake/project-is-top-level.cmake
+@@ -0,0 +1,6 @@
++# This variable is set by project() in CMake 3.21+
++string(
++    COMPARE EQUAL
++    "${CMAKE_SOURCE_DIR}" "${PROJECT_SOURCE_DIR}"
++    PROJECT_IS_TOP_LEVEL
++)
+diff --git a/cmake/tomlplusplus.cmake.in b/cmake/tomlplusplus.cmake.in
+deleted file mode 100644
+index 4a836da..0000000
+--- a/cmake/tomlplusplus.cmake.in
++++ /dev/null
+@@ -1,14 +0,0 @@
+-@PACKAGE_INIT@
+-
+-# If tomlplusplus::tomlplusplus target is not defined it will be included
+-if(NOT TARGET tomlplusplus::tomlplusplus)
+-
+-  # Import tomlplusplus interface library
+-  add_library(tomlplusplus::tomlplusplus INTERFACE IMPORTED)
+-  set_target_properties(tomlplusplus::tomlplusplus PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include")
+-
+-  # Require C++17
+-  target_compile_features(tomlplusplus::tomlplusplus INTERFACE cxx_std_17)
+-
+-endif()
+diff --git a/cmake/variables.cmake b/cmake/variables.cmake
+new file mode 100644
+index 0000000..3660bfb
+--- /dev/null
++++ b/cmake/variables.cmake
+@@ -0,0 +1,18 @@
++# ---- Warning guard ----
++
++# target_include_directories with the SYSTEM modifier will request the compiler
++# to omit warnings from the provided paths, if the compiler supports that
++# This is to provide a user experience similar to find_package when
++# add_subdirectory or FetchContent is used to consume this project
++set(tomlplusplus_warning_guard "")
++if(NOT PROJECT_IS_TOP_LEVEL)
++  option(
++      tomlplusplus_INCLUDES_WITH_SYSTEM
++      "Use SYSTEM modifier for tomlplusplus's includes, disabling warnings"
++      ON
++  )
++  mark_as_advanced(tomlplusplus_INCLUDES_WITH_SYSTEM)
++  if(tomlplusplus_INCLUDES_WITH_SYSTEM)
++    set(tomlplusplus_warning_guard SYSTEM)
++  endif()
++endif()
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index a1cf87f..c4e7946 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -1,15 +1,25 @@
+-cmake_minimum_required(VERSION 3.13...3.19)
++cmake_minimum_required(VERSION 3.14)
+ 
+ project(Examples LANGUAGES CXX)
+ 
+-if(NOT TARGET tomlplusplus::tomlplusplus)
+-    find_package(tomlplusplus REQUIRED)
++include(../cmake/project-is-top-level.cmake)
++
++if(PROJECT_IS_TOP_LEVEL)
++  find_package(tomlplusplus REQUIRED)
+ endif()
+ 
+-add_executable(toml_to_json_transcoder toml_to_json_transcoder.cpp)
+-target_link_libraries(toml_to_json_transcoder PRIVATE tomlplusplus::tomlplusplus)
++add_custom_target(run_examples COMMENT "Running all examples")
++
++function(add_example name)
++  cmake_parse_arguments(PARSE_ARGV 1 "" "" "" ARGS)
++  add_executable("${name}" "${name}.cpp")
++  target_link_libraries("${name}" PRIVATE tomlplusplus::tomlplusplus)
++  target_compile_features("${name}" PRIVATE cxx_std_17)
++  add_custom_target("run_${name}" COMMAND "${name}" ${_ARGS} VERBATIM)
++  add_dependencies(run_examples "run_${name}")
++endfunction()
+ 
+-enable_testing()
+-add_test(NAME toml_to_json_transcoder
+-    COMMAND toml_to_json_transcoder ${CMAKE_CURRENT_LIST_DIR}/example.toml
+-)
++add_example(error_printer)
++add_example(simple_parser ARGS "${PROJECT_SOURCE_DIR}/example.toml")
++add_example(toml_generator ARGS 100)
++add_example(toml_to_json_transcoder ARGS "${PROJECT_SOURCE_DIR}/example.toml")

--- a/recipes/tomlplusplus/bld.bat
+++ b/recipes/tomlplusplus/bld.bat
@@ -1,0 +1,23 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DBUILD_TESTING=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test
+ctest --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipes/tomlplusplus/build.sh
+++ b/recipes/tomlplusplus/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=ON
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/tomlplusplus/meta.yaml
+++ b/recipes/tomlplusplus/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "tomlplusplus" %}
+{% set version = "2.4.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/marzer/tomlplusplus/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: d7c28b25374241afa08c60183717d3025aa8abffe1030928dc7e1d2143852da1
+  patches:
+    - 102.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - ninja
+    - cmake
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/toml++/toml.h  # [not win]
+    - test -f ${PREFIX}/lib/cmake/tomlplusplus/tomlplusplusConfig.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\toml++\toml.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\tomlplusplus\\tomlplusplusConfig.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/marzer/tomlplusplus
+  license: MIT
+  license_file: LICENSE
+  summary: Header-only TOML config file parser and serializer for C++17 (and later!). 
+
+extra:
+  recipe-maintainers:
+    - traversaro
+    - h-vetinari


### PR DESCRIPTION
[tomlplusplus](https://github.com/marzer/tomlplusplus): is an header-only TOML config file parser and serializer for C++17.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
