### PR TITLE
Add recipe for dirty-equals

### DIFF
--- a/recipes/dirty-equals/meta.yaml
+++ b/recipes/dirty-equals/meta.yaml
@@ -37,6 +37,7 @@ about:
   summary: Doing dirty (but extremely useful) things with equals.
   license: MIT
   license_file: LICENSE
+  dev_url: https://github.com/samuelcolvin/dirty-equals
 
 extra:
   recipe-maintainers:

--- a/recipes/dirty-equals/meta.yaml
+++ b/recipes/dirty-equals/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "dirty-equals" %}
+{% set version = "0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dirty-equals-{{ version }}.tar.gz
+  sha256: dfb852ef7e69b8bc74a6d58990b1e9b516e827f3e68099fb637f9abe0a94a34f
+
+build:
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - poetry
+    - python    
+  run:
+    - python
+    - pytz >=2021.3,<2022.0
+    - typing-extensions >=4.0.1,<5.0.0  # [py<38]
+
+test:
+  imports:
+    - dirty_equals
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://dirty-equals.helpmanual.io
+  summary: Doing dirty (but extremely useful) things with equals.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - nicoddemus


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
