### PR TITLE
adds r-ggmosaic and r-productplots

### DIFF
--- a/recipes/r-ggmosaic/bld.bat
+++ b/recipes/r-ggmosaic/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ggmosaic/build.sh
+++ b/recipes/r-ggmosaic/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ggmosaic/meta.yaml
+++ b/recipes/r-ggmosaic/meta.yaml
@@ -1,0 +1,90 @@
+{% set version = '0.3.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggmosaic
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggmosaic_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggmosaic/ggmosaic_{{ version }}.tar.gz
+  sha256: fe2e8ba03c5e96be5ba4110fbca2184662ff60f830d562388b6662d096fba1fe
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dplyr
+    - r-ggplot2 >=3.3.0
+    - r-ggrepel
+    - r-plotly >=4.5.5
+    - r-productplots
+    - r-purrr
+    - r-rlang
+    - r-scales
+    - r-tidyr
+  run:
+    - r-base
+    - r-dplyr
+    - r-ggplot2 >=3.3.0
+    - r-ggrepel
+    - r-plotly >=4.5.5
+    - r-productplots
+    - r-purrr
+    - r-rlang
+    - r-scales
+    - r-tidyr
+
+test:
+  commands:
+    - $R -e "library('ggmosaic')"           # [not win]
+    - "\"%R%\" -e \"library('ggmosaic')\""  # [win]
+
+about:
+  home: https://github.com/haleyjeppson/ggmosaic
+  license: GPL-2.0-or-later
+  summary: Mosaic plots in the 'ggplot2' framework. Mosaic plot functionality is provided in
+    a single 'ggplot2' layer by calling the geom 'mosaic'.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: ggmosaic
+# Title: Mosaic Plots in the 'ggplot2' Framework
+# Version: 0.3.3
+# Authors@R: c(person(given = "Haley", family = "Jeppson", role = c("aut", "cre"), email = "hjeppson@iastate.edu"), person(given = "Heike", family = "Hofmann", role = "aut", email = "hofmann@iastate.edu"), person(given = "Di", family = "Cook", role = "aut", email = "dicook@monash.edu"), person(given = "Hadley", family = "Wickham", role = "ctb", email = "hadley@rstudio.com"))
+# Description: Mosaic plots in the 'ggplot2' framework. Mosaic plot functionality is provided in a single 'ggplot2' layer by calling the geom 'mosaic'.
+# License: GPL (>= 2)
+# URL: https://github.com/haleyjeppson/ggmosaic
+# BugReports: https://github.com/haleyjeppson/ggmosaic
+# Depends: ggplot2 (>= 3.3.0), R (>= 3.5.0)
+# Imports: productplots, dplyr, plotly (>= 4.5.5), purrr, rlang, tidyr, ggrepel, scales
+# Suggests: gridExtra, knitr, NHANES, rmarkdown, patchwork
+# VignetteBuilder: knitr
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2021-02-11 18:14:50 UTC; haley
+# Author: Haley Jeppson [aut, cre], Heike Hofmann [aut], Di Cook [aut], Hadley Wickham [ctb]
+# Maintainer: Haley Jeppson <hjeppson@iastate.edu>
+# Repository: CRAN
+# Date/Publication: 2021-02-23 19:50:02 UTC

--- a/recipes/r-productplots/bld.bat
+++ b/recipes/r-productplots/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-productplots/build.sh
+++ b/recipes/r-productplots/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-productplots/meta.yaml
+++ b/recipes/r-productplots/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '0.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-productplots
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/productplots_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/productplots/productplots_{{ version }}.tar.gz
+  sha256: fd0d778924a3afdc9c7c6594f8ef143ca93dcb7e4bf53d3e984e3f8e4133fac5
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-ggplot2
+    - r-plyr
+  run:
+    - r-base
+    - r-ggplot2
+    - r-plyr
+
+test:
+  commands:
+    - $R -e "library('productplots')"           # [not win]
+    - "\"%R%\" -e \"library('productplots')\""  # [win]
+
+about:
+  home: https://github.com/hadley/productplots
+  license: GPL-2.0-only
+  summary: Framework for visualising tables of counts, proportions and probabilities. The framework
+    is called product plots, alluding to the computation of area as a product of height
+    and width, and the statistical concept of generating a joint distribution from the
+    product of conditional and marginal distributions. The framework, with extensions,
+    is sufficient to encompass over 20 visualisations previously described in fields
+    of statistical graphics and 'infovis', including bar charts, mosaic plots, 'treemaps',
+    equal area plots and fluctuation diagrams.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: productplots
+# Title: Product Plots for R
+# Description: Framework for visualising tables of counts, proportions and probabilities. The framework is called product plots, alluding to the computation of area as a product of height and width, and the statistical concept of generating a joint distribution from the product of conditional and marginal distributions. The framework, with extensions, is sufficient to encompass over 20 visualisations previously described in fields of statistical graphics and 'infovis', including bar charts, mosaic plots, 'treemaps', equal area plots and fluctuation diagrams.
+# Version: 0.1.1
+# Authors@R: c( person("Hadley", "Wickham", , "hadley@rstudio.com", c("aut", "cre")), person("Heike", "Hofmann", , "heike.hofmann@gmail.com", role = "aut") )
+# Imports: plyr, ggplot2
+# Suggests: reshape2, testthat, covr
+# License: GPL-2
+# LazyData: true
+# RoxygenNote: 5.0.1
+# URL: https://github.com/hadley/productplots
+# BugReports: https://github.com/hadley/productplots/issues
+# NeedsCompilation: no
+# Packaged: 2016-07-01 21:51:47 UTC; hadley
+# Author: Hadley Wickham [aut, cre], Heike Hofmann [aut]
+# Maintainer: Hadley Wickham <hadley@rstudio.com>
+# Repository: CRAN
+# Date/Publication: 2016-07-02 07:38:04


### PR DESCRIPTION
Adds CRAN packages `ggmosaic` and `productplots` as `r-ggmosaic` and `r-productplots`, respectively. Recipes generated by [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper), adjusting for correct licenses.

Recipes are submitted together since `r-ggmosaic` depends on `r-productplots`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
