### PR TITLE
Added python3-memcached library

### DIFF
--- a/recipes/python3-memcached/meta.yaml
+++ b/recipes/python3-memcached/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "python3-memcached" %}
+{% set version = "1.51" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7cbe5951d68eef69d948b7a7ed7decfbd101e15e7f5be007dcd1219ccc584859
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3
+  run:
+    - python >=3
+
+test:
+  imports:
+    - python3_memcached
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/eguven/python3-memcached
+  summary: Pure python memcached client
+  license: EUPL-1.0
+  license_file: PSF.LICENSE
+
+extra:
+  recipe-maintainers:
+    - rebx


### PR DESCRIPTION
### Description

This PR adds a recipe for the [python3-memcached](https://github.com/eguven/python3-memcached) library.  The library is a python3 port of [python-memcached](https://github.com/linsomniac/python-memcached)

### Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
