### PR TITLE
adds r-maditr

### DIFF
--- a/recipes/r-maditr/bld.bat
+++ b/recipes/r-maditr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-maditr/build.sh
+++ b/recipes/r-maditr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-maditr/meta.yaml
+++ b/recipes/r-maditr/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = '0.8.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-maditr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/maditr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/maditr/maditr_{{ version }}.tar.gz
+  sha256: f06835f6d4b19cf163d6294ec20b792e6cb320699935635c99cc5ff2df2dafda
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-data.table >=1.12.6
+    - r-magrittr >=1.5
+  run:
+    - r-base
+    - r-data.table >=1.12.6
+    - r-magrittr >=1.5
+
+test:
+  commands:
+    - $R -e "library('maditr')"           # [not win]
+    - "\"%R%\" -e \"library('maditr')\""  # [win]
+
+about:
+  home: https://github.com/gdemin/maditr
+  license: GPL-2.0-or-later
+  summary: Provides pipe-style interface for 'data.table'. Package preserves all 'data.table'
+    features without significant impact on performance. 'let' and 'take' functions are
+    simplified interfaces for most common data manipulation tasks. For example, you
+    can write 'take(mtcars, mean(mpg), by = am)' for aggregation or 'let(mtcars, hp_wt
+    = hp/wt, hp_wt_mpg = hp_wt/mpg)' for modification. Use 'take_if/let_if' for conditional
+    aggregation/modification. Additionally there are some conveniences such as automatic
+    'data.frame' conversion to 'data.table'.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: maditr
+# Type: Package
+# Title: Fast Data Aggregation, Modification, and Filtering with Pipes and 'data.table'
+# Version: 0.8.2
+# Maintainer: Gregory Demin <gdemin@gmail.com>
+# Authors@R: person("Gregory", "Demin", email = "gdemin@gmail.com", role = c("aut", "cre"))
+# Depends: R (>= 3.3.0)
+# Imports: data.table (>= 1.12.6), magrittr (>= 1.5)
+# Suggests: knitr, tinytest, utils, rmarkdown, stats
+# Description: Provides pipe-style interface for 'data.table'. Package preserves all 'data.table' features without significant impact on performance. 'let' and 'take' functions are simplified interfaces for most common data manipulation tasks. For example, you can write 'take(mtcars, mean(mpg), by = am)' for aggregation or 'let(mtcars, hp_wt = hp/wt, hp_wt_mpg = hp_wt/mpg)' for modification. Use 'take_if/let_if' for conditional aggregation/modification. Additionally there are some conveniences such as automatic 'data.frame' conversion to 'data.table'.
+# License: GPL-2
+# URL: https://github.com/gdemin/maditr
+# BugReports: https://github.com/gdemin/maditr/issues
+# VignetteBuilder: knitr
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2021-05-24 19:04:05 UTC; gregory
+# Author: Gregory Demin [aut, cre]
+# Repository: CRAN
+# Date/Publication: 2021-05-24 22:00:02 UTC

--- a/recipes/r-maditr/meta.yaml
+++ b/recipes/r-maditr/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/gdemin/maditr
-  license: GPL-2.0-or-later
+  license: GPL-2.0-only
   summary: Provides pipe-style interface for 'data.table'. Package preserves all 'data.table'
     features without significant impact on performance. 'let' and 'take' functions are
     simplified interfaces for most common data manipulation tasks. For example, you


### PR DESCRIPTION
Adds the CRAN package `maditr` as `r-maditr`. Recipe generated by [`conda_r_skeleton_helper`]().

This package is required for the latest version of `r-expss`. See conda-forge/r-expss-feedstock#2.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
