### PR TITLE
h3-pyspark v1.2.2 update – unpin package versions

### DIFF
--- a/recipes/h3-pyspark/meta.yaml
+++ b/recipes/h3-pyspark/meta.yaml
@@ -19,9 +19,9 @@ requirements:
     - black
   host:
     - pip
-    - python
+    - python >=3.6
   run:
-    - python
+    - python >=3.6
     - pyspark
     - h3-py
     - shapely

--- a/recipes/h3-pyspark/meta.yaml
+++ b/recipes/h3-pyspark/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.0" %}
+{% set version = "1.2.2" %}
 
 package:
   name: h3-pyspark
@@ -14,14 +14,17 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
+  build:
+    - pytest
+    - black
   host:
     - pip
-    - python >=3.6
+    - python
   run:
-    - python >=3.6
-    - pyspark >=3.0.0
-    - h3-py >=3.7.0
-    - shapely >=1.7.0
+    - python
+    - pyspark
+    - h3-py
+    - shapely
 
 test:
   imports:


### PR DESCRIPTION
Resolve internal (corp) package resolution errors by unpinning versions. Tested locally and v1.2.2 on Pypi published via GitHub Actions.