### PR TITLE
adds r-matchit

### DIFF
--- a/recipes/r-matchit/bld.bat
+++ b/recipes/r-matchit/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-matchit/build.sh
+++ b/recipes/r-matchit/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-matchit/meta.yaml
+++ b/recipes/r-matchit/meta.yaml
@@ -1,0 +1,91 @@
+{% set version = '4.3.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-matchit
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/MatchIt_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/MatchIt/MatchIt_{{ version }}.tar.gz
+  sha256: 7d7e903a2beeb6891d0de4e3f0209392d76cbaa60af8697592a8f1cde2770cbf
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp >=1.0.7
+    - r-rcppprogress
+    - r-backports >=1.1.9
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp >=1.0.7
+    - r-rcppprogress
+    - r-backports >=1.1.9
+
+test:
+  commands:
+    - $R -e "library('MatchIt')"           # [not win]
+    - "\"%R%\" -e \"library('MatchIt')\""  # [win]
+
+about:
+  home: https://kosukeimai.github.io/MatchIt/, https://github.com/kosukeimai/MatchIt
+  license: GPL-2.0-or-later
+  summary: Selects matched samples of the original treated and control groups with similar covariate
+    distributions -- can be used to match exactly on covariates, to match on propensity
+    scores, or perform a variety of other matching procedures.  The package also implements
+    a series of recommendations offered in Ho, Imai, King, and Stuart (2007) <DOI:10.1093/pan/mpl013>.
+    (The 'gurobi' package, which is not on CRAN, is optional and comes with an installation
+    of the Gurobi Optimizer, available at <https://www.gurobi.com>.)
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: MatchIt
+# Version: 4.3.3
+# Title: Nonparametric Preprocessing for Parametric Causal Inference
+# Description: Selects matched samples of the original treated and control groups with similar covariate distributions -- can be used to match exactly on covariates, to match on propensity scores, or perform a variety of other matching procedures.  The package also implements a series of recommendations offered in Ho, Imai, King, and Stuart (2007) <DOI:10.1093/pan/mpl013>. (The 'gurobi' package, which is not on CRAN, is optional and comes with an installation of the Gurobi Optimizer, available at <https://www.gurobi.com>.)
+# Authors@R: c( person("Daniel", "Ho", email = "daniel.e.ho@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0002-2195-5469")), person("Kosuke", "Imai", email = "imai@harvard.edu", role = c("aut"), comment = c(ORCID = "0000-0002-2748-1022")), person("Gary", "King", email = "king@harvard.edu", role = c("aut"), comment = c(ORCID = "0000-0002-5327-7631")), person("Elizabeth", "Stuart", email = "estuart@jhu.edu", role = c("aut"), comment = c(ORCID = "0000-0002-9042-8611")), person("Alex", "Whitworth", email = "whitworth.alex@gmail.com", role = c("ctb")), person("Noah", "Greifer", role = c("ctb", "cre", "aut"), email = "noah.greifer@gmail.com", comment = c(ORCID="0000-0003-3067-7154")) )
+# Depends: R (>= 3.1.0)
+# Imports: backports (>= 1.1.9), Rcpp (>= 1.0.7)
+# Suggests: optmatch, Matching, rgenoud, nnet, rpart, mgcv, CBPS (>= 0.17), dbarts, randomForest, glmnet (>= 4.0), gbm (>= 2.1.7), cobalt (>= 4.2.3), boot, lmtest, sandwich (>= 2.5-1), survival, RcppProgress (>= 0.4.2), Rglpk, Rsymphony, gurobi, knitr, rmarkdown
+# LinkingTo: Rcpp, RcppProgress
+# SystemRequirements: C++11
+# Encoding: UTF-8
+# LazyData: true
+# License: GPL (>= 2)
+# URL: https://kosukeimai.github.io/MatchIt/, https://github.com/kosukeimai/MatchIt
+# BugReports: https://github.com/kosukeimai/MatchIt/issues
+# VignetteBuilder: knitr
+# NeedsCompilation: yes
+# Packaged: 2022-01-16 08:21:34 UTC; NoahGreifer
+# Author: Daniel Ho [aut] (<https://orcid.org/0000-0002-2195-5469>), Kosuke Imai [aut] (<https://orcid.org/0000-0002-2748-1022>), Gary King [aut] (<https://orcid.org/0000-0002-5327-7631>), Elizabeth Stuart [aut] (<https://orcid.org/0000-0002-9042-8611>), Alex Whitworth [ctb], Noah Greifer [ctb, cre, aut] (<https://orcid.org/0000-0003-3067-7154>)
+# Maintainer: Noah Greifer <noah.greifer@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-01-20 22:52:44 UTC


### PR DESCRIPTION
Adds CRAN package `MatchIt` as `r-matchit`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
