### PR TITLE
WIP: Add `ptxcompiler`

### DIFF
--- a/recipes/ptxcompiler/meta.yaml
+++ b/recipes/ptxcompiler/meta.yaml
@@ -1,0 +1,47 @@
+package:
+  name: ptxcompiler
+  version: 0.0.1a1
+
+source:
+  git_url: https://github.com/jakirkham/ptxcompiler
+  git_rev: bld_fixes
+
+build:
+  number: 0
+  skip: true  # [(not linux) or cuda_compiler_version in (undefined, "None")]
+  script:
+    - ln -s "${CUDA_HOME}/lib64/libnvptxcompiler_static.a" "${CONDA_BUILD_SYSROOT}/lib/libnvptxcompiler_static.a"
+    - {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  build:
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+    - {{ compiler("cuda") }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numba >=0.54
+
+test:
+  requires:
+    - pip
+    - pytest
+
+  commands:
+    - pip check
+    - python -c "from ptxcompiler import patch; patch.patch_numba_codegen_if_needed()"
+    - pytest -v --pyargs ptxcompiler
+
+about:
+  home: https://github.com/rapidsai/ptxcompiler
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: PTX Static compiler and Numba patch
+
+extra:
+  recipe-maintainers:
+    - gmarkall
+    - jakirkham


### PR DESCRIPTION
Adds a package for [`ptxcompiler`]( https://github.com/rapidsai/ptxcompiler ). This is needed for CUDA Enhanced Compatibility support with Numba when compiling PTX code.

cc @gmarkall @quasiben

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
