### PR TITLE
ENH move image to default to cos7

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -18,7 +18,7 @@ jobs:
 
       export CI=azure
       export CONFIG=linux64
-      export IMAGE_NAME=quay.io/condaforge/linux-anvil-comp7
+      export IMAGE_NAME=quay.io/condaforge/linux-anvil-cos7-x86_64
       export AZURE=True
       .scripts/run_docker_build.sh
 


### PR DESCRIPTION
This will move the default image to cos7, but keep the build using cos6 internally. I have kept the second job that uses a cos7 build for explicit cos7 testing since I think we still need that. 