### PR TITLE
ENH move master to main

### DIFF
--- a/.appveyor.yml.notused
+++ b/.appveyor.yml.notused
@@ -19,11 +19,11 @@ platform:
     - x64
 
 install:
-    # Find the recipes from master in this PR and remove them.
-    - cmd: echo Finding recipes merged in master and removing them.
+    # Find the recipes from main in this PR and remove them.
+    - cmd: echo Finding recipes merged in main and removing them.
     - cmd: cd recipes
     - cmd: |
-             for /f "tokens=*" %%a in ('git ls-tree --name-only master -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
+             for /f "tokens=*" %%a in ('git ls-tree --name-only main -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
     - cmd: cd ..
 
     # Remove cygwin (and therefore the git that comes with it).

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: linux_64
-  condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
     vmImage: ubuntu-latest
   timeoutInMinutes: 360
@@ -33,7 +33,7 @@ jobs:
 
 - job: linux_64_cuda_102
   dependsOn: linux_64
-  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
+  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
   pool:
     vmImage: ubuntu-latest
   timeoutInMinutes: 360
@@ -68,7 +68,7 @@ jobs:
 
 - job: linux_64_centos7
   dependsOn: linux_64
-  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/master')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CENTOS7'], '1'))
+  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CENTOS7'], '1'))
   pool:
     vmImage: ubuntu-latest
   timeoutInMinutes: 360
@@ -93,4 +93,3 @@ jobs:
     displayName: Run docker build for centos 7
   - publish: build_artifacts/linux-64/
     artifact: conda_pkgs_linux_64_centos7
-

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -4,7 +4,7 @@
 
 jobs:
 - job: osx
-  condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
     vmImage: macOS-10.15
   strategy:
@@ -22,4 +22,3 @@ jobs:
 
   - publish: /Users/runner/miniforge3/conda-bld/osx-64/
     artifact: conda_pkgs_osx
-

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: win_64
-  condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
     vmImage: vs2017-win2016
   strategy:
@@ -38,11 +38,11 @@ jobs:
     - script: call run_conda_forge_build_setup
       displayName: conda-forge build setup
 
-    # Find the recipes from master in this PR and remove them.
+    # Find the recipes from main in this PR and remove them.
     - script: |
-        git fetch --force origin master:master
+        git fetch --force origin main:main
         cd recipes
-        for /f "tokens=*" %%a in ('git ls-tree --name-only master -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
+        for /f "tokens=*" %%a in ('git ls-tree --name-only main -- .') do rmdir /s /q %%a && echo Removing recipe: %%a
         cd ..
 
     - script: |
@@ -53,7 +53,7 @@ jobs:
 
     # Special cased version setting some more things!
     - script: |
-        git fetch --force origin master:master
+        git fetch --force origin main:main
         python .ci_support\build_all.py --arch 64
 
       displayName: Build recipe

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ also consider asking on our [Gitter channel][2] if your recipe isn't reviewed pr
 
 Checklist
 - [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
-- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/master/recipes/example/meta.yaml#L57-L66) for an example).
+- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
 - [ ] Source is from official source.
 - [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [ ] If static libraries are linked in, the license of the static library is packaged.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,30 +6,30 @@ staleLabel: stale
 
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  Hi friend! 
-  
-  
+  Hi friend!
+
+
   We really, really, really appreciate that you have taken the time
   to make a PR on `conda-forge/staged-recipes`! `conda-forge` only exists
   because people like you donate their time to build and maintain conda recipes
-  for use by the community. 
-  
-  
+  for use by the community.
+
+
   In an effort to maintain this repository and increase
   the signal-to-noise for open PRs, the maintainers of `staged-recipes` close
   excessively old PRs after six months. This PR will remain open
-  for another month, and then will be closed. 
-  
-  
+  for another month, and then will be closed.
+
+
   If you'd like to keep it open, please comment/push and we will be happy to oblige!
-  Note that very old PRs will likely need to be rebased on master so that they can 
-  be rebuilt with the most recent CI scripts. If you have any trouble, or we missed 
-  reviewing this PR in the first place (sorry!), feel free 
-  to [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team) 
-  using a special command in a comment on the PR to get the attention of the 
+  Note that very old PRs will likely need to be rebased on `main` so that they can 
+  be rebuilt with the most recent CI scripts. If you have any trouble, or we missed
+  reviewing this PR in the first place (sorry!), feel free
+  to [ping the team](https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team)
+  using a special command in a comment on the PR to get the attention of the
   `staged-recipes` team.
-  
-  
+
+
   Cheers and thank you for contributing to this community effort!
 
 # Comment to post when closing a stale issue. Set to `false` to disable
@@ -39,6 +39,6 @@ closeComment: >
   so now it is being closed. Thank you so much for making it in the first place
   and contributing to the community project that is `conda-forge`. If you'd like
   to reopen this PR, please feel free to do so at any time!
-  
-  
+
+
   Cheers and have a great day!

--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -3,7 +3,7 @@ name: Create feedstocks
 on:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron:  '*/5 * * * *'
   workflow_dispatch: null

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -27,15 +27,15 @@ cp -r /home/conda/staged-recipes ~/staged-recipes-copy
 # Remove any macOS system files
 find ~/staged-recipes-copy/recipes -maxdepth 1 -name ".DS_Store" -delete
 
-# Find the recipes from master in this PR and remove them.
+# Find the recipes from main in this PR and remove them.
 echo "Pending recipes."
 ls -la ~/staged-recipes-copy/recipes
-echo "Finding recipes merged in master and removing them from the build."
+echo "Finding recipes merged in main and removing them from the build."
 pushd /home/conda/staged-recipes/recipes > /dev/null
 if [ "${AZURE}" == "True" ]; then
-    git fetch --force origin master:master
+    git fetch --force origin main:main
 fi
-git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf ~/staged-recipes-copy/recipes/{} && echo Removing recipe: {}"
+git ls-tree --name-only main -- . | xargs -I {} sh -c "rm -rf ~/staged-recipes-copy/recipes/{} && echo Removing recipe: {}"
 popd > /dev/null
 
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -48,16 +48,15 @@ set -e
 # make sure there is a package directory so that artifact publishing works
 mkdir -p /Users/runner/miniforge3/conda-bld/osx-64/
 
-# Find the recipes from master in this PR and remove them.
+# Find the recipes from main in this PR and remove them.
 
 echo ""
-echo "Finding recipes merged in master and removing them from the build."
+echo "Finding recipes merged in main and removing them from the build."
 pushd ./recipes > /dev/null
-git fetch --force origin master:master
-git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
+git fetch --force origin main:main
+git ls-tree --name-only main -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
 popd > /dev/null
 echo ""
 
 # We just want to build all of the recipes.
 python .ci_support/build_all.py
-

--- a/.travis_scripts/build_all
+++ b/.travis_scripts/build_all
@@ -29,11 +29,11 @@ conda config --set show_channel_urls true
 conda install --yes --quiet "conda>4.7.12" conda-forge-ci-setup=2.* conda-forge-pinning networkx=2.3 "conda-build>=3.16"
 source run_conda_forge_build_setup
 
-# Find the recipes from master in this PR and remove them.
+# Find the recipes from main in this PR and remove them.
 echo ""
-echo "Finding recipes merged in master and removing them from the build."
+echo "Finding recipes merged in main and removing them from the build."
 pushd ./recipes > /dev/null
-git ls-tree --name-only master -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
+git ls-tree --name-only main -- . | xargs -I {} sh -c "rm -rf {} && echo Removing recipe: {}"
 popd > /dev/null
 echo ""
 

--- a/.travis_scripts/create_feedstocks
+++ b/.travis_scripts/create_feedstocks
@@ -5,7 +5,7 @@ set -x
 
 # Ensure we are on the latest commit
 # of the branch where we are converting
-# recipes from. Currently this is `master`.
+# recipes from. Currently this is `main`.
 export CF_CURRENT_BRANCH="${GITHUB_REF/refs\/heads\//}"
 git checkout "${CF_CURRENT_BRANCH}"
 

--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -140,7 +140,7 @@ def sleep_until_reset(gh):
 if __name__ == '__main__':
     exit_code = 0
 
-    is_merged_pr = os.environ.get('CF_CURRENT_BRANCH') == 'master'
+    is_merged_pr = os.environ.get('CF_CURRENT_BRANCH') == 'main'
 
     smithy_conf = os.path.expanduser('~/.conda-smithy')
     if not os.path.exists(smithy_conf):

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Generating recipe: `grayskull pypi PACKAGE_NAME_HERE`
 
 ### 1. **How do I start editing the recipe?**
 
-Look at one of [these examples](https://github.com/conda-forge/staged-recipes/tree/master/recipes)
+Look at one of [these examples](https://github.com/conda-forge/staged-recipes/tree/main/recipes)
 in this repository and modify it as necessary.
 
 Your final recipe should have no comments and follow the order in the example.
@@ -106,7 +106,7 @@ The maintainers "job" is to:
 
 ### 10. Why are there recipes already in the `recipes` directory? Should I do something about it?
 
-When a PR of recipe(s) is ready to go, it is merged into `master`. This will trigger a CI build specially designed to convert the recipe(s). However, for any number of reasons the recipe(s) may not be converted right away. In the interim, the recipe(s) will remain in `master` until they can be converted. There is no action required on the part of recipe contributors to resolve this. Also it should have no impact on any other PRs being proposed. If these recipe(s) pending conversion do cause issues for your submission, please ping `conda-forge/core` for help.
+When a PR of recipe(s) is ready to go, it is merged into `main`. This will trigger a CI build specially designed to convert the recipe(s). However, for any number of reasons the recipe(s) may not be converted right away. In the interim, the recipe(s) will remain in `main` until they can be converted. There is no action required on the part of recipe contributors to resolve this. Also it should have no impact on any other PRs being proposed. If these recipe(s) pending conversion do cause issues for your submission, please ping `conda-forge/core` for help.
 
 ### 11. **Some checks failed, but it wasn't my recipe! How do I trigger a rebuild?**
 
@@ -126,7 +126,7 @@ If the problem was due to scripts in the `staged-recipes` repository, you may be
 # these lines:
 # git remote add upstream https://github.com/conda-forge/staged-recipes.git
 # git fetch --all
-git rebase upstream/master
+git rebase upstream/main
 git push -f
 ```
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,9 +5,9 @@ trigger:
     exclude:
       - "*"
 
-# Still allow PR builds to run against master
+# Still allow PR builds to run against main
 pr:
-- master
+- main
 
 jobs:
   - template: ./.azure-pipelines/azure-pipelines-linux.yml


### PR DESCRIPTION
This PR moves the default branch from master to main. A member of core needs to change the branch in the repo settings and then merge this PR. 