### PR TITLE
adds r-triangle

### DIFF
--- a/recipes/r-triangle/bld.bat
+++ b/recipes/r-triangle/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-triangle/build.sh
+++ b/recipes/r-triangle/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-triangle/meta.yaml
+++ b/recipes/r-triangle/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-triangle
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/triangle_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/triangle/triangle_{{ version }}.tar.gz
+  sha256: 47ba55f67ccd8e2427da0a80e93ada0a4c0a1fbed5cb4e18a07e425f4fa263b3
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('triangle')"           # [not win]
+    - "\"%R%\" -e \"library('triangle')\""  # [win]
+
+about:
+  home: https://bertcarnell.github.io/triangle/
+  license: GPL-2.0-or-later
+  summary: Provides the "r, q, p, and d" distribution functions for the triangle distribution.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: triangle
+# Title: Provides the Standard Distribution Functions for the Triangle Distribution
+# Version: 0.12
+# Authors@R: person(given = "Rob", family = "Carnell", role = c("aut", "cre"), email = "bertcarnell@gmail.com")
+# Description: Provides the "r, q, p, and d" distribution functions for the triangle distribution.
+# License: GPL (>= 2)
+# URL: https://bertcarnell.github.io/triangle/
+# BugReports: https://github.com/bertcarnell/triangle/issues
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 6.1.1
+# Depends: R (>= 2.14.1)
+# Collate: 'dtriangle.R' 'ltriangle.r' 'ptriangle.r' 'qtriangle.R' 'rtriangle.r'
+# Suggests: testthat, knitr, rmarkdown, covr
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2019-02-14 22:56:48 UTC; bertc
+# Author: Rob Carnell [aut, cre]
+# Maintainer: Rob Carnell <bertcarnell@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2019-02-14 23:22:15 UTC


### PR DESCRIPTION
Adds CRAN package `triangle` as `r-triangle`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

# Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
