### PR TITLE
Use Python 3.9 on Windows CI (2nd attempt)

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -24,7 +24,7 @@ jobs:
     # Configure the VM
     - script: |
         call activate base
-        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+        setup_conda_rc .\ ".\recipes" .\.ci_support\%CONFIG%.yaml
       displayName: conda-forge CI setup
 
     # Configure the VM.

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -13,7 +13,7 @@ jobs:
   steps:
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.9 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
+        packageSpecs: 'python=3.8 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -19,23 +19,19 @@ jobs:
       displayName: Install conda-build and activate environment
 
     - script: set PYTHONUNBUFFERED=1
-
-    # Add our channels.
-    - script: conda.exe config --set show_channel_urls true
-      displayName: configure conda channels
-    - script: conda.exe config --remove channels defaults
-      displayName: configure conda channels
-    - script: conda.exe config --add channels defaults
-      displayName: configure conda channels
-
-    - script: conda.exe config --add channels conda-forge
-      displayName: configure conda channels
+      displayName: Set PYTHONUNBUFFERED
 
     # Configure the VM
-    - script: setup_conda_rc .\ .\recipes .\.ci_support\%CONFIG%.yaml
+    - script: |
+        call activate base
+        setup_conda_rc .\ ".\recipe" .\.ci_support\%CONFIG%.yaml
+      displayName: conda-forge CI setup
 
     # Configure the VM.
-    - script: call run_conda_forge_build_setup
+    - script: |
+        set "CI=azure"
+        call activate base
+        run_conda_forge_build_setup
       displayName: conda-forge build setup
 
     # Find the recipes from main in this PR and remove them.

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -13,7 +13,7 @@ jobs:
   steps:
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.8 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
+        packageSpecs: 'python=3.9 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -13,7 +13,7 @@ jobs:
   steps:
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
+        packageSpecs: 'python=3.9 conda-build>=3.18 conda>4.7.12 conda-forge::conda-forge-ci-setup=3 networkx=2.4 conda-forge-pinning' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -49,6 +49,7 @@ jobs:
 
     # Special cased version setting some more things!
     - script: |
+        call activate base
         git fetch --force origin main:main
         python .ci_support\build_all.py --arch 64
 


### PR DESCRIPTION
Second attempt to bump the Windows CI `base` environment `python` version to `3.9` after issues were encountered in PR ( https://github.com/conda-forge/staged-recipes/pull/16299 )
