### PR TITLE
.DS_Store files cause build_locally to break on Mac

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -31,7 +31,7 @@ def get_config_name(arch):
 
 
 def build_all(recipes_dir, arch):
-    folders = os.listdir(recipes_dir)
+    folders = list(filter(os.path.isdir, os.listdir(recipes_dir)))
     old_comp_folders = []
     new_comp_folders = []
     if not folders:

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -58,10 +58,5 @@ git ls-tree --name-only main -- . | xargs -I {} sh -c "rm -rf {} && echo Removin
 popd > /dev/null
 echo ""
 
-# remove .DS_Store file if finder created it
-if [ -f "./recipes/.DS_Store" ] ; then
-    rm "./recipes/.DS_Store"
-fi
-
 # We just want to build all of the recipes.
 python .ci_support/build_all.py

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -58,5 +58,10 @@ git ls-tree --name-only main -- . | xargs -I {} sh -c "rm -rf {} && echo Removin
 popd > /dev/null
 echo ""
 
+# remove .DS_Store file if finder created it
+if [ -f "./recipes/.DS_Store" ] ; then
+    rm "./recipes/.DS_Store"
+fi
+
 # We just want to build all of the recipes.
 python .ci_support/build_all.py


### PR DESCRIPTION
**Background**: When building locally on OSX, I get periodic build failures caused by the .DS_Store file created automatically by Finder in every folder.  Specifically, the problem occurs when the .DS_Store file is created in the recipes directory.  Then, in .ci_support/build_all.py in the build_all function:

```folders = os.listdir(recipes_dir)```

As a result, the build tries to build the .DS_Store file as if it were a folder with a conda recipe.  

The proposed solution is to filter to only look at directories here so any files in the recipes folder are ignored.

Another approach is to rm ./recipes/.DS_Store in the .scripts/run_osx_build.sh file.  But I thought this seemed like a better/more universal solve.


