### PR TITLE
Add recipe for gz-cmake

### DIFF
--- a/recipes/gz-cmake/bld.bat
+++ b/recipes/gz-cmake/bld.bat
@@ -1,0 +1,22 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest -C Release -E "INTEGRATION|PERFORMANCE|REGRESSION" -VV
+if errorlevel 1 exit 1

--- a/recipes/gz-cmake/build.sh
+++ b/recipes/gz-cmake/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} .. \
+      -G "Ninja" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+if [[ "${CONDA_BUILD_CROSS_COMPILATION}" != "1" ]]; then
+  ctest -C Release -E "INTEGRATION|PERFORMANCE|REGRESSION" -VV
+fi

--- a/recipes/gz-cmake/meta.yaml
+++ b/recipes/gz-cmake/meta.yaml
@@ -1,0 +1,43 @@
+{% set component_name = "cmake" %}
+{% set repo_name = "gz-" + component_name %}
+{% set base_name = "lib" + repo_name %}
+{% set version = "3.0.0" %}
+{% set major_version = version.split('.')[0] %}
+{% set name = base_name + major_version %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
+    sha256: 01edf6b20c0f2f76dc48c3fa48bfeb4e82dd60186b82c0b34e38f7e1f53f21ac
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage(name, max_pin='x') }}
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+    - cmake
+    - ninja
+    - pkgconfig
+
+test:
+  commands:
+    - test -f ${PREFIX}/share/cmake/{{ repo_name }}{{ major_version }}/{{ repo_name }}{{ major_version }}-config.cmake  # [not win]
+    - if not exist %PREFIX%\\Library\\share\\cmake\\{{ repo_name }}{{ major_version }}\\{{ repo_name }}{{ major_version }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/gazebosim/gz-cmake/
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: 'A set of CMake modules that are used by the C++-based Gazebo projects.'
+
+extra:
+  feedstock-name: {{ repo_name }}
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
The ignition robotics libraries, that are currently packaged in conda-forge under the `libignition-*`, have been renamed to Gazebo libraries (see https://community.gazebosim.org/t/a-new-era-for-gazebo/1356).

To avoid confusion related to the feedstock name in the future, we are re-submitting all the `libignition-` recipes to conda-forge to have descriptive and coherent names that start with `gz-`, as described in https://github.com/conda-forge/libignition-cmake0-feedstock/issues/26#issuecomment-1255871405 . 

This the first PR, that create a new `gz-cmake-feedstock` to package [`gz-cmake`](https://github.com/gazebosim/gz-cmake), using the recipe already available in https://github.com/conda-forge/libignition-cmake0-feedstock .

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
