### PR TITLE
Add aiocircuitbreaker recipe

### DIFF
--- a/recipes/aiocircuitbreaker/meta.yaml
+++ b/recipes/aiocircuitbreaker/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "aiocircuitbreaker" %}
+{% set version = "2.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aiocircuitbreaker-{{ version }}.tar.gz
+  sha256: 21cc3ed3a4c40b8004239fedb2630dbecb8d30dab020d201721c9f745bc8f04f
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - poetry >=1.1.12
+  run:
+    - python >=3.9
+
+test:
+  imports:
+    - aiocircuitbreaker
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/GenyaSol/aiocircuitbreaker
+  summary: This is an async Python implementation of the circuitbreaker library https://github.com/fabfuel/circuitbreaker.
+  license: MIT
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - xtrojak
+    - hechth


### PR DESCRIPTION
This PR adds a recipe for [aiocircuitbreaker](https://github.com/sgenya/aiocircuitbreaker).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
