### PR TITLE
Add the `Imath` library, which seems to replace `IlmBase`

### DIFF
--- a/recipes/imath/bld.bat
+++ b/recipes/imath/bld.bat
@@ -1,0 +1,12 @@
+mkdir build
+cd build
+
+cmake -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_FIND_ROOT_PATH="%LIBRARY_PREFIX%" ^
+      -DBUILD_SHARED_LIBS=ON ^
+      -DIMATH_LIB_SUFFIX="" ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -G "NMake Makefiles" ..
+
+nmake
+nmake install

--- a/recipes/imath/build.sh
+++ b/recipes/imath/build.sh
@@ -1,17 +1,26 @@
 #!/bin/bash
+
+set -xeo pipefail
+
 mkdir build
 cd build
 
-# -lrt to help a test program link
+cmake_args=(
+      ${CMAKE_ARGS}
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_INSTALL_LIBDIR=lib
+      -DCMAKE_INSTALL_PREFIX="$PREFIX"
+      -DBUILD_SHARED_LIBS=ON
+      -DIMATH_LIB_SUFFIX=
+)
 
-cmake ${CMAKE_ARGS} \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -Wl,--no-as-needed -lrt" \
-      -DCMAKE_INSTALL_LIBDIR=lib \
-      -DCMAKE_INSTALL_PREFIX=$PREFIX \
-      -DBUILD_SHARED_LIBS=ON \
-      -DIMATH_LIB_SUFFIX="" \
-      ..
+if [[ $(uname) == "Linux" ]]; then
+      # This helps a test program link.
+      cmake_args+=(
+            -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -Wl,--no-as-needed -lrt"
+      )
+fi
 
+cmake "${cmake_args[@]}" ..
 make -j${CPU_COUNT}
 make install

--- a/recipes/imath/build.sh
+++ b/recipes/imath/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+mkdir build
+cd build
+
+# -lrt to help a test program link
+
+cmake ${CMAKE_ARGS} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS -Wl,--no-as-needed -lrt" \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DBUILD_SHARED_LIBS=ON \
+      -DIMATH_LIB_SUFFIX="" \
+      ..
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/imath/macos-portability.patch
+++ b/recipes/imath/macos-portability.patch
@@ -1,0 +1,17 @@
+diff --git a/src/ImathTest/CMakeLists.txt b/src/ImathTest/CMakeLists.txt
+index 19a630a525..709a32385f 100644
+--- a/src/ImathTest/CMakeLists.txt
++++ b/src/ImathTest/CMakeLists.txt
+@@ -70,11 +70,7 @@ if(NOT "${CMAKE_PROJECT_NAME}" STREQUAL "ImathTest")
+ 
+ endif()
+ 
+-add_executable(ImathHalfPerfTest half_perf_test.cpp)
+-set_target_properties(ImathHalfPerfTest PROPERTIES
+-RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+-)
+-target_link_libraries(ImathHalfPerfTest Imath::Imath)
++# ImathHalfPerfTest not usable on macOS (no CLOCK_MONOTONIC)
+ 
+ function(DEFINE_IMATH_TESTS)
+   foreach(curtest IN LISTS ARGN)

--- a/recipes/imath/meta.yaml
+++ b/recipes/imath/meta.yaml
@@ -16,7 +16,7 @@ build:
   number: 0
   skip: true  # [win and vc<14]
   run_exports:
-    # Not yet on ABI Laboratory, but extapolating from IlmBase:
+    # Not yet on ABI Laboratory, but extrapolating from IlmBase:
     - {{ pin_subpackage(name|lower, max_pin='x.x') }}
 
 requirements:
@@ -47,8 +47,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - npavlovikj
-    - SylvainCorlay
     - wolfv
     - JohanMabille
     - pkgw

--- a/recipes/imath/meta.yaml
+++ b/recipes/imath/meta.yaml
@@ -9,6 +9,8 @@ package:
 source:
   url: https://github.com/AcademySoftwareFoundation/Imath/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - macos-portability.patch  # [osx]
 
 build:
   number: 0

--- a/recipes/imath/meta.yaml
+++ b/recipes/imath/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "Imath" %}
+{% set version = "3.1.4" %}
+{% set sha256 = "fcca5fbb37d375a252bacd8a29935569bdc28b888f01ef1d9299ca0c9e87c17a" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/AcademySoftwareFoundation/Imath/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [win and vc<14]
+  run_exports:
+    # Not yet on ABI Laboratory, but extapolating from IlmBase:
+    - {{ pin_subpackage(name|lower, max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - make  # [unix]
+  host:
+    - zlib
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/Imath/half.h                          # [unix]
+    - test -f ${PREFIX}/include/Imath/ImathMath.h                     # [unix]
+    - test -f ${PREFIX}/lib/libImath${SHLIB_EXT}                      # [unix]
+    - if not exist %LIBRARY_PREFIX%\include\Imath\half.h exit 1       # [win]
+    - if not exist %LIBRARY_PREFIX%\include\Imath\ImathMath.h exit 1  # [win]
+    - if not exist %LIBRARY_PREFIX%\lib\Imath.lib exit 1              # [win]
+
+about:
+  home: http://www.openexr.com/
+  license: Modified BSD
+  license_family: BSD
+  license_file: LICENSE.md
+  summary: IMath libraries required for OpenEXR.
+  doc_url: http://www.openexr.com/documentation.html
+
+extra:
+  recipe-maintainers:
+    - npavlovikj
+    - SylvainCorlay
+    - wolfv
+    - JohanMabille
+    - pkgw

--- a/recipes/imath/meta.yaml
+++ b/recipes/imath/meta.yaml
@@ -37,7 +37,7 @@ test:
 
 about:
   home: http://www.openexr.com/
-  license: Modified BSD
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md
   summary: IMath libraries required for OpenEXR.


### PR DESCRIPTION
So, the motivation for this new package is basically https://github.com/conda-forge/openexr-python-feedstock/pull/6 . I think that that update is failing because conda-forge's version of OpenEXR is quite old: we have 2.5.5, while upstream is at 3.1.4. This is important because there are several CVEs that I believe apply to the 2.x series.

In order to build newer versions of OpenEXR that can be used by OpenEXR-python, I believe we need to add this package, which has been split from `ilmbase`.  The main OpenEXR build can download and use an internal version of Imath, but in that case it doesn't provide libImath, which OpenEXR-python needs to build.

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

I've propagated the maintainers from `ilmbase` — please comment regarding whether you'd like to be added as a maintainer of this package or not:

- @npavlovikj
- @SylvainCorlay
- @wolfv
- @JohanMabille