### PR TITLE
[WIP] Recipe xnnpack

### DIFF
--- a/recipes/xnnpack/build.sh
+++ b/recipes/xnnpack/build.sh
@@ -1,6 +1,6 @@
 mkdir build
 cd build
-cmake ..
+cmake ${CMAKE_ARGS} ..
 
 make -j${CPU_COUNT}
 make install

--- a/recipes/xnnpack/build.sh
+++ b/recipes/xnnpack/build.sh
@@ -1,6 +1,9 @@
 mkdir build
 cd build
-cmake ${CMAKE_ARGS} ..
+cmake ${CMAKE_ARGS} \
+  -DXNNPACK_BUILD_TESTS=0 \
+  -DXNNPACK_BUILD_BENCHMARKS=0 \
+  ..
 
 make -j${CPU_COUNT}
 make install

--- a/recipes/xnnpack/build.sh
+++ b/recipes/xnnpack/build.sh
@@ -1,0 +1,6 @@
+mkdir build
+cd build
+cmake ..
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/xnnpack/gcc11_compat.patch
+++ b/recipes/xnnpack/gcc11_compat.patch
@@ -1,0 +1,33 @@
+From 042cdaf1c24c675fca5e79eb4d2665839d7df2c2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nenad=20Miks=CC=8Ca?= <nenad.miksa@microblink.com>
+Date: Mon, 3 May 2021 13:28:59 +0200
+Subject: [PATCH] GCC 11 no longer needs this polyfill
+
+---
+ src/xnnpack/intrinsics-polyfill.h | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/xnnpack/intrinsics-polyfill.h b/src/xnnpack/intrinsics-polyfill.h
+index 3f198d886..32d7d4f39 100644
+--- a/src/xnnpack/intrinsics-polyfill.h
++++ b/src/xnnpack/intrinsics-polyfill.h
+@@ -11,8 +11,8 @@
+ #if defined(__SSE2__)
+ #include <emmintrin.h>
+ 
+-// GCC any, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-16
+-#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)) || \
++// GCC pre-11, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-16
++#if (defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && __GNUC__ < 11) || \
+     (defined(__clang__) && !defined(__apple_build_version__) && (__clang_major__ < 8)) || \
+     (defined(__clang__) && defined(__ANDROID__) && (__clang_major__ == 8) && (__clang_minor__ == 0) && (__clang_patchlevel__ < 7)) || \
+     (defined(__clang__) && defined(__apple_build_version__) && (__apple_build_version__ < 11000000)) || \
+@@ -27,7 +27,7 @@ static XNN_INTRINSIC
+ void _mm_storeu_si32(const void* address, __m128i v) {
+   *((int*) address) = _mm_cvtsi128_si32(v);
+ }
+-#endif  // GCC any, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-16
++#endif  // GCC pre-11, Clang pre-8, Android NDK Clang pre-8.0.7, Apple Clang pre-11, and ICC pre-16
+ #endif  // SSE2
+ 
+ #ifdef __AVX512F__

--- a/recipes/xnnpack/meta.yaml
+++ b/recipes/xnnpack/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "xnnpack" %}
+# Pytorch pins to 55d53a4
+# https://github.com/pytorch/pytorch/tree/v1.9.0/third_party
+# https://github.com/google/XNNPACK/commit/55d53a4
+{% set commit = "55d53a4" %}
+{% set commit_date = "2021.02.23" %}
+# XNNPACK is unreleased software
+# We create our own version numbers
+{% set version = "0.0.0" + "." + commit_date + "." + commit %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/google/XNNPACK.git
+  git_tag: {{ commit }}
+  patches:
+    - gcc11_compat.patch
+
+build:
+  number: 0
+  skip: true   # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - cmake
+  host:
+    - pthread-stubs
+  run:
+
+test:
+  commands:
+    - echo dummy
+
+about:
+  home: https://github.com/google/XNNPACK
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: 'XNNPACK is a highly optimized library of floating-point neural network inference operators for ARM, WebAssembly, and x86 platforms.'
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/xnnpack/meta.yaml
+++ b/recipes/xnnpack/meta.yaml
@@ -25,9 +25,10 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
   host:
-    - pthread-stubs
+    # - pthread-stubs
   run:
 
 test:


### PR DESCRIPTION
This may help with pytorch building. But I just want to use the CIs to test the package building process.

xref: https://github.com/conda-forge/pytorch-cpu-feedstock/issues/60

# Dependencies to unwind

- [ ] CLOG https://github.com/google/XNNPACK/blob/master/CMakeLists.txt#L91
- [ ] CPUINFO https://github.com/google/XNNPACK/blob/master/CMakeLists.txt#L101
- [ ] FP16 https://github.com/google/XNNPACK/blob/master/CMakeLists.txt#L111
- [ ] FXDIV https://github.com/google/XNNPACK/blob/master/CMakeLists.txt#L121
- [ ] PTHREADPOOL https://github.com/google/XNNPACK/blob/master/CMakeLists.txt#L131

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
