### PR TITLE
adds r-kit

### DIFF
--- a/recipes/r-kit/bld.bat
+++ b/recipes/r-kit/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-kit/build.sh
+++ b/recipes/r-kit/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-kit/meta.yaml
+++ b/recipes/r-kit/meta.yaml
@@ -34,10 +34,10 @@ requirements:
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
   host:
     - r-base
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-kit/meta.yaml
+++ b/recipes/r-kit/meta.yaml
@@ -1,0 +1,85 @@
+{% set version = '0.0.10' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-kit
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/kit_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/kit/kit_{{ version }}.tar.gz
+  sha256: 8a56c1773c9da21e2814e26c28d1c1f64a876f5aa2b1b6e62dbc3a56d2dffa15
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+  host:
+    - r-base
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+
+test:
+  commands:
+    - $R -e "library('kit')"           # [not win]
+    - "\"%R%\" -e \"library('kit')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=kit
+  license: GPL-3.0-only
+  summary: Basic functions, implemented in C, for large data manipulation. Fast vectorised ifelse()/nested
+    if()/switch() functions, psum()/pprod() functions equivalent to pmin()/pmax() plus
+    others which are missing from base R. Most of these functions are callable at C
+    level.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: kit
+# Type: Package
+# Title: Data Manipulation Functions Implemented in C
+# Version: 0.0.10
+# Date: 2021-11-28
+# Authors@R: c(person("Morgan", "Jacob", role = c("aut", "cre", "cph"), email = "morgan.emailbox@gmail.com"))
+# Author: Morgan Jacob [aut, cre, cph]
+# Maintainer: Morgan Jacob <morgan.emailbox@gmail.com>
+# Description: Basic functions, implemented in C, for large data manipulation. Fast vectorised ifelse()/nested if()/switch() functions, psum()/pprod() functions equivalent to pmin()/pmax() plus others which are missing from base R. Most of these functions are callable at C level.
+# License: GPL-3
+# Depends: R (>= 3.1.0)
+# Encoding: UTF-8
+# BugReports: https://github.com/2005m/kit/issues
+# NeedsCompilation: yes
+# ByteCompile: TRUE
+# Repository: CRAN
+# Packaged: 2021-11-28 11:14:39 UTC; giuliabertuzzi
+# Date/Publication: 2021-11-28 12:10:02 UTC

--- a/recipes/r-kit/meta.yaml
+++ b/recipes/r-kit/meta.yaml
@@ -41,8 +41,6 @@ requirements:
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
 
 test:
   commands:

--- a/recipes/r-kit/meta.yaml
+++ b/recipes/r-kit/meta.yaml
@@ -36,8 +36,7 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - llvm-openmp  # [osx]
-    - libgomp      # [linux]
+    - libgomp  # [linux]
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]


### PR DESCRIPTION
Adds CRAN package `kit` as `r-kit`. Generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper), adjusting license to SPDX and including `openmp` support.

## Related Issues
This is a step toward enabling https://github.com/conda-forge/staged-recipes/issues/17439.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
