### PR TITLE
Add pypardiso recipe

### DIFF
--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - setuptools
     - pip
   run:
-    - python
+    - python >=3.6
     - numpy
     - "libblas =*=*mkl"
     - scipy

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - "libblas =*=*mkl"
     - scipy
-    - mkl
+    - mkl =2020.2
     - mkl-service
 
 test:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypardiso" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.3.0.tar.gz
-  sha256:
+  sha256: b054262e1e58cd57660d6ebbfcac2a45ee01891dbe74bd31fcb5e69e3c07de19
 
 build:
   number: 0

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,8 +1,3 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
-# Using the name variable with the URL in line 14 is convenient
-# when copying and pasting from another recipe, but not really needed.
 {% set name = "pypardiso" %}
 {% set version = "0.2.2" %}
 
@@ -11,9 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  # If getting the source from GitHub, remove the line above,
-  # uncomment the line below, and modify as needed. Use releases if available:
-  url: https://github.com/cmutel/PyPardisoProject/archive/refs/tags/v0.2.2.tar.gz
+  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.2.2.tar.gz
   sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
 
 build:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -43,6 +43,7 @@ test:
     - tests/test_input_b.py
   commands:
     - pytest -vv tests/
+    - pip check
 
 about:
   home: https://github.com/cmutel/PyPardisoProject

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -33,7 +33,7 @@ requirements:
   run:
     - python
     - {{ pin_compatible('numpy') }}
-    - "libblas=*=*mkl"
+    - "libblas =*=*mkl"
     - scipy
     - mkl
     - mkl-service

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -36,6 +36,7 @@ test:
     - pypardiso
   requires:
     - pytest
+    - pip
   files:
     - tests/test_basic_solve.py
     - tests/test_input_A.py

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.2.2.tar.gz
+  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v{{ version }}.tar.gz
   sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
 
 build:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "pypardiso" %}
-{% set version = "0.3" %}
+{% set version = "0.2.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.3.0.tar.gz
-  sha256: b054262e1e58cd57660d6ebbfcac2a45ee01891dbe74bd31fcb5e69e3c07de19
+  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.2.2.tar.gz
+  sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
 
 build:
   number: 0
@@ -24,15 +24,15 @@ requirements:
     - numpy
     - pip
     - "libblas =*=*mkl"  # [win]
-    - mkl  # [win]
+    - mkl 2020.*  # [win]
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - "libblas =*=*mkl"
     - scipy
-    - mkl
+    - mkl  # [not win]
+    - mkl 2020.*  # [win]
     - mkl-service
-    - psutil
 
 test:
   imports:
@@ -56,5 +56,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - haasad
     - cmutel
+    - haasad

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -18,7 +18,6 @@ requirements:
   host:
     - python
     - setuptools
-    - numpy
     - pip
     - "libblas =*=*mkl"  # [win]
     - mkl 2020.*  # [win]

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - numpy
     - "libblas =*=*mkl"
     - scipy
-    - mkl # [not win]
-    - mkl 2020.* # [win]
+    - mkl  # [not win]
+    - mkl 2020.*  # [win]
     - mkl-service
     - pip
   run:
@@ -33,8 +33,8 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - "libblas =*=*mkl"
     - scipy
-    - mkl # [not win]
-    - mkl 2020.* # [win]
+    - mkl  # [not win]
+    - mkl 2020.*  # [win]
     - mkl-service
 
 test:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -44,7 +44,7 @@ test:
     - pip check
 
 about:
-  home: https://github.com/cmutel/PyPardisoProject
+  home: https://github.com/haasad/PyPardisoProject
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 41cb729c1fa9e69393d2f1d73f8758282f34a553ef333ad165f3fd41447518db
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c3846870dc2590250980d98568e9dfc99b0271e9e5a9c8714a85cc373e839788
 
 build:
   number: 0

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypardiso" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,27 +7,24 @@ package:
 
 source:
   url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
+  sha256: 41cb729c1fa9e69393d2f1d73f8758282f34a553ef333ad165f3fd41447518db
 
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  skip: True  # [py<35]
+  noarch: python
 
 requirements:
   host:
     - python
     - setuptools
     - pip
-    - "libblas =*=*mkl"  # [win]
-    - mkl 2020.*  # [win]
   run:
     - python
     - numpy
     - "libblas =*=*mkl"
     - scipy
-    - mkl  # [not win]
-    - mkl 2020.*  # [win]
+    - mkl
     - mkl-service
 
 test:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - mkl 2020.*  # [win]
   run:
     - python
-    - {{ pin_compatible('numpy') }}
+    - numpy
     - "libblas =*=*mkl"
     - scipy
     - mkl  # [not win]

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - setuptools
     - numpy
     - pip
+    - "libblas =*=*mkl"  # [win]
+    - mkl 2020.*  # [win]
   run:
     - python
     - {{ pin_compatible('numpy') }}

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -55,4 +55,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - haasad
     - cmutel

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.2.2.tar.gz
-  sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
+  url: https://github.com/haasad/PyPardisoProject/archive/refs/tags/v0.3.0.tar.gz
+  sha256:
 
 build:
   number: 0
@@ -24,14 +24,13 @@ requirements:
     - numpy
     - pip
     - "libblas =*=*mkl"  # [win]
-    - mkl 2020.*  # [win]
+    - mkl  # [win]
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - "libblas =*=*mkl"
     - scipy
-    - mkl  # [not win]
-    - mkl 2020.*  # [win]
+    - mkl
     - mkl-service
 
 test:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,0 +1,63 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+# Using the name variable with the URL in line 14 is convenient
+# when copying and pasting from another recipe, but not really needed.
+{% set name = "pypardiso" %}
+{% set version = "0.2.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # If getting the source from GitHub, remove the line above,
+  # uncomment the line below, and modify as needed. Use releases if available:
+  url: https://github.com/cmutel/PyPardisoProject/archive/refs/tags/v0.2.2.tar.gz
+  sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
+
+build:
+  number: 1
+  script: "{{ PYTHON }} -m pip install . -vv"
+  skip: True  # [py<35]
+
+requirements:
+  build:
+    - python
+    - setuptools
+  host:
+    - python
+    - setuptools
+    - numpy
+    - pip
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - "libblas=*=*mkl"
+    - scipy
+    - mkl
+    - mkl-service
+
+test:
+  imports:
+    - pypardiso
+  requires:
+    - pytest
+  files:
+    - tests/test_basic_solve.py
+    - tests/test_input_A.py
+    - tests/test_scipy_aliases.py
+    - tests/test_input_b.py
+  commands:
+    - pytest -vv tests/
+
+about:
+  home: https://github.com/cmutel/PyPardisoProject
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'Python interface to the Intel MKL Pardiso library to solve large sparse linear systems of equations'
+
+extra:
+  recipe-maintainers:
+    - cmutel

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pypardiso" %}
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c3846870dc2590250980d98568e9dfc99b0271e9e5a9c8714a85cc373e839788
+  sha256: 1116ffeedf49bb31fdeea2d45076ddf540955c4df272fc4c8bc6b17c4f9d267e
 
 build:
   number: 0

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -22,11 +22,6 @@ requirements:
     - python
     - setuptools
     - numpy
-    - "libblas =*=*mkl"
-    - scipy
-    - mkl  # [not win]
-    - mkl 2020.*  # [win]
-    - mkl-service
     - pip
   run:
     - python

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -22,13 +22,19 @@ requirements:
     - python
     - setuptools
     - numpy
+    - "libblas =*=*mkl"
+    - scipy
+    - mkl # [not win]
+    - mkl 2020.* # [win]
+    - mkl-service
     - pip
   run:
     - python
     - {{ pin_compatible('numpy') }}
     - "libblas =*=*mkl"
     - scipy
-    - mkl =2020.2
+    - mkl # [not win]
+    - mkl 2020.* # [win]
     - mkl-service
 
 test:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -15,9 +15,6 @@ build:
   skip: True  # [py<35]
 
 requirements:
-  build:
-    - python
-    - setuptools
   host:
     - python
     - setuptools

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: b1d3a139f8f04c74f8b2b5c4b55434e1f58b00ae3fe0ca975115971906d93eac
 
 build:
-  number: 1
+  number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
   skip: True  # [py<35]
 

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - scipy
     - mkl
     - mkl-service
+    - psutil
 
 test:
   imports:

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >=3.6
     - numpy
-    - "libblas =*=*mkl"
+    - libblas * *mkl
     - scipy
     - mkl
     - mkl-service

--- a/recipes/pypardiso/meta.yaml
+++ b/recipes/pypardiso/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - scipy
     - mkl
     - mkl-service
+    - psutil
 
 test:
   imports:

--- a/recipes/pypardiso/tests/test_basic_solve.py
+++ b/recipes/pypardiso/tests/test_basic_solve.py
@@ -1,0 +1,67 @@
+from pypardiso.scipy_aliases import pypardiso_solver
+import numpy as np
+import scipy.sparse as sp
+
+ps = pypardiso_solver
+
+
+def create_test_A_b_small(matrix=False, sort_indices=True):
+    """
+    --- A ---
+    scipy.sparse.csr.csr_matrix, float64
+    matrix([[5, 1, 0, 0, 0],
+            [0, 6, 2, 0, 0],
+            [0, 0, 7, 3, 0],
+            [0, 0, 0, 8, 4],
+            [0, 0, 0, 0, 9]])
+    --- b ---
+    np.ndarray, float64
+    array([[ 1],
+           [ 4],
+           [ 7],
+           [10],
+           [13]])
+    or
+    array([[ 1,  2,  3],
+           [ 4,  5,  6],
+           [ 7,  8,  9],
+           [10, 11, 12],
+           [13, 14, 15]])
+
+    """
+    A = sp.spdiags(
+        np.arange(10, dtype=np.float64).reshape(2, 5), [1, 0], 5, 5, format="csr"
+    )
+    if sort_indices:
+        A.sort_indices()
+    b = np.arange(1, 16, dtype=np.float64).reshape(5, 3)
+    if matrix:
+        return A, b
+    else:
+        return A, b[:, [0]]
+
+
+def create_test_A_b_rand(n=1000, density=0.05, matrix=False):
+    np.random.seed(27)
+    A = sp.csr_matrix(sp.rand(n, n, density) + sp.eye(n))
+    if matrix:
+        b = np.random.rand(n, 5)
+    else:
+        b = np.random.rand(n, 1)
+
+    return A, b
+
+
+def basic_solve(A, b):
+    x = ps.solve(A, b)
+    np.testing.assert_array_almost_equal(A * x, b)
+
+
+def test_bvector_smoketest():
+    A, b = create_test_A_b_rand()
+    basic_solve(A, b)
+
+
+def test_bmatrix_smoketest():
+    A, b = create_test_A_b_rand(matrix=True)
+    basic_solve(A, b)

--- a/recipes/pypardiso/tests/test_complex.py
+++ b/recipes/pypardiso/tests/test_complex.py
@@ -1,0 +1,23 @@
+import numpy as np
+import scipy.sparse as sp
+from pypardiso import PyPardisoSolver
+
+N = int(1e3)
+density = 0.01
+
+# Complex symmetric
+A = sp.csr_matrix(sp.rand(N, N, density) + 1j * sp.rand(N, N, density) + sp.eye(N))
+A = A + A.transpose()
+b = np.random.rand(N, 1) + 1j * np.random.rand(N, 1)
+
+ps = PyPardisoSolver(mtype=3)
+x = ps.solve(A, b)
+np.testing.assert_array_almost_equal(A * x, b)
+
+# Complex unsymmetric
+A = sp.csr_matrix(sp.rand(N, N, density) + 1j * sp.rand(N, N, density) + sp.eye(N))
+b = np.random.rand(N, 1) + 1j * np.random.rand(N, 1)
+
+ps = PyPardisoSolver(mtype=13)
+x = ps.solve(A, b)
+np.testing.assert_array_almost_equal(A * x, b)

--- a/recipes/pypardiso/tests/test_input_A.py
+++ b/recipes/pypardiso/tests/test_input_A.py
@@ -1,0 +1,150 @@
+import pytest
+import numpy as np
+import scipy.sparse as sp
+from pypardiso.scipy_aliases import pypardiso_solver
+
+ps = pypardiso_solver
+
+
+def create_test_A_b_small(matrix=False, sort_indices=True):
+    """
+    --- A ---
+    scipy.sparse.csr.csr_matrix, float64
+    matrix([[5, 1, 0, 0, 0],
+            [0, 6, 2, 0, 0],
+            [0, 0, 7, 3, 0],
+            [0, 0, 0, 8, 4],
+            [0, 0, 0, 0, 9]])
+    --- b ---
+    np.ndarray, float64
+    array([[ 1],
+           [ 4],
+           [ 7],
+           [10],
+           [13]])
+    or
+    array([[ 1,  2,  3],
+           [ 4,  5,  6],
+           [ 7,  8,  9],
+           [10, 11, 12],
+           [13, 14, 15]])
+
+    """
+    A = sp.spdiags(
+        np.arange(10, dtype=np.float64).reshape(2, 5), [1, 0], 5, 5, format="csr"
+    )
+    if sort_indices:
+        A.sort_indices()
+    b = np.arange(1, 16, dtype=np.float64).reshape(5, 3)
+    if matrix:
+        return A, b
+    else:
+        return A, b[:, [0]]
+
+
+def create_test_A_b_rand(n=1000, density=0.05, matrix=False):
+    np.random.seed(27)
+    A = sp.csr_matrix(sp.rand(n, n, density) + sp.eye(n))
+    if matrix:
+        b = np.random.rand(n, 5)
+    else:
+        b = np.random.rand(n, 1)
+
+    return A, b
+
+
+def basic_solve(A, b):
+    x = ps.solve(A, b)
+    np.testing.assert_array_almost_equal(A * x, b)
+
+
+def test_input_A_unsorted_indices():
+    A, b = create_test_A_b_small(sort_indices=False)
+    assert not A.has_sorted_indices
+    ps._check_A(A)
+    assert A.has_sorted_indices
+    basic_solve(A, b)
+
+
+def test_input_A_non_sparse():
+    A, b = create_test_A_b_rand(10, 0.9)
+    A = A.todense()
+    assert not sp.issparse(A)
+    with pytest.raises(TypeError):
+        ps.solve(A, b)
+
+
+def test_input_A_csc():
+    A, b = create_test_A_b_rand()
+    x_csr = ps.solve(A, b)
+    Acsc = A.copy().asformat("csc")
+    x_csc = ps.solve(Acsc, b)
+    np.testing.assert_array_almost_equal(x_csr, x_csc)
+
+
+def test_input_A_other_sparse():
+    A, b = create_test_A_b_rand(50)
+    for f in ["coo", "lil", "dia"]:
+        Aother = A.asformat(f)
+        with pytest.raises(TypeError):
+            ps.solve(Aother, b)
+
+
+def test_input_A_empty_row_and_col():
+    A, b = create_test_A_b_rand(25, 0.7)
+    A = np.array(A.todense())
+    A[0, :] = 0
+    A[:, 0] = 0
+    Asp = sp.csr_matrix(A)
+    with pytest.raises(ValueError):
+        ps.solve(Asp, b)
+
+
+def test_input_A_empty_row():
+    A, b = create_test_A_b_rand(25, 0.7)
+    A = np.array(A.todense())
+    A[0, :] = 0
+    A[1, 0] = 1
+    Asp = sp.csr_matrix(A)
+    with pytest.raises(ValueError):
+        basic_solve(Asp, b)
+
+
+def test_input_A_dtypes():
+    A, b = create_test_A_b_rand(10, 0.5)
+    for d in [
+        np.float16,
+        np.float32,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.complex64,
+        np.complex128,
+        np.complex128,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+    ]:
+        with pytest.raises(TypeError):
+            ps.solve(A.astype(d), b)
+
+
+# def test_input_A_empty_col():
+#    A, b = create_test_A_b_rand(25, 0.1)
+#    A = np.array(A.todense())
+#    A[0,:] = 0
+#    A[:,0] = 0
+#    A[0, 1] = 1
+#    Asp = sp.csr_matrix(A)
+#    with pytest.warns(PyPardisoWarning):
+#        x = ps.solve(A,b)
+#        print(x)
+
+# dosen't necessarily return inf value, can also be just really big
+
+
+def test_input_A_nonsquare():
+    A, b = create_test_A_b_rand()
+    A = sp.csr_matrix(np.concatenate([A.todense(), np.ones((A.shape[0], 1))], axis=1))
+    with pytest.raises(ValueError):
+        basic_solve(A, b)

--- a/recipes/pypardiso/tests/test_input_b.py
+++ b/recipes/pypardiso/tests/test_input_b.py
@@ -1,0 +1,75 @@
+import pytest
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse import SparseEfficiencyWarning
+from pypardiso.pardiso_wrapper import PyPardisoWarning
+from pypardiso.scipy_aliases import pypardiso_solver
+
+ps = pypardiso_solver
+
+
+def create_test_A_b_rand(n=1000, density=0.05, matrix=False):
+    np.random.seed(27)
+    A = sp.csr_matrix(sp.rand(n, n, density) + sp.eye(n))
+    if matrix:
+        b = np.random.rand(n, 5)
+    else:
+        b = np.random.rand(n, 1)
+
+    return A, b
+
+
+def basic_solve(A, b):
+    x = ps.solve(A, b)
+    np.testing.assert_array_almost_equal(A * x, b)
+
+
+def test_input_b_sparse():
+    A, b = create_test_A_b_rand()
+    bsparse = sp.csr_matrix(b)
+    with pytest.warns(SparseEfficiencyWarning):
+        x = ps.solve(A, bsparse)
+        np.testing.assert_array_almost_equal(A * x, b)
+
+
+def test_input_b_shape():
+    A, b = create_test_A_b_rand()
+    x_array = ps.solve(A, b)
+    assert x_array.shape == b.shape
+    x_vector = ps.solve(A, b.squeeze())
+    assert x_vector.shape == b.squeeze().shape
+    np.testing.assert_array_equal(x_array.squeeze(), x_vector)
+
+
+def test_input_b_dtypes():
+    A, b = create_test_A_b_rand()
+    for dt in [np.float16, np.float32, np.int16, np.int32, np.int64]:
+        bdt = b.astype(dt)
+        with pytest.warns(PyPardisoWarning):
+            basic_solve(A, bdt)
+
+    for dt in [
+        np.complex64,
+        np.complex128,
+        np.complex128,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+    ]:
+        bdt = b.astype(dt)
+        with pytest.raises(TypeError):
+            basic_solve(A, bdt)
+
+
+def test_input_b_fortran_order():
+    A, b = create_test_A_b_rand(matrix=True)
+    x = ps.solve(A, b)
+    xfort = ps.solve(A, np.asfortranarray(b))
+    np.testing.assert_array_equal(x, xfort)
+
+
+def test_input_b_wrong_shape():
+    A, b = create_test_A_b_rand()
+    b = np.append(b, 1)
+    with pytest.raises(ValueError):
+        basic_solve(A, b)

--- a/recipes/pypardiso/tests/test_scipy_aliases.py
+++ b/recipes/pypardiso/tests/test_scipy_aliases.py
@@ -1,0 +1,127 @@
+import pytest
+import numpy as np
+import scipy.sparse as sp
+from scipy.sparse.linalg import spsolve as scipyspsolve
+from scipy.sparse.linalg import factorized as scipyfactorized
+from pypardiso.scipy_aliases import pypardiso_solver, spsolve, factorized
+
+ps = pypardiso_solver
+
+
+def create_test_A_b_small(matrix=False, sort_indices=True):
+    """
+    --- A ---
+    scipy.sparse.csr.csr_matrix, float64
+    matrix([[5, 1, 0, 0, 0],
+            [0, 6, 2, 0, 0],
+            [0, 0, 7, 3, 0],
+            [0, 0, 0, 8, 4],
+            [0, 0, 0, 0, 9]])
+    --- b ---
+    np.ndarray, float64
+    array([[ 1],
+           [ 4],
+           [ 7],
+           [10],
+           [13]])
+    or
+    array([[ 1,  2,  3],
+           [ 4,  5,  6],
+           [ 7,  8,  9],
+           [10, 11, 12],
+           [13, 14, 15]])
+
+    """
+    A = sp.spdiags(
+        np.arange(10, dtype=np.float64).reshape(2, 5), [1, 0], 5, 5, format="csr"
+    )
+    if sort_indices:
+        A.sort_indices()
+    b = np.arange(1, 16, dtype=np.float64).reshape(5, 3)
+    if matrix:
+        return A, b
+    else:
+        return A, b[:, [0]]
+
+
+def create_test_A_b_rand(n=1000, density=0.05, matrix=False):
+    np.random.seed(27)
+    A = sp.csr_matrix(sp.rand(n, n, density) + sp.eye(n))
+    if matrix:
+        b = np.random.rand(n, 5)
+    else:
+        b = np.random.rand(n, 1)
+
+    return A, b
+
+
+def basic_solve(A, b):
+    x = ps.solve(A, b)
+    np.testing.assert_array_almost_equal(A * x, b)
+
+
+def test_basic_spsolve_vector():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    A, b = create_test_A_b_rand()
+    xpp = spsolve(A, b)
+    xscipy = scipyspsolve(A, b)
+    np.testing.assert_array_almost_equal(xpp, xscipy)
+
+
+def test_basic_spsolve_matrix():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    A, b = create_test_A_b_rand(matrix=True)
+    xpp = spsolve(A, b)
+    xscipy = scipyspsolve(A, b)
+    np.testing.assert_array_almost_equal(xpp, xscipy)
+
+
+def test_basic_factorized():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    A, b = create_test_A_b_rand()
+    ppfact = factorized(A)
+    xpp = ppfact(b)
+    scipyfact = scipyfactorized(A)
+    xscipy = scipyfact(b)
+    np.testing.assert_array_almost_equal(xpp, xscipy)
+
+
+def test_factorized_modified_A():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    assert ps.factorized_A.shape == (0, 0)
+    A, b = create_test_A_b_small()
+    Afact = factorized(A)
+    x1 = Afact(b)
+    A[4, 0] = 27
+    x2 = spsolve(A, b)
+    assert not np.allclose(x1, x2)
+    assert ps.factorized_A[4, 0] == 27
+    x3 = Afact(b)
+    np.testing.assert_array_equal(x1, x3)
+    assert ps.phase == 33
+
+
+def test_factorized_csc_matrix():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    A, b = create_test_A_b_rand()
+    Afact_csr = factorized(A)
+    Afact_csc = factorized(A.tocsc())
+    assert sp.isspmatrix_csr(Afact_csc.args[0])
+    x1 = Afact_csr(b)
+    x2 = Afact_csc(b)
+    np.testing.assert_array_equal(x1, x2)
+
+
+def test_spsolve_csc_matrix():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    A, b = create_test_A_b_rand()
+    x_csc = spsolve(A.tocsc(), b)
+    assert sp.isspmatrix_csr(ps.factorized_A)
+    x_csr = spsolve(A, b)
+    np.testing.assert_array_equal(x_csr, x_csc)


### PR DESCRIPTION
Library for sparse matrix math using the pardiso solver in the Intel MKL library.

Recipe builds and tests successfully on my machine.

Source is **not** from original source, but from a fork which implemented complex matrices. My intention is to expand on this library eventually to support newer versions of pardiso.

I confirm that I am willing to maintain this package.

Pinging @conda-forge/help-python :)

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
