### PR TITLE
Add a recipe for AeHMC

### DIFF
--- a/recipes/aehmc/meta.yaml
+++ b/recipes/aehmc/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.0.2" %}
+
+package:
+  name: aehmc
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/a/aehmc/aehmc-{{ version }}.tar.gz
+  sha256: 1e3e648198baf4c610c09f77d91a3affbdb83cb1f212a6c327885cf4300b2ae2
+  patches:
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+  run:
+    - python >=3.6
+    - numpy >=1.18.1
+    - scipy >=1.4.0
+    - aesara >=2.1.1
+    - aeppl >=0.0.5
+
+test:
+  imports:
+    - aehmc.hmc
+    - aehmc.nuts
+
+about:
+  home: https://github.com/aesara-devs/aehmc
+  license: MIT
+  summary: HMC samplers in Aesara
+  license_file: LICENSE
+  dev_url: https://github.com/aesara-devs/aehmc/
+
+extra:
+  recipe-maintainers:
+    - brandonwillard
+    - twiecki
+    - rlouf


### PR DESCRIPTION
This PR adds a recipe for [AeHMC](https://github.com/aesara-devs/aehmc).

~The build probably won't succeed until https://github.com/conda-forge/staged-recipes/pull/15766 goes through.~