### PR TITLE
mkdocs-table-reader-plugin: init at 1.0.0

### DIFF
--- a/recipes/mkdocs-table-reader-plugin/conda-forge.yml
+++ b/recipes/mkdocs-table-reader-plugin/conda-forge.yml
@@ -1,0 +1,8 @@
+conda_forge_output_validation: true
+bot:
+  automerge: true
+  check_solvable: true
+  run_deps_from_wheel: true
+github:
+  branch_name: main
+  tooling_branch_name: main

--- a/recipes/mkdocs-table-reader-plugin/meta.yaml
+++ b/recipes/mkdocs-table-reader-plugin/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "mkdocs-table-reader-plugin" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ef222ca5e82431a3b98fbdcc935d6d5247e8a8d4ad9a616bdcbc40f20eb18db0
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  noarch: python
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - mkdocs >=1.0
+    - pandas >=1.1
+    - tabulate >=0.8.7
+    - PyYAML >=5.4.1
+
+test:
+  imports:
+    - mkdocs_table_reader_plugin
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://timvink.github.io/mkdocs-table-reader-plugin/#documentation
+  summary: MkDocs plugin to directly insert tables from files into markdown.
+  description: MkDocs plugin to directly insert tables from files into markdown.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://timvink.github.io/mkdocs-table-reader-plugin/#documentation
+  dev_url: https://github.com/timvink/mkdocs-table-reader-plugin
+
+extra:
+  recipe-maintainers:
+    - cpcloud


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
