### PR TITLE
DOC: Add note about static libraries [ci skip]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,6 +37,7 @@ Checklist
 - [ ] Source is from official source.
 - [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [ ] If static libraries are linked in, the license of the static library is packaged.
+- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
 - [ ] Build number is 0.
 - [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
 - [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.


### PR DESCRIPTION
Add a note to the PR checklist about explicitly excluding static libraries. CFEPs are located separately from maintainer documentation, so they are less likely to be noticed.