### PR TITLE
Add diot and liquidpy

### DIFF
--- a/recipes/diot/LICENSE
+++ b/recipes/diot/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 pwwang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/diot/meta.yaml
+++ b/recipes/diot/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "diot" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/diot-{{ version }}.tar.gz
+  sha256: 543c2eaef6fba988a0d681d1102a934289ea4637a92eba6698df5533fb5e443b
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - poetry >=0.12
+    - python >=3.6
+  run:
+    - inflection <1.0.0
+    - python >=3.6
+
+test:
+  requires:
+    - pip
+  imports:
+    - diot
+  commands:
+    - python -m pip check
+
+about:
+  home: https://github.com/pwwang/diot
+  dev_url: https://github.com/pwwang/diot.git
+  doc_url: https://pwwang.github.io/diot/
+  summary: Python dictionary with dot notation
+  license: MIT
+  license_file: LICENSE
+  description: |
+    Python dictionary with dot notation (A re-implementation of
+    python-box with some issues fixed and simplified)
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod

--- a/recipes/liquidpy/meta.yaml
+++ b/recipes/liquidpy/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "liquidpy" %}
+{% set version = "0.6.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/liquidpy-{{ version }}.tar.gz
+  sha256: 9d9926fc1fa700c88135f84c15130f0d33c189c021972c04b0f9c1fa5554f300
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - poetry >=0.12
+    - python >=3.6
+  run:
+    - diot
+    - lark-parser <1.0.0
+    - python >=3.6
+    - rich >=9.0.0,<10.0.0
+
+test:
+  requires:
+    - pip
+  imports:
+    - liquid
+  commands:
+    - python -m pip check
+
+about:
+  home: https://github.com/pwwang/liquidpy
+  doc_url: https://pwwang.github.io/liquidpy/
+  dev_url: https://github.com/pwwang/liquidpy.git
+  summary: A port of liquid template engine for python
+  license: Apache-2.0
+  license_file: LICENSE
+  description:
+    A port of liquid template engine for python.
+    This is compatible with standard Liquid template engine.
+    Variations, such as Shopify and Jekyll are not fully supported yet.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds recipes for [`diot`](https://github.com/pwwang/diot) and [`liquidpy`](https://github.com/pwwang/liquidpy).

Notes:

- `diot`: the license file is manually bundled because it isn't in the 0.1.1 tarball - I think this has been fixed upstream
- both: there are no real tests, but PRs have been posted to https://github.com/pwwang/diot/pull/2 and https://github.com/pwwang/liquidpy/pull/32 to request including the upstream test suite in the tarballs for future releases

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
