### PR TITLE
adds r-glpkapi

### DIFF
--- a/recipes/r-glpkapi/bld.bat
+++ b/recipes/r-glpkapi/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-glpkapi/build.sh
+++ b/recipes/r-glpkapi/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-glpkapi/meta.yaml
+++ b/recipes/r-glpkapi/meta.yaml
@@ -49,7 +49,7 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=glpkAPI
-  license: GPL-3
+  license: GPL-3.0-only
   summary: R Interface to C API of GLPK, depends on GLPK Version >= 4.42.
   license_family: GPL3
   license_file:

--- a/recipes/r-glpkapi/meta.yaml
+++ b/recipes/r-glpkapi/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '1.3.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-glpkapi
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/glpkAPI_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/glpkAPI/glpkAPI_{{ version }}.tar.gz
+  sha256: d8635e4c1cc3b6dfdd935c22d4c012f84c423681b7ebe1469cc70a5c71d4731d
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - glpk
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - glpk
+
+test:
+  commands:
+    - $R -e "library('glpkAPI')"           # [not win]
+    - "\"%R%\" -e \"library('glpkAPI')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=glpkAPI
+  license: GPL-3
+  summary: R Interface to C API of GLPK, depends on GLPK Version >= 4.42.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: glpkAPI
+# Type: Package
+# Title: R Interface to C API of GLPK
+# Version: 1.3.3
+# Date: 2021-10-28
+# Authors@R: c(person("Mayo", "Roettger", email = "mayo.roettger@hhu.de", role = "cre"), person("Gabriel", "Gelius-Dietrich", role = "aut", email = "geliudie@uni-duesseldorf.de"), person("Louis", "Luangkesorn", email = "lugerpitt@gmail.com", role = "ctb" ))
+# Depends: R (>= 2.6.0)
+# Imports: methods
+# Description: R Interface to C API of GLPK, depends on GLPK Version >= 4.42.
+# SystemRequirements: GLPK (>= 4.42)
+# License: GPL-3
+# LazyLoad: yes
+# Collate: generics.R glpk_ptrClass.R glpk.R glpkAPI.R zzz.R
+# Packaged: 2021-10-28 12:10:17 UTC; mayo
+# NeedsCompilation: yes
+# Repository: CRAN
+# Date/Publication: 2021-10-28 12:50:02 UTC
+# Author: Mayo Roettger [cre], Gabriel Gelius-Dietrich [aut], Louis Luangkesorn [ctb]
+# Maintainer: Mayo Roettger <mayo.roettger@hhu.de>


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->
## Overview
Adds R package `glpkAPI` from CRAN as `r-glpkapi`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper), with added `glpk` requirement (`host` and `run`).

## Related Issues
This package is a required for #14362.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
