### PR TITLE
Added fileseq recipe

### DIFF
--- a/recipes/fileseq/meta.yaml
+++ b/recipes/fileseq/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/Fileseq-{{ version }}.tar.gz
   sha256: 7826047e77f4a679479a3bc90975386e1c8a879f6a43624c09a8d1ffd0fea9fa
 
 build:

--- a/recipes/fileseq/meta.yaml
+++ b/recipes/fileseq/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   host:
     - pip
-    - python >= 2.7
+    - python >=2.7
   run:
     - future
     - python >=2.7

--- a/recipes/fileseq/meta.yaml
+++ b/recipes/fileseq/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "fileseq" %}
+{% set version = "1.13.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 7826047e77f4a679479a3bc90975386e1c8a879f6a43624c09a8d1ffd0fea9fa
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >= 2.7
+  run:
+    - future
+    - python >=2.7
+
+test:
+  imports:
+    - fileseq
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/justinfx/fileseq
+  summary: A Python library for parsing frame ranges and file sequences commonly used in VFX and Animation applications.
+  doc_url: https://pythonhosted.org/Fileseq/
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - rebx
+    - justinfx


### PR DESCRIPTION
ping @conda-forge/help-python

### Description

This PR adds a recipe for the python fileseq library

### Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
