### PR TITLE
adds r-rapidoc

### DIFF
--- a/recipes/r-rapidoc/bld.bat
+++ b/recipes/r-rapidoc/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rapidoc/build.sh
+++ b/recipes/r-rapidoc/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rapidoc/meta.yaml
+++ b/recipes/r-rapidoc/meta.yaml
@@ -1,0 +1,73 @@
+{% set version = '8.4.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rapidoc
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rapidoc_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rapidoc/rapidoc_{{ version }}.tar.gz
+  sha256: 16da468894aee882d2a0a08d18d86334f2eb6d75bbbcc102546abd188508eec4
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-jsonlite
+  run:
+    - r-base
+    - r-jsonlite
+
+test:
+  commands:
+    - $R -e "library('rapidoc')"           # [not win]
+    - "\"%R%\" -e \"library('rapidoc')\""  # [win]
+
+about:
+  home: https://github.com/meztez/rapidoc
+  license: MIT
+  summary: 'A collection of ''HTML'', ''JavaScript'', ''CSS'' and fonts assets that generate
+    ''RapiDoc'' documentation from an ''OpenAPI'' Specification: <https://mrin9.github.io/RapiDoc/>.'
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: rapidoc
+# Type: Package
+# Title: Generates 'RapiDoc' Documentation from an 'OpenAPI' Specification
+# Version: 8.4.3
+# Authors@R: c( person("Bruno", "Tremblay", email = "openr@neoxone.com", role = c("aut", "cre")), person("Barret", "Schloerke", email = "barret@rstudio.com", role = "ctb", comment = c(ORCID = "0000-0001-9986-114X")), person("Mrinmoy", "Majumdar", email = "mrin9@yahoo.com", role = "cph"))
+# Maintainer: Bruno Tremblay <openr@neoxone.com>
+# Description: A collection of 'HTML', 'JavaScript', 'CSS' and fonts assets that generate 'RapiDoc' documentation from an 'OpenAPI' Specification: <https://mrin9.github.io/RapiDoc/>.
+# License: MIT + file LICENSE
+# Imports: jsonlite
+# Suggests: plumber (>= 1.0)
+# Encoding: UTF-8
+# LazyData: true
+# URL: https://github.com/meztez/rapidoc
+# BugReports: https://github.com/meztez/rapidoc/issues
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2021-02-01 03:46:30 UTC; tremb
+# Author: Bruno Tremblay [aut, cre], Barret Schloerke [ctb] (<https://orcid.org/0000-0001-9986-114X>), Mrinmoy Majumdar [cph]
+# Repository: CRAN
+# Date/Publication: 2021-02-05 10:30:05 UTC


### PR DESCRIPTION
Adds CRAN package `rapidoc` as `r-rapidoc`. Generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
