### PR TITLE
mkdocs-git-revision-date-localized-plugin: init at 1.0.1

### DIFF
--- a/recipes/mkdocs-git-revision-date-localized-plugin/conda-forge.yml
+++ b/recipes/mkdocs-git-revision-date-localized-plugin/conda-forge.yml
@@ -1,0 +1,8 @@
+conda_forge_output_validation: true
+bot:
+  automerge: true
+  check_solvable: true
+  run_deps_from_wheel: true
+github:
+  branch_name: main
+  tooling_branch_name: main

--- a/recipes/mkdocs-git-revision-date-localized-plugin/meta.yaml
+++ b/recipes/mkdocs-git-revision-date-localized-plugin/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "mkdocs-git-revision-date-localized-plugin" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f3e020b445e7b4fb4e58ccd46b07adecbca0f85ac1659e1a63e38b8779c81ba7
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - mkdocs >=1.0
+    - gitpython
+    - babel >=2.7.0
+
+test:
+  imports:
+    - mkdocs_git_revision_date_localized_plugin
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin
+  summary: 'MkDocs plugin that enables displaying the date of the last git modification of a page.'
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - cpcloud


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
