### PR TITLE
add r-paws analytics, compute, database and security

### DIFF
--- a/recipes/r-paws.analytics/LICENSE.txt
+++ b/recipes/r-paws.analytics/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.analytics/bld.bat
+++ b/recipes/r-paws.analytics/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.analytics/build.sh
+++ b/recipes/r-paws.analytics/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.analytics/meta.yaml
+++ b/recipes/r-paws.analytics/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.analytics
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.analytics_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.analytics/paws.analytics_{{ version }}.tar.gz
+  sha256: 4f2c1ffe392076463da61c7a57a081e92f10755ca9e93cbb088306216b57f611
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.analytics')"           # [not win]
+    - "\"%R%\" -e \"library('paws.analytics')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' 'analytics' services, including 'Elastic MapReduce'
+    'Hadoop' and 'Spark' big data service, 'Elasticsearch' search engine, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.analytics
+# Title: 'Amazon Web Services' Analytics Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' 'analytics' services, including 'Elastic MapReduce' 'Hadoop' and 'Spark' big data service, 'Elasticsearch' search engine, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'athena_service.R' 'athena_interfaces.R' 'athena_operations.R' 'cloudsearch_service.R' 'cloudsearch_interfaces.R' 'cloudsearch_operations.R' 'cloudsearchdomain_service.R' 'cloudsearchdomain_interfaces.R' 'cloudsearchdomain_operations.R' 'datapipeline_service.R' 'datapipeline_interfaces.R' 'datapipeline_operations.R' 'elasticsearchservice_service.R' 'elasticsearchservice_interfaces.R' 'elasticsearchservice_operations.R' 'emr_service.R' 'emr_interfaces.R' 'emr_operations.R' 'firehose_service.R' 'firehose_interfaces.R' 'firehose_operations.R' 'glue_service.R' 'glue_interfaces.R' 'glue_operations.R' 'kafka_service.R' 'kafka_interfaces.R' 'kafka_operations.R' 'kinesis_service.R' 'kinesis_interfaces.R' 'kinesis_operations.R' 'kinesisanalytics_service.R' 'kinesisanalytics_interfaces.R' 'kinesisanalytics_operations.R' 'kinesisanalyticsv2_service.R' 'kinesisanalyticsv2_interfaces.R' 'kinesisanalyticsv2_operations.R' 'mturk_service.R' 'mturk_interfaces.R' 'mturk_operations.R' 'quicksight_service.R' 'quicksight_interfaces.R' 'quicksight_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 19:23:43 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:11:20 UTC

--- a/recipes/r-paws.compute/LICENSE.txt
+++ b/recipes/r-paws.compute/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.compute/bld.bat
+++ b/recipes/r-paws.compute/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.compute/build.sh
+++ b/recipes/r-paws.compute/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.compute/meta.yaml
+++ b/recipes/r-paws.compute/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.compute
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.compute_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.compute/paws.compute_{{ version }}.tar.gz
+  sha256: 7ed2e4f9a8ff9876294f4c713810c52237c13554cdae95a964aed0689e75a6ce
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.compute')"           # [not win]
+    - "\"%R%\" -e \"library('paws.compute')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' compute services, including 'Elastic Compute Cloud'
+    ('EC2'), 'Lambda' functions-as-a-service, containers, batch processing, and more
+    <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.compute
+# Title: 'Amazon Web Services' Compute Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' compute services, including 'Elastic Compute Cloud' ('EC2'), 'Lambda' functions-as-a-service, containers, batch processing, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'batch_service.R' 'batch_interfaces.R' 'batch_operations.R' 'ec2_service.R' 'ec2_interfaces.R' 'ec2_operations.R' 'ec2instanceconnect_service.R' 'ec2instanceconnect_interfaces.R' 'ec2instanceconnect_operations.R' 'ecr_service.R' 'ecr_interfaces.R' 'ecr_operations.R' 'ecs_service.R' 'ecs_interfaces.R' 'ecs_operations.R' 'eks_service.R' 'eks_interfaces.R' 'eks_operations.R' 'elasticbeanstalk_service.R' 'elasticbeanstalk_interfaces.R' 'elasticbeanstalk_operations.R' 'lambda_service.R' 'lambda_interfaces.R' 'lambda_operations.R' 'lightsail_service.R' 'lightsail_interfaces.R' 'lightsail_operations.R' 'serverlessapplicationrepository_service.R' 'serverlessapplicationrepository_interfaces.R' 'serverlessapplicationrepository_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 21:45:08 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:11:03 UTC

--- a/recipes/r-paws.database/LICENSE.txt
+++ b/recipes/r-paws.database/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.database/bld.bat
+++ b/recipes/r-paws.database/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.database/build.sh
+++ b/recipes/r-paws.database/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.database/meta.yaml
+++ b/recipes/r-paws.database/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.database
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.database_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.database/paws.database_{{ version }}.tar.gz
+  sha256: df63e063e06ccd097d064b354a1d9cc0587bcaa302760e24326e7057d2e75722
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.database')"           # [not win]
+    - "\"%R%\" -e \"library('paws.database')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' database services, including 'Relational Database
+    Service' ('RDS'), 'DynamoDB' 'NoSQL' database, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.database
+# Title: 'Amazon Web Services' Database Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' database services, including 'Relational Database Service' ('RDS'), 'DynamoDB' 'NoSQL' database, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'dax_service.R' 'dax_interfaces.R' 'dax_operations.R' 'docdb_service.R' 'docdb_interfaces.R' 'docdb_operations.R' 'dynamodb_service.R' 'dynamodb_interfaces.R' 'dynamodb_operations.R' 'dynamodbstreams_service.R' 'dynamodbstreams_interfaces.R' 'dynamodbstreams_operations.R' 'elasticache_service.R' 'elasticache_interfaces.R' 'elasticache_operations.R' 'neptune_service.R' 'neptune_interfaces.R' 'neptune_operations.R' 'rds_service.R' 'rds_operations.R' 'rds_custom.R' 'rds_interfaces.R' 'rdsdataservice_service.R' 'rdsdataservice_interfaces.R' 'rdsdataservice_operations.R' 'redshift_service.R' 'redshift_interfaces.R' 'redshift_operations.R' 'simpledb_service.R' 'simpledb_interfaces.R' 'simpledb_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 22:20:28 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:10:46 UTC

--- a/recipes/r-paws.security.identity/LICENSE.txt
+++ b/recipes/r-paws.security.identity/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.security.identity/bld.bat
+++ b/recipes/r-paws.security.identity/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.security.identity/build.sh
+++ b/recipes/r-paws.security.identity/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.security.identity/meta.yaml
+++ b/recipes/r-paws.security.identity/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.security.identity
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.security.identity_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.security.identity/paws.security.identity_{{ version }}.tar.gz
+  sha256: c9c5ee36595e66fe281dacd51286719e18b900432a9f3e52c938167ba3f85424
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.security.identity')"           # [not win]
+    - "\"%R%\" -e \"library('paws.security.identity')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' security, identity, and compliance services, including
+    the 'Identity & Access Management' ('IAM') service for managing access to services
+    and resources, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.security.identity
+# Title: 'Amazon Web Services' Security, Identity, & Compliance Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' security, identity, and compliance services, including the 'Identity & Access Management' ('IAM') service for managing access to services and resources, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'acm_service.R' 'acm_interfaces.R' 'acm_operations.R' 'acmpca_service.R' 'acmpca_interfaces.R' 'acmpca_operations.R' 'clouddirectory_service.R' 'clouddirectory_interfaces.R' 'clouddirectory_operations.R' 'cloudhsm_service.R' 'cloudhsm_interfaces.R' 'cloudhsm_operations.R' 'cloudhsmv2_service.R' 'cloudhsmv2_interfaces.R' 'cloudhsmv2_operations.R' 'cognitoidentity_service.R' 'cognitoidentity_interfaces.R' 'cognitoidentity_operations.R' 'cognitoidentityprovider_service.R' 'cognitoidentityprovider_interfaces.R' 'cognitoidentityprovider_operations.R' 'cognitosync_service.R' 'cognitosync_interfaces.R' 'cognitosync_operations.R' 'directoryservice_service.R' 'directoryservice_interfaces.R' 'directoryservice_operations.R' 'fms_service.R' 'fms_interfaces.R' 'fms_operations.R' 'guardduty_service.R' 'guardduty_interfaces.R' 'guardduty_operations.R' 'iam_service.R' 'iam_interfaces.R' 'iam_operations.R' 'inspector_service.R' 'inspector_interfaces.R' 'inspector_operations.R' 'kms_service.R' 'kms_interfaces.R' 'kms_operations.R' 'macie_service.R' 'macie_interfaces.R' 'macie_operations.R' 'ram_service.R' 'ram_interfaces.R' 'ram_operations.R' 'secretsmanager_service.R' 'secretsmanager_interfaces.R' 'secretsmanager_operations.R' 'securityhub_service.R' 'securityhub_interfaces.R' 'securityhub_operations.R' 'shield_service.R' 'shield_interfaces.R' 'shield_operations.R' 'sts_service.R' 'sts_interfaces.R' 'sts_operations.R' 'waf_service.R' 'waf_interfaces.R' 'waf_operations.R' 'wafregional_service.R' 'wafregional_interfaces.R' 'wafregional_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 23:45:53 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:10:06 UTC


### PR DESCRIPTION
follow up PR for https://paws-r.github.io/ - that completes the subset of paws functionality I actually plan to use.

two more PRs planned: the rest of paws-r and the umbrella paws package.

@conda-forge/help-r - Could you point me to an example showing how to run the tests provided by the "testthat" framework of the upstream source (https://github.com/paws-r/paws/tree/main/paws/tests/testthat) against the conda packages themselves?