### PR TITLE
adds r-tidygate

### DIFF
--- a/recipes/r-tidygate/bld.bat
+++ b/recipes/r-tidygate/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tidygate/build.sh
+++ b/recipes/r-tidygate/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tidygate/meta.yaml
+++ b/recipes/r-tidygate/meta.yaml
@@ -1,0 +1,101 @@
+{% set version = '0.4.9' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tidygate
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/tidygate_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/tidygate/tidygate_{{ version }}.tar.gz
+  sha256: 4e63660cfcad9f251f06b4d755b538066fa9e31aed72fe0f87a999e33af9427f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcolorbrewer
+    - r-dplyr
+    - r-lifecycle
+    - r-magrittr
+    - r-purrr
+    - r-rlang
+    - r-scales
+    - r-stringr
+    - r-tibble
+    - r-tidyr
+    - r-viridis
+  run:
+    - r-base
+    - r-rcolorbrewer
+    - r-dplyr
+    - r-lifecycle
+    - r-magrittr
+    - r-purrr
+    - r-rlang
+    - r-scales
+    - r-stringr
+    - r-tibble
+    - r-tidyr
+    - r-viridis
+
+test:
+  commands:
+    - $R -e "library('tidygate')"           # [not win]
+    - "\"%R%\" -e \"library('tidygate')\""  # [win]
+
+about:
+  home: https://github.com/stemangiola/tidygate
+  license: GPL-3.0-only
+  summary: It interactively or programmatically label points within custom gates on two dimensions
+    <https://github.com/stemangiola/tidygate>. The information is added to your tibble.
+    It is based on the package 'gatepoints' from Wajid Jawaid (who is also author of
+    this package). The code of 'gatepoints' was nto integrated in 'tidygate'. The benefits
+    are (i) in interactive mode you can draw your gates on extensive 'ggplot'-like scatter
+    plots; (ii) you can draw multiple gates; and (iii) you can save your gates and apply
+    the programmatically.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: tidygate
+# Type: Package
+# Title: Add Gate Information to Your Tibble
+# Version: 0.4.9
+# Authors@R: c(person(given = "Stefano", family = "Mangiola", role = c("aut", "cre"), email = "mangiolastefano@gmail.com"), person(given = "Wajid", family = "Jawaid", role = "ctb"))
+# Maintainer: Stefano Mangiola <mangiolastefano@gmail.com>
+# Description: It interactively or programmatically label points within custom gates on two dimensions <https://github.com/stemangiola/tidygate>. The information is added to your tibble. It is based on the package 'gatepoints' from Wajid Jawaid (who is also author of this package). The code of 'gatepoints' was nto integrated in 'tidygate'. The benefits are (i) in interactive mode you can draw your gates on extensive 'ggplot'-like scatter plots; (ii) you can draw multiple gates; and (iii) you can save your gates and apply the programmatically.
+# License: GPL-3
+# Depends: R (>= 3.6.0)
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.1.2
+# Imports: utils, graphics, lifecycle, scales, magrittr, tibble, dplyr, purrr, rlang, tidyr, viridis, grDevices, RColorBrewer, stringr
+# RdMacros: lifecycle
+# Suggests: testthat, markdown, knitr
+# VignetteBuilder: knitr
+# Biarch: true
+# URL: https://github.com/stemangiola/tidygate
+# BugReports: https://github.com/stemangiola/tidygate/issues
+# NeedsCompilation: no
+# Packaged: 2022-01-20 12:07:21 UTC; mangiola.s
+# Author: Stefano Mangiola [aut, cre], Wajid Jawaid [ctb]
+# Repository: CRAN
+# Date/Publication: 2022-01-20 12:40:02 UTC


### PR DESCRIPTION
Adds CRAN package `tidygate` as `r-tidygate`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
