### PR TITLE
Add CPL recipe

### DIFF
--- a/recipes/cpl/build.sh
+++ b/recipes/cpl/build.sh
@@ -7,6 +7,7 @@
 env LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}" \
   ./configure --prefix=${PREFIX}
 make
+make check
 make install
 
 # The build produces some libtool `.la` files. Remove them. See

--- a/recipes/cpl/build.sh
+++ b/recipes/cpl/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# CPL's custom M4 macro that detects FFTW needs to find its shared library.
+# Putting the lib path directly in LD_LIBRARY_PATH does the trick,
+# and is actually recommended by the CPL documentation,
+# https://ftp.eso.org/pub/dfs/pipelines/libraries/cpl/docs/cpl-user-manual_6.0.pdf
+env LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}" \
+  ./configure --prefix=${PREFIX}
+make
+make install
+
+# https://github.com/conda-forge/conda-forge.github.io/issues/621
+find ${PREFIX} -name '*.la'

--- a/recipes/cpl/build.sh
+++ b/recipes/cpl/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # CPL's custom M4 macro that detects FFTW needs to find its shared library.
 # Putting the lib path directly in LD_LIBRARY_PATH does the trick,
@@ -9,5 +9,6 @@ env LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}" \
 make
 make install
 
+# The build produces some libtool `.la` files. Remove them. See
 # https://github.com/conda-forge/conda-forge.github.io/issues/621
-find ${PREFIX} -name '*.la'
+find ${PREFIX} -name '*.la' -delete

--- a/recipes/cpl/meta.yaml
+++ b/recipes/cpl/meta.yaml
@@ -29,9 +29,15 @@ requirements:
     - fftw
     - wcslib
   run:
-    - cfitsio
-    - fftw
+    # wcslib has no run_exports
     - wcslib
+    # libcurl is not a direct dependency of CPL, but libtool links CPL to it because
+    # pkg-config detects libcurl, probably due to this cfitsio recipe patch:
+    # https://github.com/conda-forge/cfitsio-feedstock/blob/master/recipe/lcurl-pkg-config.patch
+    # If we were to manually tell libtool not to do so, libtool links to libnsl.
+    # So we either need to include libnsl here and do some funky replacements
+    # in all the Makefiles, or just include libcurl here.
+    - libcurl
 
 test:
   commands:
@@ -40,7 +46,7 @@ test:
 
 about:
   home: https://www.eso.org/sci/software/cpl/
-  license: GPL-2.0-only
+  license: GPL-2.0-or-later
   license_family: GPL
   license_file: COPYING
   summary: 'A software toolkit to develop astronomical data-reduction tasks'
@@ -58,3 +64,4 @@ about:
 extra:
   recipe-maintainers:
     - teake
+    - hugobuddel

--- a/recipes/cpl/meta.yaml
+++ b/recipes/cpl/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "cpl" %}
+{% set version = "7.1.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://ftp.eso.org/pub/dfs/pipelines/libraries//{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: cb43adba7ab15e315fbfcba4e2d8b88fa56d29a5a16036a7f082621b8416bd6c
+
+build:
+  number: 0
+  skip: True  # [win or osx]
+  run_exports:
+    # The ABI doesn't seem to change for minor or patch release,
+    # https://abi-laboratory.pro/?view=timeline&l=cpl.
+    # So we pin only major releases.
+    - {{ pin_compatible('cpl', max_pin='x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - make
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+  host:
+    - cfitsio
+    - fftw
+    - wcslib
+  run:
+    - cfitsio
+    - fftw
+    - wcslib
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libcplcore{{ SHLIB_EXT }}
+    - test -f ${PREFIX}/lib/libcplui{{ SHLIB_EXT }}
+
+about:
+  home: https://www.eso.org/sci/software/cpl/
+  license: GPL-2.0-only
+  license_family: GPL
+  license_file: COPYING
+  summary: 'A software toolkit to develop astronomical data-reduction tasks'
+  description: |
+    The Common Pipeline Library (CPL) comprises a set of ISO-C libraries 
+    that provide a comprehensive, efficient and robust software toolkit 
+    to develop astronomical data-reduction tasks (known as "recipes"). 
+    These data-reduction tasks can then be executed manually by a user, 
+    or can be triggered in an automated data-reduction framework (known
+    as "pipelines") which are used at ESO to monitor the health status
+    of VLT instruments, for quick-look data processing at the observatory, 
+    and the creation of data products available from the ESO archive facility.
+  doc_url: https://www.eso.org/sci/software/cpl/documentation.html
+
+extra:
+  recipe-maintainers:
+    - teake


### PR DESCRIPTION
@conda-forge/help-c-cpp

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

**Question**

~~Libtool somehow wants to link to `libcurl` (see output below), but that is not a direct dependency of CPL. It is a dependency of `cfitsio`. This should not be problematic since `libcurl` will be installed when installing CPL, but I'd rather stop the overlinking. How do I do this?~~

Edit: I've resolved the overlinking by explicitly adding libcurl as a runtime dependency.

<details>

Conda build output before adding libcurl as a dependency:

```
   INFO: sysroot: '/opt/conda/conda-bld/cpl_1646047462161/_build_env/x86_64-conda-linux-gnu/sysroot/' files: '['/opt/conda/conda-bld/cpl_1646047462161/_build_env/x86_64-conda-linux-gnu/sysroot/usr/share/zoneinfo/zone.tab', '/opt/conda/conda-bld/cpl_1646047462161/_build_env/x86_64-conda-linux-gnu/sysroot/usr/share/zoneinfo/tzdata.zi', '/opt/conda/conda-bld/cpl_1646047462161/_build_env/x86_64-conda-linux-gnu/sysroot/usr/share/zoneinfo/right/Zulu', '/opt/conda/conda-bld/cpl_1646047462161/_build_env/x86_64-conda-linux-gnu/sysroot/usr/share/zoneinfo/right/WET']'
   INFO (cpl,lib/libcpldfs.so.26.1.4): lib/libcplui.so.26 found in this package
   INFO (cpl,lib/libcpldfs.so.26.1.4): lib/libcplcore.so.26 found in this package
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO lib/libfftw3.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO lib/libfftw3f.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO lib/libcfitsio.so.9 found in conda-forge::cfitsio-4.0.0-h9a35b8e_0
WARNING (cpl,lib/libcpldfs.so.26.1.4): Needed DSO lib/libcurl.so.4 found in ['libcurl']
WARNING (cpl,lib/libcpldfs.so.26.1.4): .. but ['libcurl'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
   INFO (cpl,lib/libcpldfs.so.26.1.4): lib/libcext.so.0 found in this package
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libpthread.so.0 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libm.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO lib/libgomp.so.1 found in conda-forge::_openmp_mutex-4.5-1_gnu
   INFO (cpl,lib/libcpldfs.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libc.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcext.so.0.2.3): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libpthread.so.0 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcext.so.0.2.3): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libc.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplui.so.26.1.4): lib/libcplcore.so.26 found in this package
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO lib/libfftw3.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO lib/libfftw3f.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO lib/libcfitsio.so.9 found in conda-forge::cfitsio-4.0.0-h9a35b8e_0
WARNING (cpl,lib/libcplui.so.26.1.4): Needed DSO lib/libcurl.so.4 found in ['libcurl']
WARNING (cpl,lib/libcplui.so.26.1.4): .. but ['libcurl'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
   INFO (cpl,lib/libcplui.so.26.1.4): lib/libcext.so.0 found in this package
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libpthread.so.0 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libm.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO lib/libgomp.so.1 found in conda-forge::_openmp_mutex-4.5-1_gnu
   INFO (cpl,lib/libcplui.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libc.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcpldrs.so.26.1.4): lib/libcplcore.so.26 found in this package
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO lib/libcfitsio.so.9 found in conda-forge::cfitsio-4.0.0-h9a35b8e_0
WARNING (cpl,lib/libcpldrs.so.26.1.4): Needed DSO lib/libcurl.so.4 found in ['libcurl']
WARNING (cpl,lib/libcpldrs.so.26.1.4): .. but ['libcurl'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO lib/libwcs.so.7 found in conda-forge::wcslib-7.3-hbf76ebc_2
   INFO (cpl,lib/libcpldrs.so.26.1.4): lib/libcext.so.0 found in this package
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libpthread.so.0 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO lib/libfftw3.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO lib/libfftw3f.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libm.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO lib/libgomp.so.1 found in conda-forge::_openmp_mutex-4.5-1_gnu
   INFO (cpl,lib/libcpldrs.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libc.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplcore.so.26.1.4): lib/libcext.so.0 found in this package
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libpthread.so.0 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO lib/libcfitsio.so.9 found in conda-forge::cfitsio-4.0.0-h9a35b8e_0
WARNING (cpl,lib/libcplcore.so.26.1.4): Needed DSO lib/libcurl.so.4 found in ['libcurl']
WARNING (cpl,lib/libcplcore.so.26.1.4): .. but ['libcurl'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO lib/libfftw3.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO lib/libfftw3f.so.3 found in conda-forge::fftw-3.3.10-nompi_h77c792f_102
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libm.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO lib/libgomp.so.1 found in conda-forge::_openmp_mutex-4.5-1_gnu
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/libc.so.6 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
   INFO (cpl,lib/libcplcore.so.26.1.4): Needed DSO x86_64-conda-linux-gnu/sysroot/lib64/ld-linux-x86-64.so.2 found in CDT/compiler package conda-forge::sysroot_linux-64-2.12-he073ed8_15
```
</details>