### PR TITLE
add cmark-gfm library

### DIFF
--- a/recipes/cmark-gfm/bld.bat
+++ b/recipes/cmark-gfm/bld.bat
@@ -1,0 +1,21 @@
+setlocal EnableDelayedExpansion
+
+mkdir build
+cd build
+
+:: Configure
+cmake -G "NMake Makefiles" ^
+      -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+      -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+      -DCMAKE_BUILD_TYPE:STRING=Release ^
+      -DCMAKE_LIBRARY_PATH:PATH="%LIBRARY_PREFIX%;%LIBRARY_PREFIX%/bin" ^
+      ..
+if errorlevel 1 exit 1
+
+:: Build
+nmake
+if errorlevel 1 exit 1
+
+:: Install
+nmake install
+

--- a/recipes/cmark-gfm/build.sh
+++ b/recipes/cmark-gfm/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+mkdir build
+cd build
+
+cmake \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_PREFIX_PATH=$PREFIX \
+  -DCMAKE_BUILD_TYPE=Release \
+  ..
+
+make -j${CPU_COUNT} VERBOSE=1
+make install

--- a/recipes/cmark-gfm/build.sh
+++ b/recipes/cmark-gfm/build.sh
@@ -3,7 +3,7 @@
 mkdir build
 cd build
 
-cmake \
+cmake ${CMAKE_ARGS} \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \
   -DCMAKE_PREFIX_PATH=$PREFIX \
   -DCMAKE_BUILD_TYPE=Release \

--- a/recipes/cmark-gfm/meta.yaml
+++ b/recipes/cmark-gfm/meta.yaml
@@ -23,10 +23,14 @@ requirements:
 test:
   commands:
     - cmark-gfm --version
-    - if not exist %LIBRARY_LIB%\cmark-gfm.lib exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\cmark-gfm.dll exit 1  # [win]
-    - test -f $PREFIX/lib/libcmark-gfm.so              # [linux]
-    - test -f $PREFIX/lib/libcmark-gfm.dylib           # [osx]
+    - if not exist %LIBRARY_BIN%\cmark-gfm.dll exit 1              # [win]
+    - test -f $PREFIX/lib/libcmark-gfm.so                          # [linux]
+    - test -f $PREFIX/lib/libcmark-gfm.dylib                       # [osx]
+    - if not exist %LIBRARY_BIN%\cmark-gfm-extensions.dll exit 1   # [win]
+    - test -f $PREFIX/lib/libcmark-gfm-extensions.so               # [linux]
+    - test -f $PREFIX/lib/libcmark-gfm-extensions.dylib            # [osx]
+    - if not exist %LIBRARY_INC%\cmark-gfm-extension_api.h exit 1  # [win]
+    - test -f $PREFIX/include/cmark-gfm-extension_api.h            # [unix]
 
 about:
   home: https://github.com/github/cmark-gfm

--- a/recipes/cmark-gfm/meta.yaml
+++ b/recipes/cmark-gfm/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
 test:
   commands:
-    - cmark --version
+    - cmark-gfm --version
     - if not exist %LIBRARY_LIB%\cmark.lib exit 1  # [win]
     - if not exist %LIBRARY_BIN%\cmark.dll exit 1  # [win]
     - test -f $PREFIX/lib/libcmark.so              # [linux]

--- a/recipes/cmark-gfm/meta.yaml
+++ b/recipes/cmark-gfm/meta.yaml
@@ -23,10 +23,10 @@ requirements:
 test:
   commands:
     - cmark-gfm --version
-    - if not exist %LIBRARY_LIB%\cmark.lib exit 1  # [win]
-    - if not exist %LIBRARY_BIN%\cmark.dll exit 1  # [win]
-    - test -f $PREFIX/lib/libcmark.so              # [linux]
-    - test -f $PREFIX/lib/libcmark.dylib           # [osx]
+    - if not exist %LIBRARY_LIB%\cmark-gfm.lib exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\cmark-gfm.dll exit 1  # [win]
+    - test -f $PREFIX/lib/libcmark-gfm.so              # [linux]
+    - test -f $PREFIX/lib/libcmark-gfm.dylib           # [osx]
 
 about:
   home: https://github.com/github/cmark-gfm

--- a/recipes/cmark-gfm/meta.yaml
+++ b/recipes/cmark-gfm/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "cmark-gfm" %}
+{% set version = "0.29.0.gfm.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/github/cmark-gfm/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 66d92c8bef533744674c5b64d8744227584b12704bcfebbe16dab69f81e62029
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("cmark-gfm") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - cmake
+
+test:
+  commands:
+    - cmark --version
+    - if not exist %LIBRARY_LIB%\cmark.lib exit 1  # [win]
+    - if not exist %LIBRARY_BIN%\cmark.dll exit 1  # [win]
+    - test -f $PREFIX/lib/libcmark.so              # [linux]
+    - test -f $PREFIX/lib/libcmark.dylib           # [osx]
+
+about:
+  home: https://github.com/github/cmark-gfm
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: COPYING
+  summary: "GitHub's Fork of cmark"
+  description: |
+    cmark-gfm is an extended version of the C reference implementation of
+    CommonMark, a rationalized version of Markdown syntax with a spec. This
+    repository adds GitHub Flavored Markdown extensions to the upstream
+    implementation, as defined in the spec.
+  dev_url: https://github.com/github/cmark-gfm
+  doc_url: https://github.github.com/gfm/
+
+extra:
+  recipe-maintainers:
+    - saraedum

--- a/recipes/cmark-gfm/meta.yaml
+++ b/recipes/cmark-gfm/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - cmake
 
 test:

--- a/recipes/cmark-gfm/meta.yaml
+++ b/recipes/cmark-gfm/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/github/cmark-gfm/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/github/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: 66d92c8bef533744674c5b64d8744227584b12704bcfebbe16dab69f81e62029
 
 build:
@@ -40,9 +40,9 @@ about:
   summary: "GitHub's Fork of cmark"
   description: |
     cmark-gfm is an extended version of the C reference implementation of
-    CommonMark, a rationalized version of Markdown syntax with a spec. This
-    repository adds GitHub Flavored Markdown extensions to the upstream
-    implementation, as defined in the spec.
+    CommonMark, a rationalized version of Markdown syntax with a spec.
+    cmark-gfm adds GitHub Flavored Markdown extensions to the upstream
+    implementation.
   dev_url: https://github.com/github/cmark-gfm
   doc_url: https://github.github.com/gfm/
 


### PR DESCRIPTION
This adds the GitHub's fork of the commonmark reference implementation.

Note that there is already a cmarkgfm package in conda-forge, but it is a python wrapper for cmark-gfm.