### PR TITLE
add pywin32-on-windows

### DIFF
--- a/recipes/pywin32-on-windows/LICENSE.txt
+++ b/recipes/pywin32-on-windows/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2015-2022, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of staged-recipes nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/pywin32-on-windows/conda_build_config.yaml
+++ b/recipes/pywin32-on-windows/conda_build_config.yaml
@@ -1,0 +1,3 @@
+pkg_type:
+  - 'noop'
+  - 'pywin32'

--- a/recipes/pywin32-on-windows/conda_build_config.yaml
+++ b/recipes/pywin32-on-windows/conda_build_config.yaml
@@ -1,3 +1,3 @@
 pkg_type:
-  - 'noop'
-  - 'pywin32'
+  - 'noop'  # [not win]
+  - 'pywin32'  # [win]

--- a/recipes/pywin32-on-windows/meta.yaml
+++ b/recipes/pywin32-on-windows/meta.yaml
@@ -6,12 +6,11 @@ package:
   version: {{ version }}
 
 build:
-  {% if pkg_type == 'noop' %}
+  noarch: python
+  {% if pkg_type == 'pywin32' %}
   number: {{ build_number | int * 2 }}
-  skip: true  # [win]
   {% else %}
   number: {{ build_number | int * 2 + 1 }}
-  skip: true  # [not win]
   {% endif %}
 
 requirements:

--- a/recipes/pywin32-on-windows/meta.yaml
+++ b/recipes/pywin32-on-windows/meta.yaml
@@ -15,9 +15,9 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=2.7
   run:
-    - python
+    - python >=2.7
     {% if pkg_type == 'pywin32' %}
     - pywin32
     {% else %}
@@ -25,13 +25,12 @@ requirements:
     {% endif %}
 
 test:
+  {% if pkg_type == 'pywin32' %}
   imports:
-    {% if pkg_type == 'pywin32' %}
     - win32api
-    {% endif %}
+  {% endif %}
   requires:
     - pip
-    - python
   commands:
     - pip check
 
@@ -41,6 +40,13 @@ about:
   license_family: BSD
   license_file: LICENSE.txt
   summary: 'A virtual package for pywin32... but only on windows'
+  description: |-
+    This package exists so other packages can depend on `pywin32`, often the only
+    platform specific dependency, while remaining `noarch: python`. On non-Windows
+    platforms, installing it is a no-op.
+
+    A specific version constraint for `pywin32` itself can be specified at build
+    time with `run_constrained`.
 
 extra:
   recipe-maintainers:

--- a/recipes/pywin32-on-windows/meta.yaml
+++ b/recipes/pywin32-on-windows/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "0.1.0" %}
+{% set build_number = 0 %}
+
+package:
+  name: pywin32-on-windows
+  version: {{ version }}
+
+build:
+  {% if pkg_type == 'noop' %}
+  number: {{ build_number | int * 2 }}
+  skip: true  # [win]
+  {% else %}
+  number: {{ build_number | int * 2 + 1 }}
+  skip: true  # [not win]
+  {% endif %}
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+    {% if pkg_type == 'pywin32' %}
+    - pywin32
+    {% else %}
+    - __unix
+    {% endif %}
+
+test:
+  imports:
+    {% if pkg_type == 'pywin32' %}
+    - win32api
+    {% endif %}
+  requires:
+    - pip
+    - python
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/conda-forge/maybe-pywin32-feedstock
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
+  summary: 'A virtual package for pywin32... but only on windows'
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


Notes:
- an option for https://github.com/conda-forge/pywin32-feedstock/issues/34
- alternative to https://github.com/conda-forge/pywin32-feedstock/pull/37
- as described in the description:

> This package exists so other packages can depend on `pywin32`, often the only
> platform specific dependency, while remaining `noarch: python`. On non-Windows
> platforms, installing it is a no-op.
>
> A specific version constraint for `pywin32` itself can be specified at build
> time with `run_constrained`.
