### PR TITLE
add jupyterlab-webrtc-docprovider 0.1.0

### DIFF
--- a/recipes/jupyterlab-webrtc-docprovider/meta.yaml
+++ b/recipes/jupyterlab-webrtc-docprovider/meta.yaml
@@ -29,7 +29,7 @@ test:
     - jupyter labextension list
     - jupyter labextension list 1>labextensions 2>&1
     - cat labextensions | grep -ie "@jupyterlite/webrtc-docprovider .*OK"  # [unix]
-    - pytest -vv --pyargs jupyterlab_webrtc_docprovider --cov=ipydrawio --cov-fail-under=100 --cov-report=term-missing:skip-covered
+    - pytest -vv --pyargs jupyterlab_webrtc_docprovider --cov=jupyterlab_webrtc_docprovider --cov-fail-under=100 --cov-report=term-missing:skip-covered
   requires:
     - pip
     - pytest-cov

--- a/recipes/jupyterlab-webrtc-docprovider/meta.yaml
+++ b/recipes/jupyterlab-webrtc-docprovider/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: jupyterlab-webrtc-docprovider
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/j/jupyterlab-webrtc-docprovider/jupyterlab-webrtc-docprovider-{{ version }}.tar.gz
+  sha256: 95c542bfd06eafa679a7196a339dfe27d20847dddef03ec23a0b1c12c73b3460
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - jupyter-packaging >=0.10,<1.0
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+
+test:
+  imports:
+    - jupyterlab_webrtc_docprovider
+  commands:
+    - pip check
+    - jupyter labextension list
+    - jupyter labextension list 1>labextensions 2>&1
+    - cat labextensions | grep -ie "@jupyterlite/webrtc-docprovider .*OK"  # [unix]
+    - pytest -vv --pyargs jupyterlab_webrtc_docprovider --cov=ipydrawio --cov-fail-under=100 --cov-report=term-missing:skip-covered
+  requires:
+    - pip
+    - pytest-cov
+    - jupyterlab >=3.1,<4
+
+about:
+  home: https://github.com/jupyterlite/jupyterlab-webrtc-docprovider
+  summary: Document collaboration for JupyterLab and JupyterLite, powered by y-webrtc
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/jupyterlab-webrtc-docprovider/meta.yaml
+++ b/recipes/jupyterlab-webrtc-docprovider/meta.yaml
@@ -39,7 +39,9 @@ about:
   home: https://github.com/jupyterlite/jupyterlab-webrtc-docprovider
   summary: Document collaboration for JupyterLab and JupyterLite, powered by y-webrtc
   license: BSD-3-Clause
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - jupyterlab_webrtc_docprovider/labextension/static/third-party-licenses.json
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
