### PR TITLE
Adding nb_cron - jupyter notebook extension for managing cron jobs

### DIFF
--- a/recipes/nb_cron/meta.yaml
+++ b/recipes/nb_cron/meta.yaml
@@ -34,7 +34,6 @@ test:
   source_files:
     - setup.cfg
     - .coveragerc
-    - package.json
     - tests
   requires:
     - pytest

--- a/recipes/nb_cron/meta.yaml
+++ b/recipes/nb_cron/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/alexanghh/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: a493cd9b9652f35f2d3a56b6b272c9758ecf9df5d6a85d44ce043b29f227f295
+  sha256: b66d84bf4a8e04dca27cf7a0647477f5c0a6c62dc3a258665c8ba4caa1d5edab
 
 build:
   number: 0
@@ -39,10 +39,9 @@ test:
   requires:
     - pytest
     - pytest-cov
-    - notebook >=4.3.1
     - requests
     - selenium
-    - python-chromedriver-binary
+    - geckodriver
   commands:
     - pytest
 

--- a/recipes/nb_cron/meta.yaml
+++ b/recipes/nb_cron/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "nb_cron" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/alexanghh/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: a493cd9b9652f35f2d3a56b6b272c9758ecf9df5d6a85d44ce043b29f227f295
+
+build:
+  number: 0
+  script:
+    - "{{ PYTHON }} -m pip install . -vv"
+    - "jupyter nbextension install nb_cron --py --sys-prefix --overwrite"
+  skip: true  # [win]
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - pip
+    - notebook >=4.3.1
+    - croniter
+    - python-crontab
+  run:
+    - python
+    - notebook >=4.3.1
+    - croniter
+    - python-crontab
+
+test:
+  source_files:
+    - setup.cfg
+    - .coveragerc
+    - package.json
+    - tests
+  requires:
+    - pytest
+    - pytest-cov
+    - notebook >=4.3.1
+    - requests
+    - mock
+    - selenium
+    - python-chromedriver-binary
+  commands:
+    - pytest
+
+about:
+  home: https://github.com/alexanghh/nb_cron
+  license: BSD-3-Clause
+  license_family: BS
+  license_file: LICENSE
+  summary: 'Cron tab access extension from within Jupyter'
+  description: |
+    nb_cron is a simple tool to allow managing of crontab from within Jupyter.
+  dev_url: https://github.com/alexanghh/nb_cron
+
+extra:
+  recipe-maintainers:
+    - alexanghh

--- a/recipes/nb_cron/meta.yaml
+++ b/recipes/nb_cron/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/alexanghh/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: b66d84bf4a8e04dca27cf7a0647477f5c0a6c62dc3a258665c8ba4caa1d5edab
+  sha256: 851bc536d58e16213ab4d10b4b5deb2cefcf9c7dd23afce395f27da4528d8ef9
 
 build:
   number: 0

--- a/recipes/nb_cron/meta.yaml
+++ b/recipes/nb_cron/meta.yaml
@@ -41,7 +41,6 @@ test:
     - pytest-cov
     - notebook >=4.3.1
     - requests
-    - mock
     - selenium
     - python-chromedriver-binary
   commands:
@@ -50,7 +49,7 @@ test:
 about:
   home: https://github.com/alexanghh/nb_cron
   license: BSD-3-Clause
-  license_family: BS
+  license_family: BSD
   license_file: LICENSE
   summary: 'Cron tab access extension from within Jupyter'
   description: |

--- a/recipes/nb_cron/yum_requirements.txt
+++ b/recipes/nb_cron/yum_requirements.txt
@@ -1,0 +1,2 @@
+crontabs
+firefox


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
