### PR TITLE
Add r-wikidataqueryservicer.

### DIFF
--- a/recipes/r-wikidataqueryservicer/bld.bat
+++ b/recipes/r-wikidataqueryservicer/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-wikidataqueryservicer/build.sh
+++ b/recipes/r-wikidataqueryservicer/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-wikidataqueryservicer/meta.yaml
+++ b/recipes/r-wikidataqueryservicer/meta.yaml
@@ -1,0 +1,64 @@
+{% set version = '1.0.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-wikidataqueryservicer
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/WikidataQueryServiceR_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/WikidataQueryServiceR/WikidataQueryServiceR_{{ version }}.tar.gz
+  sha256: 0e14eec8471a72227f800b41b331cfc49a94b4d4f49e68936448ebbae0b281ae
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-wikipedir >=1.5.0
+    - r-dplyr >=1.0.0
+    - r-httr >=1.2.1
+    - r-jsonlite >=1.2
+    - r-purrr >=0.3.4
+    - r-ratelimitr >=0.4.1
+    - r-readr >=1.3.1
+    - r-rex >=1.2.0
+  run:
+    - r-base
+    - r-wikipedir >=1.5.0
+    - r-dplyr >=1.0.0
+    - r-httr >=1.2.1
+    - r-jsonlite >=1.2
+    - r-purrr >=0.3.4
+    - r-ratelimitr >=0.4.1
+    - r-readr >=1.3.1
+    - r-rex >=1.2.0
+
+test:
+  commands:
+    - $R -e "library('WikidataQueryServiceR')"           # [not win]
+    - "\"%R%\" -e \"library('WikidataQueryServiceR')\""  # [win]
+
+about:
+  home: https://github.com/bearloga/WikidataQueryServiceR
+  license: MIT
+  summary: An API client for the 'Wikidata Query Service' <https://query.wikidata.org/>.
+  license_family: MIT
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
