### PR TITLE
Add robot-testing-framework recipe

### DIFF
--- a/recipes/robot-testing-framework/bld.bat
+++ b/recipes/robot-testing-framework/bld.bat
@@ -1,0 +1,22 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTING=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipes/robot-testing-framework/bld.bat
+++ b/recipes/robot-testing-framework/bld.bat
@@ -18,5 +18,5 @@ cmake --build . --config Release --target install
 if errorlevel 1 exit 1
 
 :: Test.
-ctest --output-on-failure -C Release
+ctest --output-on-failure -C Release -E "misc::check_license"
 if errorlevel 1 exit 1

--- a/recipes/robot-testing-framework/build.sh
+++ b/recipes/robot-testing-framework/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=ON
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+ctest --output-on-failure -C Release

--- a/recipes/robot-testing-framework/build.sh
+++ b/recipes/robot-testing-framework/build.sh
@@ -9,4 +9,4 @@ cmake ${CMAKE_ARGS} -GNinja .. \
 
 cmake --build . --config Release
 cmake --build . --config Release --target install
-ctest --output-on-failure -C Release
+ctest --output-on-failure -C Release -E "misc::check_license"

--- a/recipes/robot-testing-framework/meta.yaml
+++ b/recipes/robot-testing-framework/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/robotology/robot-testing-framework/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 42afdd754ba69a9d9b30279be3525bd9aefc8189ae5012701f37edf7be7e194d
+  sha256: e7e5194823215246410dba6f2fe34b75e0197079924631aeb3e2ed3b8fd281ad
 
 build:
   number: 0

--- a/recipes/robot-testing-framework/meta.yaml
+++ b/recipes/robot-testing-framework/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "2.0.1" %}
+
+package:
+  name: robot-testing-framework
+  version: {{ version }}
+
+source:
+  url: https://github.com/robotology/robot-testing-framework/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 42afdd754ba69a9d9b30279be3525bd9aefc8189ae5012701f37edf7be7e194d
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x.x.x') }}
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - ninja
+  host:
+    - tinyxml
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/robottestingframework/TestCase.h  # [not win]
+    - test -f ${PREFIX}/lib/librobottestingframework-dll.so  # [linux]
+    - test -f ${PREFIX}/lib/librobottestingframework-dll.dylib  # [osx]
+    - test -f ${PREFIX}/lib/cmake/RobotTestingFramework/RobotTestingFrameworkConfig.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\include\\robottestingframework\\TestCase.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\robottestingframework-dll.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\robottestingframework-dll.dll exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\RobotTestingFramework\\RobotTestingFrameworkConfig.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/robotology/robot-testing-framework
+  license: LGPL-2.1-or-later
+  license_file: LICENSE
+  summary: Robot Testing Framework (RTF) .
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/robot-testing-framework/meta.yaml
+++ b/recipes/robot-testing-framework/meta.yaml
@@ -32,7 +32,7 @@ test:
     - if not exist %PREFIX%\\Library\\include\\robottestingframework\\TestCase.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\robottestingframework-dll.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\robottestingframework-dll.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\cmake\\RobotTestingFramework\\RobotTestingFrameworkConfig.cmake exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\CMake\\RobotTestingFramework\\RobotTestingFrameworkConfig.cmake exit 1  # [win]
 
 about:
   home: https://github.com/robotology/robot-testing-framework

--- a/recipes/robot-testing-framework/meta.yaml
+++ b/recipes/robot-testing-framework/meta.yaml
@@ -1,7 +1,8 @@
+{% set name = "robot-testing-framework" %}
 {% set version = "2.0.1" %}
 
 package:
-  name: robot-testing-framework
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipes/robot-testing-framework/meta.yaml
+++ b/recipes/robot-testing-framework/meta.yaml
@@ -32,7 +32,7 @@ test:
     - if not exist %PREFIX%\\Library\\include\\robottestingframework\\TestCase.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\robottestingframework-dll.lib exit 1  # [win]
     - if not exist %PREFIX%\\Library\\bin\\robottestingframework-dll.dll exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\CMake\\RobotTestingFramework\\RobotTestingFrameworkConfig.cmake exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\CMake\\RobotTestingFrameworkConfig.cmake exit 1  # [win]
 
 about:
   home: https://github.com/robotology/robot-testing-framework


### PR DESCRIPTION
[`robot-testing-framework`](https://robotology.github.io/robot-testing-framework/) is a testing framework specifically taylored for robotic and cypher physicals systems, that is described in detail in the paper ["A Generic Testing Framework for Test Driven Development of Robotic Systems"](https://link.springer.com/chapter/10.1007/978-3-319-22383-4_17) . 
`robot-testing-framework` is already packaged under the same name in the Debian/Ubuntu distros: https://repology.org/project/robot-testing-framework/versions .


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
