### PR TITLE
Update base linux image to linux-anvil-cos7-x86_64 in line with rerendered recipes

### DIFF
--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -9,6 +9,6 @@ target_platform:
 channel_sources:
 - conda-forge
 docker_image:
-- quay.io/condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler_version:
 - None


### PR DESCRIPTION
There is currently some inconsistency with the rerendered recipes and this.

This should help alleviate that.