### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -8,6 +8,9 @@
     pull_request_target:
       types: [unlabeled]
 
+  permissions:
+    issues: write # for adding label to an issue
+
   jobs:
 
     add-review-team-label:

--- a/.github/workflows/create_feedstocks.yml
+++ b/.github/workflows/create_feedstocks.yml
@@ -8,8 +8,13 @@ on:
     - cron:  '*/10 * * * *'
   workflow_dispatch: null
 
+permissions: {}
 jobs:
   create-feedstocks:
+    permissions:
+      contents: write # for git push
+      actions: read # to read runs
+
     if: github.repository == 'conda-forge/staged-recipes'
     name: Create feedstocks
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.