### PR TITLE
Drop `go.mod`  [ci skip]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module example.com/hello
-
-go 1.17


### PR DESCRIPTION
This was leftover from a recipe. So go ahead and clean it up

xref: https://github.com/conda-forge/staged-recipes/pull/15972#discussion_r694122477

cc @xhochy