### PR TITLE
[FIX] Wrong artifacts path on Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -44,7 +44,7 @@ jobs:
     - script: |
         REM make sure there is a package directory so that artifact publishing works
         setlocal enableextensions
-        if not exist C:\\Miniconda\\conda-bld\\win-64\\ mkdir C:\\Miniconda\\conda-bld\\win-64\\
+        if not exist C:\\bld\\win-64\\ mkdir C:\\bld\\win-64\\
       displayName: Make artifact dir
 
     # Special cased version setting some more things!
@@ -55,5 +55,5 @@ jobs:
 
       displayName: Build recipe
 
-    - publish: C:\\Miniconda\\conda-bld\\win-64\\
+    - publish: C:\\bld\\win-64\\
       artifact: conda_pkgs_win


### PR DESCRIPTION
CONDA_BLD_PATH is set to `C:\bld` but the artifact steps are hardcoding `C:\Miniconda\conda-bld`, which works but generates empty artifacts. 