### PR TITLE
Add oldest-supported-numpy-conda-forge

### DIFF
--- a/recipes/oldest-supported-numpy-conda-forge/LICENSE.txt
+++ b/recipes/oldest-supported-numpy-conda-forge/LICENSE.txt
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2021, Duncan Macleod
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/oldest-supported-numpy-conda-forge/meta.yaml
+++ b/recipes/oldest-supported-numpy-conda-forge/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "oldest-supported-numpy-conda-forge" %}
+{% set version = datetime.datetime.utcnow().strftime('%Y.%m.%d.%H.%M.%S') %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - numpy
+    - python
+  run:
+    - {{ pin_compatible('numpy', max_pin='x.x') }}
+    - python
+
+test:
+  imports:
+    - numpy
+
+about:
+  home: https://github.com/conda-forge/{{ name }}-feedstock
+  dev_url: https://github.com/conda-forge/{{ name }}-feedstock.git
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: Meta-package to install the conda-forge-pinnings pinned version of numpy
+  description: |
+    This is a meta-package which depends upon the minor version of numpy that
+    is referenced in the
+    [conda-forge-pinning](https://github.com/conda-forge/conda-forge-pinning-feedstock)
+    pinned package list.
+
+    This is meant to make it easier to construct development environments that
+    build software against the oldest conda-forge supported version of NumPy,
+    maximising ABI compatibility.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds a recipe for a conda-forge version of [`oldest-supported-numpy`](https://pypi.org/project/oldest-supported-numpy/), providing a runtime pin to the minor version of numpy referenced in the conda-forge-pinning set for the relevant platform/python-version.

I'm not sold on the name, but (as with the original PyPI package) it's at least descriptive. I don't think this should be called `oldest-supported-numpy` given that this version pins things in a different way to the PyPI version. This could just as easily be called `conda-forge-pinned-numpy` or similar.

I also don't have a good sense of how this will be kept up-to-date with changes in the conda-forge-pinning pins for `numpy`, so any advice from @conda-forge/core would be appreciated.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
