### PR TITLE
Add changeforest recipe

### DIFF
--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
-    - python
+    - python >=3.7
     - pip
     - maturin
   run:

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -18,11 +18,11 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
   host:
-    - python >=3.7
+    - python
     - pip
     - maturin
   run:
-    - python >=3.7
+    - python
     - numpy
 
 test:

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -17,12 +17,12 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('rust') }}
-    - maturin
   host:
     - python
     - pip
+    - maturin
   run:
-    - python
+    - python >=3.7
     - numpy
 
 test:

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "changeforest" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 630c1e93d6fd08c791e2ab9fc40d5ea4d2f80c980b9abe0485fecae76b6f5992
+  sha256: e17b087297b9d3f5843bc37a7b44e55c229fe93c7c915a3f64a72da1e66ba911
 
 build:
   number: 0
@@ -29,27 +29,22 @@ test:
   imports:
     - changeforest
   requires:
-  # TODO: This depends of testdata, originally in changeforest-py/../testdata, now at
-  # changeforest-py/local_dependencies/changeforest/testdata. Should we copy these around
-  # or fix the tests s.t. they don't depend on the project folder structure?
     - python
     - pip
     - numpy
-    - pytest
+    # - pytest
   commands:
     - pip check
-    - pytest tests
+    # TODO: This depends of testdata, originally in changeforest-py/../testdata, now at
+    # changeforest-py/local_dependencies/changeforest/testdata. Make the testpath
+    # flexible in a future release.
+    # - pytest tests
 
 about:
   home: https://github.com/mlondschien/changeforest
   license: GPL-3.0-or-later
-  # It is strongly encouraged to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
-  # TODO: Add license file to next release.
-  # license_file: LICENSE.txt
+  license_file: LICENSE
   summary: 'Classifier based non-parametric change point detection'
-  # The remaining entries in this section are optional, but recommended.
   description: |
     Change point detection tries to identify times when the probability distribution of a
     stochastic process or time series changes. Existing methods either assume a parametric
@@ -62,7 +57,6 @@ about:
 
     [1] M. Londschien, S. Kovács and P. Bühlmann (2021), "Random Forests and other
     nonparametric classifiers for multivariate change point detection", working paper.
-  # doc_url: TODO
   dev_url: https://github.com/mlondschien/changeforest
 
 extra:

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: https://github.com/mlondschien/changeforest
-  license: BSD-3-clause
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: 'Classifier based non-parametric change point detection'
   description: |

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -1,0 +1,70 @@
+{% set name = "changeforest" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 630c1e93d6fd08c791e2ab9fc40d5ea4d2f80c980b9abe0485fecae76b6f5992
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - maturin
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - changeforest
+  requires:
+  # TODO: This depends of testdata, originally in changeforest-py/../testdata, now at
+  # changeforest-py/local_dependencies/changeforest/testdata. Should we copy these around
+  # or fix the tests s.t. they don't depend on the project folder structure?
+    - python
+    - pip
+    - numpy
+    - pytest
+  commands:
+    - pip check
+    - pytest tests
+
+about:
+  home: https://github.com/mlondschien/changeforest
+  license: GPL-3.0-or-later
+  # It is strongly encouraged to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
+  # TODO: Add license file to next release.
+  # license_file: LICENSE.txt
+  summary: 'Classifier based non-parametric change point detection'
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    Change point detection tries to identify times when the probability distribution of a
+    stochastic process or time series changes. Existing methods either assume a parametric
+    model for within-segment distributions or a based on ranks or distances, and thus fail
+    in scenarios with reasonably large dimensionality.
+
+    `changeforest` implements a classifier based algorithm that consistently estimates
+    change points without any parametric assumptions even in high-dimensional scenarios.
+    See [1] for details.
+
+    [1] M. Londschien, S. Kovács and P. Bühlmann (2021), "Random Forests and other
+    nonparametric classifiers for multivariate change point detection", working paper.
+  # doc_url: TODO
+  dev_url: https://github.com/mlondschien/changeforest
+
+extra:
+  recipe-maintainers:
+    - mlondschien

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -35,7 +35,7 @@ test:
 
 about:
   home: https://github.com/mlondschien/changeforest
-  license: GPL-3.0-or-later
+  license: BSD-3-clause
   license_file: LICENSE
   summary: 'Classifier based non-parametric change point detection'
   description: |

--- a/recipes/changeforest/meta.yaml
+++ b/recipes/changeforest/meta.yaml
@@ -29,16 +29,9 @@ test:
   imports:
     - changeforest
   requires:
-    - python
     - pip
-    - numpy
-    # - pytest
   commands:
     - pip check
-    # TODO: This depends of testdata, originally in changeforest-py/../testdata, now at
-    # changeforest-py/local_dependencies/changeforest/testdata. Make the testpath
-    # flexible in a future release.
-    # - pytest tests
 
 about:
   home: https://github.com/mlondschien/changeforest


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->
TODO:
- [x] Add a license file. Is it sufficient if I do this in a separate release to pypi (adding the file to the source distribution)?
- ~~[ ] _Package does not vendor other packages_: This depends on the rust crate `changeforest`. This is currently not on crates.io as it depends on a non-released version of the rust crate `smartlib`. Currently the rust crate `changeforest` is packaged within the pypi source distribution (built with `pip install . --use-feature="in-tree-build"`). Note that this also includes the R-bindings. Should we remove them? How?~~
- [x] ~~Should we run python tests with `pytest` as part of the build? If so, we need to change test code or copy test data around.~~ Fix this in the original repo in a future release.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example). 
- [x] Source is from official source.
- ~~[ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).~~ See below
- ~~[ ] If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

I am unsure how to handle the licensing. This depends on the `changeforest` crate (same github repo), which has the exact same license as the `changeforest` python package and is part of the tarball. It also depends on rust. Should I include the license of rust somewhere?
@xhochy