### PR TITLE
add cppyythonizations

### DIFF
--- a/recipes/cppyythonizations/build.sh
+++ b/recipes/cppyythonizations/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+./configure --prefix="$PREFIX" --without-pytest || (cat config.log; false)
+make install

--- a/recipes/cppyythonizations/meta.yaml
+++ b/recipes/cppyythonizations/meta.yaml
@@ -16,6 +16,7 @@ build:
 requirements:
   build:
     - automake
+    - coreutils
     - make
   host:
     - python >=3.6

--- a/recipes/cppyythonizations/meta.yaml
+++ b/recipes/cppyythonizations/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - make
   host:
     - python >=3.6
+    - setuptools
   run:
     - python >=3.6
     - cppyy

--- a/recipes/cppyythonizations/meta.yaml
+++ b/recipes/cppyythonizations/meta.yaml
@@ -18,9 +18,9 @@ requirements:
     - automake
     - make
   host:
-    - python
+    - python >=3.6
   run:
-    - python
+    - python >=3.6
     - cppyy
 
 test:

--- a/recipes/cppyythonizations/meta.yaml
+++ b/recipes/cppyythonizations/meta.yaml
@@ -28,6 +28,11 @@ requirements:
 test:
   imports:
     - cppyythonizations
+    - cppyythonizations.operators.arithmetic
+    - cppyythonizations.operators.order
+    - cppyythonizations.vector
+    - cppyythonizations.tuple
+    - cppyythonizations.util
 
 about:
   home: https://github.com/flatsurf/cppyythonizations

--- a/recipes/cppyythonizations/meta.yaml
+++ b/recipes/cppyythonizations/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "cppyythonizations" %}
+{% set version = "1.1.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/flatsurf/cppyythonizations/releases/download/{{ version }}/cppyythonizations-{{ version }}.tar.gz
+  sha256: 94cf064dc6c5f048b5987fb9dab295700403255ab993ff9b29cda9f3a9629517
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  build:
+    - automake
+    - make
+  host:
+    - python
+  run:
+    - python
+    - cppyy
+
+test:
+  imports:
+    - cppyythonizations
+
+about:
+  home: https://github.com/flatsurf/cppyythonizations
+  license: MIT
+  license_family: MIT
+  license_file: COPYING
+  summary: 'A collection of Pythonizations for cppyy.'
+  description: |
+    A collection of Pythonizations for cppyy to work around known limitations
+    of cppyy or provide some reusable extensions such as Python pickling of
+    C++ classes.
+  dev_url: https://github.com/flatsurf/cppyythonizations
+
+extra:
+  recipe-maintainers:
+    - saraedum


### PR DESCRIPTION
A pure-python package (with non-pure Python dependencies at runtime) that builds with autotools.

This is required to upgrade e-antic: https://github.com/conda-forge/e-antic-feedstock/pull/21