### PR TITLE
Adding `pipreqsnb` from PyPI

### DIFF
--- a/recipes/pipreqsnb/LICENSE.txt
+++ b/recipes/pipreqsnb/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Ivan Lengyel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/pipreqsnb/meta.yaml
+++ b/recipes/pipreqsnb/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "pipreqsnb" %}
+{% set version = "0.2.4" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pipreqsnb-{{ version }}.tar.gz
+  sha256: ca4306d526ea3ec3cc4fdcf753cae3eaa359b626a4f88ef267badce4bf2efc10
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - pipreqsnb=pipreqsnb.pipreqsnb:main
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - python >=3.6
+    - pipreqs
+
+test:
+  imports:
+    - pipreqsnb
+  commands:
+    - pip check
+    - pipreqsnb --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/ivanlen/pipreqsnb
+  summary: Pipreqs with jupyter notebook support
+  license: MIT
+  license_file: LICENSE.txt
+  # TODO: remove the file "LICENSE.txt" from the recipe 
+  #       once the PR (https://github.com/ivanlen/pipreqsnb/pull/23) 
+  #       to include license file in pypi-source gets merged.
+  description: |
+    This is a very simple fully compatible pipreqs wrapper that 
+    supports python files and jupyter notebooks.
+
+    - All the arguments and options are the same as pipreqs.
+    - pipreqs commands are still valid
+    
+    Please see [pipreqs][_pipreqs] documenation for more information.
+
+    [_pipreqs]: https://github.com/bndr/pipreqs/
+
+  doc_url: https://github.com/ivanlen/pipreqsnb
+  dev_url: https://github.com/ivanlen/pipreqsnb
+
+extra:
+  recipe-maintainers:
+    - sugatoray


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged. `NA`
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
