### PR TITLE
Add ycm-cmake-modules recipe

### DIFF
--- a/recipes/ycm-cmake-modules/bld.bat
+++ b/recipes/ycm-cmake-modules/bld.bat
@@ -18,5 +18,6 @@ cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest --output-on-failure -C Release
+:: Some tests disabled for https://github.com/robotology/ycm/issues/382
+ctest --output-on-failure -C Release -E "YCMBootstrap-not-use-system|YCMBootstrap-disable-find|RunCMake.IncludeUrl"
 if errorlevel 1 exit 1

--- a/recipes/ycm-cmake-modules/bld.bat
+++ b/recipes/ycm-cmake-modules/bld.bat
@@ -18,5 +18,5 @@ cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest -C Release
+ctest --output-on-failure -C Release
 if errorlevel 1 exit 1

--- a/recipes/ycm-cmake-modules/bld.bat
+++ b/recipes/ycm-cmake-modules/bld.bat
@@ -1,0 +1,22 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTING=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest -C Release
+if errorlevel 1 exit 1

--- a/recipes/ycm-cmake-modules/build.sh
+++ b/recipes/ycm-cmake-modules/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=ON
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/ycm-cmake-modules/build.sh
+++ b/recipes/ycm-cmake-modules/build.sh
@@ -9,4 +9,5 @@ cmake ${CMAKE_ARGS} -GNinja .. \
 
 cmake --build . --config Release
 cmake --build . --config Release --target install
-ctest --output-on-failure -C Release
+# Some tests disabled due to https://github.com/robotology/ycm/issues/382
+ctest --output-on-failure -C Release -E "YCMBootstrap-not-use-system|YCMBootstrap-disable-find|RunCMake.IncludeUrl"

--- a/recipes/ycm-cmake-modules/meta.yaml
+++ b/recipes/ycm-cmake-modules/meta.yaml
@@ -26,7 +26,7 @@ test:
 about:
   home: https://github.com/robotology/ycm
   license: BSD-3-Clause
-  license_file: LICENSE
+  license_file: Copyright.txt
   summary: Extra CMake Modules for YARP and friends.
 
 extra:

--- a/recipes/ycm-cmake-modules/meta.yaml
+++ b/recipes/ycm-cmake-modules/meta.yaml
@@ -1,0 +1,34 @@
+{% set version = "0.12.2" %}
+
+package:
+  name: ycm-cmake-modules
+  version: {{ version }}
+
+source:
+  url: https://github.com/robotology/ycm/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: e18941da05bca12a796ebbeacb83993bc0f10e817fa10bb45124a421c2384690
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - ninja
+
+test:
+  commands:
+    - test -f ${PREFIX}/share/cmake/YCM/YCMConfig.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\share\\cmake\\YCM\\YCMConfig.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/robotology/ycm
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Extra CMake Modules for YARP and friends.
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/ycm-cmake-modules/meta.yaml
+++ b/recipes/ycm-cmake-modules/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/robotology/ycm/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e18941da05bca12a796ebbeacb83993bc0f10e817fa10bb45124a421c2384690
+  sha256: 42afdd754ba69a9d9b30279be3525bd9aefc8189ae5012701f37edf7be7e194d
 
 build:
   number: 0


### PR DESCRIPTION
[ycm-cmake-modules](https://github.com/robotology/ycm) is a collection of CMake modules, similar to [ECM](https://github.com/KDE/extra-cmake-modules) but developed in the context of robotics software, so it contains several CMake modules that are then used in [YARP](https://github.com/robotology/yarp) or similar robotics software.

The repo is still called `ycm`, but that name is quite ambigous, so the name used for debian packaging is `ycm-cmake-modules` (see https://repology.org/project/ycm-cmake-modules/versions), so for consistency it is convenient to use the same name also in conda-forge .

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
