### PR TITLE
Add pycbf

### DIFF
--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pycbf" %}
-{% set version = "0.9.6.2" %}
+{% set version = "0.9.6.3" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e7cb566269be56c543c59ef75da770a6c9fe6b9891cc42b4d12d4e99f439b175
+  sha256: 56f1d5b67003ac1e7e96bf13fb4586160799ead41e520217cf18e9758e5decfe
 
 build:
   skip: True  # [win]

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - cython
+    - poetry-core
   host:
     - python
     - pip

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -49,3 +49,4 @@ about:
 extra:
   recipe-maintainers:
     - ndevenish
+    - anthchirp

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -39,7 +39,7 @@ about:
   home: https://github.com/ndevenish/pycbf
   license: LGPL-2.1-or-later
   license_family: LGPL
-  license_file: LICENSE.txt
+  license_file: LICENCE.txt
   summary: 'An API for CBF/imgCIF Crystallographic Binary Files'
   description: |
     pycbf is a Python library for reading CBF formatted files.

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -37,14 +37,14 @@ test:
     - pip check
 
 about:
-  home: https://github.com/ndevenish/pycbf
+  home: https://github.com/dials/pycbf
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: LICENCE.txt
   summary: 'An API for CBF/imgCIF Crystallographic Binary Files'
   description: |
     pycbf is a Python library for reading CBF formatted files.
-  dev_url: https://github.com/ndevenish/pycbf
+  dev_url: https://github.com/dials/pycbf
 
 extra:
   recipe-maintainers:

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: e7cb566269be56c543c59ef75da770a6c9fe6b9891cc42b4d12d4e99f439b175
 
 build:
+  skip: True  # [win]
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
 

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "pycbf" %}
+{% set version = "0.9.6.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: e7cb566269be56c543c59ef75da770a6c9fe6b9891cc42b4d12d4e99f439b175
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - cython
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy x.x
+
+test:
+  # Some packages might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - pycbf
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/ndevenish/pycbf
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  license_file: LICENSE.txt
+  summary: 'An API for CBF/imgCIF Crystallographic Binary Files'
+  description: |
+    pycbf is a Python library for reading CBF formatted files.
+  dev_url: https://github.com/ndevenish/pycbf
+
+extra:
+  recipe-maintainers:
+    - ndevenish

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: True  # [win]
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   build:
@@ -24,11 +24,9 @@ requirements:
     - poetry-core
   run:
     - python
-    - numpy
+    - numpy >=1.17
 
 test:
-  # Some packages might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - pycbf
   requires:
@@ -41,7 +39,7 @@ about:
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: LICENCE.txt
-  summary: 'An API for CBF/imgCIF Crystallographic Binary Files'
+  summary: An API for CBF/imgCIF Crystallographic Binary Files
   description: |
     pycbf is a Python library for reading CBF formatted files.
   dev_url: https://github.com/dials/pycbf

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -17,10 +17,10 @@ requirements:
   build:
     - {{ compiler('c') }}
     - cython
-    - poetry-core
   host:
     - python
     - pip
+    - poetry-core
   run:
     - python
     - numpy

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -16,8 +16,8 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - cython
   host:
+    - cython
     - python
     - pip
     - poetry-core

--- a/recipes/pycbf/meta.yaml
+++ b/recipes/pycbf/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - python
-    - numpy x.x
+    - numpy
 
 test:
   # Some packages might need a `test/commands` key to check CLI.


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


The upstream package https://github.com/yayahjb/cbflib sources are used to compile statically into the build python extension module. The licence is the same (>=LGPL2.1).

There are issues with the current upstream windows build, so these are disabled initially.

Mac-arm64 compilation works but appears to require enabling post-merge: https://conda-forge.org/blog/posts/2020-10-29-macos-arm64/#how-to-add-a-osx-arm64-build-to-a-feedstock
