### PR TITLE
add recipe for retropath2-wrapper v2.0.2

### DIFF
--- a/recipes/retropath2-wrapper/meta.yaml
+++ b/recipes/retropath2-wrapper/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "RetroPath2-wrapper" %}
+{% set version = "2.0.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/brsynth/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: "bd0b5202aaac5cf438eed53e051e2aae5366e0cf3ed1fe5b99024d1d5b85d129"
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install -vv .
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - brs_utils
+    - filetype
+    - colored
+
+test:
+  source_files:
+    - tests
+  imports:
+    - {{ name|lower }}
+  requires:
+    - pytest
+  commands:
+    - python -m {{ name|lower }} --help
+    - cd tests
+    - pytest -v
+
+about:
+  home: https://github.com/brsynth/{{ name|lower }}
+  summary: "Python wrapper to run RetroPath2.0 KNIME workflow"
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - breakthewall


### PR DESCRIPTION
Python wrapper to run RetroPath2.0 KNIME workflow.

Takes for input the minimal (dmin) and maximal (dmax) diameter for the reaction rules and the maximal path length (maxSteps). The tool expects the following files: rules.csv, sink.csv and source.csv and produces results in an output folder.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
