### PR TITLE
WIP: use cuda 11

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -31,7 +31,7 @@ jobs:
   - publish: build_artifacts/noarch/
     artifact: conda_pkgs_noarch
 
-- job: linux_64_cuda_102
+- job: linux_64_cuda_11
   dependsOn: linux_64
   condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
   pool:
@@ -54,18 +54,18 @@ jobs:
       export CI=azure
       export CONFIG=linux64
       if [[ "$(NEED_CENTOS7)" == "1" ]]; then
-        export IMAGE_NAME=quay.io/condaforge/linux-anvil-cos7-cuda:10.2
+        export IMAGE_NAME=quay.io/condaforge/linux-anvil-cos7-cuda:11.0
         export DEFAULT_LINUX_VERSION=cos7
       else
-        export IMAGE_NAME=quay.io/condaforge/linux-anvil-cuda:10.2
+        export IMAGE_NAME=quay.io/condaforge/linux-anvil-cuda:11.0
       fi
       export AZURE=True
-      export CF_CUDA_VERSION="10.2"
+      export CF_CUDA_VERSION="11.0"
       .scripts/run_docker_build.sh
 
-    displayName: Run docker build for CUDA 10.2
+    displayName: Run docker build for CUDA 11.0
   - publish: build_artifacts/linux-64/
-    artifact: conda_pkgs_linux_64_cuda102
+    artifact: conda_pkgs_linux_64_cuda110
 
 - job: linux_64_centos7
   dependsOn: linux_64


### PR DESCRIPTION
Now that https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/2052 is in, opening a PR here in anticipation of https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1708 being finished soon.

Not sure about all the components that might need changing, this is just a draft. I was briefly considering to set the default to CUDA 11.2 (which is where the enhanced cuda compat starts), but went with the oldest-remaining 11.0 for now. Happy to change it either way.

CC @jakirkham