### PR TITLE
add UGrid c-lib

### DIFF
--- a/recipes/UGrid/build.sh
+++ b/recipes/UGrid/build.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+mkdir build && pushd build
+cmake \
+    -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D netCDFCxx_DIR=${PREFIX}/lib/cmake/netCDF \
+    ${SRC_DIR}
+
+make
+ctest
+make install

--- a/recipes/UGrid/build.sh
+++ b/recipes/UGrid/build.sh
@@ -3,6 +3,7 @@
 mkdir build && pushd build
 cmake \
     -D CMAKE_INSTALL_PREFIX=${PREFIX} \
+    -D CXX_STANDARD=17 \
     -D netCDFCxx_DIR=${PREFIX}/lib/cmake/netCDF \
     ${SRC_DIR}
 

--- a/recipes/UGrid/conda_build_config.yaml
+++ b/recipes/UGrid/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+  - conda-forge ugrid_dev

--- a/recipes/UGrid/meta.yaml
+++ b/recipes/UGrid/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "UGrid" %}
+{% set version = "0.0.1.dev" %}
+{% set commit = "79841fe3af2cf60eece683e6cff2d5dc31690698" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/Deltares/UGrid/archive/{{ commit }}.zip
+  sha256: a8c42f8d23c947de342dcb3a82102487c9af207a3e10da0d0228b8e9c1df7575
+  patches:
+    - patches/constans.patch
+    - patches/use_runtime_error.patch
+
+build:
+  skip: True  # [win]
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - make
+  host:
+    - boost
+    - boost-cpp
+    - netcdf-cxx4
+  run:
+    - boost
+    - boost-cpp
+    - netcdf-cxx4
+
+test:
+  commands:
+    - test -f ${PREFIX}/UGrid/lib/libUGridApi${SHLIB_EXT}  # [not win]
+
+about:
+  home: https://github.com/Deltares/UGrid
+  summary: Deltares library for reading/writing UGrid compliant files
+  description: |
+     Deltares library for reading/writing UGrid files. The UGrid entities available in this library are: Network1d, Mesh1d, Mesh2d and Contacts.
+     Network1d, Mesh1d, and Contacts concern Deltares extensions to UGrid, which will be submitted to the UGrid community.
+  license: LGPL-2.1-or-later
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - ocefpaf

--- a/recipes/UGrid/meta.yaml
+++ b/recipes/UGrid/meta.yaml
@@ -20,16 +20,17 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - cmake
+    - cmake >=3.19
     - make
   host:
     - boost
     - boost-cpp
-    - netcdf-cxx4
+    - netcdf-cxx4 >=4.3.1
+    - openlibm
   run:
     - boost
     - boost-cpp
-    - netcdf-cxx4
+    - netcdf-cxx4 >=4.3.1
 
 test:
   commands:

--- a/recipes/UGrid/patches/constans.patch
+++ b/recipes/UGrid/patches/constans.patch
@@ -1,0 +1,12 @@
+--- UGrid-79841fe3af2cf60eece683e6cff2d5dc31690698.orig/include/UGrid/Constants.hpp	2022-05-03 12:07:03.000000000 -0300
++++ UGrid-79841fe3af2cf60eece683e6cff2d5dc31690698/include/UGrid/Constants.hpp	2022-06-27 14:53:46.091974807 -0300
+@@ -25,6 +25,9 @@
+ //
+ //------------------------------------------------------------------------------
+ 
++#include <stdexcept>
++#include <limits>
++
+ #pragma once
+ 
+ /// \namespace ugrid

--- a/recipes/UGrid/patches/use_runtime_error.patch
+++ b/recipes/UGrid/patches/use_runtime_error.patch
@@ -1,0 +1,16 @@
+--- UGrid-79841fe3af2cf60eece683e6cff2d5dc31690698.orig/tests/utils/include/TestUtils/Utils.hpp	2022-05-03 12:07:03.000000000 -0300
++++ UGrid-79841fe3af2cf60eece683e6cff2d5dc31690698/tests/utils/include/TestUtils/Utils.hpp	2022-06-27 15:11:28.239944112 -0300
+@@ -70,11 +70,11 @@
+ {
+     if (value.empty())
+     {
+-        throw std::exception("string_to_char_array: value string is empty.");
++        throw std::runtime_error("string_to_char_array: value string is empty.");
+     }
+     if (char_array == nullptr)
+     {
+-        throw std::exception("string_to_char_array: char_array is nullptr.");
++        throw std::runtime_error("string_to_char_array: char_array is nullptr.");
+     }
+     for (auto i = 0; i < value.size(); ++i)
+     {


### PR DESCRIPTION
Adding https://github.com/Deltares/UGrid

@rsignell-usgs this is the first step but UGridpy will be more challenging b/c that is not ready to use an external c-lib for UGrid yet. They are bundling a pre-built .so/.dll files it in their source code and that is a no-no is most packaging ecosystems.

TODO:
- [ ] patch UGridpy to use the c-lib
- [ ] package the `meshkernel` dependency