### PR TITLE
added pymatting as a package

### DIFF
--- a/recipes/pymatting/meta.yaml
+++ b/recipes/pymatting/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pymatting" %}
+{% set version = "1.1.3" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/PyMatting-{{ version }}.tar.gz
+  sha256: 47e5dffdb2cdfd2a2af2dc7e46ccd0bd76b9515f2029cb045ecd92962cff6888
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - numba >=0.47.0,<0.49.0
+    - numpy >=1.16.0
+    - pillow >=5.2.0
+    - python >=3.6
+    - scipy >=1.1.0
+
+test:
+  imports:
+    - pymatting
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pymatting.github.io
+  summary: Python package for alpha matting.
+  dev_url: https://github.com/pymatting/pymatting
+  license: MIT
+  license_file: LICENSE.md
+  description: |
+    Given an input image and a hand-drawn trimap (top row), alpha matting
+     estimates the alpha channel of a foreground object which can then be
+     composed onto a different background (bottom row).
+
+extra:
+  recipe-maintainers:
+    - thewchan


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
