### PR TITLE
add lazy-loader

### DIFF
--- a/recipes/lazy-loader/meta.yaml
+++ b/recipes/lazy-loader/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "lazy-loader" %}
+{% set version = "0.1rc2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/lazy_loader-{{ version }}.tar.gz
+  sha256: 1130fe8ddf64e7bfbeea185e14a08575b55a4680ed1585482eaeb796faca242b
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >=3.8
+  run:
+    - python >=3.8
+
+test:
+  imports:
+    - lazy_loader
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/lazy_loader/
+  summary: lazy_loader
+  dev_url: https://github.com/scientific-python/lazy-loader
+  license: BSD-3-Clause
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - ocefpaf


### PR DESCRIPTION
We can wait a bit for a stable release. This is needed in https://github.com/conda-forge/pandas_flavor-feedstock/pull/4 and releasing in a dev channel won't help us there.