### PR TITLE
adds r-zipfr

### DIFF
--- a/recipes/r-zipfr/bld.bat
+++ b/recipes/r-zipfr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-zipfr/build.sh
+++ b/recipes/r-zipfr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-zipfr/meta.yaml
+++ b/recipes/r-zipfr/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '0.6-70' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-zipfr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/zipfR_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/zipfR/zipfR_{{ version }}.tar.gz
+  sha256: 0c318569cf5dd13ab5ea22f7cf797a2daeda09d8332d89ba54fd2d7c643ecf96
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('zipfR')"           # [not win]
+    - "\"%R%\" -e \"library('zipfR')\""  # [win]
+
+about:
+  home: https://zipfR.R-Forge.R-project.org/
+  license: GPL-3.0-only
+  summary: Statistical models and utilities for the analysis of word frequency distributions.
+    The utilities include functions for loading, manipulating and visualizing word frequency
+    data and vocabulary growth curves.  The package also implements several statistical
+    models for the distribution of word frequencies in a population.  (The name of this
+    package derives from the most famous word frequency distribution, Zipf's law.)
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: zipfR
+# Type: Package
+# Title: Statistical Models for Word Frequency Distributions
+# Version: 0.6-70
+# Depends: R (>= 3.0.0)
+# Imports: methods, utils, stats, graphics, grDevices, parallel
+# Date: 2020-10-10
+# Author: Stefan Evert <stefan.evert@fau.de>, Marco Baroni <marco.baroni@unitn.it>
+# Maintainer: Stefan Evert <stefan.evert@fau.de>
+# Description: Statistical models and utilities for the analysis of word frequency distributions. The utilities include functions for loading, manipulating and visualizing word frequency data and vocabulary growth curves.  The package also implements several statistical models for the distribution of word frequencies in a population.  (The name of this package derives from the most famous word frequency distribution, Zipf's law.)
+# License: GPL-3
+# URL: https://zipfR.R-Forge.R-project.org/
+# LazyData: yes
+# NeedsCompilation: no
+# Packaged: 2020-10-11 18:25:21 UTC; evert
+# Repository: CRAN
+# Date/Publication: 2020-10-11 19:40:02 UTC


### PR DESCRIPTION
Adds CRAN package `zipfR` as `r-zipfr`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper), modified to conform license to SPDX.

# Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
