### PR TITLE
Add mapserver

### DIFF
--- a/recipes/mapserver/LICENSE.txt
+++ b/recipes/mapserver/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright (c) 2008-2021 Open Source Geospatial Foundation. Copyright (c) 1996-2008 Regents of the University of Minnesota.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies of this Software or works derived from this Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/mapserver/build.sh
+++ b/recipes/mapserver/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set +x
+
+export PKG_CONFIG_LIBDIR=$PREFIX/lib
+
+mkdir -p build
+cd build
+
+cmake                                                \
+    -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX              \
+    -DWITH_CAIRO=0                                   \
+    -DWITH_CLIENT_WFS=1                              \
+    -DWITH_FCGI=0                                    \
+    -DWITH_FRIBIDI=0                                 \
+    -DWITH_HARFBUZZ=0                                \
+    -DWITH_PHP=0                                     \
+    -DWITH_PROTOBUFC=0                               \
+    -DWITH_PYTHON=1                                  \
+    --debug-output ${SRC_DIR}
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/mapserver/meta.yaml
+++ b/recipes/mapserver/meta.yaml
@@ -1,0 +1,75 @@
+# NB: Lowercase!
+{% set name = "mapserver" %}
+{% set version = "7.6.4" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://download.osgeo.org/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b46c884bc42bd49873806a05325872e4418fc34e97824d4e13d398e86ea474ac
+
+build:
+  number: 0
+  # Any volunteers? :)
+  skip: True  # [win]
+  run_exports:
+    # Presently libmapserver.so.2 is linked to libmapserver.so.x.y.z
+    - {{ pin_subpackage(name, max_pin='x.x.x') }}
+
+requirements:
+  build:
+    - python
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - pkg-config  # [not win]
+  host:
+    - python
+    - pip
+    - freetype
+    - geos=3.10.1
+    - giflib
+    - libcurl
+    - libgdal=3.4.0
+    - libpng
+    - libpq
+    - libxml2
+    - jpeg
+    - postgresql
+    - proj=8.2.0
+    - swig
+  run:
+    - python
+    - freetype
+    - geos
+    - giflib
+    - libcurl
+    - libgdal
+    - libpng
+    - libxml2
+    - jpeg
+    - proj
+
+test:
+  imports:
+    - mapscript
+
+about:
+  home: https://mapserver.org/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'Platform for publishing spatial data and interative mapping.'
+  # The remaining entries in this section are optional, but recommended.
+  description: |
+    MapServer is an Open Source platform for publishing spatial data and
+    interactive mapping applications to the web. MapServer is not a
+    full-featured GIS system, nor does it aspire to be
+  doc_url: https://mapserver.org/documentation.html
+  dev_url: https://github.com/MapServer/MapServer
+
+extra:
+  recipe-maintainers:
+    - akrherz


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

This PR adds Open Source Web Mapping application [Mapserver](https://mapserver.org/).  Mapserver provides a CGI interface used from a web server and a mapscript interface more popular with PHP than python (only python is included here for now :) ).  Some notes on this initial implementation...

1) I struggled with naming this thing and attempting various iterations of sub-packages bundling different parts of mapserver.  There a SO library, some bin/ scripts and the `mapscript` python interface.  I finally settled on a monolith of `mapserver` to hopefully make this most obvious to end-users.
2) I punted on windows for now, I will attempt it once the feedstock is up and running.
3) There's dependency problems still within `conda-forge` and things that touch GDAL.  I have pinned some things down just to get dep solving to work.  I will work to undo this as the bot can help migrate things, etc.  I also continue to actively work to complete the GDAL, GEOS, and proj migrations so to march pinning forward.
4) There's many more options that could be enabled in this build given what conda-forge supports, but I had big time dependency solving troubles, so will need to piecemill it once I can get migrations done.
5) Again with the naming, the python module created is called `mapscript`, but I sort of doubt users would intuitively attempt to `conda install mapscript`, but rather would expect mapserver to be the package name.  If somebody wants to help with splitting things up, I would be happy to work with them.

I am shamelessly pinging @hobu here to see if he has any thoughts on this feedstock creation and if he knows of any others that may be interested in maintaining.  I will ping mapserver-users email list as well after initial feedstock creation.

Thanks for the consideration.