### PR TITLE
Import of dwclib 2022.3.22. https://pypi.org/project/dwclib

### DIFF
--- a/recipes/dwclib/meta.yaml
+++ b/recipes/dwclib/meta.yaml
@@ -16,7 +16,6 @@ build:
 
 requirements:
   build:
-    - flit-core >=2,<4
   host:
     - python >=3.6
     - pip
@@ -47,7 +46,6 @@ about:
     dataframes. Optional dask support is included in the library.
     Waveform queries are accelerated with the numba JIT compiler.
   license: ISC
-  license_family: MIT
   license_file: LICENSE
   dev_url: https://framagit.org/jaj/dwclib
 


### PR DESCRIPTION
This adds dwclib 2022.3.22 which is a pure Python wrapper to Philips DataWarehouse Connect SQL database.

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.