### PR TITLE
Add partialwrap

### DIFF
--- a/recipes/partialwrap/meta.yaml
+++ b/recipes/partialwrap/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "partialwrap" %}
+{% set version = "1.5" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/partialwrap-{{ version }}.tar.gz
+  sha256: 890dabaff6973dfbdb87ce0c71842a3d60b6e4c13dbccdc514049f718529d410
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools >=42
+    - setuptools_scm >=3.5
+  run:
+    - python >=3.6
+    - numpy
+
+test:
+  imports:
+    - partialwrap
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/mcuntz/partialwrap
+  summary: 'A small Python library providing wrappers for external executables and Python functions so that they can easily be partialised with Pythons functools.partial'
+  dev_url: https://github.com/mcuntz/partialwrap
+  license: MIT
+  license_file: LICENSE
+  description: |
+    partialwrap is a Python library providing easy wrapper functions to use with
+    Python's functools.partial. It allows to use any external executable as well
+    as any Python function with arbitrary arguments and keywords to be used with
+    libraries that call functions simply in the form func(x). This includes the
+    functions of the scipy.optimize package or external packages such as emcee
+    or pyeee, and allows the use of distributed function evaluations with
+    Python's multiprocessing or via mpi4py.
+  doc_url: https://partialwrap.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - mcuntz


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
