### PR TITLE
add remaining r-paws sub-packages

### DIFF
--- a/recipes/r-paws.application.integration/LICENSE.txt
+++ b/recipes/r-paws.application.integration/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.application.integration/bld.bat
+++ b/recipes/r-paws.application.integration/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.application.integration/build.sh
+++ b/recipes/r-paws.application.integration/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.application.integration/meta.yaml
+++ b/recipes/r-paws.application.integration/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.application.integration
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.application.integration_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.application.integration/paws.application.integration_{{ version }}.tar.gz
+  sha256: 82e0a7065b4fea37f36688660e6dfcb7f782d1602c03184353371dc3606a9e52
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.application.integration')"           # [not win]
+    - "\"%R%\" -e \"library('paws.application.integration')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' application integration services, including 'Simple
+    Queue Service' ('SQS') message queue, 'Simple Notification Service' ('SNS') publish/subscribe
+    messaging, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+
+  # Package: paws.application.integration
+# Title: 'Amazon Web Services' Application Integration Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' application integration services, including 'Simple Queue Service' ('SQS') message queue, 'Simple Notification Service' ('SNS') publish/subscribe messaging, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'eventbridge_service.R' 'eventbridge_interfaces.R' 'eventbridge_operations.R' 'mq_service.R' 'mq_interfaces.R' 'mq_operations.R' 'sfn_service.R' 'sfn_interfaces.R' 'sfn_operations.R' 'sns_service.R' 'sns_interfaces.R' 'sns_operations.R' 'sqs_service.R' 'sqs_interfaces.R' 'sqs_operations.R' 'swf_service.R' 'swf_interfaces.R' 'swf_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 20:58:33 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:11:15 UTC

--- a/recipes/r-paws.cost.management/LICENSE.txt
+++ b/recipes/r-paws.cost.management/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.cost.management/bld.bat
+++ b/recipes/r-paws.cost.management/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.cost.management/build.sh
+++ b/recipes/r-paws.cost.management/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.cost.management/meta.yaml
+++ b/recipes/r-paws.cost.management/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.cost.management
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.cost.management_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.cost.management/paws.cost.management_{{ version }}.tar.gz
+  sha256: d0ce81eca3bd93d20868abfab010a48fd25036f0e2d341b7d9e215fe3c72c446
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.cost.management')"           # [not win]
+    - "\"%R%\" -e \"library('paws.cost.management')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' cost management services, including cost and usage
+    reports, budgets, pricing, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.cost.management
+# Title: 'Amazon Web Services' Cost Management Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' cost management services, including cost and usage reports, budgets, pricing, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'budgets_service.R' 'budgets_interfaces.R' 'budgets_operations.R' 'costandusagereportservice_service.R' 'costandusagereportservice_interfaces.R' 'costandusagereportservice_operations.R' 'costexplorer_service.R' 'costexplorer_interfaces.R' 'costexplorer_operations.R' 'marketplacecommerceanalytics_service.R' 'marketplacecommerceanalytics_interfaces.R' 'marketplacecommerceanalytics_operations.R' 'marketplaceentitlementservice_service.R' 'marketplaceentitlementservice_interfaces.R' 'marketplaceentitlementservice_operations.R' 'marketplacemetering_service.R' 'marketplacemetering_interfaces.R' 'marketplacemetering_operations.R' 'pricing_service.R' 'pricing_interfaces.R' 'pricing_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 21:52:25 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:11:00 UTC

--- a/recipes/r-paws.customer.engagement/LICENSE.txt
+++ b/recipes/r-paws.customer.engagement/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.customer.engagement/bld.bat
+++ b/recipes/r-paws.customer.engagement/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.customer.engagement/build.sh
+++ b/recipes/r-paws.customer.engagement/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.customer.engagement/meta.yaml
+++ b/recipes/r-paws.customer.engagement/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.customer.engagement
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.customer.engagement_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.customer.engagement/paws.customer.engagement_{{ version }}.tar.gz
+  sha256: b2cd2ef84835013f1a0ec3cf6ac2672850975202a82756db87d2d148ec878629
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.customer.engagement')"           # [not win]
+    - "\"%R%\" -e \"library('paws.customer.engagement')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' customer engagement services, including 'Simple
+    Email Service', 'Connect' contact center service, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.customer.engagement
+# Title: 'Amazon Web Services' Customer Engagement Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' customer engagement services, including 'Simple Email Service', 'Connect' contact center service, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'connect_service.R' 'connect_interfaces.R' 'connect_operations.R' 'pinpoint_service.R' 'pinpoint_interfaces.R' 'pinpoint_operations.R' 'pinpointemail_service.R' 'pinpointemail_interfaces.R' 'pinpointemail_operations.R' 'pinpointsmsvoice_service.R' 'pinpointsmsvoice_interfaces.R' 'pinpointsmsvoice_operations.R' 'ses_service.R' 'ses_interfaces.R' 'ses_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 22:06:45 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:10:54 UTC

--- a/recipes/r-paws.developer.tools/LICENSE.txt
+++ b/recipes/r-paws.developer.tools/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.developer.tools/bld.bat
+++ b/recipes/r-paws.developer.tools/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.developer.tools/build.sh
+++ b/recipes/r-paws.developer.tools/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.developer.tools/meta.yaml
+++ b/recipes/r-paws.developer.tools/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.developer.tools
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.developer.tools_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.developer.tools/paws.developer.tools_{{ version }}.tar.gz
+  sha256: c2af18ab595c10f5d8707e527d6e5209c689fb8bcb95d41a3e541da3d143eb99
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.developer.tools')"           # [not win]
+    - "\"%R%\" -e \"library('paws.developer.tools')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' developer tools services, including version control,
+    continuous integration and deployment, and more <https://aws.amazon.com/products/developer-tools/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: paws.developer.tools
+# Title: 'Amazon Web Services' Developer Tools Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' developer tools services, including version control, continuous integration and deployment, and more <https://aws.amazon.com/products/developer-tools/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'cloud9_service.R' 'cloud9_interfaces.R' 'cloud9_operations.R' 'codebuild_service.R' 'codebuild_interfaces.R' 'codebuild_operations.R' 'codecommit_service.R' 'codecommit_interfaces.R' 'codecommit_operations.R' 'codedeploy_service.R' 'codedeploy_interfaces.R' 'codedeploy_operations.R' 'codepipeline_service.R' 'codepipeline_interfaces.R' 'codepipeline_operations.R' 'codestar_service.R' 'codestar_interfaces.R' 'codestar_operations.R' 'xray_service.R' 'xray_interfaces.R' 'xray_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 22:30:38 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-24 19:30:06 UTC

--- a/recipes/r-paws.end.user.computing/LICENSE.txt
+++ b/recipes/r-paws.end.user.computing/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.end.user.computing/bld.bat
+++ b/recipes/r-paws.end.user.computing/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.end.user.computing/build.sh
+++ b/recipes/r-paws.end.user.computing/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.end.user.computing/meta.yaml
+++ b/recipes/r-paws.end.user.computing/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.end.user.computing
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.end.user.computing_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.end.user.computing/paws.end.user.computing_{{ version }}.tar.gz
+  sha256: 63b3a8a867c0073c49f26c9b382ea87ecddfe846d7a6ea7fd448846e0dfabaf7
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.end.user.computing')"           # [not win]
+    - "\"%R%\" -e \"library('paws.end.user.computing')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' end user computing services, including collaborative
+    document editing, mobile intranet, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.end.user.computing
+# Title: 'Amazon Web Services' End User Computing Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' end user computing services, including collaborative document editing, mobile intranet, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'appstream_service.R' 'appstream_interfaces.R' 'appstream_operations.R' 'workdocs_service.R' 'workdocs_interfaces.R' 'workdocs_operations.R' 'worklink_service.R' 'worklink_interfaces.R' 'worklink_operations.R' 'workspaces_service.R' 'workspaces_interfaces.R' 'workspaces_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 22:38:27 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-24 19:30:02 UTC

--- a/recipes/r-paws.machine.learning/LICENSE.txt
+++ b/recipes/r-paws.machine.learning/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.machine.learning/bld.bat
+++ b/recipes/r-paws.machine.learning/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.machine.learning/build.sh
+++ b/recipes/r-paws.machine.learning/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.machine.learning/meta.yaml
+++ b/recipes/r-paws.machine.learning/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.machine.learning
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.machine.learning_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.machine.learning/paws.machine.learning_{{ version }}.tar.gz
+  sha256: 4af7e9feeb8232105688b1aeeeaefc79e61e0abbc2afbf6407655e5152f18207
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.machine.learning')"           # [not win]
+    - "\"%R%\" -e \"library('paws.machine.learning')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' machine learning services, including 'SageMaker'
+    managed machine learning service, natural language processing, speech recognition,
+    translation, and more <https://aws.amazon.com/machine-learning/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.machine.learning
+# Title: 'Amazon Web Services' Machine Learning Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' machine learning services, including 'SageMaker' managed machine learning service, natural language processing, speech recognition, translation, and more <https://aws.amazon.com/machine-learning/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'comprehend_service.R' 'comprehend_interfaces.R' 'comprehend_operations.R' 'comprehendmedical_service.R' 'comprehendmedical_interfaces.R' 'comprehendmedical_operations.R' 'lexmodelbuildingservice_service.R' 'lexmodelbuildingservice_interfaces.R' 'lexmodelbuildingservice_operations.R' 'lexruntimeservice_service.R' 'lexruntimeservice_interfaces.R' 'lexruntimeservice_operations.R' 'machinelearning_service.R' 'machinelearning_interfaces.R' 'machinelearning_operations.R' 'personalize_service.R' 'personalize_interfaces.R' 'personalize_operations.R' 'personalizeevents_service.R' 'personalizeevents_interfaces.R' 'personalizeevents_operations.R' 'personalizeruntime_service.R' 'personalizeruntime_interfaces.R' 'personalizeruntime_operations.R' 'polly_service.R' 'polly_interfaces.R' 'polly_operations.R' 'rekognition_service.R' 'rekognition_interfaces.R' 'rekognition_operations.R' 'sagemaker_service.R' 'sagemaker_interfaces.R' 'sagemaker_operations.R' 'sagemakerruntime_service.R' 'sagemakerruntime_interfaces.R' 'sagemakerruntime_operations.R' 'textract_service.R' 'textract_interfaces.R' 'textract_operations.R' 'transcribeservice_service.R' 'transcribeservice_interfaces.R' 'transcribeservice_operations.R' 'translate_service.R' 'translate_interfaces.R' 'translate_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 22:51:01 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:10:38 UTC

--- a/recipes/r-paws.management/LICENSE.txt
+++ b/recipes/r-paws.management/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.management/bld.bat
+++ b/recipes/r-paws.management/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.management/build.sh
+++ b/recipes/r-paws.management/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.management/meta.yaml
+++ b/recipes/r-paws.management/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.management
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.management_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.management/paws.management_{{ version }}.tar.gz
+  sha256: 8f6b0414bbf496dc6961c7a274d57992b5799d6b748fe585fe80482ac1e36726
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.management')"           # [not win]
+    - "\"%R%\" -e \"library('paws.management')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' management and governance services, including 'CloudWatch'
+    application and infrastructure monitoring, 'Auto Scaling' for automatically scaling
+    resources, and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.management
+# Title: 'Amazon Web Services' Management & Governance Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' management and governance services, including 'CloudWatch' application and infrastructure monitoring, 'Auto Scaling' for automatically scaling resources, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'applicationautoscaling_service.R' 'applicationautoscaling_interfaces.R' 'applicationautoscaling_operations.R' 'applicationinsights_service.R' 'applicationinsights_interfaces.R' 'applicationinsights_operations.R' 'autoscaling_service.R' 'autoscaling_interfaces.R' 'autoscaling_operations.R' 'autoscalingplans_service.R' 'autoscalingplans_interfaces.R' 'autoscalingplans_operations.R' 'cloudformation_service.R' 'cloudformation_interfaces.R' 'cloudformation_operations.R' 'cloudtrail_service.R' 'cloudtrail_interfaces.R' 'cloudtrail_operations.R' 'cloudwatch_service.R' 'cloudwatch_interfaces.R' 'cloudwatch_operations.R' 'cloudwatchevents_service.R' 'cloudwatchevents_interfaces.R' 'cloudwatchevents_operations.R' 'cloudwatchlogs_service.R' 'cloudwatchlogs_interfaces.R' 'cloudwatchlogs_operations.R' 'configservice_service.R' 'configservice_interfaces.R' 'configservice_operations.R' 'health_service.R' 'health_interfaces.R' 'health_operations.R' 'licensemanager_service.R' 'licensemanager_interfaces.R' 'licensemanager_operations.R' 'opsworks_service.R' 'opsworks_interfaces.R' 'opsworks_operations.R' 'opsworkscm_service.R' 'opsworkscm_interfaces.R' 'opsworkscm_operations.R' 'organizations_service.R' 'organizations_interfaces.R' 'organizations_operations.R' 'pi_service.R' 'pi_interfaces.R' 'pi_operations.R' 'resourcegroups_service.R' 'resourcegroups_interfaces.R' 'resourcegroups_operations.R' 'resourcegroupstaggingapi_service.R' 'resourcegroupstaggingapi_interfaces.R' 'resourcegroupstaggingapi_operations.R' 'servicecatalog_service.R' 'servicecatalog_interfaces.R' 'servicecatalog_operations.R' 'servicequotas_service.R' 'servicequotas_interfaces.R' 'servicequotas_operations.R' 'ssm_service.R' 'ssm_interfaces.R' 'ssm_operations.R' 'support_service.R' 'support_interfaces.R' 'support_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 23:05:50 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:10:27 UTC

--- a/recipes/r-paws.networking/LICENSE.txt
+++ b/recipes/r-paws.networking/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws.networking/bld.bat
+++ b/recipes/r-paws.networking/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws.networking/build.sh
+++ b/recipes/r-paws.networking/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws.networking/meta.yaml
+++ b/recipes/r-paws.networking/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws.networking
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws.networking_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws.networking/paws.networking_{{ version }}.tar.gz
+  sha256: 927f436fbe820c5688f3fa375a20aa3d01eb868ce90cf85eabe0486a8b521d0a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.common >=0.3.0
+  run:
+    - r-base
+    - r-paws.common >=0.3.0
+
+test:
+  commands:
+    - $R -e "library('paws.networking')"           # [not win]
+    - "\"%R%\" -e \"library('paws.networking')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to 'Amazon Web Services' networking and content delivery services, including
+    'Route 53' Domain Name System service, 'CloudFront' content delivery, load balancing,
+    and more <https://aws.amazon.com/>.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws.networking
+# Title: 'Amazon Web Services' Networking & Content Delivery Services
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to 'Amazon Web Services' networking and content delivery services, including 'Route 53' Domain Name System service, 'CloudFront' content delivery, load balancing, and more <https://aws.amazon.com/>.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.common (>= 0.3.0)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Collate: 'apigateway_service.R' 'apigateway_interfaces.R' 'apigateway_operations.R' 'apigatewaymanagementapi_service.R' 'apigatewaymanagementapi_interfaces.R' 'apigatewaymanagementapi_operations.R' 'apigatewayv2_service.R' 'apigatewayv2_interfaces.R' 'apigatewayv2_operations.R' 'appmesh_service.R' 'appmesh_interfaces.R' 'appmesh_operations.R' 'cloudfront_service.R' 'cloudfront_interfaces.R' 'cloudfront_operations.R' 'directconnect_service.R' 'directconnect_interfaces.R' 'directconnect_operations.R' 'elb_service.R' 'elb_interfaces.R' 'elb_operations.R' 'elbv2_service.R' 'elbv2_interfaces.R' 'elbv2_operations.R' 'globalaccelerator_service.R' 'globalaccelerator_interfaces.R' 'globalaccelerator_operations.R' 'route53_service.R' 'route53_interfaces.R' 'route53_operations.R' 'route53domains_service.R' 'route53domains_interfaces.R' 'route53domains_operations.R' 'route53resolver_service.R' 'route53resolver_interfaces.R' 'route53resolver_operations.R' 'servicediscovery_service.R' 'servicediscovery_interfaces.R' 'servicediscovery_operations.R'
+# NeedsCompilation: no
+# Packaged: 2021-08-22 23:26:04 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-08-23 07:10:18 UTC


### PR DESCRIPTION
follow up from PR #16552 and #16541 

remaining r sub-packages for paws AWS services support - once those are available, I'll get the recipe for the "umbrella" package `paws` uploaded.