### PR TITLE
add ephemeral-port-reserve 1.1.4

### DIFF
--- a/recipes/ephemeral-port-reserve/meta.yaml
+++ b/recipes/ephemeral-port-reserve/meta.yaml
@@ -26,6 +26,9 @@ requirements:
   run:
     - python >=3.5
 
+{% set pytest_args = "--cov-fail-under 92" %}
+{% set pytest_args = '-k "not fqdn"' %}  # [osx]
+
 test:
   source_files:
     - src/tests
@@ -34,7 +37,7 @@ test:
   commands:
     - pip check
     - ephemeral-port-reserve
-    - cd src/tests && pytest -vv --cov ephemeral_port_reserve --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 92
+    - cd src/tests && pytest -vv --cov ephemeral_port_reserve --cov-report term-missing:skip-covered --no-cov-on-fail {{ pytest_args }}  # [unix]
   requires:
     - pip
     - pytest-cov

--- a/recipes/ephemeral-port-reserve/meta.yaml
+++ b/recipes/ephemeral-port-reserve/meta.yaml
@@ -37,7 +37,6 @@ test:
   commands:
     - pip check
     - ephemeral-port-reserve
-    - cd src/tests && pytest -vv --cov ephemeral_port_reserve --cov-report term-missing:skip-covered --no-cov-on-fail {{ pytest_args }}  # [unix]
   requires:
     - pip
     - pytest-cov

--- a/recipes/ephemeral-port-reserve/meta.yaml
+++ b/recipes/ephemeral-port-reserve/meta.yaml
@@ -26,9 +26,6 @@ requirements:
   run:
     - python >=3.5
 
-{% set pytest_args = "--cov-fail-under 92" %}
-{% set pytest_args = '-k "not fqdn"' %}  # [osx]
-
 test:
   source_files:
     - src/tests

--- a/recipes/ephemeral-port-reserve/meta.yaml
+++ b/recipes/ephemeral-port-reserve/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "1.1.4" %}
+
+package:
+  name: ephemeral-port-reserve
+  version: {{ version }}
+
+source:
+  - folder: dist
+    url: https://pypi.io/packages/source/e/ephemeral-port-reserve/ephemeral_port_reserve-{{ version }}.tar.gz
+    sha256: b8f7da2c97090cb0801949dec1d6d40c97220505b742a70935ffbd43234c14b2
+  - folder: src
+    url: https://github.com/Yelp/ephemeral-port-reserve/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 522a3b80e885c62b9561c4150cefda7a67cad954d22d474c6f9362348828e079
+
+build:
+  entry_points:
+    - ephemeral-port-reserve = ephemeral_port_reserve:main
+  noarch: python
+  script: cd dist && {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >=3.5
+  run:
+    - python >=3.5
+
+test:
+  source_files:
+    - src/tests
+  imports:
+    - ephemeral_port_reserve
+  commands:
+    - pip check
+    - ephemeral-port-reserve
+    - cd src/tests && pytest -vv --cov ephemeral_port_reserve --cov-report term-missing:skip-covered --no-cov-on-fail --cov-fail-under 92
+  requires:
+    - pip
+    - pytest-cov
+
+about:
+  home: https://github.com/Yelp/ephemeral-port-reserve
+  summary: Bind to an ephemeral port, force it into the TIME_WAIT state, and unbind it.
+  license: MIT
+  license_file: dist/LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/ephemeral-port-reserve/run_test.py
+++ b/recipes/ephemeral-port-reserve/run_test.py
@@ -1,0 +1,24 @@
+import platform
+import subprocess
+import sys
+
+PLATFORM = platform.system()
+WIN = PLATFORM == "Windows"
+OSX = PLATFORM == "Darwin"
+
+PYTEST_ARGS = [
+    "-vv",
+    "--cov=ephemeral_port_reserve",
+    "--cov-report=term-missing:skip-covered",
+    "--no-cov-on-fail"
+]
+
+if OSX:
+    PYTEST_ARGS += ["-k", "not fqdn"]
+elif WIN:
+    PYTEST_ARGS += ["-k", "not (fqdn or port_in_use or localhost)"]
+else:
+    PYTEST_ARGS += ["--cov-fail-under", "92"]
+
+if __name__ == "__main__":
+    sys.exit(subprocess.call(["pytest", *PYTEST_ARGS], cwd="src/tests"))


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


Notes:
- blocks https://github.com/conda-forge/werkzeug-feedstock/pull/29