### PR TITLE
add codeclimate-test-reporter

### DIFF
--- a/recipes/codeclimate-test-reporter/LICENSE.txt
+++ b/recipes/codeclimate-test-reporter/LICENSE.txt
@@ -1,0 +1,40 @@
+Copyright (c) 2016 Code Climate LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+This gem includes code by Wil Gieseler, distributed under the MIT license:
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be
+    included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+    NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+    LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+    OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+    WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/codeclimate-test-reporter/meta.yaml
+++ b/recipes/codeclimate-test-reporter/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "codeclimate-test-reporter" %}
+{% set version = "0.2.3" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/codeclimate-test-reporter-{{ version }}.tar.gz
+  sha256: d4a5962323e0ebf7d0e9959bcb605910dbb937ff93b21035421b7967dc242865
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - codeclimate-test-reporter=codeclimate_test_reporter.__main__:run
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - coverage >=4.0
+    - python
+    - requests
+
+test:
+  imports:
+    - codeclimate_test_reporter
+    - codeclimate_test_reporter.components
+  commands:
+    - pip check
+    - codeclimate-test-reporter --help
+  requires:
+    - pip
+
+about:
+  home: http://github.com/codeclimate/python-test-reporter
+  summary: Report test coverage to Code Climate
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - jan-janssen

--- a/recipes/codeclimate-test-reporter/meta.yaml
+++ b/recipes/codeclimate-test-reporter/meta.yaml
@@ -38,9 +38,19 @@ test:
 
 about:
   home: http://github.com/codeclimate/python-test-reporter
-  summary: Report test coverage to Code Climate
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
+  summary: 'Uploads Python test coverage data to Code Climate'
+  description: |
+    These configuration instructions refer to a language-specific test
+    reporter which is now deprecated in favor of our new unified test
+    reporter client. The new test reporter is faster, distributed as a
+    static binary, has support for parallelized CI builds, and will
+    receive ongoing support by the team here. The existing test reporters
+    for Ruby, Python, PHP, and Javascript are now deprecated.
+  doc_url: http://github.com/codeclimate/python-test-reporter
+  dev_url: http://github.com/codeclimate/python-test-reporter
 
 extra:
   recipe-maintainers:

--- a/recipes/codeclimate-test-reporter/meta.yaml
+++ b/recipes/codeclimate-test-reporter/meta.yaml
@@ -20,10 +20,10 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
   run:
     - coverage >=4.0
-    - python
+    - python >=3.6
     - requests
 
 test:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
