### PR TITLE
adds r-vetiver

### DIFF
--- a/recipes/r-vetiver/bld.bat
+++ b/recipes/r-vetiver/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-vetiver/build.sh
+++ b/recipes/r-vetiver/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-vetiver/meta.yaml
+++ b/recipes/r-vetiver/meta.yaml
@@ -1,0 +1,106 @@
+{% set version = '0.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-vetiver
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/vetiver_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/vetiver/vetiver_{{ version }}.tar.gz
+  sha256: f73b7eb50ce42917aa5fe7dee39a0633d18718ac29cb37e73638198ff9ab6760
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-butcher
+    - r-cli
+    - r-generics
+    - r-glue
+    - r-hardhat
+    - r-httr
+    - r-jsonlite
+    - r-pins >=1.0.0
+    - r-plumber >=1.0.0
+    - r-purrr
+    - r-rapidoc
+    - r-readr >=1.4.0
+    - r-rlang
+    - r-tibble
+    - r-vctrs
+    - r-withr
+  run:
+    - r-base
+    - r-butcher
+    - r-cli
+    - r-generics
+    - r-glue
+    - r-hardhat
+    - r-httr
+    - r-jsonlite
+    - r-pins >=1.0.0
+    - r-plumber >=1.0.0
+    - r-purrr
+    - r-rapidoc
+    - r-readr >=1.4.0
+    - r-rlang
+    - r-tibble
+    - r-vctrs
+    - r-withr
+
+test:
+  commands:
+    - $R -e "library('vetiver')"           # [not win]
+    - "\"%R%\" -e \"library('vetiver')\""  # [win]
+
+about:
+  home: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver
+  license: MIT
+  summary: The goal of 'vetiver' is to provide fluent tooling to version, share, deploy, and
+    monitor a trained model. Functions handle both recording and checking the model's
+    input data prototype, and predicting from a remote API endpoint. The 'vetiver' package
+    is extensible, with generics that can support many kinds of models.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: vetiver
+# Title: Version, Share, Deploy, and Monitor Models
+# Version: 0.1.1
+# Authors@R: c( person("Julia", "Silge", , "julia.silge@rstudio.com", role = c("cre", "aut"), comment = c(ORCID = "0000-0002-3671-836X")), person("RStudio", role = c("cph", "fnd")) )
+# Description: The goal of 'vetiver' is to provide fluent tooling to version, share, deploy, and monitor a trained model. Functions handle both recording and checking the model's input data prototype, and predicting from a remote API endpoint. The 'vetiver' package is extensible, with generics that can support many kinds of models.
+# License: MIT + file LICENSE
+# URL: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver
+# BugReports: https://github.com/tidymodels/vetiver/issues
+# Imports: butcher, cli, generics, glue, hardhat, httr, jsonlite, pins (>= 1.0.0), plumber (>= 1.0.0), purrr, rapidoc, readr (>= 1.4.0), rlang, tibble, vctrs, withr
+# Suggests: caret, covr, knitr, LiblineaR, mlr3, mlr3learners, modeldata, parsnip, ranger, recipes, rmarkdown, rpart, rsconnect, testthat (>= 3.0.0), workflows, xgboost
+# Config/Needs/website: tidyverse/tidytemplate
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# RoxygenNote: 7.1.2
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2022-01-07 17:57:52 UTC; juliasilge
+# Author: Julia Silge [cre, aut] (<https://orcid.org/0000-0002-3671-836X>), RStudio [cph, fnd]
+# Maintainer: Julia Silge <julia.silge@rstudio.com>
+# Repository: CRAN
+# Date/Publication: 2022-01-07 18:10:02 UTC


### PR DESCRIPTION
Adds CRAN package `vetiver` as `r-vetiver`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
