### PR TITLE
Add recipe for nbgitpuller-link package

### DIFF
--- a/recipes/nbgitpuller-link/LICENSE.md
+++ b/recipes/nbgitpuller-link/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+===========
+
+Copyright (c) 2021 Mark Piper
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/nbgitpuller-link/meta.yaml
+++ b/recipes/nbgitpuller-link/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "nbgitpuller-link" %}
+{% set version = "0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 55c959e6e35b1b656f1ac848078aef45480af3b475576c4c67d5466f9af0caf5
+
+build:
+  noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+  entry-points:
+    - nbgitpuller-link=nbgitpuller_link.cli:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - click
+    - validators
+
+test:
+  imports:
+    - nbgitpuller_link
+  requires:
+    - pip
+  commands:
+    - pip check
+    - nbgitpuller-link --version
+    - nbgitpuller-link --help
+
+about:
+  home: https://github.com/mdpiper/nbgitpuller-link
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  summary: |
+    Generate an nbgitpuller link through a command-line interface or Python code
+  description: |
+    Use nbgitpuller-link to create an URL used by nbgitpuller
+    <https://jupyterhub.github.io/nbgitpuller> to provision files from a git
+    repository on a JupyterHub. nbgitpuller-link has a handy, scriptable CLI
+    and a Python API.
+  doc_url: https://bmi-topography.readthedocs.io
+  dev_url: https://github.com/csdms/bmi-topography
+
+extra:
+  recipe-maintainers:
+    - mdpiper

--- a/recipes/nbgitpuller-link/meta.yaml
+++ b/recipes/nbgitpuller-link/meta.yaml
@@ -13,15 +13,15 @@ build:
   noarch: python
   number: 0
   script: "{{ PYTHON }} -m pip install . -vv"
-  entry-points:
+  entry_points:
     - nbgitpuller-link=nbgitpuller_link.cli:main
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
     - click
     - validators
 


### PR DESCRIPTION
This PR adds a recipe for the nbgitpuller-link package, which provides an API and CLI to generate an URL for nbgitpuller to provision files on a JupyterHub.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

(No static libraries are used.)