### PR TITLE
add gromacswrapper

### DIFF
--- a/recipes/gromacswrapper/meta.yaml
+++ b/recipes/gromacswrapper/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "gromacswrapper" %}
+{% set version = "0.8.2" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/GromacsWrapper-{{ version }}.tar.gz
+  sha256: 4d695db79e536ee9752a82551de5f58451bd1c0aa0b7d6cb30fe7e3b9e19768f
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python
+  run:
+    - matplotlib-base
+    - numkit
+    - numpy >=1.0
+    - python
+    - six
+
+test:
+  imports:
+    - gromacs
+    - gromacs.fileformats
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/Becksteinlab/GromacsWrapper
+  summary: A python wrapper around the Gromacs tools.
+  doc_url: https://pythonhosted.org/GromacsWrapper/
+  dev_url: https://github.com/Becksteinlab/GromacsWrapper
+  license: GPL-3.0
+  license_family: GPL
+  license_file: COPYING
+  description: |
+    GromacsWrapper is a Python package that wraps system calls to GROMACS
+    tools into thin classes. This allows for fairly seamless integration
+    of the GROMACS tools into Python scripts.
+
+extra:
+  recipe-maintainers:
+    - njzjz

--- a/recipes/gromacswrapper/meta.yaml
+++ b/recipes/gromacswrapper/meta.yaml
@@ -18,12 +18,12 @@ build:
 requirements:
   host:
     - pip
-    - python
+    - python >=3.6
   run:
     - matplotlib-base
     - numkit
     - numpy >=1.0
-    - python
+    - python >=3.6
     - six
 
 test:
@@ -40,7 +40,7 @@ about:
   summary: A python wrapper around the Gromacs tools.
   doc_url: https://pythonhosted.org/GromacsWrapper/
   dev_url: https://github.com/Becksteinlab/GromacsWrapper
-  license: GPL-3.0
+  license: GPL-3.0-only
   license_family: GPL
   license_file: COPYING
   description: |

--- a/recipes/gromacswrapper/meta.yaml
+++ b/recipes/gromacswrapper/meta.yaml
@@ -40,7 +40,7 @@ about:
   summary: A python wrapper around the Gromacs tools.
   doc_url: https://pythonhosted.org/GromacsWrapper/
   dev_url: https://github.com/Becksteinlab/GromacsWrapper
-  license: GPL-3.0-only
+  license: GPL-3.0-or-later
   license_family: GPL
   license_file: COPYING
   description: |


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->
Add `gromacswrapper`, the new dependency of `dpgen`.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
