### PR TITLE
adds r-eikosograms

### DIFF
--- a/recipes/r-eikosograms/bld.bat
+++ b/recipes/r-eikosograms/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-eikosograms/build.sh
+++ b/recipes/r-eikosograms/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-eikosograms/meta.yaml
+++ b/recipes/r-eikosograms/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '0.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-eikosograms
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/eikosograms_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/eikosograms/eikosograms_{{ version }}.tar.gz
+  sha256: 3a7435754c15d56c192f3bdd91fca27c25bcb36b09665d87859647c418e6458f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-plyr
+  run:
+    - r-base
+    - r-plyr
+
+test:
+  commands:
+    - $R -e "library('eikosograms')"           # [not win]
+    - "\"%R%\" -e \"library('eikosograms')\""  # [win]
+
+about:
+  home: https://github.com/rwoldford/eikosograms
+  license: GPL-3.0-only
+  summary: An eikosogram (ancient Greek for probability picture) divides the unit square into
+    rectangular regions whose areas, sides, and widths, represent various probabilities
+    associated with the values of one or more categorical variates. Rectangle areas
+    are joint probabilities, widths are always marginal (though possibly joint margins,
+    i.e. marginal joint distributions of two or more variates), and heights of rectangles
+    are always conditional probabilities. Eikosograms embed the rules of probability
+    and are useful for introducing elementary probability theory, including axioms,
+    marginal, conditional, and joint probabilities, and their relationships (including
+    Bayes theorem as a completely trivial consequence). They are markedly superior to
+    Venn diagrams for this purpose, especially in distinguishing probabilistic independence,
+    mutually exclusive events, coincident events, and associations. They also are useful
+    for identifying and understanding conditional independence structure. As data analysis
+    tools, eikosograms display categorical data in a manner similar to Mosaic plots,
+    especially when only two variates are involved (the only case in which they are
+    essentially identical, though eikosograms purposely disallow spacing between rectangles).
+    Unlike Mosaic plots, eikosograms do not alternate axes as each new categorical variate
+    (beyond two) is introduced. Instead, only one categorical variate, designated the
+    "response", presents on the vertical axis and all others, designated the "conditioning"
+    variates, appear on the horizontal. In this way, conditional probability appears
+    only as height and marginal probabilities as widths. The eikosogram is therefore
+    much better suited to a response model analysis (e.g. logistic model) than is a
+    Mosaic plot. Mosaic plots are better suited to log-linear style modelling as in
+    discrete multivariate analysis. Of course, eikosograms are also suited to discrete
+    multivariate analysis with each variate in turn appearing as the response. This
+    makes it better suited than Mosaic plots to discrete graphical models based on conditional
+    independence graphs (i.e. "Bayesian Networks" or "BayesNets"). The eikosogram and
+    its superiority to Venn diagrams in teaching probability is described in W.H. Cherry
+    and R.W. Oldford (2003) <https://math.uwaterloo.ca/~rwoldfor/papers/eikosograms/paper.pdf>,
+    its value in exploring conditional independence structure and relation to graphical
+    and log-linear models is described in R.W. Oldford (2003) <https://math.uwaterloo.ca/~rwoldfor/papers/eikosograms/independence/paper.pdf>,
+    and a number of problems, puzzles, and paradoxes that are easily explained with
+    eikosograms are given in R.W. Oldford (2003) <https://math.uwaterloo.ca/~rwoldfor/papers/eikosograms/examples/paper.pdf>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler


### PR DESCRIPTION
Adds CRAN package `eikosograms` as `r-eikosograms`. Recipe generated with `conda_r_skeleton_helper`, with license adjusted to SPDX specification.

Closes #18536

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
