### PR TITLE
Add a recipe for miniKanren

### DIFF
--- a/recipes/miniKanren/meta.yaml
+++ b/recipes/miniKanren/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "1.0.2" %}
+
+package:
+  name: minikanren
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/m/miniKanren/miniKanren-{{ version }}.tar.gz
+  sha256: f1c41085ee69803d42ea543f61ad804bcba2e0ab7aa04d50f32d803b4fb7e42e
+  patches:
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+  run:
+    - python >=3.6
+    - toolz
+    - cons >=0.4.0
+    - multipledispatch
+    - etuples >=0.3.1
+    - logical-unification >=0.4.1
+
+test:
+  imports:
+    - kanren
+
+about:
+  home: https://github.com/pythological/kanren
+  license: BSD-3-Clause
+  summary: An extensible, lightweight relational/logic programming DSL written in pure Python
+  license_file: LICENSE.txt
+  dev_url: https://github.com/pythological/kanren
+
+extra:
+  recipe-maintainers:
+    - brandonwillard


### PR DESCRIPTION
This PR adds a recipe for the [miniKanren](https://pypi.org/project/miniKanren/) package.

This recipe has https://github.com/conda-forge/staged-recipes/pull/16568, https://github.com/conda-forge/staged-recipes/pull/16567, and https://github.com/conda-forge/staged-recipes/pull/16569 as dependencies.