### PR TITLE
Add recipes for OpenTelemetry C++ packages

### DIFF
--- a/recipes/cpp-opentelemetry-api/bld.bat
+++ b/recipes/cpp-opentelemetry-api/bld.bat
@@ -5,14 +5,13 @@ if errorlevel 1 exit 1
 
 cd build-cpp
 cmake .. ^
-      -GNinja %
-      -DCMAKE_BUILD_TYPE=Release %
-      -DCMAKE_CXX_FLAGS="$CXXFLAGS" %
-      -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% %
-      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %
-      -DBUILD_TESTING=OFF %
-      -DWITH_API_ONLY=ON %
-      -DWITH_ETW=OFF %
+      -GNinja ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DBUILD_TESTING=OFF ^
+      -DWITH_API_ONLY=ON ^
+      -DWITH_ETW=OFF ^
       -DWITH_EXAMPLES=OFF
 
 cmake --build . --config Release --target install

--- a/recipes/cpp-opentelemetry-api/bld.bat
+++ b/recipes/cpp-opentelemetry-api/bld.bat
@@ -1,0 +1,19 @@
+@echo on
+
+mkdir build-cpp
+if errorlevel 1 exit 1
+
+cd build-cpp
+cmake .. ^
+      -GNinja %
+      -DCMAKE_BUILD_TYPE=Release %
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS" %
+      -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% %
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %
+      -DBUILD_TESTING=OFF %
+      -DWITH_API_ONLY=ON %
+      -DWITH_ETW=OFF %
+      -DWITH_EXAMPLES=OFF
+
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/cpp-opentelemetry-api/build.sh
+++ b/recipes/cpp-opentelemetry-api/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -ex
+
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_STANDARD=11"
+
+mkdir -p build-cpp
+pushd build-cpp
+
+cmake ${CMAKE_ARGS} ..  \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DBUILD_TESTING=OFF \
+      -DWITH_API_ONLY=ON \
+      -DWITH_EXAMPLES=OFF
+
+ninja install
+popd

--- a/recipes/cpp-opentelemetry-api/meta.yaml
+++ b/recipes/cpp-opentelemetry-api/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "cpp-opentelemetry-api" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f8fd3adddd47be382dc79c19d7e7efcf86a0dfbb5a237db6e0618dbb7eb8e058
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake >=3.1
+    - ninja
+
+test:
+  commands:
+    - test -d $PREFIX/include/opentelemetry/  # [unix]
+    - if not exist %PREFIX%\\include\\opentelemetry exit 1  # [win]
+
+about:
+  home:
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'The OpenTelemetry C++ Client'
+  description: |
+    OpenTelemetry is a collection of tools, APIs, and SDKs. Use it to
+    instrument, generate, collect, and export telemetry data (metrics,
+    logs, and traces) to help you analyze your software’s performance
+    and behavior.
+  doc_url: https://opentelemetry.io/docs/instrumentation/cpp/
+  dev_url: https://github.com/open-telemetry/opentelemetry-cpp
+
+extra:
+  recipe-maintainers:
+    - lidavidm

--- a/recipes/cpp-opentelemetry-api/meta.yaml
+++ b/recipes/cpp-opentelemetry-api/meta.yaml
@@ -24,7 +24,7 @@ test:
     - if not exist %PREFIX%\\include\\opentelemetry exit 1  # [win]
 
 about:
-  home:
+  home: https://github.com/open-telemetry/opentelemetry-cpp
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/cpp-opentelemetry-api/meta.yaml
+++ b/recipes/cpp-opentelemetry-api/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 test:
   commands:
     - test -d $PREFIX/include/opentelemetry/  # [unix]
-    - if not exist %PREFIX%\\include\\opentelemetry exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\opentelemetry exit 1  # [win]
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-cpp

--- a/recipes/cpp-opentelemetry-api/meta.yaml
+++ b/recipes/cpp-opentelemetry-api/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 test:
   commands:
     - test -d $PREFIX/include/opentelemetry/  # [unix]
-    - if not exist %LIBRARY_INC%\\opentelemetry exit 1  # [win]
+    - if not exist %LIBRARY_INC%\opentelemetry exit 1  # [win]
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-cpp

--- a/recipes/cpp-opentelemetry-api/meta.yaml
+++ b/recipes/cpp-opentelemetry-api/meta.yaml
@@ -26,7 +26,7 @@ test:
 about:
   home:
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: 'The OpenTelemetry C++ Client'
   description: |

--- a/recipes/cpp-opentelemetry-sdk/bld.bat
+++ b/recipes/cpp-opentelemetry-sdk/bld.bat
@@ -3,8 +3,10 @@
 mkdir build-cpp
 if errorlevel 1 exit 1
 
-# Release tarballs do not contain the required Protobuf definitions.
+REM Release tarballs do not contain the required Protobuf definitions.
 robocopy /S /E %LIBRARY_PREFIX%\share\opentelemetry\opentelemetry-proto\opentelemetry .\third_party\opentelemetry-proto\opentelemetry
+REM Stop CMake from trying to git clone the Protobuf definitions.
+mkdir .\third_party\opentelemetry-proto\.git
 
 cd build-cpp
 cmake .. ^

--- a/recipes/cpp-opentelemetry-sdk/bld.bat
+++ b/recipes/cpp-opentelemetry-sdk/bld.bat
@@ -3,6 +3,9 @@
 mkdir build-cpp
 if errorlevel 1 exit 1
 
+# Release tarballs do not contain the required Protobuf definitions.
+robocopy /S /E %CONDA_PREFIX%\share\opentelemetry\opentelemetry-proto\opentelemetry .\third_party\opentelemetry-proto\
+
 cd build-cpp
 cmake .. ^
       -GNinja %

--- a/recipes/cpp-opentelemetry-sdk/bld.bat
+++ b/recipes/cpp-opentelemetry-sdk/bld.bat
@@ -8,15 +8,15 @@ robocopy /S /E %CONDA_PREFIX%\share\opentelemetry\opentelemetry-proto\openteleme
 
 cd build-cpp
 cmake .. ^
-      -GNinja %
-      -DCMAKE_BUILD_TYPE=Release %
-      -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% %
-      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %
-      -DBUILD_TESTING=OFF %
-      -DWITH_API_ONLY=OFF %
-      -DWITH_ETW=OFF %
-      -DWITH_EXAMPLES=OFF %
-      -DWITH_OTLP=ON %
+      -GNinja ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DBUILD_TESTING=OFF ^
+      -DWITH_API_ONLY=OFF ^
+      -DWITH_ETW=OFF ^
+      -DWITH_EXAMPLES=OFF ^
+      -DWITH_OTLP=ON ^
       -DWITH_OTLP_GRPC=ON
 
 cmake --build . --config Release --target install

--- a/recipes/cpp-opentelemetry-sdk/bld.bat
+++ b/recipes/cpp-opentelemetry-sdk/bld.bat
@@ -1,0 +1,21 @@
+@echo on
+
+mkdir build-cpp
+if errorlevel 1 exit 1
+
+cd build-cpp
+cmake .. ^
+      -GNinja %
+      -DCMAKE_BUILD_TYPE=Release %
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS" %
+      -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% %
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %
+      -DBUILD_TESTING=OFF %
+      -DWITH_API_ONLY=OFF %
+      -DWITH_ETW=OFF %
+      -DWITH_EXAMPLES=OFF %
+      -DWITH_OTLP=ON %
+      -DWITH_OTLP_GRPC=ON
+
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/cpp-opentelemetry-sdk/bld.bat
+++ b/recipes/cpp-opentelemetry-sdk/bld.bat
@@ -7,7 +7,6 @@ cd build-cpp
 cmake .. ^
       -GNinja %
       -DCMAKE_BUILD_TYPE=Release %
-      -DCMAKE_CXX_FLAGS="$CXXFLAGS" %
       -DCMAKE_PREFIX_PATH=%CONDA_PREFIX% %
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %
       -DBUILD_TESTING=OFF %

--- a/recipes/cpp-opentelemetry-sdk/bld.bat
+++ b/recipes/cpp-opentelemetry-sdk/bld.bat
@@ -4,7 +4,7 @@ mkdir build-cpp
 if errorlevel 1 exit 1
 
 # Release tarballs do not contain the required Protobuf definitions.
-robocopy /S /E %CONDA_PREFIX%\share\opentelemetry\opentelemetry-proto\opentelemetry .\third_party\opentelemetry-proto\
+robocopy /S /E %LIBRARY_PREFIX%\share\opentelemetry\opentelemetry-proto\opentelemetry .\third_party\opentelemetry-proto\opentelemetry
 
 cd build-cpp
 cmake .. ^

--- a/recipes/cpp-opentelemetry-sdk/build.sh
+++ b/recipes/cpp-opentelemetry-sdk/build.sh
@@ -6,6 +6,8 @@ export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_STANDARD=11"
 
 # Release tarballs do not contain the required Protobuf definitions.
 cp -r $PREFIX/share/opentelemetry/opentelemetry-proto/opentelemetry ./third_party/opentelemetry-proto/
+# Stop CMake from trying to git clone the Protobuf definitions.
+mkdir ./third_party/opentelemetry-proto/.git
 
 mkdir -p build-cpp
 pushd build-cpp

--- a/recipes/cpp-opentelemetry-sdk/build.sh
+++ b/recipes/cpp-opentelemetry-sdk/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CXX_STANDARD=11"
+
+# Release tarballs do not contain the required Protobuf definitions.
+cp -r $PREFIX/share/opentelemetry/opentelemetry-proto/opentelemetry ./third_party/opentelemetry-proto/
+
+mkdir -p build-cpp
+pushd build-cpp
+
+cmake ${CMAKE_ARGS} ..  \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_CXX_FLAGS="$CXXFLAGS" \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DBUILD_TESTING=OFF \
+      -DWITH_API_ONLY=OFF \
+      -DWITH_EXAMPLES=OFF \
+      -DWITH_OTLP=ON \
+      -DWITH_OTLP_GRPC=ON
+
+ninja install
+popd

--- a/recipes/cpp-opentelemetry-sdk/meta.yaml
+++ b/recipes/cpp-opentelemetry-sdk/meta.yaml
@@ -40,7 +40,7 @@ test:
     - if not exist %PREFIX%\\lib\\opentelemetry\\libopentelemetry_exporter_otlp_grpc.lib exit 1  # [win]
 
 about:
-  home:
+  home: https://github.com/open-telemetry/opentelemetry-cpp
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/cpp-opentelemetry-sdk/meta.yaml
+++ b/recipes/cpp-opentelemetry-sdk/meta.yaml
@@ -34,10 +34,10 @@ test:
     - test -d $PREFIX/lib/cmake/opentelemetry-cpp/  # [unix]
     - test -f $PREFIX/lib/libopentelemetry_common.a  # [unix]
     - test -f $PREFIX/lib/libopentelemetry_exporter_otlp_grpc.a  # [unix]
-    - if not exist %PREFIX%\\include\\opentelemetry\\sdk exit 1  # [win]
-    - if not exist %PREFIX%\\lib\\opentelemetry\\cmake\\opentelemetry-cpp exit 1  # [win]
-    - if not exist %PREFIX%\\lib\\opentelemetry\\libopentelemetry_common.lib exit 1  # [win]
-    - if not exist %PREFIX%\\lib\\opentelemetry\\libopentelemetry_exporter_otlp_grpc.lib exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\opentelemetry\\sdk exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\opentelemetry\\cmake\\opentelemetry-cpp exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\opentelemetry\\libopentelemetry_common.lib exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\opentelemetry\\libopentelemetry_exporter_otlp_grpc.lib exit 1  # [win]
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-cpp

--- a/recipes/cpp-opentelemetry-sdk/meta.yaml
+++ b/recipes/cpp-opentelemetry-sdk/meta.yaml
@@ -41,7 +41,7 @@ test:
 about:
   home:
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: 'The OpenTelemetry C++ Client'
   description: |

--- a/recipes/cpp-opentelemetry-sdk/meta.yaml
+++ b/recipes/cpp-opentelemetry-sdk/meta.yaml
@@ -34,10 +34,10 @@ test:
     - test -d $PREFIX/lib/cmake/opentelemetry-cpp/  # [unix]
     - test -f $PREFIX/lib/libopentelemetry_common.a  # [unix]
     - test -f $PREFIX/lib/libopentelemetry_exporter_otlp_grpc.a  # [unix]
-    - if not exist %LIBRARY_INC%\\opentelemetry\\sdk exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\opentelemetry\\cmake\\opentelemetry-cpp exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\opentelemetry\\libopentelemetry_common.lib exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\opentelemetry\\libopentelemetry_exporter_otlp_grpc.lib exit 1  # [win]
+    - if not exist %LIBRARY_INC%\opentelemetry\sdk exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\cmake\opentelemetry-cpp exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\opentelemetry_common.lib exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\opentelemetry_exporter_otlp_grpc.lib exit 1  # [win]
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-cpp

--- a/recipes/cpp-opentelemetry-sdk/meta.yaml
+++ b/recipes/cpp-opentelemetry-sdk/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "cpp-opentelemetry-sdk" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f8fd3adddd47be382dc79c19d7e7efcf86a0dfbb5a237db6e0618dbb7eb8e058
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake >=3.1
+    - ninja
+  host:
+    - grpc-cpp
+    - nlohmann_json
+    - proto-opentelemetry-proto
+    - libprotobuf >=3.18
+    - zlib
+  run:
+    - grpc-cpp
+    - libprotobuf >=3.18
+
+test:
+  commands:
+    - test -d $PREFIX/include/opentelemetry/sdk/  # [unix]
+    - test -d $PREFIX/lib/cmake/opentelemetry-cpp/  # [unix]
+    - test -f $PREFIX/lib/libopentelemetry_common.a  # [unix]
+    - test -f $PREFIX/lib/libopentelemetry_exporter_otlp_grpc.a  # [unix]
+    - if not exist %PREFIX%\\include\\opentelemetry\\sdk exit 1  # [win]
+    - if not exist %PREFIX%\\lib\\opentelemetry\\cmake\\opentelemetry-cpp exit 1  # [win]
+    - if not exist %PREFIX%\\lib\\opentelemetry\\libopentelemetry_common.lib exit 1  # [win]
+    - if not exist %PREFIX%\\lib\\opentelemetry\\libopentelemetry_exporter_otlp_grpc.lib exit 1  # [win]
+
+about:
+  home:
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'The OpenTelemetry C++ Client'
+  description: |
+    OpenTelemetry is a collection of tools, APIs, and SDKs. Use it to
+    instrument, generate, collect, and export telemetry data (metrics,
+    logs, and traces) to help you analyze your software’s performance
+    and behavior.
+  doc_url: https://opentelemetry.io/docs/instrumentation/cpp/
+  dev_url: https://github.com/open-telemetry/opentelemetry-cpp
+
+extra:
+  recipe-maintainers:
+    - lidavidm

--- a/recipes/cpp-opentelemetry-sdk/meta.yaml
+++ b/recipes/cpp-opentelemetry-sdk/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - cmake >=3.1
     - ninja
   host:
+    - cpp-opentelemetry-api
     - grpc-cpp
     - nlohmann_json
     - proto-opentelemetry-proto

--- a/recipes/proto-opentelemetry-proto/bld.bat
+++ b/recipes/proto-opentelemetry-proto/bld.bat
@@ -8,5 +8,5 @@ copy LICENSE %DEST_DIR%
 if %ERRORLEVEL% NEQ 0 exit 1
 
 REM robocopy returns non-zero exit codes on success
-robocopy /S /E opentelemetry\ %DEST_DIR%\
+robocopy /S /E opentelemetry\ %DEST_DIR%\opentelemetry
 if %ERRORLEVEL% GEQ 8 exit 1

--- a/recipes/proto-opentelemetry-proto/bld.bat
+++ b/recipes/proto-opentelemetry-proto/bld.bat
@@ -1,0 +1,11 @@
+@echo on
+
+set DEST_DIR=%LIBRARY_PREFIX%\share\opentelemetry\opentelemetry-proto
+mkdir %DEST_DIR%
+if %ERRORLEVEL% NEQ 0 exit 1
+
+copy LICENSE %DEST_DIR%
+if %ERRORLEVEL% NEQ 0 exit 1
+
+robocopy /S /E opentelemetry\ %DEST_DIR%\
+if %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/proto-opentelemetry-proto/bld.bat
+++ b/recipes/proto-opentelemetry-proto/bld.bat
@@ -7,5 +7,6 @@ if %ERRORLEVEL% NEQ 0 exit 1
 copy LICENSE %DEST_DIR%
 if %ERRORLEVEL% NEQ 0 exit 1
 
+REM robocopy returns non-zero exit codes on success
 robocopy /S /E opentelemetry\ %DEST_DIR%\
-if %ERRORLEVEL% NEQ 0 exit 1
+if %ERRORLEVEL% GEQ 8 exit 1

--- a/recipes/proto-opentelemetry-proto/build.sh
+++ b/recipes/proto-opentelemetry-proto/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -ex
+
+main() {
+    local -r dest_dir="$PREFIX/share/opentelemetry/opentelemetry-proto"
+    mkdir -p "$dest_dir"
+    cp LICENSE "$dest_dir"
+    cp -r opentelemetry/ "$dest_dir"
+}
+
+main

--- a/recipes/proto-opentelemetry-proto/build.sh
+++ b/recipes/proto-opentelemetry-proto/build.sh
@@ -6,7 +6,7 @@ main() {
     local -r dest_dir="$PREFIX/share/opentelemetry/opentelemetry-proto"
     mkdir -p "$dest_dir"
     cp LICENSE "$dest_dir"
-    cp -r opentelemetry/ "$dest_dir"
+    cp -r opentelemetry "$dest_dir/opentelemetry"
 }
 
 main

--- a/recipes/proto-opentelemetry-proto/meta.yaml
+++ b/recipes/proto-opentelemetry-proto/meta.yaml
@@ -28,7 +28,7 @@ test:
 about:
   home: https://github.com/open-telemetry/opentelemetry-proto
   license: Apache-2.0
-  license_family: Apache
+  license_family: APACHE
   license_file: LICENSE
   summary: 'Protobuf definitions for the OpenTelemetry protocol (OTLP)'
   description: |

--- a/recipes/proto-opentelemetry-proto/meta.yaml
+++ b/recipes/proto-opentelemetry-proto/meta.yaml
@@ -22,8 +22,8 @@ test:
   commands:
     - test -f $PREFIX/share/opentelemetry/opentelemetry-proto/LICENSE  # [unix]
     - test -f $PREFIX/share/opentelemetry/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto  # [unix]
-    - if not exist %PREFIX%\\share\\opentelemetry\\opentelemetry-proto\\LICENSE exit 1  # [win]
-    - if not exist %PREFIX%\\share\\opentelemetry\\opentelemetry-proto\\opentelemetry\\proto\\common\\v1\\common.proto exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\share\\opentelemetry\\opentelemetry-proto\\LICENSE exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\share\\opentelemetry\\opentelemetry-proto\\opentelemetry\\proto\\common\\v1\\common.proto exit 1  # [win]
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-proto

--- a/recipes/proto-opentelemetry-proto/meta.yaml
+++ b/recipes/proto-opentelemetry-proto/meta.yaml
@@ -22,8 +22,8 @@ test:
   commands:
     - test -f $PREFIX/share/opentelemetry/opentelemetry-proto/LICENSE  # [unix]
     - test -f $PREFIX/share/opentelemetry/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto  # [unix]
-    - if not exist %PREFIX%\\Library\\share\\opentelemetry\\opentelemetry-proto\\LICENSE exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\share\\opentelemetry\\opentelemetry-proto\\opentelemetry\\proto\\common\\v1\\common.proto exit 1  # [win]
+    - if not exist %PREFIX%\Library\share\opentelemetry\opentelemetry-proto\LICENSE exit 1  # [win]
+    - if not exist %PREFIX%\Library\share\opentelemetry\opentelemetry-proto\opentelemetry\proto\common\v1\common.proto exit 1  # [win]
 
 about:
   home: https://github.com/open-telemetry/opentelemetry-proto

--- a/recipes/proto-opentelemetry-proto/meta.yaml
+++ b/recipes/proto-opentelemetry-proto/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "proto-opentelemetry-proto" %}
+{% set version = "0.11.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/open-telemetry/opentelemetry-proto/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 985367f8905e91018e636cbf0d83ab3f834b665c4f5899a27d10cae9657710e2
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  build:
+  host:
+  run:
+
+test:
+  commands:
+    - test -f $PREFIX/share/opentelemetry/opentelemetry-proto/LICENSE  # [unix]
+    - test -f $PREFIX/share/opentelemetry/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto  # [unix]
+    - if not exist %PREFIX%\\share\\opentelemetry\\opentelemetry-proto\\LICENSE exit 1  # [win]
+    - if not exist %PREFIX%\\share\\opentelemetry\\opentelemetry-proto\\opentelemetry\\proto\\common\\v1\\common.proto exit 1  # [win]
+
+about:
+  home: https://github.com/open-telemetry/opentelemetry-proto
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: 'Protobuf definitions for the OpenTelemetry protocol (OTLP)'
+  description: |
+    OpenTelemetry is a collection of tools, APIs, and SDKs. Use it to
+    instrument, generate, collect, and export telemetry data (metrics,
+    logs, and traces) to help you analyze your software’s performance
+    and behavior.
+  doc_url: https://github.com/open-telemetry/opentelemetry-proto
+  dev_url: https://opentelemetry.io/docs/reference/specification/
+
+extra:
+  recipe-maintainers:
+    - lidavidm


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Adds three packages:

- proto-opentelemetry-proto contains Protobuf definitions for OpenTelemetry (but no code or generated code)
- cpp-opentelemetry-api contains an "api-only" build of the OpenTelemetry C++ SDK (which contains only headers)
- cpp-opentelemetry-sdk contains a build of the OpenTelemetry C++ SDK along with the OTLP gRPC exporter (but no other exporters)

Unfortunately, while it would be best to have individual packages for each exporter, I don't think they can be built separately from the SDK itself.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
