### PR TITLE
adds r-rglpk

### DIFF
--- a/recipes/r-rglpk/bld.bat
+++ b/recipes/r-rglpk/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rglpk/build.sh
+++ b/recipes/r-rglpk/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rglpk/meta.yaml
+++ b/recipes/r-rglpk/meta.yaml
@@ -1,0 +1,82 @@
+{% set version = '0.6-4' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rglpk
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/Rglpk_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/Rglpk/Rglpk_{{ version }}.tar.gz
+  sha256: a28dbc3130b9618d6ed2ef718d2c55df8ed8c44a47161097c53fe15fa3bfbfa6
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-slam >=0.1_9
+    - glpk
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-slam >=0.1_9
+    - glpk
+
+test:
+  commands:
+    - $R -e "library('Rglpk')"           # [not win]
+    - "\"%R%\" -e \"library('Rglpk')\""  # [win]
+
+about:
+  home: http://R-Forge.R-project.org/projects/rglp/, http://www.gnu.org/software/glpk/
+  license: GPL-2.0-or-later
+  summary: R interface to the GNU Linear Programming Kit. 'GLPK' is open source software for
+    solving large-scale linear programming (LP), mixed integer linear programming ('MILP')
+    and other related problems.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: Rglpk
+# Version: 0.6-4
+# Title: R/GNU Linear Programming Kit Interface
+# Description: R interface to the GNU Linear Programming Kit. 'GLPK' is open source software for solving large-scale linear programming (LP), mixed integer linear programming ('MILP') and other related problems.
+# Authors@R: c(person("Stefan", "Theussl", role = c("aut", "cre"), email = "Stefan.Theussl@R-project.org"), person("Kurt", "Hornik", role = "aut"), person("Christian", "Buchta", role = "ctb"), person("Florian", "Schwendinger", role = "ctb"), person("Heinrich", "Schuchardt", role = "ctb"))
+# Depends: slam (>= 0.1-9)
+# SystemRequirements: GLPK library package (e.g., libglpk-dev on Debian/Ubuntu)
+# License: GPL-2 | GPL-3
+# URL: http://R-Forge.R-project.org/projects/rglp/, http://www.gnu.org/software/glpk/
+# NeedsCompilation: yes
+# Packaged: 2019-02-08 18:08:20 UTC; theussl
+# Author: Stefan Theussl [aut, cre], Kurt Hornik [aut], Christian Buchta [ctb], Florian Schwendinger [ctb], Heinrich Schuchardt [ctb]
+# Maintainer: Stefan Theussl <Stefan.Theussl@R-project.org>
+# Repository: CRAN
+# Date/Publication: 2019-02-09 15:33:16 UTC

--- a/recipes/r-rglpk/meta.yaml
+++ b/recipes/r-rglpk/meta.yaml
@@ -11,6 +11,8 @@ source:
     - {{ cran_mirror }}/src/contrib/Rglpk_{{ version }}.tar.gz
     - {{ cran_mirror }}/src/contrib/Archive/Rglpk/Rglpk_{{ version }}.tar.gz
   sha256: a28dbc3130b9618d6ed2ef718d2c55df8ed8c44a47161097c53fe15fa3bfbfa6
+  patches:
+    - patches/0001-force-conftest.so.patch
 
 build:
   merge_build_host: True  # [win]

--- a/recipes/r-rglpk/patches/0001-force-conftest.so.patch
+++ b/recipes/r-rglpk/patches/0001-force-conftest.so.patch
@@ -1,0 +1,33 @@
+From 01dfc743be3bef48f79aa615dbbfcb5ad90235c1 Mon Sep 17 00:00:00 2001
+From: Mervin Fansler <mmfansler@gmail.com>
+Date: Wed, 15 Dec 2021 19:30:50 -0500
+Subject: [PATCH] force conftest.so
+
+---
+ configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 8a45474..7cb5fa8 100755
+--- a/configure
++++ b/configure
+@@ -30,14 +30,14 @@ int main ()
+ EOF
+ 
+ _R_SHLIB_BUILD_OBJECTS_SYMBOL_TABLES_=false \
+-  "${R}" CMD SHLIB conftest.cc ${GLPK_LIBS} >/dev/null 2>&1 \
++  "${R}" CMD SHLIB conftest.cc ${GLPK_LIBS} -o conftest.so >/dev/null 2>&1 \
+   && "$R" --slave --vanilla -e 'dyn.load("conftest.so")'
+ status=${?}
+ if test ${status} -ne 0; then
+   rm -f conftest.*o
+   GLPK_LIBS="-lglpk -lgmp -lm"
+   _R_SHLIB_BUILD_OBJECTS_SYMBOL_TABLES_=false \
+-    "${R}" CMD SHLIB conftest.cc ${GLPK_LIBS} >/dev/null 2>&1 \
++    "${R}" CMD SHLIB conftest.cc ${GLPK_LIBS} -o conftest.so >/dev/null 2>&1 \
+     && "$R" --slave --vanilla -e 'dyn.load("conftest.so")'
+   status=${?}
+ fi
+-- 
+2.33.0
+


### PR DESCRIPTION
## Overview

Adds `Rglpk` package from CRAN as `r-rglpk`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper), with addition of `glpk` requirements (`host` and `run`) and adjustment of non-standard `GLP2 | GLP3` license specification to `GPL-2.0-or-later`.

## Related Issue(s)

Provides dependency for #14362 

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
