### PR TITLE
Add a recipe for `aemcmc`

### DIFF
--- a/recipes/aemcmc/meta.yaml
+++ b/recipes/aemcmc/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.0.1" %}
+
+package:
+  name: aemcmc
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/a/aemcmc/aemcmc-{{ version }}.tar.gz
+  sha256: c3396596814585dad9664aca93ada79ca419ba5ccc4f303c48c4738ae2d18713
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  noarch: python
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+  run:
+    - python >=3.6
+    - numpy >=1.18.1
+    - scipy >=1.4.0
+    - aesara >=2.1.1
+    - aeppl >=0.0.5
+    - polyagamma >=1.3.2
+
+test:
+  imports:
+    - aemcmc
+    - aemcmc.dists
+
+about:
+  home: https://github.com/aesara-devs/aemcmc
+  license: MIT
+  summary: Miscellaneous MCMC samplers written in Aesara
+  license_file: LICENSE
+  dev_url: https://github.com/aesara-devs/aemcmc/
+
+extra:
+  recipe-maintainers:
+    - brandonwillard


### PR DESCRIPTION
This PR adds a recipe for the [`aemcmc` package](https://pypi.org/project/aemcmc).