### PR TITLE
adds r-spatialreg

### DIFF
--- a/recipes/r-spatialreg/bld.bat
+++ b/recipes/r-spatialreg/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-spatialreg/build.sh
+++ b/recipes/r-spatialreg/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-spatialreg/meta.yaml
+++ b/recipes/r-spatialreg/meta.yaml
@@ -42,6 +42,8 @@ requirements:
     - r-sf
     - r-spdata
     - r-spdep
+    - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-spatialreg/meta.yaml
+++ b/recipes/r-spatialreg/meta.yaml
@@ -1,0 +1,115 @@
+{% set version = '1.2-1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-spatialreg
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/spatialreg_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/spatialreg/spatialreg_{{ version }}.tar.gz
+  sha256: 4c40b6b331aa8818254633cfb80d4b9a03b2b6fac2c0104b3b99201d447ba081
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-learnbayes
+    - r-mass
+    - r-matrix
+    - r-boot
+    - r-coda
+    - r-expm
+    - r-gmodels
+    - r-nlme
+    - r-sf
+    - r-spdata
+    - r-spdep
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-learnbayes
+    - r-mass
+    - r-matrix
+    - r-boot
+    - r-coda
+    - r-expm
+    - r-gmodels
+    - r-nlme
+    - r-sf
+    - r-spdata
+    - r-spdep
+
+test:
+  commands:
+    - $R -e "library('spatialreg')"           # [not win]
+    - "\"%R%\" -e \"library('spatialreg')\""  # [win]
+
+about:
+  home: https://github.com/r-spatial/spatialreg/, https://r-spatial.github.io/spatialreg/
+  license: GPL-2.0-or-later
+  summary: A collection of all the estimation functions for spatial cross-sectional models (on
+    lattice/areal data using spatial weights matrices) contained up to now in 'spdep',
+    'sphet' and 'spse'. These model fitting functions include maximum likelihood methods
+    for cross-sectional models proposed by 'Cliff' and 'Ord' (1973, ISBN:0850860369)
+    and (1981, ISBN:0850860814), fitting methods initially described by 'Ord' (1975)
+    <doi:10.1080/01621459.1975.10480272>. The models are further described by 'Anselin'
+    (1988) <doi:10.1007/978-94-015-7799-1>. Spatial two stage least squares and spatial
+    general method of moment models initially proposed by 'Kelejian' and 'Prucha' (1998)
+    <doi:10.1023/A:1007707430416> and (1999) <doi:10.1111/1468-2354.00027> are provided.
+    Impact methods and MCMC fitting methods proposed by 'LeSage' and 'Pace' (2009) <doi:10.1201/9781420064254>
+    are implemented for the family of cross-sectional spatial regression models. Methods
+    for fitting the log determinant term in maximum likelihood and MCMC fitting are
+    compared by 'Bivand et al.' (2013) <doi:10.1111/gean.12008>, and model fitting methods
+    by 'Bivand' and 'Piras' (2015) <doi:10.18637/jss.v063.i18>; both of these articles
+    include extensive lists of references. 'spatialreg' >= 1.1-* correspond to 'spdep'
+    >= 1.1-1, in which the model fitting functions are deprecated and pass through to
+    'spatialreg', but will mask those in 'spatialreg'. From versions 1.2-*, the functions
+    will be made defunct in 'spdep'.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: spatialreg
+# Version: 1.2-1
+# Date: 2021-11-10
+# Title: Spatial Regression Analysis
+# Encoding: UTF-8
+# Authors@R: c(person("Roger", "Bivand", role = c("cre", "aut"), email = "Roger.Bivand@nhh.no", comment=c(ORCID="0000-0003-2392-6140")), person(given = "Gianfranco", family = "Piras", role = c("aut"), email = "gpiras@mac.com"), person("Luc", "Anselin", role = "ctb"), person("Andrew", "Bernat", role = "ctb"), person("Eric", "Blankmeyer", role = "ctb"), person("Yongwan", "Chun", role = "ctb"), person("Virgilio", "Gomez-Rubio", role = "ctb"), person("Daniel", "Griffith", role = "ctb"), person("Martin", "Gubri", role = "ctb"), person("Rein", "Halbersma", role = "ctb"), person("James", "LeSage", role = "ctb"), person("Angela", "Li", role = "ctb"), person("Hongfei", "Li", role = "ctb"), person("Jielai", "Ma", role = "ctb"), person("Abhirup", "Mallik", role = c("ctb", "trl")), person("Giovanni", "Millo", role = "ctb"), person("Kelley", "Pace", role = "ctb"), person("Pedro", "Peres-Neto", role = "ctb"), person("Tobias", "Ruttenauer", role = "ctb"), person(given = "Mauricio", family = "Sarrias", role = c("ctb"), email = "mauricio.sarrias@ucn.cl"), person(given = "JuanTomas", family = "Sayago", role = c("ctb"), email = "juantomas.sayago@gmail.com"), person("Michael", "Tiefelsdorf", role = "ctb"))
+# Depends: R (>= 3.3.0), spData, Matrix, sf
+# Imports: spdep, expm, coda, methods, MASS, boot, splines, LearnBayes, nlme, gmodels
+# Suggests: parallel, RSpectra, tmap, foreign, spam, knitr, lmtest, sandwich, rmarkdown, igraph
+# Description: A collection of all the estimation functions for spatial cross-sectional models (on lattice/areal data using spatial weights matrices) contained up to now in 'spdep', 'sphet' and 'spse'. These model fitting functions include maximum likelihood methods for cross-sectional models proposed by 'Cliff' and 'Ord' (1973, ISBN:0850860369) and (1981, ISBN:0850860814), fitting methods initially described by 'Ord' (1975) <doi:10.1080/01621459.1975.10480272>. The models are further described by 'Anselin' (1988) <doi:10.1007/978-94-015-7799-1>. Spatial two stage least squares and spatial general method of moment models initially proposed by 'Kelejian' and 'Prucha' (1998) <doi:10.1023/A:1007707430416> and (1999) <doi:10.1111/1468-2354.00027> are provided. Impact methods and MCMC fitting methods proposed by 'LeSage' and 'Pace' (2009) <doi:10.1201/9781420064254> are implemented for the family of cross-sectional spatial regression models. Methods for fitting the log determinant term in maximum likelihood and MCMC fitting are compared by 'Bivand et al.' (2013) <doi:10.1111/gean.12008>, and model fitting methods by 'Bivand' and 'Piras' (2015) <doi:10.18637/jss.v063.i18>; both of these articles include extensive lists of references. 'spatialreg' >= 1.1-* correspond to 'spdep' >= 1.1-1, in which the model fitting functions are deprecated and pass through to 'spatialreg', but will mask those in 'spatialreg'. From versions 1.2-*, the functions will be made defunct in 'spdep'.
+# License: GPL-2
+# URL: https://github.com/r-spatial/spatialreg/, https://r-spatial.github.io/spatialreg/
+# BugReports: https://github.com/r-spatial/spatialreg/issues/
+# VignetteBuilder: knitr
+# NeedsCompilation: yes
+# RoxygenNote: 6.1.1
+# Packaged: 2021-11-11 13:04:13 UTC; rsb
+# Author: Roger Bivand [cre, aut] (<https://orcid.org/0000-0003-2392-6140>), Gianfranco Piras [aut], Luc Anselin [ctb], Andrew Bernat [ctb], Eric Blankmeyer [ctb], Yongwan Chun [ctb], Virgilio Gomez-Rubio [ctb], Daniel Griffith [ctb], Martin Gubri [ctb], Rein Halbersma [ctb], James LeSage [ctb], Angela Li [ctb], Hongfei Li [ctb], Jielai Ma [ctb], Abhirup Mallik [ctb, trl], Giovanni Millo [ctb], Kelley Pace [ctb], Pedro Peres-Neto [ctb], Tobias Ruttenauer [ctb], Mauricio Sarrias [ctb], JuanTomas Sayago [ctb], Michael Tiefelsdorf [ctb]
+# Maintainer: Roger Bivand <Roger.Bivand@nhh.no>
+# Repository: CRAN
+# Date/Publication: 2021-11-11 14:10:02 UTC

--- a/recipes/r-spatialreg/meta.yaml
+++ b/recipes/r-spatialreg/meta.yaml
@@ -66,7 +66,7 @@ test:
 
 about:
   home: https://github.com/r-spatial/spatialreg/, https://r-spatial.github.io/spatialreg/
-  license: GPL-2.0-or-later
+  license: GPL-2.0-only
   summary: A collection of all the estimation functions for spatial cross-sectional models (on
     lattice/areal data using spatial weights matrices) contained up to now in 'spdep',
     'sphet' and 'spse'. These model fitting functions include maximum likelihood methods


### PR DESCRIPTION
# Overview

Adds the R package `spatialreg` from CRAN as `r-spatialreg`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

Closes #17239

# Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
