### PR TITLE
Add wheel-inspect recipe and required dependencies

### DIFF
--- a/recipes/entry-points-txt/meta.yaml
+++ b/recipes/entry-points-txt/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "entry-points-txt" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/entry-points-txt-{{ version }}.tar.gz
+  sha256: b3e4e976b8c18f479ecad42594cac8d75e42293e8ba9e3f4892d927b02099e6a
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - python >=3.6
+
+test:
+  imports:
+    - entry_points_txt
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/jwodder/entry-points-txt
+  summary: Read & write entry_points.txt files
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - beenje

--- a/recipes/headerparser/meta.yaml
+++ b/recipes/headerparser/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "headerparser" %}
+{% set version = "0.4.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/headerparser-{{ version }}.tar.gz
+  sha256: b8ceae4c5e6133fda666d022684e93f9b3d45815c2c7881018123c71ff28c5cc
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - python >=3.6
+    - six >=1.1
+
+test:
+  imports:
+    - headerparser
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/jwodder/headerparser
+  summary: argparse for mail-style headers
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - beenje

--- a/recipes/wheel-inspect/meta.yaml
+++ b/recipes/wheel-inspect/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "wheel-inspect" %}
+{% set version = "1.7.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/wheel-inspect-{{ version }}.tar.gz
+  sha256: e3a930c841e1d6d233fd2d213ee6ce07e990006a32d73b0f89937b539db26af6
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  entry_points:
+    - wheel2json = wheel_inspect.__main__:main
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+  run:
+    - attrs >=18.1
+    - entry-points-txt >=0.1.0
+    - headerparser >=0.4.0
+    - packaging >=17.1
+    - python >=3.6
+    - readme_renderer >=24.0
+    - wheel-filename >=1.1
+
+test:
+  imports:
+    - wheel_inspect
+
+about:
+  home: https://github.com/jwodder/wheel-inspect
+  summary: Extract information from wheels
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - beenje


### PR DESCRIPTION
Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


Add wheel-inspect recipe as well as 2 needed dependencies (entry-points-txt and headerparser)

I think the original package is too strict on some dependencies:
```
entry-points-txt ~= 0.1.0
headerparser     ~= 0.4.0
```

I didn't put any upper limits.
The `wheel2json` entry point doesn't have any `--help` so I don't test it.