### PR TITLE
Update link in PR template to specific commit to avoid stale links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,7 +30,7 @@ also consider asking on our [Gitter channel][2] if your recipe isn't reviewed pr
 
 Checklist
 - [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
-- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example/meta.yaml#L57-L66) for an example).
+- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
 - [ ] Source is from official source.
 - [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [ ] If static libraries are linked in, the license of the static library is packaged.


### PR DESCRIPTION
The link is currently showing the 'wrong' part of `meta.yaml`, by referencing a specific commit we avoid this issue.