### PR TITLE
Adding Recipe for pytest-grpc

### DIFF
--- a/recipes/pytest-grpc/LICENSE
+++ b/recipes/pytest-grpc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Denis Kataev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pytest-grpc/meta.yaml
+++ b/recipes/pytest-grpc/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "pytest-grpc" %}
+{% set version = "0.8.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pytest-grpc-{{ version }}.tar.gz
+  sha256: 0bd2683ffd34199444d707c0ab01970b22e0afbba6cb1ddb6d578c85ebfe09bd
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - pytest >=3.6.0
+    - python
+
+test:
+  imports:
+    - pytest_grpc
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/pytest-grpc/
+  summary: pytest plugin for grpc
+  license: MIT
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - k-dominik

--- a/recipes/pytest-grpc/meta.yaml
+++ b/recipes/pytest-grpc/meta.yaml
@@ -35,7 +35,7 @@ about:
   home: https://pypi.org/project/pytest-grpc/
   summary: pytest plugin for grpc
   license: MIT
-  license_file: PLEASE_ADD_LICENSE_FILE
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipes/pytest-grpc/meta.yaml
+++ b/recipes/pytest-grpc/meta.yaml
@@ -18,10 +18,10 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6.0
   run:
     - pytest >=3.6.0
-    - python
+    - python >=3.6.0
 
 test:
   imports:

--- a/recipes/pytest-grpc/meta.yaml
+++ b/recipes/pytest-grpc/meta.yaml
@@ -24,8 +24,8 @@ requirements:
     - python >=3.6.0
 
 test:
-  imports:
-    - pytest_grpc
+  commands:
+    - pytest --traceconfig | grep pytest_grpc-{{ version }}
   commands:
     - pip check
   requires:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


Hello dearest Conda-forge team,

I'd like to add a recipe for pytest plugin that allows grpc testing, [pytest-grpc](https://github.com/kataev/pytest-grpc).

LICENSE was added (from [here](https://github.com/kataev/pytest-grpc/blob/3f21554fd821074c2836f65078eaace5c0569c2a/LICENSE)) manually, as current pypi package doesn't contain it.

Cheers!