### PR TITLE
Adding omsl - OpenModelica Modelica Standard Library

### DIFF
--- a/recipes/omsl/LICENSE.txt
+++ b/recipes/omsl/LICENSE.txt
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 1998-2020, Modelica Association and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/omsl/build.sh
+++ b/recipes/omsl/build.sh
@@ -13,7 +13,7 @@ case $MSLVERSION in
   cp -R $SRC_DIR/ModelicaServices $PREFIX/"lib/omlibrary/ModelicaServices 4.0.0"
 ;;
 *)
-  echo don\'t know
+  echo don\'t know what to build. MSLVERSION requests a non existing version or not defined.
   exit 1
 ;;
 esac

--- a/recipes/omsl/build.sh
+++ b/recipes/omsl/build.sh
@@ -1,4 +1,19 @@
 mkdir $PREFIX/lib/omlibrary
-cp -R $SRC_DIR/Complex.mo $PREFIX/"lib/omlibrary/Complex 4.0.0.mo"
-cp -R $SRC_DIR/Modelica $PREFIX/"lib/omlibrary/Modelica 3.2.3"
-cp -R $SRC_DIR/ModelicaServices $PREFIX/"lib/omlibrary/ModelicaServices 4.0.0"
+case $MSLVERSION in
+'3.2.3')
+  echo 'Installing MSL 3.2.3 ...'
+  cp -R $SRC_DIR/Complex.mo $PREFIX/"lib/omlibrary/Complex 4.0.0.mo"
+  cp -R $SRC_DIR/Modelica $PREFIX/"lib/omlibrary/Modelica 3.2.3"
+  cp -R $SRC_DIR/ModelicaServices $PREFIX/"lib/omlibrary/ModelicaServices 4.0.0"
+;;
+'4.0.0')
+  echo 'Installing MSL 4.0.0 ...'
+  cp -R $SRC_DIR/Complex.mo $PREFIX/"lib/omlibrary/Complex 4.0.0.mo"
+  cp -R $SRC_DIR/Modelica $PREFIX/"lib/omlibrary/Modelica 4.0.0"
+  cp -R $SRC_DIR/ModelicaServices $PREFIX/"lib/omlibrary/ModelicaServices 4.0.0"
+;;
+*)
+  echo don\'t know
+  exit 1
+;;
+esac

--- a/recipes/omsl/build.sh
+++ b/recipes/omsl/build.sh
@@ -1,0 +1,4 @@
+mkdir $PREFIX/lib/omlibrary
+cp -R $SRC_DIR/Complex.mo $PREFIX/"lib/omlibrary/Complex 4.0.0.mo"
+cp -R $SRC_DIR/Modelica $PREFIX/"lib/omlibrary/Modelica 3.2.3"
+cp -R $SRC_DIR/ModelicaServices $PREFIX/"lib/omlibrary/ModelicaServices 4.0.0"

--- a/recipes/omsl/conda_build_config.yaml
+++ b/recipes/omsl/conda_build_config.yaml
@@ -1,0 +1,17 @@
+mslversion:
+  - 3.2.3
+  - 4.0.0
+mslsourceurl:
+  - https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
+  - https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/c11123102e94d4b5acb139331a6d85f45d8adcc0.zip
+mslsourcesha256:
+  - 16dbb64fc3e2badde01cecd6af73b95f88e12355e393abeb827927beba3fc289
+  - 0792c4841a0ab8e2ffb750a0a1fffa45d6a5b6b224c045db67c241fef570c229
+mslscript:
+  - build_3_2_3.sh
+  - build_4_0_0.sh
+zip_keys:
+  - mslversion
+  - mslsourceurl
+  - mslsourcesha256
+  - mslscript

--- a/recipes/omsl/conda_build_config.yaml
+++ b/recipes/omsl/conda_build_config.yaml
@@ -7,11 +7,7 @@ mslsourceurl:
 mslsourcesha256:
   - 16dbb64fc3e2badde01cecd6af73b95f88e12355e393abeb827927beba3fc289
   - 0792c4841a0ab8e2ffb750a0a1fffa45d6a5b6b224c045db67c241fef570c229
-mslscript:
-  - build_3_2_3.sh
-  - build_4_0_0.sh
 zip_keys:
   - mslversion
   - mslsourceurl
   - mslsourcesha256
-  - mslscript

--- a/recipes/omsl/meta.yaml
+++ b/recipes/omsl/meta.yaml
@@ -6,21 +6,19 @@
 # Using the name variable with the URL in line 14 is convenient
 # when copying and pasting from another recipe, but not really needed.
 {% set name = "omsl" %}
-{% set version = "3.2.3" %}
 
 package:
   name: {{ name|lower }}
-  version: {{ version }}
+  version: {{ mslversion }}
 
 source:
-  url: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
-  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # If getting the source from GitHub, remove the line above,
-  # uncomment the line below, and modify as needed. Use releases if available:
-  # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
-  # and otherwise fall back to archive:
-  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
-  sha256: 16dbb64fc3e2badde01cecd6af73b95f88e12355e393abeb827927beba3fc289
+  #path: ../../archive
+  # /e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
+  
+  #url: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
+  #sha256: 16dbb64fc3e2badde01cecd6af73b95f88e12355e393abeb827927beba3fc289
+  url: {{ mslsourceurl }}
+  sha256: {{ mslsourcesha256 }}
   # sha256 is the preferred checksum -- you can get it for a file with:
   #  `openssl sha256 <file name>`.
   # You may need the openssl package, available on conda-forge:
@@ -30,20 +28,19 @@ build:
   # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
   # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
   # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
-  # noarch: python
+  noarch: generic
   # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
   # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
   # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   # More info about selectors can be found in the conda-build docs: 
   # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors
   #script: {{ PYTHON }} -m pip install . -vv
+  script_env:
+   - MSLVERSION={{ mslversion }}
+  #script: {{ mslscript }}
   number: 0
 
 requirements:
-  build:
-    # If your project compiles code (such as a C extension) then add the required compilers as separate entries here.
-    # Compilers are named 'c', 'cxx' and 'fortran'.
-    #- {{ compiler('c') }}
   host:
     - python
     - pip
@@ -57,28 +54,18 @@ requirements:
     - make               # required by omcompiler (if not already present on the host)
     - cmake              # required by omcompiler (if not already present on the host)
 
-#test:
-  # Some packages might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
-  #imports:
-  #  - simplejson
-  #  - simplejson.tests
-  # For python packages, it is useful to run pip check. However, sometimes the
-  # metadata used by pip is out of date. Thus this section is optional if it is
-  # failing.
-  #requires:
-  #  - pip
-  #commands:
-  #  - pip check
-
 about:
   home: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary
   summary: 'OpenModelica Patched Version of the Modelica Standard Library'
   description: |
-    simplejson is a simple, fast, complete, correct and extensible
-    JSON <https://json.org> encoder and decoder for Python 2.5+ and
-    Python 3.3+. It is pure Python code with no dependencies, but includes
-    an optional C extension for a serious speed boost.
+    The package Modelica is a free library that is developed together with
+    the Modelica language from the Modelica Association. It is also called
+    Modelica Standard Library. It provides model components and standard
+    component interfaces from many engineering domains. Each model comes
+    with documentation included.
+    OpenModelica <https://openmodelica.org> is a Modelica simulation
+    environment. It is required for the usage of this library and is provided
+    by the conda package omcompiler.
   # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
   # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
   # See https://spdx.org/licenses/
@@ -91,12 +78,7 @@ about:
   # Please also note that some projects have multiple license files which all need to be added using a valid yaml list.
   # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
   license_file: LICENSE.txt
-  # The doc_url and dev_url are optional.
-  #doc_url: https://simplejson.readthedocs.io/
-  #dev_url: https://github.com/simplejson/simplejson
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - joewa

--- a/recipes/omsl/meta.yaml
+++ b/recipes/omsl/meta.yaml
@@ -28,6 +28,12 @@ requirements:
     - make               # required by omcompiler (if not already present on the host)
     - cmake              # required by omcompiler (if not already present on the host)
 
+test:
+  script_env:
+   - MSLVERSION={{ mslversion }}
+  requires:
+    - pytest
+
 about:
   home: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary
   summary: 'OpenModelica Patched Version of the Modelica Standard Library'

--- a/recipes/omsl/meta.yaml
+++ b/recipes/omsl/meta.yaml
@@ -1,10 +1,3 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-# If your package is python based, we recommend using Grayskull to generate it instead:
-# https://github.com/conda-incubator/grayskull
-
-# Jinja variables help maintain the recipe as you'll update the version only here.
-# Using the name variable with the URL in line 14 is convenient
-# when copying and pasting from another recipe, but not really needed.
 {% set name = "omsl" %}
 
 package:
@@ -12,33 +5,15 @@ package:
   version: {{ mslversion }}
 
 source:
-  #path: ../../archive
-  # /e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
-  
-  #url: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
-  #sha256: 16dbb64fc3e2badde01cecd6af73b95f88e12355e393abeb827927beba3fc289
   url: {{ mslsourceurl }}
   sha256: {{ mslsourcesha256 }}
-  # sha256 is the preferred checksum -- you can get it for a file with:
-  #  `openssl sha256 <file name>`.
-  # You may need the openssl package, available on conda-forge:
-  #  `conda install openssl -c conda-forge``
 
 build:
-  # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
   noarch: generic
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
-  # More info about selectors can be found in the conda-build docs: 
-  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors
-  #script: {{ PYTHON }} -m pip install . -vv
   script_env:
    - MSLVERSION={{ mslversion }}
-  #script: {{ mslscript }}
   number: 0
+  skip: true  # [not linux]
 
 requirements:
   host:
@@ -66,17 +41,8 @@ about:
     OpenModelica <https://openmodelica.org> is a Modelica simulation
     environment. It is required for the usage of this library and is provided
     by the conda package omcompiler.
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
-  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
-  # See https://spdx.org/licenses/
   license: BSD-3-Clause
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". 
-  # Optional
   license_family: BSD
-  # It is required to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # Please also note that some projects have multiple license files which all need to be added using a valid yaml list.
-  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
   license_file: LICENSE.txt
 
 extra:

--- a/recipes/omsl/meta.yaml
+++ b/recipes/omsl/meta.yaml
@@ -9,7 +9,6 @@ source:
   sha256: {{ mslsourcesha256 }}
 
 build:
-  noarch: generic
   script_env:
    - MSLVERSION={{ mslversion }}
   number: 0

--- a/recipes/omsl/meta.yaml
+++ b/recipes/omsl/meta.yaml
@@ -1,0 +1,102 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+# If your package is python based, we recommend using Grayskull to generate it instead:
+# https://github.com/conda-incubator/grayskull
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+# Using the name variable with the URL in line 14 is convenient
+# when copying and pasting from another recipe, but not really needed.
+{% set name = "omsl" %}
+{% set version = "3.2.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary/archive/e68d7a0317c565ee00c1b8d44c527979ea0304bf.zip
+  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # If getting the source from GitHub, remove the line above,
+  # uncomment the line below, and modify as needed. Use releases if available:
+  # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
+  # and otherwise fall back to archive:
+  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
+  sha256: 16dbb64fc3e2badde01cecd6af73b95f88e12355e393abeb827927beba3fc289
+  # sha256 is the preferred checksum -- you can get it for a file with:
+  #  `openssl sha256 <file name>`.
+  # You may need the openssl package, available on conda-forge:
+  #  `conda install openssl -c conda-forge``
+
+build:
+  # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
+  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
+  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
+  # noarch: python
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  # More info about selectors can be found in the conda-build docs: 
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors
+  #script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  build:
+    # If your project compiles code (such as a C extension) then add the required compilers as separate entries here.
+    # Compilers are named 'c', 'cxx' and 'fortran'.
+    #- {{ compiler('c') }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - omcompiler
+    - libiconv           # required by omcompiler (if not already present on the host)
+    - gcc_linux-64       # required by omcompiler (if not already present on the host)
+    - gxx_linux-64       # required by omcompiler (if not already present on the host)
+    - gfortran_linux-64  # required by omcompiler (if not already present on the host)
+    - make               # required by omcompiler (if not already present on the host)
+    - cmake              # required by omcompiler (if not already present on the host)
+
+#test:
+  # Some packages might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  #imports:
+  #  - simplejson
+  #  - simplejson.tests
+  # For python packages, it is useful to run pip check. However, sometimes the
+  # metadata used by pip is out of date. Thus this section is optional if it is
+  # failing.
+  #requires:
+  #  - pip
+  #commands:
+  #  - pip check
+
+about:
+  home: https://github.com/OpenModelica/OpenModelica-ModelicaStandardLibrary
+  summary: 'OpenModelica Patched Version of the Modelica Standard Library'
+  description: |
+    simplejson is a simple, fast, complete, correct and extensible
+    JSON <https://json.org> encoder and decoder for Python 2.5+ and
+    Python 3.3+. It is pure Python code with no dependencies, but includes
+    an optional C extension for a serious speed boost.
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
+  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
+  # See https://spdx.org/licenses/
+  license: BSD-3-Clause
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". 
+  # Optional
+  license_family: BSD
+  # It is required to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # Please also note that some projects have multiple license files which all need to be added using a valid yaml list.
+  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
+  license_file: LICENSE.txt
+  # The doc_url and dev_url are optional.
+  #doc_url: https://simplejson.readthedocs.io/
+  #dev_url: https://github.com/simplejson/simplejson
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - joewa

--- a/recipes/omsl/run_test.py
+++ b/recipes/omsl/run_test.py
@@ -1,0 +1,45 @@
+import os
+import json
+import glob
+import sys
+
+
+def create_mos_file(mosfn, mofile=None, modelName=None, install_msl=False, load_msl=False):
+    mos_file = open(mosfn, 'w', 1)
+    if install_msl:
+        # TODO: check if already installed
+        mos_file.write('installPackage(Modelica, "3.2.3");')
+        mos_file.write('getErrorString();')
+    if load_msl:
+        mos_file.write('loadModel(Modelica);\n')
+        mos_file.write('getErrorString();')
+    if mofile is not None:
+        mos_file.write('loadFile("' + mofile + '");\n')
+        mos_file.write('getErrorString();')
+    if modelName is not None:
+        mos_file.write('buildModel(' + modelName + ');\n')
+        mos_file.write('getErrorString();')
+    mos_file.close()
+    pass
+
+
+def run_mos_file(mosfn):
+    r = os.popen("omc " + mosfn).readlines()
+    return r
+
+
+def main():
+    prefix = os.environ['CONDA_PREFIX']
+    msl_version = os.environ['MSLVERSION']
+
+    msl_directory = glob.glob(os.path.join(prefix, 'lib', 'omlibrary', 'Modelica ' + msl_version))
+    assert len(msl_directory) == 1, "did not find MSL directory - check recipe and build.sh"
+
+    create_mos_file('load_msl.mos', load_msl=True)
+    r = run_mos_file('load_msl.mos')
+    assert len(r) > 0, "calling omc did not return anything"
+    assert 'true' in r[0], "loadModel(Modelica) did not succeed"
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adding the OpenModelica Modelica Standard Library for usage with omcompiler in a conda environment.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
