### PR TITLE
Add recipe for gz-common

### DIFF
--- a/recipes/gz-common/bld_cxx.bat
+++ b/recipes/gz-common/bld_cxx.bat
@@ -1,0 +1,20 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DUSE_EXTERNAL_TINYXML2=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/gz-common/build_cxx.sh
+++ b/recipes/gz-common/build_cxx.sh
@@ -6,6 +6,7 @@ cd build
 if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+    CMAKE_ARGS="${CMAKE_ARGS} -DGZ_PROFILER_REMOTERY:BOOL=ON"
 fi
 
 if [ ${target_platform} == "linux-ppc64le" ]; then

--- a/recipes/gz-common/build_cxx.sh
+++ b/recipes/gz-common/build_cxx.sh
@@ -3,6 +3,11 @@
 mkdir build
 cd build
 
+if [[ "${target_platform}" == osx-* ]]; then
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
 if [ ${target_platform} == "linux-ppc64le" ]; then
   # Disable tests
   GZ_TEST_CMD=-DBUILD_TESTING:BOOL=OFF

--- a/recipes/gz-common/build_cxx.sh
+++ b/recipes/gz-common/build_cxx.sh
@@ -6,7 +6,7 @@ cd build
 if [[ "${target_platform}" == osx-* ]]; then
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
-    CMAKE_ARGS="${CMAKE_ARGS} -DGZ_PROFILER_REMOTERY:BOOL=ON"
+    CMAKE_ARGS="${CMAKE_ARGS} -DGZ_PROFILER_REMOTERY:BOOL=OFF"
 fi
 
 if [ ${target_platform} == "linux-ppc64le" ]; then

--- a/recipes/gz-common/build_cxx.sh
+++ b/recipes/gz-common/build_cxx.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+if [ ${target_platform} == "linux-ppc64le" ]; then
+  # Disable tests
+  GZ_TEST_CMD=-DBUILD_TESTING:BOOL=OFF
+  NUM_PARALLEL=-j1
+else
+  GZ_TEST_CMD=
+  NUM_PARALLEL=
+fi
+
+cmake ${CMAKE_ARGS} .. \
+      -G "Ninja" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
+      -DFREEIMAGE_RUNS:BOOL=ON \
+      -DFREEIMAGE_RUNS__TRYRUN_OUTPUT:STRING="" \
+      -DFREEIMAGE_COMPILES:BOOL=ON \
+      ${GZ_TEST_CMD}
+
+cmake --build . --config Release ${NUM_PARALLEL}
+cmake --build . --config Release --target install ${NUM_PARALLEL}

--- a/recipes/gz-common/librt_linkage.patch
+++ b/recipes/gz-common/librt_linkage.patch
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index e5b780e..78fd4ec 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -17,7 +17,8 @@ if(NOT WIN32)
+   # Link the libraries that we don't expect to find on Windows
+   target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+     PUBLIC UUID::UUID
+-    pthread)
++    pthread
++    rt)
+ else()
+   target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+     PRIVATE shlwapi)

--- a/recipes/gz-common/macro_path_binary_relocation.patch
+++ b/recipes/gz-common/macro_path_binary_relocation.patch
@@ -1,0 +1,22 @@
+From 8d90eee1109a79135b5858d0d7a5fcb0f6cab641 Mon Sep 17 00:00:00 2001
+From: Diego <diego.ferigo@iit.it>
+Date: Tue, 6 Jul 2021 15:47:04 +0200
+Subject: [PATCH] Fix path in conda due to its binary relocation hacks
+
+---
+ src/SystemPaths.cc | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/SystemPaths.cc b/src/SystemPaths.cc
+index f809686..16e6e66 100644
+--- a/src/SystemPaths.cc
++++ b/src/SystemPaths.cc
+@@ -235,6 +235,8 @@ void SystemPaths::AddFilePaths(const std::string &_path)
+ std::string SystemPaths::NormalizeDirectoryPath(const std::string &_path)
+ {
+   std::string path = _path;
++  path.erase(std::find(path.begin(), path.end(), '\0'), path.end());
++
+   // Use '/' because it works on Linux, OSX, and Windows
+   std::replace(path.begin(), path.end(), '\\', '/');
+   // Make last character '/'

--- a/recipes/gz-common/meta.yaml
+++ b/recipes/gz-common/meta.yaml
@@ -1,0 +1,95 @@
+{% set component_name = "transport" %}
+{% set repo_name = "gz-" + component_name %}
+{% set version = "12.0.0" %}
+{% set major_version = version.split('.')[0] %}
+{% set name = repo_name + major_version %}
+{% set component_version = component_name + major_version %}
+{% set cxx_name = "lib" + name %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
+    sha256: af9e5b862e10aa0cedd97d9c5ca3eb9a443b7c9e560a083e8f0399e93e1cfafa
+    patches:
+      - librt_linkage.patch  # [linux]
+      - macro_path_binary_relocation.patch
+
+build:
+  number: 0
+
+outputs:
+  - name: {{ cxx_name }}
+    script: build_cxx.sh  # [unix]
+    script: bld_cxx.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage(cxx_name, max_pin='x') }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - {{ compiler('c') }}
+        - ninja
+        - cmake
+        - pkg-config
+      host:
+        - libgz-math7
+        - libgz-cmake3
+        - libgz-utils2
+        - dlfcn-win32  # [win]
+        - libuuid      # [linux]
+        - freeimage
+        - gts
+        - tinyxml2
+        - glib
+        - ffmpeg
+    test:
+      commands:
+        - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
+        - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
+
+  - name: {{ name }}
+    build:
+      run_exports:
+        - {{ pin_subpackage(cxx_name, max_pin='x') }}
+    requirements:
+      run:
+        - {{ pin_subpackage(cxx_name, exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
+        - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/lib{{ name }}-graphics.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}-graphics.dylib  # [osx]
+        - test -f ${PREFIX}/lib/lib{{ name }}-av.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}-av.dylib  # [osx]
+        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}-graphics.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}-graphics.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}-av.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}-av.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/gazebosim/{{ repo_name }}
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: 'An audio-visual library supports processing audio and video files, a graphics library can load a variety 3D mesh file formats into a generic in-memory representation, and the core library of Gazebo Common contains functionality that spans Base64 encoding/decoding to thread pools.'
+
+extra:
+  feedstock-name: {{ repo_name }}
+  recipe-maintainers:
+    - Tobias-Fischer
+    - traversaro

--- a/recipes/gz-common/meta.yaml
+++ b/recipes/gz-common/meta.yaml
@@ -45,6 +45,7 @@ outputs:
         - tinyxml2
         - glib
         - ffmpeg
+        - libgdal
     test:
       commands:
         - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]

--- a/recipes/gz-common/meta.yaml
+++ b/recipes/gz-common/meta.yaml
@@ -12,7 +12,7 @@ package:
 
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ major_version }}_{{ version }}.tar.gz
-    sha256: af9e5b862e10aa0cedd97d9c5ca3eb9a443b7c9e560a083e8f0399e93e1cfafa
+    sha256: 046552ca440fd9b8bcb2900da4bd0b9eacc1a5561373bdfae10e99d41536b159
     patches:
       - librt_linkage.patch  # [linux]
       - macro_path_binary_relocation.patch

--- a/recipes/gz-common/meta.yaml
+++ b/recipes/gz-common/meta.yaml
@@ -46,6 +46,7 @@ outputs:
         - glib
         - ffmpeg
         - libgdal
+        - assimp
     test:
       commands:
         - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]

--- a/recipes/gz-common/meta.yaml
+++ b/recipes/gz-common/meta.yaml
@@ -1,6 +1,6 @@
-{% set component_name = "transport" %}
+{% set component_name = "common" %}
 {% set repo_name = "gz-" + component_name %}
-{% set version = "12.0.0" %}
+{% set version = "5.0.0" %}
 {% set major_version = version.split('.')[0] %}
 {% set name = repo_name + major_version %}
 {% set component_version = component_name + major_version %}
@@ -50,10 +50,18 @@ outputs:
         - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
         - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
         - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/lib{{ name }}-graphics.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}-graphics.dylib  # [osx]
+        - test -f ${PREFIX}/lib/lib{{ name }}-av.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}-av.dylib  # [osx]
         - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
         - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
         - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}-graphics.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}-graphics.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}-av.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}-av.dll exit 1  # [win]
         - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
 
   - name: {{ name }}


### PR DESCRIPTION
The ignition robotics libraries, that are currently packaged in conda-forge under the `libignition-*`, have been renamed to Gazebo libraries (see https://community.gazebosim.org/t/a-new-era-for-gazebo/1356).

To avoid confusion related to the feedstock name in the future, we are re-submitting all the `libignition-` recipes to conda-forge to have descriptive and coherent names that start with `gz-`, as described in https://github.com/conda-forge/libignition-cmake0-feedstock/issues/26#issuecomment-1255871405 . 

This PR creates a new `gz-common-feedstock` to package [`gz-common`](https://github.com/gazebosim/gz-common), using the recipe already available in https://github.com/conda-forge/libignition-common-feedstock .

As discussed in https://github.com/conda-forge/libignition-cmake0-feedstock/issues/26, for consistency with Gazebo/Ignition libraries that have Python bindings also this PRs structured the recipe as a multiple-output one, in which the `gz-common5` package is used to install all the outputs. 

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
