### PR TITLE
adds r-lifecontingencies

### DIFF
--- a/recipes/r-lifecontingencies/bld.bat
+++ b/recipes/r-lifecontingencies/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-lifecontingencies/build.sh
+++ b/recipes/r-lifecontingencies/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-lifecontingencies/meta.yaml
+++ b/recipes/r-lifecontingencies/meta.yaml
@@ -1,0 +1,90 @@
+{% set version = '1.3.8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-lifecontingencies
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/lifecontingencies_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/lifecontingencies/lifecontingencies_{{ version }}.tar.gz
+  sha256: f0f29276ffb687fbfa803573a6ba0738786f8e05ab1000683f88a3d426db3461
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp >=0.12.18
+    - r-markovchain
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp >=0.12.18
+    - r-markovchain
+
+test:
+  commands:
+    - $R -e "library('lifecontingencies')"           # [not win]
+    - "\"%R%\" -e \"library('lifecontingencies')\""  # [win]
+
+about:
+  home: https://github.com/spedygiorgio/lifecontingencies
+  license: MIT
+  summary: "Classes and methods that allow the user to manage life table, actuarial tables (also
+    multiple decrements tables). Moreover, functions to easily perform demographic,
+    financial and actuarial mathematics on life contingencies insurances calculations
+    are contained therein. See Spedicato (2013)\t<doi:10.18637/jss.v055.i10>."
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: lifecontingencies
+# Type: Package
+# Title: Financial and Actuarial Mathematics for Life Contingencies
+# Version: 1.3.8
+# Authors@R: c(person("Giorgio Alfredo", "Spedicato", role = c("aut", "cre"), email = "spedicato_giorgio@yahoo.it",comment = c(ORCID = "0000-0002-0315-8888")), person("Christophe", "Dutang", role = "ctb",comment = c(ORCID = "0000-0001-6732-1501")), person("Reinhold", "Kainhofer", role = "ctb",comment = c(ORCID = "0000-0002-7895-1311")), person("Kevin J", "Owens", role = "ctb"), person("Ernesto", "Schirmacher", role = "ctb"), person("Gian Paolo", "Clemente", role = "ctb",comment = c(ORCID = "0000-0001-6795-4595")), person("Ivan", "Williams", role = "ctb") )
+# Maintainer: Giorgio Alfredo Spedicato <spedicato_giorgio@yahoo.it>
+# Description: Classes and methods that allow the user to manage life table, actuarial tables (also multiple decrements tables). Moreover, functions to easily perform demographic, financial and actuarial mathematics on life contingencies insurances calculations are contained therein. See Spedicato (2013)	<doi:10.18637/jss.v055.i10>.
+# Depends: R (>= 3.5), methods
+# Imports: parallel, utils, markovchain, Rcpp (>= 0.12.18), stats
+# Suggests: demography, forecast, testthat, knitr, formatR, StMoMo, rmarkdown
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# LazyLoad: yes
+# LazyData: true
+# BugReports: https://github.com/spedygiorgio/lifecontingencies/issues
+# BuildVignettes: yes
+# VignetteBuilder: utils, knitr
+# URL: https://github.com/spedygiorgio/lifecontingencies
+# LinkingTo: Rcpp
+# RoxygenNote: 7.1.2
+# NeedsCompilation: yes
+# Packaged: 2022-01-03 14:15:01 UTC; giorgio
+# Author: Giorgio Alfredo Spedicato [aut, cre] (<https://orcid.org/0000-0002-0315-8888>), Christophe Dutang [ctb] (<https://orcid.org/0000-0001-6732-1501>), Reinhold Kainhofer [ctb] (<https://orcid.org/0000-0002-7895-1311>), Kevin J Owens [ctb], Ernesto Schirmacher [ctb], Gian Paolo Clemente [ctb] (<https://orcid.org/0000-0001-6795-4595>), Ivan Williams [ctb]
+# Repository: CRAN
+# Date/Publication: 2022-01-07 13:53:00 UTC


### PR DESCRIPTION
Adds [CRAN package `lifecontingencies`](https://cran.r-project.org/package=lifecontingencies) as `r-lifecontingencies`. Recipe generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
