### PR TITLE
adds r-distributionutils

### DIFF
--- a/recipes/r-distributionutils/bld.bat
+++ b/recipes/r-distributionutils/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-distributionutils/build.sh
+++ b/recipes/r-distributionutils/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-distributionutils/meta.yaml
+++ b/recipes/r-distributionutils/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = '0.6-0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-distributionutils
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/DistributionUtils_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/DistributionUtils/DistributionUtils_{{ version }}.tar.gz
+  sha256: 7443d6cd154760d55b6954142908eae30385672c4f3f838dd49876ec2f297823
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('fortran') }}        # [not win]
+    - {{ compiler('m2w64_fortran') }}  # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+
+test:
+  commands:
+    - $R -e "library('DistributionUtils')"           # [not win]
+    - "\"%R%\" -e \"library('DistributionUtils')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=DistributionUtils
+  license: GPL-2.0-or-later
+  summary: Utilities are provided which are of use in the packages I have developed for dealing
+    with distributions. Currently these packages are GeneralizedHyperbolic, VarianceGamma,
+    and SkewHyperbolic and NormalLaplace. Each of these packages requires DistributionUtils.
+    Functionality includes sample skewness and kurtosis, log-histogram, tail plots,
+    moments by integration, changing the point about which a moment is calculated, functions
+    for testing distributions using inversion tests and the Massart inequality. Also
+    includes an implementation of the incomplete Bessel K function.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: DistributionUtils
+# Version: 0.6-0
+# Date: 2018-11-26
+# Title: Distribution Utilities
+# Author: David Scott <d.scott@auckland.ac.nz>
+# Maintainer: David Scott <d.scott@auckland.ac.nz>
+# Depends: R (>= 3.0.1)
+# Suggests: GeneralizedHyperbolic, VarianceGamma, SkewHyperbolic, RUnit
+# Encoding: latin1
+# Description: Utilities are provided which are of use in the packages I have developed for dealing with distributions. Currently these packages are GeneralizedHyperbolic, VarianceGamma, and SkewHyperbolic and NormalLaplace. Each of these packages requires DistributionUtils. Functionality includes sample skewness and kurtosis, log-histogram, tail plots, moments by integration, changing the point about which a moment is calculated, functions for testing distributions using inversion tests and the Massart inequality. Also includes an implementation of the incomplete Bessel K function.
+# License: GPL (>= 2)
+# NeedsCompilation: yes
+# Packaged: 2018-11-27 10:02:48 UTC; dsco036
+# Repository: CRAN
+# Date/Publication: 2018-11-27 10:40:06 UTC


### PR DESCRIPTION
Adds CRAN package `DistributionUtils` as `r-distributionutils`. Recipe generated by [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
