### PR TITLE
Add JAXopt recipe to conda-forge

### DIFF
--- a/recipes/jaxopt/meta.yaml
+++ b/recipes/jaxopt/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:  
-  noarch: python  
+  script: {{ PYTHON }} -m pip install . -vv 
   number: 0
 
 requirements:  

--- a/recipes/jaxopt/meta.yaml
+++ b/recipes/jaxopt/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "jaxopt" %}
 {% set version = "0.5" %}
-{% set sha256 = "9d48c30c78285ec5beea0264bb21fa69bbf9b82354136f0aaab0f956f82dd797" %}
 
 package:
   name: {{ name|lower }}
@@ -8,20 +7,20 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz  
-  sha256: {{ sha256 }}
+  sha256: 9d48c30c78285ec5beea0264bb21fa69bbf9b82354136f0aaab0f956f82dd797
 
 build:  
   script: {{ PYTHON }} -m pip install . -vv  
-  skip: true  # [win or py<37]
+  noarch: python
   number: 0
 
 requirements:  
   host:
-    - python
+    - python >=3.7
     - setuptools
     - pip
   run:
-    - python
+    - python >=3.7
     - absl-py
     - jaxlib >=0.1.69
     - jax >=0.2.18

--- a/recipes/jaxopt/meta.yaml
+++ b/recipes/jaxopt/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "JAXopt" %}
+{% set name = "jaxopt" %}
 {% set version = "0.5" %}
 {% set sha256 = "9d48c30c78285ec5beea0264bb21fa69bbf9b82354136f0aaab0f956f82dd797" %}
 

--- a/recipes/jaxopt/meta.yaml
+++ b/recipes/jaxopt/meta.yaml
@@ -11,22 +11,23 @@ source:
   sha256: {{ sha256 }}
 
 build:  
-  script: {{ PYTHON }} -m pip install . -vv 
+  script: {{ PYTHON }} -m pip install . -vv  
+  skip: true  # [win or py<37]
   number: 0
 
 requirements:  
   host:
-    - python >=3.7
+    - python
     - setuptools
     - pip
   run:
-    - python >=3.7
+    - python
     - absl-py
-    - jaxlib
-    - jax
-    - numpy
-    - scipy
-    - matplotlib-base
+    - jaxlib >=0.1.69
+    - jax >=0.2.18
+    - numpy >=1.18.4
+    - scipy >=1.0.0
+    - matplotlib-base >=2.0.1
 
 test:  
    imports:

--- a/recipes/jaxopt/meta.yaml
+++ b/recipes/jaxopt/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "JAXopt" %}
+{% set version = "0.5" %}
+{% set sha256 = "9d48c30c78285ec5beea0264bb21fa69bbf9b82354136f0aaab0f956f82dd797" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz  
+  sha256: {{ sha256 }}
+
+build:  
+  noarch: python  
+  number: 0
+
+requirements:  
+  host:
+    - python >=3.7
+    - setuptools
+    - pip
+  run:
+    - python >=3.7
+    - absl-py
+    - jaxlib
+    - jax
+    - numpy
+    - scipy
+    - matplotlib-base
+
+test:  
+   imports:
+    - {{ name|lower }}
+
+about:
+  home: https://jaxopt.github.io/stable/
+  summary: 'Hardware accelerated, batchable and differentiable optimizers in JAX'
+  description: |
+    Hardware accelerated, batchable and differentiable optimizers in JAX  
+  license: Apache-2.0    
+  license_file: LICENSE 
+  doc_url: https://jaxopt.github.io/stable/
+  dev_url: https://github.com/google/jaxopt
+
+extra:
+  recipe-maintainers:    
+    - dirmeier


### PR DESCRIPTION
Hi all,

this PR adds [JAXopt](https://github.com/google/jaxopt) as recipe.

Greets,
Simon

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
