### PR TITLE
absolufy-imports: init at 0.3.1

### DIFF
--- a/recipes/absolufy-imports/conda-forge.yml
+++ b/recipes/absolufy-imports/conda-forge.yml
@@ -1,0 +1,8 @@
+conda_forge_output_validation: true
+bot:
+  automerge: true
+  check_solvable: true
+  run_deps_from_wheel: true
+github:
+  branch_name: main
+  tooling_branch_name: main

--- a/recipes/absolufy-imports/meta.yaml
+++ b/recipes/absolufy-imports/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "absolufy_imports" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|replace("_", "-") }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c90638a6c0b66826d1fb4880ddc20ef7701af34192c94faf40b95d32b59f9793
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - absolufy_imports
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/MarcoGorelli/absolufy-imports
+  summary: 'A tool and pre-commit hook to automatically convert relative imports to absolute.'
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - cpcloud


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
