### PR TITLE
Add rtxpy

### DIFF
--- a/recipes/rtxpy/meta.yaml
+++ b/recipes/rtxpy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rtxpy" %}
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/rtxpy-{{ version }}.tar.gz
-  sha256: a7053a306e7b7fce15cb4515fc88cc5ba714fe72489103b33c777ae2b598da8a
+  sha256: 86aadaeb7d062944469fb69d53688c1a4d14e4b7781ecba74756fc886c8a14d1
 
 build:
   number: 0
@@ -17,9 +17,9 @@ build:
 
 requirements:
   build:
-    - cmake >=3.10
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - cmake >=3.10
   host:
     - pip
     - python
@@ -30,7 +30,6 @@ requirements:
 test:
   imports:
     - rtxpy
-    - rtxpy.RTX
     - rtxpy.tests
   commands:
     - pip check


### PR DESCRIPTION
`rtxpy` (https://github.com/makepath/rtxpy) is C/C++/CUDA code with a Python interface to perform ray tracing, and will be a dependency of `xarray-spatial` (https://github.com/makepath/xarray-spatial) on next release.

Not building on macOS as does not support CUDA.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
