### PR TITLE
NCAR's GeoCAT-F2Py ready to be brought into conda-forge

### DIFF
--- a/recipes/geocat-f2py/build.sh
+++ b/recipes/geocat-f2py/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cd src/geocat/f2py/fortran
+f2py -c --fcompiler=gnu95 dpres_plevel_dp.pyf dpres_plevel_dp.f
+f2py -c --fcompiler=gnu95 grid2triple.pyf grid2triple.f
+f2py -c --fcompiler=gnu95 linint2.pyf linint2.f
+f2py -c --fcompiler=gnu95 moc_loops.pyf moc_loops.f
+f2py -c --fcompiler=gnu95 rcm2points.pyf rcm2points.f rcm2rgrid.f linmsg_dp.f linint2.f
+f2py -c --fcompiler=gnu95 rcm2rgrid.pyf rcm2rgrid.f linmsg_dp.f linint2.f
+f2py -c --fcompiler=gnu95 triple2grid.pyf triple2grid.f
+cd ../../../..
+
+python -m pip install . --no-deps -vv

--- a/recipes/geocat-f2py/meta.yaml
+++ b/recipes/geocat-f2py/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "geocat-f2py" %}
+{% set version = "2022.03.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: http://github.com/NCAR/geocat-f2py/archive/v{{ version }}.tar.gz # For building from a specific tag's tarball
+  sha256: 8ee37f26084d2a2454dfd9ba476138f3d05ac9511e1d11e19ad04862e70a7fed
+  # git_tag: v{{ version }}   # For building from a specific tag
+  # git_rev: march # For building from main branch for debugging purposes
+  # git_url: https://github.com/NCAR/geocat-f2py.git
+
+build:
+  number: 0
+  skip: true  # [py<38 or win]
+
+requirements:
+  build:
+    - python                              # [build_platform != target_platform]
+    - pip                                 # [build_platform != target_platform]
+    - setuptools <60.0.0                  # [build_platform != target_platform]
+    - numpy >=1.22                        # [build_platform != target_platform]
+    - {{ compiler('fortran') }}
+    - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+  host:
+    - python
+    - pip
+    - setuptools <60.0.0
+    - numpy >=1.22
+    - {{ compiler('fortran') }}
+  run:
+    - python
+    - numpy >=1.22
+    - xarray
+    - dask
+
+test:
+  requires:
+    - pytest
+  imports:
+    - geocat
+    - geocat.f2py
+  commands:
+    - pytest test
+  source_files:
+    - test
+
+about:
+  home: https://github.com/NCAR/geocat-f2py
+  summary: GeoCAT-f2py wraps, in Python, the compiled language implementations of some of the computational functions found under the GeoCAT-comp umbrella.
+  dev_url: https://github.com/NCAR/geocat-f2py
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - pilotchute


### PR DESCRIPTION
Signed-off-by: pilotchute <akootz@ucar.edu>

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR or once it's ready for review, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
  - This a computational package from the U.S. National Center for Atmospheric Research. ~700 downloads per monthly release. 
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
  - Apache 2.0 Included.
- [x] Source is from official source.
  - Source developed and maintained by NCAR staff.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
  - Does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
  - Static libraries are packaged
- [x] Build number is 0.
  - Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
  - github version tarball used
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
  - Yes, me. Hi, how are you doing today?
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
  - I'm always either trouble or in trouble, not gonna stop for you ;)
