### PR TITLE
Update meta.yaml

### DIFF
--- a/recipes/splipy/meta.yaml
+++ b/recipes/splipy/meta.yaml
@@ -15,8 +15,7 @@ source:
     sha256: 3972dc9744f6499f0f9b2dbf76696f2ae7ad8af9b23dde66d6af86c9dfb36986
   
 build:
-  number: 0
-  noarch: python
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
remove noarch, set build=1

@conda-forge/help-python-c  please help!  this package does not work with python3.8, I think it was wrong to specify 'noarch', I just used greyskull to generate the recipe
