### PR TITLE
Use Python 3.9 on Windows CI

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -13,7 +13,7 @@ jobs:
   steps:
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
+        packageSpecs: 'python=3.9 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment


### PR DESCRIPTION
Same change as PR ( https://github.com/conda-forge/conda-smithy/pull/1504 )

Bumps the Windows CI `base` environment `python` version to `3.9`.