### PR TITLE
Added cucumber-tag-expressions as a package

### DIFF
--- a/recipes/cucumber-tag-expressions/meta.yaml
+++ b/recipes/cucumber-tag-expressions/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cucumber-tag-expressions" %}
-{% set version = "3.0.0" %}
+{% set version = "2.0.4" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cucumber-tag-expressions-{{ version }}.tar.gz
-  sha256: bc2f250961fc08bc5340fa3698a97e9e63022e4c5baca704e5d46954086e684d
+  sha256: 72197b9330c023ce2643847fd6659c5c000f7f286f5b42cbcfd19adb3be92d30
 
 build:
   number: 0

--- a/recipes/cucumber-tag-expressions/meta.yaml
+++ b/recipes/cucumber-tag-expressions/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cucumber-tag-expressions" %}
-{% set version = "3.0.1" %}
+{% set version = "3.0.0" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cucumber-tag-expressions-{{ version }}.tar.gz
-  sha256: 71823468f567726332b87f40530b27fc83b35daea6514f5cbb03f0533d96e5be
+  sha256: bc2f250961fc08bc5340fa3698a97e9e63022e4c5baca704e5d46954086e684d
 
 build:
   number: 0
@@ -32,7 +32,6 @@ test:
 
 about:
   home: https://github.com/cucumber/tag-expressions-python
-  doc_url: https://cucumber.io/docs/cucumber/api/#tag-expressions
   summary: Provides tag-expression parser for cucumber/behave
   license: MIT
   license_file: LICENSE

--- a/recipes/cucumber-tag-expressions/meta.yaml
+++ b/recipes/cucumber-tag-expressions/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "cucumber-tag-expressions" %}
+{% set version = "3.0.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cucumber-tag-expressions-{{ version }}.tar.gz
+  sha256: 71823468f567726332b87f40530b27fc83b35daea6514f5cbb03f0533d96e5be
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - enum34  # [py<34]
+    - python
+
+test:
+  imports:
+    - cucumber_tag_expressions
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/cucumber/tag-expressions-python
+  doc_url: https://cucumber.io/docs/cucumber/api/#tag-expressions
+  summary: Provides tag-expression parser for cucumber/behave
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - thewchan

--- a/recipes/cucumber-tag-expressions/meta.yaml
+++ b/recipes/cucumber-tag-expressions/meta.yaml
@@ -11,16 +11,17 @@ source:
   sha256: 72197b9330c023ce2643847fd6659c5c000f7f286f5b42cbcfd19adb3be92d30
 
 build:
+  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
   run:
-    - enum34  # [py<34]
-    - python
+    - enum34
+    - python >=3.6
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
