### PR TITLE
adds r-generalizedhyperbolic

### DIFF
--- a/recipes/r-generalizedhyperbolic/bld.bat
+++ b/recipes/r-generalizedhyperbolic/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-generalizedhyperbolic/build.sh
+++ b/recipes/r-generalizedhyperbolic/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-generalizedhyperbolic/meta.yaml
+++ b/recipes/r-generalizedhyperbolic/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '0.8-4' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-generalizedhyperbolic
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/GeneralizedHyperbolic_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/GeneralizedHyperbolic/GeneralizedHyperbolic_{{ version }}.tar.gz
+  sha256: 95967156dd694d40654fd5a1f626c866c2525a1e74fd176deb906af7eb76f805
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-distributionutils
+    - r-mass
+  run:
+    - r-base
+    - r-distributionutils
+    - r-mass
+
+test:
+  commands:
+    - $R -e "library('GeneralizedHyperbolic')"           # [not win]
+    - "\"%R%\" -e \"library('GeneralizedHyperbolic')\""  # [win]
+
+about:
+  home: https://r-forge.r-project.org/projects/rmetrics/
+  license: GPL-2.0-or-later
+  summary: Functions for the hyperbolic and related distributions. Density, distribution and
+    quantile functions and random number generation are provided for the hyperbolic
+    distribution, the generalized hyperbolic distribution, the generalized inverse Gaussian
+    distribution and the skew-Laplace distribution. Additional functionality is provided
+    for the hyperbolic distribution, normal inverse Gaussian distribution and generalized
+    inverse Gaussian distribution, including fitting of these distributions to data.
+    Linear models with hyperbolic errors may be fitted using hyperblmFit.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: GeneralizedHyperbolic
+# Version: 0.8-4
+# Date: 2018-05-15
+# Title: The Generalized Hyperbolic Distribution
+# Author: David Scott <d.scott@auckland.ac.nz>
+# Maintainer: David Scott <d.scott@auckland.ac.nz>
+# Depends: R (>= 3.0.1)
+# Imports: DistributionUtils, MASS
+# Suggests: VarianceGamma, actuar, SkewHyperbolic, RUnit
+# Encoding: latin1
+# Description: Functions for the hyperbolic and related distributions. Density, distribution and quantile functions and random number generation are provided for the hyperbolic distribution, the generalized hyperbolic distribution, the generalized inverse Gaussian distribution and the skew-Laplace distribution. Additional functionality is provided for the hyperbolic distribution, normal inverse Gaussian distribution and generalized inverse Gaussian distribution, including fitting of these distributions to data. Linear models with hyperbolic errors may be fitted using hyperblmFit.
+# License: GPL (>= 2)
+# URL: https://r-forge.r-project.org/projects/rmetrics/
+# NeedsCompilation: no
+# Packaged: 2018-05-15 13:49:02 UTC; dsco036
+# Repository: CRAN
+# Date/Publication: 2018-05-15 14:38:15 UTC


### PR DESCRIPTION
Adds CRAN package `GeneralizedHyperbolic` as `r-generalizedhyperbolic`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
