### PR TITLE
add independent fenics-ufl

### DIFF
--- a/recipes/fenics-ufl/meta.yaml
+++ b/recipes/fenics-ufl/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python >=3.7
     - pip
-    - setuptools
+    - setuptools >=58
     - wheel
   run:
     - python >=3.7

--- a/recipes/fenics-ufl/meta.yaml
+++ b/recipes/fenics-ufl/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "fenics-ufl" %}
+{% set version = "2022.1.0" %}
+{% set extra = ".post0" %}
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # 0.4.1 isn't on PyPI
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ extra }}.tar.gz
+  sha256: 8bf5e2d30d48ab250664c6d6d539e52635c3fd708c8139c557868d6167d54de7
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install --no-deps -vv .
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >=3.7
+    - numpy
+test:
+  requires:
+    - pip
+  imports:
+    - ufl
+  commands:
+    - pip check
+
+about:
+  home: https://fenicsproject.org
+  summary: Unified Form Language
+  description: |
+    The Unified Form Language (UFL) is a domain specific language
+    for declaration of finite element discretizations of variational forms.
+    More precisely, it defines a flexible interface for choosing finite element spaces
+    and defining expressions for weak forms in a notation close to mathematical notation.
+
+    UFL is part of the FEniCS Project.
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  license_file: COPYING.LESSER
+  doc_url: https://fenics.readthedocs.io/projects/ufl/en/latest/
+  dev_url: https://github.com/fenics/ufl
+
+extra:
+  recipe-maintainers:
+    - minrk

--- a/recipes/fenics-ufl/meta.yaml
+++ b/recipes/fenics-ufl/meta.yaml
@@ -6,7 +6,6 @@ package:
   version: {{ version }}
 
 source:
-  # 0.4.1 isn't on PyPI
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ extra }}.tar.gz
   sha256: 8bf5e2d30d48ab250664c6d6d539e52635c3fd708c8139c557868d6167d54de7
 


### PR DESCRIPTION
fenics-ufl is part of the newer fenicsx project, and versioned independently of the previously coordinated fenics recipe, so starting a new feedstock for one package at a time.

Related: #18888

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
