### PR TITLE
Adding PyTorch Geometric Temporal CAVEAT: Tests fail, need help

### DIFF
--- a/recipes/pytorch-geometric-temporal/LICENSE
+++ b/recipes/pytorch-geometric-temporal/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Benedek Rozemberczki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pytorch-geometric-temporal/meta.yaml
+++ b/recipes/pytorch-geometric-temporal/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "torch-geometric-temporal" %}
+{% set version = "0.37" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/torch_geometric_temporal-{{ version }}.tar.gz
+  sha256: ed5ea5c3571449ae01defd5a578a20a3fc990ca8e76cac69fb66e933106c2e84
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - pytest-runner
+    - python >=3.6
+  run:
+    - decorator ==4.4.2
+    - numpy
+    - python >=3.6
+    - scipy
+    - six
+    - pytorch
+    - pytorch_cluster
+    - pytorch_geometric
+    - pytorch_scatter
+    - pytorch_sparse
+    - pytorch_spline_conv
+    - tqdm
+
+test:
+  imports:
+    - torch_geometric_temporal
+    - torch_geometric_temporal.dataset
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/benedekrozemberczki/pytorch_geometric_temporal
+  summary: A Temporal Extension Library for PyTorch Geometric.
+  license: MIT
+  license_file: LICENSE 
+
+extra:
+  recipe-maintainers:
+    - MoRoBe-Work


### PR DESCRIPTION
Hello everyone and especially @conda-forge/help-python,
I'm trying to make the mentioned PyTorch Geometric Temporal package found on [GitHub](https://github.com/benedekrozemberczki/pytorch_geometric_temporal) and [PyPI](https://pypi.org/project/torch-geometric-temporal/) available through conda-forge. The original author has been informed I'm planning to do so. I was able to perform the necessary basic steps, using grayskull to create the meta.yml. I did some small adaption, mostly changing "torch-" from the PyPI-packages to "pytorch-" from the conda-forge packages. Unfrotunately the tests fail with the following error:
`
OSError: /home/conda/staged-recipes/build_artifacts/torch-geometric-temporal_1623933364794/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_p/lib/python3.8/site-packages/torch_sparse/_version.so: undefined symbol: _ZN3c1017RegisterOperatorsC1Ev`

According to https://github.com/rusty1s/pytorch_geometric/issues/1657 this happens when "when external libraries are compiled with a different PyTorch version than the one you are using". The solution there is to build the other packages from source as well which is not a proper solution here. Can you help me modify the recipe in a way that leads to matching versions of the different pytorch packages? I am absolutely happy with a certain amount of RTFM, but please provide relevant documentation as I'm pretty inexperienced in the whole making software available beyond "works on my machine" world. 

I'm not entirely sure whether static libraries with a license different from MIT are linked, therefor I didn't check that box. I'm the only listed maintainer, do I need to post a comment somewhere special or does this PR suffice?

Thank you for maintaining this great project!
MoRoBe

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
