### PR TITLE
BUG: Use correct team slug for review action

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -58,7 +58,7 @@
                         owner: context.repo.owner,
                         repo: context.repo.repo,
                         pull_number: context.issue.number,
-                        team_reviewers: [team],
+                        team_reviewers: [team.replace("@", "")],
                       });
                   }
               };


### PR DESCRIPTION
Tries to use the correct team slug for automated review labels using GitHub actions.

https://github.com/conda-forge/staged-recipes/pull/18453