### PR TITLE
Adding oras-py feedstock for OCI registry as storage (ORAS) in Python

### DIFF
--- a/recipes/oras-py/meta.yaml
+++ b/recipes/oras-py/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - setuptools
     - jsonschema
     - requests
     - docker-py ==5.0.1

--- a/recipes/oras-py/meta.yaml
+++ b/recipes/oras-py/meta.yaml
@@ -15,6 +15,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - oras-py=oras.cli:run
+
 requirements:
   host:
     - python >=3.7

--- a/recipes/oras-py/meta.yaml
+++ b/recipes/oras-py/meta.yaml
@@ -20,6 +20,7 @@ requirements:
   host:
     - python >=3.7
     - pip
+    - pytest-runner
   run:
     - python >=3.7
     - jsonschema
@@ -30,9 +31,7 @@ test:
   requires:
     - pip
   imports:
-    oras
-  source_files:
-    - oras/
+    - oras
   commands:
     - pip check
     - oras-py --help
@@ -52,3 +51,4 @@ about:
 extra:
   recipe-maintainers:
     - vsoch
+    - wolfv

--- a/recipes/oras-py/meta.yaml
+++ b/recipes/oras-py/meta.yaml
@@ -19,18 +19,7 @@ build:
 requirements:
   host:
     - python >=3.7
-    - setuptools
     - pip
-    - jsonschema
-    - requests
-    - docker-py ==5.0.1
-    - pytest-runner
-    - pytest
-    - mypy
-    - pyflakes
-    - black
-    - types-requests
-    - isort
   run:
     - python >=3.7
     - setuptools

--- a/recipes/oras-py/meta.yaml
+++ b/recipes/oras-py/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "oras-py" %}
+{% set version = "0.0.11" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/oras-project/oras-py/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 3a1c991e122435cc3ae080fbdb0f7addcb75b17a5ec8afa22f87afc55dc93b7b
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - oras-py=oras.cli:run
+requirements:
+  host:
+    - python >=3.7
+    - setuptools
+    - pip
+    - jsonschema
+    - requests
+    - docker-py ==5.0.1
+    - pytest-runner
+    - pytest
+    - mypy
+    - pyflakes
+    - black
+    - types-requests
+    - isort
+  run:
+    - python >=3.7
+    - setuptools
+    - jsonschema
+    - requests
+    - docker-py ==5.0.1
+
+test:
+  source_files:
+    - oras/
+  commands:
+    - oras-py --help
+
+about:
+  home: https://github.com/oras-project/oras-py
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: OCI Registry as Storage Python client
+  doc_url: https://oras-project.github.io/oras-py
+  dev_url: https://github.com/oras-project/oras-py
+
+  description: |
+    OCI Registry as Storage (ORAS) enables client libraries to push OCI Artifacts to OCI Conformant registries.
+    This is a Python client for these interactions.
+
+extra:
+  recipe-maintainers:
+    - vsoch

--- a/recipes/oras-py/meta.yaml
+++ b/recipes/oras-py/meta.yaml
@@ -27,9 +27,14 @@ requirements:
     - docker-py ==5.0.1
 
 test:
+  requires:
+    - pip
+  imports:
+    oras
   source_files:
     - oras/
   commands:
+    - pip check
     - oras-py --help
 
 about:


### PR DESCRIPTION
I'm installing from the GitHub release (which triggers the pypi release) but if folks think pypi is better, we can do that too.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.