### PR TITLE
Adds NormalLaplace, SkewHyperbolic, and VarianceGamma CRAN packages

### DIFF
--- a/recipes/r-normallaplace/bld.bat
+++ b/recipes/r-normallaplace/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-normallaplace/build.sh
+++ b/recipes/r-normallaplace/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-normallaplace/meta.yaml
+++ b/recipes/r-normallaplace/meta.yaml
@@ -1,0 +1,74 @@
+{% set version = '0.3-0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-normallaplace
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/NormalLaplace_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/NormalLaplace/NormalLaplace_{{ version }}.tar.gz
+  sha256: b04a3c595d9144457e099bc5b956990c96dfe4c9dfd85f962c7e6f2f7a934f5a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-distributionutils
+    - r-generalizedhyperbolic
+  run:
+    - r-base
+    - r-distributionutils
+    - r-generalizedhyperbolic
+
+test:
+  commands:
+    - $R -e "library('NormalLaplace')"           # [not win]
+    - "\"%R%\" -e \"library('NormalLaplace')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=NormalLaplace
+  license: GPL-2.0-or-later
+  summary: Functions for the normal Laplace distribution. The package is under development and
+    provides only limited functionality. Density, distribution and quantile functions,
+    random number generation, and moments are provided.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: NormalLaplace
+# Version: 0.3-0
+# Date: 2018-11-26
+# Title: The Normal Laplace Distribution
+# Author: David Scott <d.scott@auckland.ac.nz>, Jason Shicong Fu and Simon Potter
+# Maintainer: David Scott <d.scott@auckland.ac.nz>
+# Depends: R (>= 3.0.1),
+# Imports: DistributionUtils, GeneralizedHyperbolic
+# Suggests: RUnit
+# Encoding: latin1
+# Description: Functions for the normal Laplace distribution. The package is under development and provides only limited functionality. Density, distribution and quantile functions, random number generation, and moments are provided.
+# License: GPL (>= 2)
+# Repository: CRAN
+# Repository/R-Forge/Project: rmetrics
+# Repository/R-Forge/Revision: 4777
+# Date/Publication: 2018-11-26 12:00:03 UTC
+# Packaged: 2018-11-26 09:08:59 UTC; dsco036
+# NeedsCompilation: no

--- a/recipes/r-skewhyperbolic/bld.bat
+++ b/recipes/r-skewhyperbolic/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-skewhyperbolic/build.sh
+++ b/recipes/r-skewhyperbolic/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-skewhyperbolic/meta.yaml
+++ b/recipes/r-skewhyperbolic/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '0.4-0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-skewhyperbolic
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/SkewHyperbolic_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/SkewHyperbolic/SkewHyperbolic_{{ version }}.tar.gz
+  sha256: 995b31e8e528840b9ff6a1a007bd82c77ad3062677abe50546e3ac97e58a9dae
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-distributionutils
+    - r-generalizedhyperbolic
+  run:
+    - r-base
+    - r-distributionutils
+    - r-generalizedhyperbolic
+
+test:
+  commands:
+    - $R -e "library('SkewHyperbolic')"           # [not win]
+    - "\"%R%\" -e \"library('SkewHyperbolic')\""  # [win]
+
+about:
+  home: https://r-forge.r-project.org/projects/rmetrics/
+  license: GPL-2.0-or-later
+  summary: Functions are provided for the density function, distribution function, quantiles
+    and random number generation for the skew hyperbolic t-distribution. There are also
+    functions that fit the distribution to data. There are functions for the mean, variance,
+    skewness, kurtosis and mode of a given distribution and to calculate moments of
+    any order about any centre. To assess goodness of fit, there are functions to generate
+    a Q-Q plot, a P-P plot and a tail plot.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: SkewHyperbolic
+# Type: Package
+# Version: 0.4-0
+# Date: 2018-11-29
+# Title: The Skew Hyperbolic Student t-Distribution
+# Author: David Scott <d.scott@auckland.ac.nz>, Fiona Grimson
+# Maintainer: David Scott <d.scott@auckland.ac.nz>
+# Depends: R (>= 3.0.1)
+# Imports: grDevices, graphics, stats, DistributionUtils, GeneralizedHyperbolic
+# Suggests: RUnit
+# Encoding: latin1
+# Description: Functions are provided for the density function, distribution function, quantiles and random number generation for the skew hyperbolic t-distribution. There are also functions that fit the distribution to data. There are functions for the mean, variance, skewness, kurtosis and mode of a given distribution and to calculate moments of any order about any centre. To assess goodness of fit, there are functions to generate a Q-Q plot, a P-P plot and a tail plot.
+# License: GPL (>= 2)
+# URL: https://r-forge.r-project.org/projects/rmetrics/
+# NeedsCompilation: no
+# Packaged: 2018-11-29 08:36:00 UTC; dsco036
+# Repository: CRAN
+# Date/Publication: 2018-11-29 09:20:03 UTC

--- a/recipes/r-variancegamma/bld.bat
+++ b/recipes/r-variancegamma/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-variancegamma/build.sh
+++ b/recipes/r-variancegamma/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-variancegamma/meta.yaml
+++ b/recipes/r-variancegamma/meta.yaml
@@ -1,0 +1,75 @@
+{% set version = '0.4-0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-variancegamma
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/VarianceGamma_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/VarianceGamma/VarianceGamma_{{ version }}.tar.gz
+  sha256: 3722cb111fb59924e27017be475a73f69d481128c892aebe695103ebbaaf7b58
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-distributionutils
+    - r-generalizedhyperbolic
+  run:
+    - r-base
+    - r-distributionutils
+    - r-generalizedhyperbolic
+
+test:
+  commands:
+    - $R -e "library('VarianceGamma')"           # [not win]
+    - "\"%R%\" -e \"library('VarianceGamma')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=VarianceGamma
+  license: GPL-2.0-or-later
+  summary: Provides functions for the variance gamma distribution. Density, distribution and
+    quantile functions. Functions for random number generation and fitting of the variance
+    gamma to data. Also, functions for computing moments of the variance gamma distribution
+    of any order about any location. In addition, there are functions for checking the
+    validity of parameters and to interchange different sets of parameterizations for
+    the variance gamma distribution.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: VarianceGamma
+# Version: 0.4-0
+# Date: 2018-11-26
+# Title: The Variance Gamma Distribution
+# Author: David Scott <d.scott@auckland.ac.nz> and Christine Yang Dong <c.dong@auckland.ac.nz>
+# Maintainer: David Scott <d.scott@auckland.ac.nz>
+# Depends: R (>= 3.0.1),
+# Imports: grDevices, graphics, stats, DistributionUtils, GeneralizedHyperbolic
+# Suggests: RUnit
+# Encoding: latin1
+# Description: Provides functions for the variance gamma distribution. Density, distribution and quantile functions. Functions for random number generation and fitting of the variance gamma to data. Also, functions for computing moments of the variance gamma distribution of any order about any location. In addition, there are functions for checking the validity of parameters and to interchange different sets of parameterizations for the variance gamma distribution.
+# License: GPL (>= 2)
+# NeedsCompilation: no
+# Packaged: 2018-11-26 10:49:51 UTC; dsco036
+# Repository: CRAN
+# Date/Publication: 2018-11-26 11:50:04 UTC


### PR DESCRIPTION
Adds CRAN packages `NormalLaplace`, `SkewHyperbolic`, and `VarianceGamma` as `r-normallaplace`, `r-skewhyperbolic`, and `r-variancegamma`, respectively. Recipes generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

I'm submitting multiple recipes in a single PR because they are all probability distribution variants by the same developer. They are all `noarch` (pure R packages), have identical licensing, and common dependencies. Figured we could knock them all out at once.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
