### PR TITLE
Add r-ggvenndiagram, r-rvenn

### DIFF
--- a/recipes/r-ggvenndiagram/bld.bat
+++ b/recipes/r-ggvenndiagram/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ggvenndiagram/build.sh
+++ b/recipes/r-ggvenndiagram/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ggvenndiagram/meta.yaml
+++ b/recipes/r-ggvenndiagram/meta.yaml
@@ -1,0 +1,74 @@
+{% set version = '1.2.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggvenndiagram
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggVennDiagram_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggVennDiagram/ggVennDiagram_{{ version }}.tar.gz
+  sha256: 939c0bd3e7c01c87560a9dd938cfc46ac7bd52a56147d9464f58b053998d8cd0
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rvenn
+    - r-dplyr
+    - r-ggplot2
+    - r-magrittr
+    - r-plotly
+    - r-purrr
+    - r-sf
+    - r-tibble
+    - r-yulab.utils
+  run:
+    - r-base
+    - r-rvenn
+    - r-dplyr
+    - r-ggplot2
+    - r-magrittr
+    - r-plotly
+    - r-purrr
+    - r-sf
+    - r-tibble
+    - r-yulab.utils
+
+test:
+  commands:
+    - $R -e "library('ggVennDiagram')"           # [not win]
+    - "\"%R%\" -e \"library('ggVennDiagram')\""  # [win]
+
+about:
+  home: https://github.com/gaospecial/ggVennDiagram
+  license: GPL-3.0-only
+  summary: 'Easy-to-use functions to generate 2-7 sets Venn plot in publication quality. ''ggVennDiagram''
+    plot Venn using well-defined geometry dataset and ''ggplot2''. The shapes of 2-4
+    sets Venn use circles and ellipses, while the shapes of 4-7 sets Venn use irregular
+    polygons (4 has both forms), which are developed and imported from another package
+    ''venn'', authored by Adrian Dusa. We provided internal functions to integrate shape
+    data with user provided sets data, and calculated the geometry of every regions/intersections
+    of them, then separately plot Venn in three components: set edges, set labels, and
+    regions. From version 1.0, it is possible to customize these components as you demand
+    in ordinary ''ggplot2'' grammar.'
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler

--- a/recipes/r-rvenn/bld.bat
+++ b/recipes/r-rvenn/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rvenn/build.sh
+++ b/recipes/r-rvenn/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rvenn/meta.yaml
+++ b/recipes/r-rvenn/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = '1.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rvenn
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/RVenn_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/RVenn/RVenn_{{ version }}.tar.gz
+  sha256: c41a96dd4a9b51e7dcc8647cdbaa0faa704ab22d5b0c1d45e593a6b23b00d504
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-ggforce >=0.2.1
+    - r-ggplot2 >=3.0.0
+    - r-magrittr >=1.5
+    - r-pheatmap >=1.0.10
+    - r-purrr >=0.2.5
+    - r-rlang >=0.2.2
+    - r-vegan >=2.5.2
+  run:
+    - r-base
+    - r-ggforce >=0.2.1
+    - r-ggplot2 >=3.0.0
+    - r-magrittr >=1.5
+    - r-pheatmap >=1.0.10
+    - r-purrr >=0.2.5
+    - r-rlang >=0.2.2
+    - r-vegan >=2.5.2
+
+test:
+  commands:
+    - $R -e "library('RVenn')"           # [not win]
+    - "\"%R%\" -e \"library('RVenn')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=RVenn
+  license: GPL-3.0-only
+  summary: Set operations for many sets. The base functions for set operations in R can be used
+    for only two sets. This package uses 'purr' to find the union, intersection and
+    difference of three or more sets. This package also provides functions for pairwise
+    set operations among several sets. Further, based on 'ggplot2' and 'ggforce', a
+    Venn diagram can be drawn for two or three sets. For bigger data sets, a clustered
+    heatmap showing presence/absence of the elements of the sets can be drawn based
+    on the 'pheatmap' package. Finally, enrichment test can be applied to two sets whether
+    an overlap is statistically significant or not.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler


### PR DESCRIPTION
## Overview
Adds CRAN packages [`ggVennDiagram`](https://cran.r-project.org/web/packages/ggVennDiagram/index.html) and [`RVenn`](https://cran.r-project.org/web/packages/RVenn/index.html) as `r-ggvenndiagram` and `r-rvenn`, respectively. Recipes generated with `conda_r_skeleton_helper`, with licenses conformed to SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] ~If static libraries are linked in, the license of the static library is packaged.~
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
