### PR TITLE
PROD turn off GitHub actions for now

### DIFF
--- a/.travis_scripts/create_feedstocks.py
+++ b/.travis_scripts/create_feedstocks.py
@@ -313,6 +313,7 @@ if __name__ == '__main__':
                 subprocess.check_call(
                     ['conda', 'smithy', 'rotate-binstar-token',
                      '--without-appveyor', '--without-azure',
+                     "--without-github-actions",
                      '--token_name', 'STAGING_BINSTAR_TOKEN'],
                     cwd=feedstock_dir)
 


### PR DESCRIPTION
This pr turns off the failing ci bits for GitHub actions. We’ll have to roll out this token anyways and we can use a global secret. Thus we do not need. 

cc @isuruf 