### PR TITLE
add "umbrella" package for r-paws.* packages

### DIFF
--- a/recipes/r-paws/LICENSE.txt
+++ b/recipes/r-paws/LICENSE.txt
@@ -1,0 +1,15 @@
+Copyright 2018 David Kretch
+Copyright 2018 Adam Banker
+Copyright 2015 Amazon.com, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/r-paws/bld.bat
+++ b/recipes/r-paws/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paws/build.sh
+++ b/recipes/r-paws/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paws/meta.yaml
+++ b/recipes/r-paws/meta.yaml
@@ -1,0 +1,94 @@
+{% set version = '0.1.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paws
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paws_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paws/paws_{{ version }}.tar.gz
+  sha256: 86334963d000111ca5938aa543205d2cc325c082a27cc5307706845c08f8c14e
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-paws.analytics >=0.1.12
+    - r-paws.application.integration >=0.1.12
+    - r-paws.compute >=0.1.12
+    - r-paws.cost.management >=0.1.12
+    - r-paws.customer.engagement >=0.1.12
+    - r-paws.database >=0.1.12
+    - r-paws.developer.tools >=0.1.12
+    - r-paws.end.user.computing >=0.1.12
+    - r-paws.machine.learning >=0.1.12
+    - r-paws.management >=0.1.12
+    - r-paws.networking >=0.1.12
+    - r-paws.security.identity >=0.1.12
+    - r-paws.storage >=0.1.12
+  run:
+    - r-base
+    - r-paws.analytics >=0.1.12
+    - r-paws.application.integration >=0.1.12
+    - r-paws.compute >=0.1.12
+    - r-paws.cost.management >=0.1.12
+    - r-paws.customer.engagement >=0.1.12
+    - r-paws.database >=0.1.12
+    - r-paws.developer.tools >=0.1.12
+    - r-paws.end.user.computing >=0.1.12
+    - r-paws.machine.learning >=0.1.12
+    - r-paws.management >=0.1.12
+    - r-paws.networking >=0.1.12
+    - r-paws.security.identity >=0.1.12
+    - r-paws.storage >=0.1.12
+
+test:
+  commands:
+    - $R -e "library('paws')"           # [not win]
+    - "\"%R%\" -e \"library('paws')\""  # [win]
+
+about:
+  home: https://github.com/paws-r/paws
+  license: Apache-2.0
+  summary: Interface to Amazon Web Services <https://aws.amazon.com>, including storage, database,
+    and compute services, such as 'Simple Storage Service' ('S3'), 'DynamoDB' 'NoSQL'
+    database, and 'Lambda' functions-as-a-service.
+  license_family: APACHE
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - achimgaedke
+
+# Package: paws
+# Title: Amazon Web Services Software Development Kit
+# Version: 0.1.12
+# Authors@R: c(person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"), person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"), person(given = "Amazon.com, Inc.", role = "cph"))
+# Description: Interface to Amazon Web Services <https://aws.amazon.com>, including storage, database, and compute services, such as 'Simple Storage Service' ('S3'), 'DynamoDB' 'NoSQL' database, and 'Lambda' functions-as-a-service.
+# License: Apache License (>= 2.0)
+# URL: https://github.com/paws-r/paws
+# BugReports: https://github.com/paws-r/paws/issues
+# Imports: paws.analytics (>= 0.1.12), paws.application.integration (>= 0.1.12), paws.compute (>= 0.1.12), paws.cost.management (>= 0.1.12), paws.customer.engagement (>= 0.1.12), paws.database (>= 0.1.12), paws.developer.tools (>= 0.1.12), paws.end.user.computing (>= 0.1.12), paws.machine.learning (>= 0.1.12), paws.management (>= 0.1.12), paws.networking (>= 0.1.12), paws.security.identity (>= 0.1.12), paws.storage (>= 0.1.12)
+# Suggests: testthat
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2021-09-02 23:50:19 UTC; david.kretch
+# Author: David Kretch [aut, cre], Adam Banker [aut], Amazon.com, Inc. [cph]
+# Maintainer: David Kretch <david.kretch@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-09-03 04:50:11 UTC


### PR DESCRIPTION
uses all (sub)packages from PR #16554, #16552 and #16541 - the final recipe for https://paws-r.github.io/

as this recipe is dependent on the previous PR, it is expected to fail initially, needs re-trigger once the PR are successfully merged.