### PR TITLE
Skip http errors in actions workflow and remove review team check

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -36,11 +36,11 @@
                 '@conda-forge/help-r',
                 '@conda-forge/help-ruby'
               ];
+              let found_label = false;
               for (const team of teams) {
                   let text = context.payload.comment.body;
                   const regex = new RegExp(team + '[^\-]|' + team + '$');
                   let result = regex.test(text);
-                  let found_label = false;
                   if (result) {
                       label = team.replace("@conda-forge/help-", "");
                       label_no_staged = label.replace("@conda-forge/", "");

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -18,6 +18,7 @@
       runs-on: ubuntu-latest
       steps:
         - name: check-teams
+          id: check_teams
           uses: actions/github-script@v6
           with:
             result-encoding: json
@@ -44,7 +45,7 @@
                   if (result) {
                       label = team.replace("@conda-forge/help-", "");
                       label_no_staged = label.replace("@conda-forge/", "");
-                      let found_label = true;
+                      found_label = true;
                       github.rest.issues.addLabels({
                           issue_number: context.issue.number,
                           owner: context.repo.owner,
@@ -55,9 +56,9 @@
                   }
               };
               return found_label
-        - name: add-labels
+        - name: remove-labels
           if: >
-            steps.check-teams.outputs.result
+            (steps.check_teams.outputs.result == 'true')
             && contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
           uses: actions/github-script@v6
           with:
@@ -86,6 +87,7 @@
       runs-on: ubuntu-latest
       steps:
         - name: check-membership
+          id: check_membership
           uses: actions/github-script@v6
           with:
             github-token: ${{ secrets.GH_TOKEN }}
@@ -102,13 +104,15 @@
               membership_response.then(function(result) {
                  console.log(result);
                  if (result.data.state == 'active'){
-                   return;
+                   return true;
                  } else {
-                   throw new Error('Reviewer not active member of conda-forge/staged-recipes');
+                   return false;
                  }
               });
-        - name: swap-labels
-          if: ${{ success() }}
+        - name: remove-labels
+          if: >
+            (steps.check_membership.outputs.result == 'true')
+            && contains(github.event.issue.labels.*.name, 'review-requested')
           uses: actions/github-script@v6
           with:
             script: |
@@ -118,6 +122,12 @@
                   repo: context.repo.repo,
                   name: ['review-requested']
               });
+        - name: add-labels
+          if: >
+            (steps.check_membership.outputs.result == 'true')
+          uses: actions/github-script@v6
+          with:
+            script: |
               github.rest.issues.addLabels({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -57,7 +57,7 @@
               return found_label
         - name: add-labels
           if: >
-            steps.set-result.outputs.result
+            steps.check-teams.outputs.result
             && contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
           uses: actions/github-script@v6
           with:

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -17,9 +17,10 @@
         && !contains(github.event.issue.labels.*.name, 'review-requested')
       runs-on: ubuntu-latest
       steps:
-        - name: add-labels
+        - name: check-teams
           uses: actions/github-script@v6
           with:
+            result-encoding: json
             script: |
               const teams = [
                 '@conda-forge/staged-recipes',
@@ -39,24 +40,35 @@
                   let text = context.payload.comment.body;
                   const regex = new RegExp(team + '[^\-]|' + team + '$');
                   let result = regex.test(text);
+                  let found_label = false;
                   if (result) {
                       label = team.replace("@conda-forge/help-", "");
                       label_no_staged = label.replace("@conda-forge/", "");
+                      let found_label = true;
                       github.rest.issues.addLabels({
                           issue_number: context.issue.number,
                           owner: context.repo.owner,
                           repo: context.repo.repo,
                           labels: [label_no_staged, 'review-requested']
-                      })
-                      github.rest.issues.removeLabel({
-                          issue_number: context.issue.number,
-                          owner: context.repo.owner,
-                          repo: context.repo.repo,
-                          name: ['Awaiting author contribution']
                       });
                       // TODO: Maybe use GitHub API to request review / assign team
                   }
-              }
+              };
+              return found_label
+        - name: add-labels
+          if: >
+            steps.set-result.outputs.result
+            && contains(github.event.issue.labels.*.name, 'Awaiting author contribution')
+          uses: actions/github-script@v6
+          with:
+            script: |
+              github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: ['Awaiting author contribution']
+              })
+
 
     remove-review-requested-label:
       name: 'When reviewed, remove review-requested label'

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -43,17 +43,21 @@
                   const regex = new RegExp(team + '[^\-]|' + team + '$');
                   let result = regex.test(text);
                   if (result) {
-                      label = team.replace("@conda-forge/help-", "");
-                      label_no_staged = label.replace("@conda-forge/", "");
+                      const slug = team.replace("@conda-forge/", "");
+                      const label = slug.replace("help-", "");
                       found_label = true;
                       github.rest.issues.addLabels({
                           issue_number: context.issue.number,
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          labels: [label_no_staged, 'review-requested']
+                          labels: [label, 'review-requested']
                       });
-                      // TODO: Maybe use GitHub API to request review / assign team
-                  }
+                      github.rest.pulls.requestReviewers({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        pull_number: context.issue.number,
+                        team_reviewers: [slug],
+                      });
               };
               return found_label
         - name: remove-labels

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -21,7 +21,7 @@
           id: check_teams
           uses: actions/github-script@v6
           with:
-            result-encoding: json
+            debug: true
             script: |
               const teams = [
                 '@conda-forge/staged-recipes',
@@ -52,12 +52,15 @@
                           repo: context.repo.repo,
                           labels: [label, 'review-requested']
                       });
+                      // NOTE: Team review request is required to be posted for
+                      // membership check to work.
                       github.rest.pulls.requestReviewers({
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         pull_number: context.issue.number,
                         team_reviewers: [slug],
                       });
+                  }
               };
               return found_label
         - name: remove-labels
@@ -78,57 +81,49 @@
     remove-review-requested-label:
       name: 'When reviewed, remove review-requested label'
       if: >
-        (
-          github.event.issue
-          && github.event.issue.pull_request
-          && (github.event.sender.login != github.event.issue.user.login)
-          && contains(github.event.issue.labels.*.name, 'review-requested')
-        ) || (
-          github.event.pull_request
-          && (github.event.sender.login != github.event.pull_request.user.login)
-          && contains(github.event.pull_request.labels.*.name, 'review-requested')
-        )
+        github.event.pull_request
+        && (github.event.sender.login != github.event.pull_request.user.login)
+        && contains(github.event.pull_request.labels.*.name, 'review-requested')
       runs-on: ubuntu-latest
       steps:
-        - name: check-membership
-          id: check_membership
+        - name: check-team-review
+          id: check_team_review
           uses: actions/github-script@v6
           with:
-            github-token: ${{ secrets.GH_TOKEN }}
+            debug: true
             script: |
-              // This step is separate from the labeling step because it uses a token
-              // with different permissions. If it is combined with the following step,
-              // then the labeling actions are marked as being completed by whomever
-              // created the token.
-              const membership_response = github.rest.teams.getMembershipForUserInOrg({
-                  org: 'conda-forge',
-                  team_slug: 'staged-recipes',
-                  username: '${{ github.event.sender.login }}'
+              const labelsPromise = github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
               });
-              membership_response.then(function(result) {
-                 console.log(result);
-                 if (result.data.state == 'active'){
-                   return true;
-                 } else {
-                   return false;
-                 }
+              const requestedReviewersPromise = github.rest.pulls.listRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
               });
-        - name: remove-labels
-          if: >
-            (steps.check_membership.outputs.result == 'true')
-            && contains(github.event.issue.labels.*.name, 'review-requested')
-          uses: actions/github-script@v6
-          with:
-            script: |
-              github.rest.issues.removeLabel({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: ['review-requested']
+              return Promise.all([labelsPromise, requestedReviewersPromise])
+                .then( responses => {
+                  console.log(responses);
+                  const labels = responses[0].data.map(a => a.name);
+                  const team_review_requests = responses[1].data.teams;
+                  console.log(labels);
+                  console.log(team_review_requests);
+                  console.log(team_review_requests.length);
+                  if (team_review_requests.length == 0){
+                    // Must have been reviewed by team member because no team
+                    // requests remaining. NOTE: If multiple teams requested,
+                    // review-requested label will not clear until all team
+                    // requests satisfied.
+                    console.log("No more requested team reviews.");
+                    return true;
+                  }
+                  console.log("Team reviews still pending.");
+                  return false;
               });
         - name: add-labels
           if: >
-            (steps.check_membership.outputs.result == 'true')
+            (steps.check_team_review.outputs.result == 'true')
           uses: actions/github-script@v6
           with:
             script: |
@@ -137,4 +132,17 @@
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   labels: ['Awaiting author contribution']
+              });
+        - name: remove-labels
+          if: >
+            (steps.check_team_review.outputs.result == 'true')
+            && contains(github.event.pull_request.labels.*.name, 'review-requested')
+          uses: actions/github-script@v6
+          with:
+            script: |
+              github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: ['review-requested']
               });


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with
a PR, please let the right people know.
There are language-specific teams for reviewing recipes.

Currently available teams are:
- python `@conda-forge/help-python`
- python/c hybrid `@conda-forge/help-python-c`
- r `@conda-forge/help-r`
- java `@conda-forge/help-java`
- nodejs `@conda-forge/help-nodejs`
- c/c++ `@conda-forge/help-c-cpp`
- perl `@conda-forge/help-perl`
- Julia `@conda-forge/help-julia`
- ruby `@conda-forge/help-ruby`

If your PR doesn't fall into those categories please contact
the full review team `@conda-forge/staged-recipes`.

Once the PR is ready for review, please contact
`@conda-forge/staged-recipes` to have it merged by writing
<code>@</code>`conda-forge-admin, please ping team` in a new comment.

Due to GitHub limitations first time contributors to conda-forge are unable
to ping these teams. You can [ping the team][1] using a special command in
a comment on the PR to get the attention of the `staged-recipes` team. You can
also consider asking on our [Gitter channel][2] if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
