### PR TITLE
Add the gi-docgen documentation tool

### DIFF
--- a/recipes/gi-docgen/meta.yaml
+++ b/recipes/gi-docgen/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "gi-docgen" %}
+{% set version = "2022.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/gi-docgen-{{ version }}.tar.gz
+  sha256: f91d879ff28d7d5265cde84275ee510e32386bfeb7ec6203a647342aead55cec
+
+build:
+  entry_points:
+    - gi-docgen=gidocgen.gidocmain:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >=3.6
+    - setuptools
+  run:
+    - jinja2
+    - markdown
+    - markupsafe
+    - pygments
+    - python >=3.6
+    - toml
+    - typogrify
+
+test:
+  imports:
+    - gidocgen
+  commands:
+    - pip check
+    - gi-docgen --help
+  requires:
+    - pip
+
+about:
+  home: https://gitlab.gnome.org/GNOME/gi-docgen
+  summary: Documentation tool for GObject-based libraries
+  license: GPL-3.0-or-later
+  license_file: LICENSES/
+
+extra:
+  recipe-maintainers:
+    - pkgw


### PR DESCRIPTION
This is needed to build the latest stable release of librsvg (conda-forge/librsvg-feedstock#92).

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [N/A] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
