### PR TITLE
Add recipe for pyoptsparse

### DIFF
--- a/recipes/pyoptsparse/build.sh
+++ b/recipes/pyoptsparse/build.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 cd ${SRC_DIR}
-IPOPT_DIR=${CONDA_PREFIX} ${PYTHON} -m pip install . -vv
+IPOPT_DIR=${PREFIX} ${PYTHON} -m pip install . -vv

--- a/recipes/pyoptsparse/build.sh
+++ b/recipes/pyoptsparse/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd ${SRC_DIR}
+IPOPT_DIR=${CONDA_PREFIX} ${PYTHON} -m pip install . -vv

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -39,9 +39,6 @@ requirements:
     - scipy >1.2
     - mdolab-baseclasses >=1.3.1
 
-  run_constrained:
-    - {{ pin_compatible('ipopt', max_pin='x.x') }}
-
 test:
   imports:
     - pyoptsparse

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -55,8 +55,8 @@ test:
 
 about:
   home: https://mdolab-pyoptsparse.readthedocs-hosted.com/
-  license: GPL-3.0
-  license_family: GPL
+  license: LGPL-3.0-only
+  license_family: LGPL
   license_file: LICENSE
   summary: 'Package for formulating and solving nonlinear constrained optimization problems.'
   description: |

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -76,4 +76,5 @@ extra:
   recipe-maintainers:
     - nwu63
     - marcomangano
+    - eirikurj
     - whophil

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -26,6 +26,8 @@ requirements:
     - numpy
     - swig
     - ipopt 3.13.*
+    - libblas
+    - liblapack
 
   run:
     - python

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -26,6 +26,7 @@ requirements:
 
   host:
     - python
+    - pip
     - numpy
 
   run:

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -50,6 +50,7 @@ test:
     - testflo
     - parameterized
     - ipopt
+    - setuptools
 
   commands:
     - testflo --verbose .

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -14,12 +14,6 @@ source:
 build:
   number: 0
   skip: True  # [win]
-  ignore_run_exports:
-    - ipopt
-  missing_dso_whitelist:
-    # add ipopt libs to whitelist, as IPOPT is optional but is linked to by
-    # pyipoptcore
-    - lib*ipopt*  # [linux or osx]
 
 
 requirements:
@@ -36,6 +30,7 @@ requirements:
     - ipopt
     - libblas
     - liblapack
+    - ipopt
 
   run:
     - python

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -50,6 +50,7 @@ test:
     - test
 
   requires:
+    - pip
     - testflo
     - parameterized
     - ipopt

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
-    - ipopt 3.13.*
 
   host:
     - python

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -65,9 +65,8 @@ about:
     nonlinear constrained optimization problems in an efficient, reusable, and
     portable manner. It is a fork of pyOpt that uses sparse matrices throughout
     the code to more efficiently handle large-scale optimization problems.
-    Interfaces are provided for a number of optimizers - ALPSO, CONMIN, IPOPT,
-    NLPQLP, NSGA2, PSQP, SLSQP, ParOpt and SNOPT are currently tested and
-    supported.
+    Interfaces are provided for a number of optimizers -- for the conda package the optimizers
+    ALPSO, CONMIN, IPOPT, NSGA2, PSQP, and SLSQP are supported.
 
 
   doc_url: https://mdolab-pyoptsparse.readthedocs-hosted.com/

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -16,20 +16,20 @@ build:
 
 requirements:
   build:
-    - python >=3.6
+    - python
     - numpy
     - swig
     - ipopt 3.13.*
-    - {{ compiler('c')}}
-    - {{ compiler('cxx')}}
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
 
   host:
-    - python >=3.6
+    - python
     - numpy
 
   run:
-    - python >=3.6
+    - python
     - numpy
     - sqlitedict >=1.6
     - scipy >1.2

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -34,6 +34,8 @@ requirements:
     - numpy
     - swig
     - ipopt
+    - libblas
+    - liblapack
 
   run:
     - python

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -14,6 +14,8 @@ source:
 build:
   number: 0
   skip: True  # [win]
+  ignore_run_exports:
+    - ipopt
 
 requirements:
   build:
@@ -26,7 +28,7 @@ requirements:
     - pip
     - numpy
     - swig
-    - ipopt 3.13.*
+    - ipopt
     - libblas
     - liblapack
 
@@ -38,7 +40,7 @@ requirements:
     - mdolab-baseclasses >=1.3.1
 
   run_constrained:
-    - ipopt 3.13.*
+    - {{ pin_compatible('ipopt', max_pin='x.x') }}
 
 test:
   imports:
@@ -55,6 +57,7 @@ test:
 
   commands:
     - testflo --verbose .
+    - pip check
 
 about:
   home: https://mdolab-pyoptsparse.readthedocs-hosted.com/

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -16,6 +16,11 @@ build:
   skip: True  # [win]
   ignore_run_exports:
     - ipopt
+  missing_dso_whitelist:
+    # add ipopt libs to whitelist, as IPOPT is optional but is linked to by
+    # pyipoptcore
+    - lib*ipopt*  # [linux or osx]
+
 
 requirements:
   build:
@@ -29,8 +34,6 @@ requirements:
     - numpy
     - swig
     - ipopt
-    - libblas
-    - liblapack
 
   run:
     - python

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -16,18 +16,17 @@ build:
 
 requirements:
   build:
-    - python
-    - numpy
-    - swig
-    - ipopt 3.13.*
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - {{ compiler('fortran') }}
+    - ipopt 3.13.*
 
   host:
     - python
     - pip
     - numpy
+    - swig
+    - ipopt 3.13.*
 
   run:
     - python

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -1,0 +1,79 @@
+{% set name = "pyoptsparse" %}
+{% set version = "2.6.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: "https://github.com/mdolab/pyoptsparse/archive/refs/tags/v{{ version }}.tar.gz"
+  sha256: 4f28eefa4eb5724f3d0a2b6118c45aedee24a7dea72a6672a49feb77220ecf32
+  patches:
+    - patch-IPOPT-setup-for-conda.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python >=3.6
+    - numpy
+    - swig
+    - ipopt 3.13.*
+    - {{ compiler('c')}}
+    - {{ compiler('cxx')}}
+    - {{ compiler('fortran') }}
+
+  host:
+    - python >=3.6
+    - numpy
+
+  run:
+    - python >=3.6
+    - numpy
+    - sqlitedict >=1.6
+    - scipy >1.2
+    - mdolab-baseclasses >=1.3.1
+
+  run_constrained:
+    - ipopt 3.13.*
+
+test:
+  imports:
+    - pyoptsparse
+
+  source_files:
+    - test
+
+  requires:
+    - testflo
+    - parameterized
+    - ipopt
+
+  commands:
+    - testflo --verbose .
+
+about:
+  home: https://mdolab-pyoptsparse.readthedocs-hosted.com/
+  license: GPL-3.0
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'Package for formulating and solving nonlinear constrained optimization problems.'
+  description: |
+    pyOptSparse is an object-oriented framework for formulating and solving
+    nonlinear constrained optimization problems in an efficient, reusable, and
+    portable manner. It is a fork of pyOpt that uses sparse matrices throughout
+    the code to more efficiently handle large-scale optimization problems.
+    Interfaces are provided for a number of optimizers - ALPSO, CONMIN, IPOPT,
+    NLPQLP, NSGA2, PSQP, SLSQP, ParOpt and SNOPT are currently tested and
+    supported.
+
+
+  doc_url: https://mdolab-pyoptsparse.readthedocs-hosted.com/
+  dev_url: https://github.com/mdolab/pyoptsparse
+
+extra:
+  recipe-maintainers:
+    - nwu63
+    - marcomangano
+    - whophil

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -50,7 +50,6 @@ test:
     - pip
     - testflo
     - parameterized
-    - ipopt
     - setuptools
 
   commands:

--- a/recipes/pyoptsparse/meta.yaml
+++ b/recipes/pyoptsparse/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/pyoptsparse/patch-IPOPT-setup-for-conda.patch
+++ b/recipes/pyoptsparse/patch-IPOPT-setup-for-conda.patch
@@ -1,0 +1,13 @@
+diff --git a/pyoptsparse/pyIPOPT/setup.py b/pyoptsparse/pyIPOPT/setup.py
+index f875ca2..c2ebf0d 100644
+--- a/pyoptsparse/pyIPOPT/setup.py
++++ b/pyoptsparse/pyIPOPT/setup.py
+@@ -51,7 +51,7 @@ def configuration(parent_package="", top_path=None):
+             "pyipoptcore",
+             FILES,
+             library_dirs=[IPOPT_LIB],
+-            libraries=["ipopt", "coinmumps", "coinmetis", "dl", "m", "blas", "lapack"],
++            libraries=["ipopt", "mumps_common_seq", "scotchmetis", "dl", "m", "blas", "lapack"],
+             extra_link_args=["-Wl,-rpath,%s -L%s" % (IPOPT_LIB, IPOPT_LIB)],
+             include_dirs=[numpy_include, IPOPT_INC],
+         )


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Adds recipe for https://github.com/mdolab/pyoptsparse.

@nwu63 I've cut up bits of descriptions that I found in order to provide the `summary` and `description` fields, please take look and modify as you see fit.

@nwu63 and @marcomangano please confirm that you are willing to be listed as maintainers for this recipe.

Notes:
- IPOPT interfaces are compiled but are not required to run.
- The recipe runs the full test suite, which takes about 45 s on my 8-core machine.
    + **Question for the conda-forge team:** should we remove these tests from the conda-forge build?

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
