### PR TITLE
PROD redo token handling

### DIFF
--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -44,7 +44,6 @@ jobs:
 
             source ./.travis_scripts/create_feedstocks
         env:
-          PROD_BINSTAR_TOKEN: ${{ secrets.PROD_BINSTAR_TOKEN }}
           STAGING_BINSTAR_TOKEN: ${{ secrets.STAGING_BINSTAR_TOKEN }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}

--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -51,10 +51,4 @@ conda install --yes --quiet \
 conda info
 conda config --get
 
-set +x
-mkdir -p ~/.conda-smithy
-echo $TRAVIS_TOKEN > ~/.conda-smithy/travis.token
-echo $PROD_BINSTAR_TOKEN > ~/.conda-smithy/anaconda.token
-set -x
-
 python .travis_scripts/create_feedstocks.py


### PR DESCRIPTION
This PR reconfigures the token handling so we can turn off the last admin migration from cfep-13.