### PR TITLE
Add tl-optional recipe

### DIFF
--- a/recipes/tl-optional/bld.bat
+++ b/recipes/tl-optional/bld.bat
@@ -1,0 +1,22 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTING=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest -C Release
+if errorlevel 1 exit 1

--- a/recipes/tl-optional/build.sh
+++ b/recipes/tl-optional/build.sh
@@ -3,7 +3,7 @@
 mkdir build
 cd build
 
-cmake -GNinja .. \
+cmake ${CMAKE_ARGS} -GNinja .. \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_INSTALL_LIBDIR=lib \

--- a/recipes/tl-optional/build.sh
+++ b/recipes/tl-optional/build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DBUILD_TESTING=ON
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/tl-optional/build.sh
+++ b/recipes/tl-optional/build.sh
@@ -5,8 +5,6 @@ cd build
 
 cmake ${CMAKE_ARGS} -GNinja .. \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_INSTALL_PREFIX=$PREFIX \
-      -DCMAKE_INSTALL_LIBDIR=lib \
       -DBUILD_TESTING=ON
 
 cmake --build . --config Release

--- a/recipes/tl-optional/meta.yaml
+++ b/recipes/tl-optional/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - cmake
     - {{ compiler('cxx') }}
     - ninja
-    - cmake
 
 test:
   commands:

--- a/recipes/tl-optional/meta.yaml
+++ b/recipes/tl-optional/meta.yaml
@@ -1,0 +1,35 @@
+{% set version = "3.3.9" %}
+
+package:
+  name: tl-optional
+  version: {{ version }}
+
+source:
+  url: https://github.com/TartanLlama/optional/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('cxx') }}
+    - ninja
+    - cmake
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/tl/optional.hpp  # [not win]
+    - test -f ${PREFIX}/share/cmake/tl-optional/tl-optional-config.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\tl\\optinal.hpp exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\share\\cmake\\tl-optional\\tl-optional-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/TartanLlama/optional
+  license: CC0-1.0
+  summary: C++11/14/17 std::optional with functional-style extensions and reference support
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/tl-optional/meta.yaml
+++ b/recipes/tl-optional/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/TartanLlama/optional/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7985975b787340124786f092b3a07d594b2e9cd53bbfe5f3d9b1daee7d55f56f
+  sha256: e18941da05bca12a796ebbeacb83993bc0f10e817fa10bb45124a421c2384690
 
 build:
   number: 0

--- a/recipes/tl-optional/meta.yaml
+++ b/recipes/tl-optional/meta.yaml
@@ -28,6 +28,7 @@ test:
 about:
   home: https://github.com/TartanLlama/optional
   license: CC0-1.0
+  license_file: COPYING
   summary: C++11/14/17 std::optional with functional-style extensions and reference support
 
 extra:

--- a/recipes/tl-optional/meta.yaml
+++ b/recipes/tl-optional/meta.yaml
@@ -22,7 +22,7 @@ test:
   commands:
     - test -f ${PREFIX}/include/tl/optional.hpp  # [not win]
     - test -f ${PREFIX}/share/cmake/tl-optional/tl-optional-config.cmake  # [not win]
-    - if not exist %PREFIX%\\Library\\include\\tl\\optinal.hpp exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\include\\tl\\optional.hpp exit 1  # [win]
     - if not exist %PREFIX%\\Library\\share\\cmake\\tl-optional\\tl-optional-config.cmake exit 1  # [win]
 
 about:

--- a/recipes/tl-optional/meta.yaml
+++ b/recipes/tl-optional/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.9" %}
+{% set version = "1.0.0" %}
 
 package:
   name: tl-optional


### PR DESCRIPTION
This is a simple helper library that provides a C++11/14/17 std::optional with functional-style extensions and reference support. 
It is already packaged in ConanCenter and vcpkg: https://repology.org/project/tl-optional/versions . Furthermore, it is a dependency (currently vendored) of the manif package: https://github.com/conda-forge/manif-feedstock/issues/2 .

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
