### PR TITLE
add gmpxxyy

### DIFF
--- a/recipes/gmpxxyy/build.sh
+++ b/recipes/gmpxxyy/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+./configure --prefix="$PREFIX" --without-pytest --without-sage || (cat config.log; false)
+make install

--- a/recipes/gmpxxyy/meta.yaml
+++ b/recipes/gmpxxyy/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "gmpxxyy" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/flatsurf/gmpxxyy/releases/download/{{ version }}/gmpxxyy-{{ version }}.tar.gz
+  sha256: e441f7ce1d5f83deb67b26bb9d7a4bebc09af8309b119b5e2b12468ab276e6e5
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  build:
+    - automake
+    - coreutils
+    - make
+  host:
+    - python >=3.6
+    - setuptools
+  run:
+    - python >=3.6
+    - cppyy
+    - cppyythonizations
+    - gmp
+
+test:
+  imports:
+    - gmpxxyy
+
+about:
+  home: https://github.com/flatsurf/gmpxxyy
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: COPYING
+  summary: 'A Python Wrapper for GMP'
+  description: |
+    This is another Python wrapper for GMP.
+    This wrapper is powered by cppyy, i.e., it wraps libgmpxx, the C++ interface of GMP.
+  dev_url: https://github.com/flatsurf/gmpxxyy
+
+extra:
+  recipe-maintainers:
+    - saraedum


### PR DESCRIPTION
[GMP](https://gmplib.org) wrappers for Python. This library wraps the the C++ interface of GMP using cppyy. Unlike existing wrappers such as gmpy and gmpy2, this library is meant to be used in a cppyy stack. This package itself is part of the flatsurf stack, a collection of mathematical research tools to study translation surfaces.

All of the flatsurf stack uses autotools. Therefore, this package also uses autotools even though it is a pure Python package. (This recipe only specifies the autotools dependencies on Linux/macOS. This is why the Windows build fails. But in the end the package will be built on Linux, so this should not matter.)

Note that `make install` does not compile any code (so this is indeed a noarch package.) The glue between Python and GMP is compiled at runtime when `import gmpxxyy` is evaluated. The compiler for this is pulled in by the cppyy runtime dependency.