### PR TITLE
Add a recipe for `etuples`

### DIFF
--- a/recipes/etuples/meta.yaml
+++ b/recipes/etuples/meta.yaml
@@ -1,0 +1,40 @@
+{% set version = "0.3.3" %}
+
+package:
+  name: etuples
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/e/etuples/etuples-{{ version }}.tar.gz
+  sha256: 88e10ff8a81b34d4431b48507804f813176df0e90ef31301cd67ec73c2f50e4a
+  patches:
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+  run:
+    - python >=3.6
+    - cons
+    - multipledispatch
+
+test:
+  imports:
+    - etuples
+
+about:
+  home: https://github.com/pythological/etuples
+  license: Apache-2.0
+  summary: Python S-expression emulation using tuple-like objects.
+  license_file: LICENSE
+  dev_url: https://github.com/pythological/etuples
+
+extra:
+  recipe-maintainers:
+    - brandonwillard


### PR DESCRIPTION
This PR adds a recipe for the [`etuples`](https://pypi.org/project/etuples) package.

This recipe has https://github.com/conda-forge/staged-recipes/pull/16568 as a dependency.