### PR TITLE
adds celer, download, libsvmdata (pypi)

### DIFF
--- a/recipes/celer/meta.yaml
+++ b/recipes/celer/meta.yaml
@@ -15,7 +15,7 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
   host:
     - python
     - pip

--- a/recipes/celer/meta.yaml
+++ b/recipes/celer/meta.yaml
@@ -20,8 +20,8 @@ requirements:
     - numpy
     - pip
     - python
-  run:
     - cython >=0.26
+  run:
     - download
     - libsvmdata >=0.3
     - matplotlib-base >=2.0.0

--- a/recipes/celer/meta.yaml
+++ b/recipes/celer/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "celer" %}
+{% set version = "0.6.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/celer-{{ version }}.tar.gz
+  sha256: 0a726e120f09dfdba871efa8f93c9d3db218b8926c20362a9d36022e3fc44ea6
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+  host:
+    - numpy
+    - pip
+    - python
+  run:
+    - cython >=0.26
+    - download
+    - libsvmdata >=0.3
+    - matplotlib-base >=2.0.0
+    - python
+    - scikit-learn >=1.0
+    - scipy >=0.18.0
+    - seaborn >=0.7
+    - tqdm
+    - xarray
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - celer
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://mathurinm.github.io/celer
+  summary: Fast algorithm with dual extrapolation for sparse problems
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mfansler

--- a/recipes/celer/meta.yaml
+++ b/recipes/celer/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - {{ compiler('c') }}
   host:
     - numpy
+    - scipy >=0.18.0
     - pip
     - python
     - cython >=0.26

--- a/recipes/celer/meta.yaml
+++ b/recipes/celer/meta.yaml
@@ -24,16 +24,17 @@ requirements:
     - scipy >=0.18.0
     - scikit-learn >=1.0
   run:
-    - download
-    - libsvmdata >=0.3
-    - matplotlib-base >=2.0.0
     - python
-    - scikit-learn >=1.0
+    - cython >=0.26
+    - {{ pin_compatible('numpy') }}
     - scipy >=0.18.0
+    - scikit-learn >=1.0
+    - matplotlib-base >=2.0.0
     - seaborn >=0.7
     - tqdm
     - xarray
-    - {{ pin_compatible('numpy') }}
+    - download
+    - libsvmdata >=0.3
 
 test:
   imports:

--- a/recipes/celer/meta.yaml
+++ b/recipes/celer/meta.yaml
@@ -17,11 +17,12 @@ requirements:
   build:
     - {{ compiler('c') }}
   host:
+    - python
+    - pip
+    - cython >=0.26
     - numpy
     - scipy >=0.18.0
-    - pip
-    - python
-    - cython >=0.26
+    - scikit-learn >=1.0
   run:
     - download
     - libsvmdata >=0.3

--- a/recipes/download/LICENSE
+++ b/recipes/download/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Chris Holdgraf
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/recipes/download/meta.yaml
+++ b/recipes/download/meta.yaml
@@ -10,15 +10,16 @@ source:
   sha256: 884a885475b3cdbec0aa277e41643995c3394a1e064a0816f53fffae4a382130
 
 build:
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
   run:
-    - python
+    - python >=3.6
     - requests
     - six
     - tqdm

--- a/recipes/download/meta.yaml
+++ b/recipes/download/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "download" %}
+{% set version = "0.3.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/download-{{ version }}.tar.gz
+  sha256: 884a885475b3cdbec0aa277e41643995c3394a1e064a0816f53fffae4a382130
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - python
+    - requests
+    - six
+    - tqdm
+
+test:
+  imports:
+    - download
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/choldgraf/download
+  summary: A quick module to help downloading files using python.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mfansler

--- a/recipes/libsvmdata/meta.yaml
+++ b/recipes/libsvmdata/meta.yaml
@@ -17,11 +17,11 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
   run:
     - download
     - numpy >=1.12
-    - python
+    - python >=3.6
     - scikit-learn
     - scipy
 

--- a/recipes/libsvmdata/meta.yaml
+++ b/recipes/libsvmdata/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "libsvmdata" %}
+{% set version = "0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/libsvmdata-{{ version }}.tar.gz
+  sha256: 65c742b40053b5d9c5a88a1bab54097d3f70d31e510a71d1e33b29e7e69d12ba
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - download
+    - numpy >=1.12
+    - python
+    - scikit-learn
+    - scipy
+
+test:
+  imports:
+    - libsvmdata
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/libsvmdata/
+  summary: Fetcher for LIBSVM datasets
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mfansler


### PR DESCRIPTION
This adds recipes for the PyPI packages `celer`, `download`, and `libsvmdata`, generated using [`grayskull`](https://github.com/conda-incubator/grayskull). The main intent is to add `celer`, and the other two are dependencies which are not already available.

The package names "download" and "libsvmdata" seem odd to retain. I am considering adding a `python-` prefix for those two. Please comment in the review.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
