### PR TITLE
Adding pdfcrop.pl

### DIFF
--- a/recipes/pdfcrop/meta.yaml
+++ b/recipes/pdfcrop/meta.yaml
@@ -32,7 +32,7 @@ about:
   home: https://github.com/ho-tex/pdfcrop
   license: LPPL-1.3c
   license_family: OTHER
-  license_file: LICENSE
+  license_file: LICENCE
   summary: Calculates the BoundingBox for each page using ghostscript and removes margins.
 
 extra:

--- a/recipes/pdfcrop/meta.yaml
+++ b/recipes/pdfcrop/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "pdfcrop.pl" %}
+{% set version = "1.40" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ho-tex/pdfcrop/archive/v{{ version }}.tar.gz
+  sha256: 592e8e0ba8e462e7364fd43b4d33116b92573658626eb9391b73c46124f64029
+
+build:
+  number: 0
+  noarch: generic
+  script:
+    - cp {{ name }} $PREFIX/bin/
+
+requirements:
+  build:
+    - make
+  host:
+    - perl
+  run:
+    - perl
+    - ghostscript
+
+test:
+  commands:
+    - {{ name }} --version 2>&1 | grep {{ version }}
+
+about:
+  home: https://github.com/ho-tex/pdfcrop
+  license: LPPL-1.3c
+  license_family: LPPL
+  license_file: LICENSE
+  summary: Calculates the BoundingBox for each page using ghostscript and removes margins.
+
+extra:
+  recipe-maintainers:
+    - tdegeus

--- a/recipes/pdfcrop/meta.yaml
+++ b/recipes/pdfcrop/meta.yaml
@@ -31,7 +31,7 @@ test:
 about:
   home: https://github.com/ho-tex/pdfcrop
   license: LPPL-1.3c
-  license_family: LPPL
+  license_family: OTHER
   license_file: LICENSE
   summary: Calculates the BoundingBox for each page using ghostscript and removes margins.
 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Ready for review @conda-forge/help-perl (Windows error acceptable as feedstock is generic)