### PR TITLE
Add lodepng recipe

### DIFF
--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 
+include(GNUInstallDirs)
+
 project(lodepng)
 
 # To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE.
@@ -25,3 +27,6 @@ install(TARGETS lodepng
 
 install(EXPORT lodepng-targets 
         DESTINATION ${LODEPNG_CMAKE_INSTALL_DIR})
+
+install(FILES lodepng.h 
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -21,7 +21,12 @@ set(LODEPNG_CMAKE_INSTALL_DIR lib/cmake/lodepng)
 
 file(WRITE "${CMAKE_BINARY_DIR}/lodepng-config.cmake" 
            "include(\"\${CMAKE_CURRENT_LIST_DIR}/lodepng-targets.cmake\")")
-install(FILES "${CMAKE_BINARY_DIR}/lodepng-config.cmake" 
+           
+write_basic_package_version_file("${CMAKE_BINARY_DIR}/lodepng-config-version.cmake" 
+                                 COMPATIBILITY AnyNewerVersion)
+
+install(FILES "${CMAKE_BINARY_DIR}/lodepng-config.cmake"
+              "${CMAKE_BINARY_DIR}/lodepng-config-version.cmake"
         DESTINATION ${LODEPNG_CMAKE_INSTALL_DIR})
 
 install(TARGETS lodepng 

--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.23)
 
 project(lodepng)
 
+# To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE.
+# See https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html
+# See https://blog.kitware.com/create-dlls-on-windows-without-declspec-using-new-cmake-export-all-feature/
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
 add_library(lodepng lodepng.cpp)
 
 target_include_directories(lodepng PUBLIC

--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -24,7 +24,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/lodepng-config.cmake"
            "include(\"\${CMAKE_CURRENT_LIST_DIR}/lodepng-targets.cmake\")")
            
 write_basic_package_version_file("${CMAKE_BINARY_DIR}/lodepng-config-version.cmake" 
-                                 COMPATIBILITY AnyNewerVersion)
+                                 COMPATIBILITY ExactVersion)
 
 install(FILES "${CMAKE_BINARY_DIR}/lodepng-config.cmake"
               "${CMAKE_BINARY_DIR}/lodepng-config-version.cmake"

--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.23)
 
 include(GNUInstallDirs)
 
-project(lodepng)
+project(lodepng
+        VERSION "$ENV{PKG_VERSION}"
+        LANGUAGES CXX)
 
 # To build shared libraries in Windows, we set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to TRUE.
 # See https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html

--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.23)
+
+project(lodepng)
+
+add_library(lodepng lodepng.cpp)
+
+target_include_directories(lodepng PUBLIC
+  $<INSTALL_INTERFACE:include>
+)
+
+set(LODEPNG_CMAKE_INSTALL_DIR lib/cmake/lodepng)
+
+file(WRITE "${CMAKE_BINARY_DIR}/lodepng-config.cmake" 
+           "include(\"\${CMAKE_CURRENT_LIST_DIR}/lodepng-targets.cmake\")")
+install(FILES "${CMAKE_BINARY_DIR}/lodepng-config.cmake" 
+        DESTINATION ${LODEPNG_CMAKE_INSTALL_DIR})
+
+install(TARGETS lodepng 
+        EXPORT lodepng-targets)
+
+install(EXPORT lodepng-targets 
+        DESTINATION ${LODEPNG_CMAKE_INSTALL_DIR})

--- a/recipes/lodepng/CMakeLists.txt
+++ b/recipes/lodepng/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 project(lodepng
         VERSION "$ENV{PKG_VERSION}"

--- a/recipes/lodepng/bld.bat
+++ b/recipes/lodepng/bld.bat
@@ -1,0 +1,20 @@
+xcopy %RECIPE_DIR%\CMakeLists.txt %SRC_DIR%
+
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_SHARED_LIBS:BOOL=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/lodepng/build.sh
+++ b/recipes/lodepng/build.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS:BOOL=ON \
+      ..
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/lodepng/build.sh
+++ b/recipes/lodepng/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+cp $RECIPE_DIR/CMakeLists.txt $SRC_DIR
+
 mkdir build
 cd build
 

--- a/recipes/lodepng/meta.yaml
+++ b/recipes/lodepng/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/lvandeve/lodepng/archive/cf81b74d23c2be8137a1ac5fe342e1b5738676b7.zip
-  sha256: 8470ed1b0e9fbe88e10c34770505c8a1dc8ccb78cadcf673331aaf5224f963d2
+  sha256: a5b4a7dfff678c7f00609f0f464a8987ac712d5b3cf9e6f94f0f75445737642c
 
 build:
   number: 0

--- a/recipes/lodepng/meta.yaml
+++ b/recipes/lodepng/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "lodepng" %}
+{% set version = "20220109" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/lvandeve/lodepng/archive/cf81b74d23c2be8137a1ac5fe342e1b5738676b7.zip
+  sha256: 8470ed1b0e9fbe88e10c34770505c8a1dc8ccb78cadcf673331aaf5224f963d2
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - cmake
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - ninja
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/lodepng.h  # [not win]
+    - test -f ${PREFIX}/lib/liblodepng.so  # [linux]
+    - test -f ${PREFIX}/lib/liblodepng.dylib  # [osx]
+    - if not exist %PREFIX%\\Library\\include\\lodepng.h exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\lodepng.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\lodepng.dll exit 1  # [win]
+
+about:
+  home: https://github.com/lvandeve/lodepng
+  license: Zlib
+  license_file: LICENSE
+  summary: PNG encoder and decoder in C and C++. 
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/lodepng/meta.yaml
+++ b/recipes/lodepng/meta.yaml
@@ -5,6 +5,7 @@ package:
   name: {{ name }}
   version: {{ version }}
 
+# The repo does not have tags, but the libraries uses a date-based versioning scheme that is tracked in comments and in the source code
 source:
   url: https://github.com/lvandeve/lodepng/archive/cf81b74d23c2be8137a1ac5fe342e1b5738676b7.zip
   sha256: a5b4a7dfff678c7f00609f0f464a8987ac712d5b3cf9e6f94f0f75445737642c
@@ -17,7 +18,6 @@ build:
 requirements:
   build:
     - cmake
-    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - ninja
 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

This PR adds the recipe for the [lodepng](https://lodev.org/lodepng/) library, a dependeny of mujoco being packaged in https://github.com/conda-forge/staged-recipes/pull/19049 .

The repo does not have tags, but the libraries uses a date-based versioning scheme that is tracked in comments and in the source code, so effectively every commit that bumps that version number can be considered a release (see for example https://github.com/lvandeve/lodepng/commit/cf81b74d23c2be8137a1ac5fe342e1b5738676b7#diff-7e2e5727ba8edc29847668353e6f0bea8f67f7f14b04c4a01912bd46f1862d79L2).

Furthermore, the library  repo does not contain any build system, as quoting from the Makefile (https://github.com/lvandeve/lodepng/blob/3d9fda048393e32cc11d0c3d3caba0a85c1c2dfe/Makefile#L1):
~~~
# This makefile only makes the unit test, benchmark and pngdetail and showpng
# utilities. It does not make the PNG codec itself as shared or static library.
# That is because:
# LodePNG itself has only 1 source file (lodepng.cpp, can be renamed to
# lodepng.c) and is intended to be included as source file in other projects and
# their build system directly.
~~~

For this reason, a minimal `CMakeLists.txt` is included to compile the library and install it together with configuration file to find the library.


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
