### PR TITLE
add kubo (ne go-ipfs) 0.15.0

### DIFF
--- a/recipes/kubo/bld.bat
+++ b/recipes/kubo/bld.bat
@@ -1,0 +1,13 @@
+copy "%RECIPE_DIR%\build_win.sh" .
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+set PREFIX=%PREFIX:\=/%
+set SRC_DIR=%SRC_DIR:\=/%
+set MSYSTEM=MINGW%ARCH%
+set MSYS2_PATH_TYPE=inherit
+set CHERE_INVOKING=1
+
+bash -lc "./build_win.sh"
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+exit /b 0

--- a/recipes/kubo/build.sh
+++ b/recipes/kubo/build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eux
+
+export GOPATH="$( pwd )"
+export CGO_ENABLED=1
+export CGO_CFLAGS="${CFLAGS}"
+export CGO_LDFLAGS="${LDFLAGS}"
+export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=vendor -modcacherw"
+export GOTAGS="openssl"
+
+module='github.com/ipfs/kubo'
+
+if [ $(uname) == Darwin ]; then
+    export CGO_CFLAGS="-I${PREFIX}/include/ ${CGO_CFLAGS}"
+    export CGO_LDFLAGS="-L${PREFIX}/lib/ ${CGO_LDFLAGS}"
+    pushd "src/${module}/vendor/github.com/libp2p/go-openssl"
+        sed -i '' -e "s|/usr/local/opt/openssl@1.1|${PREFIX}|g" build.go
+        sed -i '' -e "s|-I/usr/local/opt/openssl/include||" build.go
+        sed -i '' -e "s|-L/usr/local/opt/openssl/lib||" build.go
+        cat build.go
+    popd
+fi
+
+make -C "src/${module}" install nofuse
+
+pushd "src/${module}"
+    mkdir -p ${PREFIX}/bin
+    cp cmd/ipfs/ipfs ${PREFIX}/bin
+    bash $RECIPE_DIR/build_library_licenses.sh
+popd

--- a/recipes/kubo/build_library_licenses.sh
+++ b/recipes/kubo/build_library_licenses.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eux
+
+export LIBRARY_LICENSES_PATH="$SRC_DIR/library_licenses/"
+
+go-licenses save \
+    "." \
+    --save_path "$LIBRARY_LICENSES_PATH" \
+    2>&1 \
+    | tee "$SRC_DIR/go-licenses.log" \
+    || echo "ignoring errors until go-licenses --ignore is available"
+
+find "$LIBRARY_LICENSES_PATH"

--- a/recipes/kubo/build_win.sh
+++ b/recipes/kubo/build_win.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eux
+
+export GOPATH="$( pwd )"
+export CGO_ENABLED=0
+export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=vendor -modcacherw"
+
+# omissions from the unix build, needs investigation
+# export GOTAGS="openssl"
+# export CGO_CFLAGS="${CFLAGS}"
+# export CGO_CXXFLAGS="${CPPFLAGS}"
+# export CGO_LDFLAGS="${LDFLAGS}"
+
+module='github.com/ipfs/kubo'
+
+make -C "src/${module}" install nofuse
+
+pushd "src/${module}"
+    bash $RECIPE_DIR/build_library_licenses.sh
+popd

--- a/recipes/kubo/conda_build_config.yaml
+++ b/recipes/kubo/conda_build_config.yaml
@@ -1,0 +1,9 @@
+# Please consult conda-forge/core before doing this
+MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
+- '10.14'                  # [osx and x86_64]
+MACOSX_SDK_VERSION:        # [osx and x86_64]
+- '10.14'                  # [osx and x86_64]
+go_compiler:  # [win]
+- go-nocgo  # [win]
+openssl:
+- "1.1.1"

--- a/recipes/kubo/meta.yaml
+++ b/recipes/kubo/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "kubo" %}
+{% set version = "0.15.0" %}
+{% set gomodule = "github.com/ipfs/" ~ name %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - folder: src/{{ gomodule }}
+    url: https://{{ gomodule }}/releases/download/v{{ version }}/{{ name }}-source.tar.gz
+    sha256: 1a4398d46d822976cc6c75e4c39bf6ec799f909225da764e9a38d96f3b9a456b
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - go >=1.18  # [unix]
+    - go-cgo >=1.18  # [unix]
+    - {{ compiler('go') }}  # [win]
+    - posix  # [win]
+    - go-licenses
+    - make  # [unix]
+  host:
+    - openssl  # [unix]
+  run_constrained:
+    - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.14") }}  # [osx and x86_64]
+    - go-ipfs >=9000
+
+{% set cid = "/ipfs/QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc" %}
+{% set ipfs_args = "-c ./.ipfs-repo --debug" %}
+
+test:
+  commands:
+    - ipfs --version
+    - ipfs --help
+    - ipfs commands
+    - ipfs {{ ipfs_args }} init
+    - ipfs {{ ipfs_args }} ls {{ cid }}
+    - ipfs {{ ipfs_args }} refs {{ cid }}
+    - ipfs {{ ipfs_args }} cat {{ cid }}/readme
+    - ipfs {{ ipfs_args }} get {{ cid }}
+    - echo 'hello world' > hello.txt
+    - ipfs {{ ipfs_args }} add hello.txt
+
+about:
+  home: https://ipfs.tech
+  license: Apache-2.0 or MIT
+  license_file:
+    # directly provided by upstream
+    - src/{{ gomodule }}/LICENSE-APACHE
+    - src/{{ gomodule }}/LICENSE-MIT
+    - library_licenses/
+    - go-licenses.log
+
+  summary: IPFS implementation in Go
+
+  description: |
+    Kubo (go-ipfs) the earliest and most widely used implementation of IPFS.
+
+    It includes:
+      - an IPFS daemon server
+      - extensive command line tooling
+      - an HTTP Gateway (/ipfs/, /ipns/) for serving content to HTTP browsers
+      - an HTTP RPC API (/api/v0) for controlling the daemon node
+
+  doc_url: https://docs.ipfs.tech
+  dev_url: https://{{ gomodule }}
+
+extra:
+  feedstock-name: go-ipfs
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
  - [x] _This CFEP excludes languages like Rust, Haskell, Go where binaries are always statically linked. The mentioned downsides apply there too but there isn't the option of using dynamic linkage._
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


Notes:
- fixes https://github.com/conda-forge/go-ipfs-feedstock/issues/17
- after this, should do https://github.com/conda-forge/go-ipfs-feedstock/issues/19