### PR TITLE
Add haesleinhuepf-pyqode.python recipe

### DIFF
--- a/recipes/haesleinhuepf-pyqode.python/meta.yaml
+++ b/recipes/haesleinhuepf-pyqode.python/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "haesleinhuepf-pyqode.python" %}
+{% set version = "2.15.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/haesleinhuepf-pyqode.python-{{ version }}.tar.gz
+  sha256: c9d7e61d1e56ef0a547a380738aac6c4285b7f7cf7e0f09170f3cdde7b5e93b4
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - pyqt_distutils
+    - pytest
+    - python >=3.7
+  run:
+    - docutils
+    - haesleinhuepf-pyqode.core
+    - jedi
+    - pycodestyle
+    - pyflakes
+    - python >=3.7
+
+test:
+  imports:
+    - pyqode
+  commands:
+    - pip list
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/haesleinhuepf/pyqode.python
+  summary: Fork of PyQode, adds python support to pyqode.core, maintained by haesleinhuepf
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - goanpeca
+    - haesleinhuepf

--- a/recipes/haesleinhuepf-pyqode.python/meta.yaml
+++ b/recipes/haesleinhuepf-pyqode.python/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - pycodestyle
     - pyflakes
     - python >=3.7
+  run_constrained:
+    - pyqode.python ==9999999
 
 test:
   imports:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
