### PR TITLE
Adding dust v0.7.5 (disk usage tool written in rust)

### DIFF
--- a/recipes/dust/bld.bat
+++ b/recipes/dust/bld.bat
@@ -1,0 +1,26 @@
+:: Install cargo-license
+set CARGO_HOME=%BUILD_PREFIX%\cargo
+mkdir %CARGO_HOME%
+icacls %CARGO_HOME% /grant Users:F
+cargo install cargo-license --version 0.3.0 --locked
+:: Check that all downstream libraries licenses are present
+set PATH=%PATH%;%CARGO_HOME%\bin
+cargo-license --json > dependencies.json
+cat dependencies.json
+:: TODO - bundle the licenses
+:: python %RECIPE_DIR%\check_licenses.py
+
+:: build
+cargo install --locked --root "%PREFIX%" --path . || goto :error
+
+:: strip debug symbols
+strip "%PREFIX%\bin\dust.exe" || goto :error
+
+:: remove extra build file
+del /F /Q "%PREFIX%\.crates.toml"
+
+goto :EOF
+
+:error
+echo Failed with error #%errorlevel%.
+exit 1

--- a/recipes/dust/build.sh
+++ b/recipes/dust/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+### Assert licenses are available
+# Install cargo-license
+export CARGO_HOME="$BUILD_PREFIX/cargo"
+mkdir $CARGO_HOME
+cargo install cargo-license --version 0.3.0 --locked
+
+# Check that all downstream libraries licenses are present
+export PATH=$PATH:$CARGO_HOME/bin
+cargo-license --json > dependencies.json
+cat dependencies.json
+# TODO:
+# python $RECIPE_DIR/check_licenses.py
+
+# build statically linked binary with Rust
+cargo install --locked --root "$PREFIX" --path .
+
+# strip debug symbols
+"$STRIP" "$PREFIX/bin/dust"
+
+# remove extra build file
+rm -f "${PREFIX}/.crates.toml"

--- a/recipes/dust/check_licenses.py
+++ b/recipes/dust/check_licenses.py
@@ -1,0 +1,40 @@
+"""Verify that compiled rust dependency licenses are present."""
+
+import os
+import sys
+import json
+import glob
+import os.path as osp
+
+RECIPE_DIR = os.environ['RECIPE_DIR']
+
+BASE_GLOB = '{0}-{1}-license'
+# Output of 'cargo-license --json', generated during build:
+DEPENDENCIES = 'dependencies.json'
+LIBRARY_LICENSES = osp.join(RECIPE_DIR, 'library_licenses')
+# Package license is packaged on the recipe root.
+WHITELIST = {'dust'}
+
+
+def main():
+    deps = json.load(open(DEPENDENCIES, 'r'))
+    missing = []
+    for pkg in deps:
+        pkg_name = pkg['name']
+        repo_url = pkg['repository']
+        pkg_license_type = pkg['license']
+        pkg_glob = BASE_GLOB.format(pkg_name, pkg['version'])
+        matches = glob.glob(osp.join(LIBRARY_LICENSES, pkg_glob))
+        if len(matches) == 0 and pkg_name not in WHITELIST:
+            missing.append((pkg_name, pkg_license_type, repo_url))
+            sys.exit(f"ERROR: Missing {osp.join(LIBRARY_LICENSES, pkg_glob)}")
+    if len(missing) > 0:
+        print('Licenses for the following dependencies are '
+              'not being packaged:')
+        for name, pkg_license, repo in missing:
+            print('* {0} ({1}) -> {2}'.format(name, pkg_license, repo))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/dust/meta.yaml
+++ b/recipes/dust/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = "0.7.5" %}
+
+package:
+  name: dust
+  version: {{ version }}
+
+source:
+  url: https://github.com/bootandy/dust/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: a0e164a04fb3868bae53e0fe386ef22e6f3025a2
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}   # [unix]
+    - m2w64-binutils    # [win]
+
+test:
+  commands:
+    - dust --version
+
+about:
+  home: https://github.com/bootandy/dust
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: Alternative tool to du written in rust
+
+extra:
+  recipe-maintainers:
+    - peterjc

--- a/recipes/dust/meta.yaml
+++ b/recipes/dust/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/bootandy/dust/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: a0e164a04fb3868bae53e0fe386ef22e6f3025a2
+  sha256: f892aaf7a0a7852e12d01b2ced6c2484fb6dc5fe7562abdf0c44a2d08aa52618
 
 build:
   number: 0


### PR DESCRIPTION
If this works, it would supersede #15655 by @asafkahlon who is most welcome to be a co-maintainer.

The build scripts etc are based on https://github.com/conda-forge/sd-feedstock/tree/master/recipe by @jonashaag who is again welcome to be a co-maintainer. However, the PR does not yet include the licenses of all the dependencies included in the static binary compiled by rust, see script ``check_licenses.py`` and:

```
$ cargo-license --json | sort | grep '"name":' -c
59
```

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
