### PR TITLE
Add igwn-auth-utils

### DIFF
--- a/recipes/igwn-auth-utils/meta.yaml
+++ b/recipes/igwn-auth-utils/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "igwn-auth-utils" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0da323ed333bad61bb0a34545b1f97aafc364de2d2c94cfc229132beff2cba9e
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools >=38.2.5
+    - setuptools-scm
+  run:
+    - cryptography
+    - scitokens
+    - python >=3.6
+
+test:
+  requires:
+    - pip
+    - pytest >=3.6.3
+    - requests
+    - requests-mock
+    - safe-netrc
+  commands:
+    - python -m pip check
+    - python -m pytest --pyargs igwn_auth_utils.tests
+
+about:
+  home: https://igwn-auth-utils.readthedocs.io
+  dev_url: https://github.com/duncanmmacleod/igwn-auth-utils.git
+  doc_url: https://igwn-auth-utils.readthedocs.io
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: Authorisation utilities for IGWN
+  description: |
+    Python library functions to simplify using IGWN authorisation credentials.
+
+    This project is primarily aimed at discovering X.509 credentials and
+    SciTokens for use with HTTP(S) requests to IGWN-operated services.
+
+extra:
+  recipe-maintainers:
+    - duncanmmacleod


### PR DESCRIPTION
This PR adds a recipe for igwn-auth-utils, an authn/authz utilities library used by the International Gravitational-Wave Observatory Network (IGWN).

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
