### PR TITLE
Adding ReaDDy package

### DIFF
--- a/recipes/readdy/LICENSE.txt
+++ b/recipes/readdy/LICENSE.txt
@@ -1,0 +1,26 @@
+Copyright 2018 AI4Science Group, Freie Universität Berlin (GER)
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+ - Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+ - Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ - Neither the name of the copyright holder nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/readdy/build.sh
+++ b/recipes/readdy/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+mkdir -p build
+cd build || true
+rm -rf ./*
+
+export HDF5_ROOT=${PREFIX}
+
+cmake .. \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DCMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DPYTHON_EXECUTABLE="${PYTHON}" \
+  -DPYTHON_PREFIX="${PREFIX}" \
+  -DHDF5_INCLUDE_DIRS="${PREFIX}/include" \
+  -DREADDY_CREATE_TEST_TARGET:BOOL=OFF \
+  -DREADDY_INSTALL_UNIT_TEST_EXECUTABLE:BOOL=OFF \
+  -DREADDY_VERSION=${PKG_VERSION} \
+  -DREADDY_BUILD_STRING=${PKG_BUILDNUM} \
+  -DSP_DIR="${SP_DIR}" \
+  -GNinja
+
+ninja -j${CPU_COUNT}
+ninja install
+
+exit ${ret_code}
+

--- a/recipes/readdy/meta.yaml
+++ b/recipes/readdy/meta.yaml
@@ -1,0 +1,73 @@
+{% set name = "readdy" %}
+{% set version = "2.0.9" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 0d4474d545837e3c7afc3f2a98ca21da1e2cc46691149db8ca03b05dd9d49028
+
+build:
+  number: 0
+  skip: true  # [win]
+  rpaths:
+    - lib/
+    - lib/readdy_plugins
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - python
+    - h5py
+    - hdf5
+    - bzip2
+    - zlib
+    - spdlog
+    - nlohmann_json
+    - pybind11
+    - blosc
+    - fmt
+    - numpy
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - h5py
+    - pint
+    - tqdm
+    - hdf5
+    - zlib
+
+test:
+  imports:
+    - readdy
+  requires:
+    - nose
+  commands:
+    - nosetests readdy -s -vv --with-doctest --doctest-options=+NORMALIZE_WHITESPACE,+ELLIPSIS
+
+about:
+  home: https://github.com/readdy/readdy
+  license: BSD-3-Clause
+  license_family: BSD
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
+  license_file: LICENSE.txt
+  summary: 'Python / C++ based particle reaction-diffusion simulator'
+  description: |
+    ReaDDy (standing for [Rea]ction [D]iffusion [Dy]namics) is a particle based
+    reaction-diffusion simulator that can be configured and run with Python 3.6+.
+    The Python interface wraps around a C++ implementation for good performance.
+    Trajectories are written using the flexible HDF5 format.
+  doc_url: https://{{ name }}.github.io/
+  dev_url: https://github.com/{{ name }}/{{ name }}
+
+extra:
+  recipe-maintainers:
+    - clonker


### PR DESCRIPTION
Adding the [ReaDDy](github.com/readdy/readdy) package. I have previously released this software on my own anaconda channel, and would now like to add it to conda-forge to increase availability and make it easier to install.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
