### PR TITLE
Add recipe for gz-fuel-tools

### DIFF
--- a/recipes/gz-fuel-tools/bld_cxx.bat
+++ b/recipes/gz-fuel-tools/bld_cxx.bat
@@ -1,0 +1,18 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/gz-fuel-tools/build_cxx.sh
+++ b/recipes/gz-fuel-tools/build_cxx.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} .. \
+      -G "Ninja" \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP=True \
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/gz-fuel-tools/meta.yaml
+++ b/recipes/gz-fuel-tools/meta.yaml
@@ -1,10 +1,12 @@
 {% set component_name = "fuel-tools" %}
+{% set cmake_name = "fuel_tools" %}
 {% set repo_name = "gz-" + component_name %}
 {% set version = "8_8.0.0" %}
 {% set version_package = version.split('_')[1] %}
 {% set major_version = version_package.split('.')[0] %}
 {% set name = repo_name + major_version %}
 {% set component_version = component_name + major_version %}
+{% set cmake_version = cmake_name + major_version %}
 {% set cxx_name = "lib" + name %}
 
 package:
@@ -46,14 +48,14 @@ outputs:
         - libprotobuf
     test:
       commands:
-        - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
-        - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
-        - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
-        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
-        - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
+        - test -f ${PREFIX}/include/gz/{{ cmake_version }}/gz/{{ cmake_name }}.hh  # [not win]
+        - test -f ${PREFIX}/lib/libgz-{{ cmake_version }}.so  # [linux]
+        - test -f ${PREFIX}/lib/libgz-{{ cmake_version }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/cmake/gz-{{ cmake_version }}/gz-{{ cmake_version }}-config.cmake  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\gz\\{{ cmake_version }}\\gz\\{{ cmake_name }}.hh exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\gz-{{ cmake_version }}.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\gz-{{ cmake_version }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\gz-{{ cmake_version }}\\gz-{{ cmake_version }}-config.cmake exit 1  # [win]
 
   - name: {{ name }}
     build:
@@ -64,14 +66,14 @@ outputs:
         - {{ pin_subpackage(cxx_name, exact=True) }}
     test:
       commands:
-        - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
-        - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
-        - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
-        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
-        - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
-        - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
+        - test -f ${PREFIX}/include/gz/{{ cmake_version }}/gz/{{ cmake_name }}.hh  # [not win]
+        - test -f ${PREFIX}/lib/libgz-{{ cmake_version }}.so  # [linux]
+        - test -f ${PREFIX}/lib/libgz-{{ cmake_version }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/cmake/gz-{{ cmake_version }}/gz-{{ cmake_version }}-config.cmake  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\gz\\{{ cmake_version }}\\gz\\{{ cmake_name }}.hh exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\gz-{{ cmake_version }}.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\gz-{{ cmake_version }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\gz-{{ cmake_version }}\\gz-{{ cmake_version }}-config.cmake exit 1  # [win]
 
 about:
   home: https://github.com/gazebosim/{{ repo_name }}

--- a/recipes/gz-fuel-tools/meta.yaml
+++ b/recipes/gz-fuel-tools/meta.yaml
@@ -16,7 +16,7 @@ source:
     sha256: af9e5b862e10aa0cedd97d9c5ca3eb9a443b7c9e560a083e8f0399e93e1cfafa
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: {{ cxx_name }}
@@ -80,6 +80,7 @@ about:
   summary: 'A client library and command line tools for interacting with Gazebo Fuel servers.'
 
 extra:
+  feedstock-name: {{ repo_name }}
   recipe-maintainers:
     - traversaro
     - Tobias-Fischer

--- a/recipes/gz-fuel-tools/meta.yaml
+++ b/recipes/gz-fuel-tools/meta.yaml
@@ -13,7 +13,7 @@ package:
 
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ version }}.tar.gz
-    sha256: af9e5b862e10aa0cedd97d9c5ca3eb9a443b7c9e560a083e8f0399e93e1cfafa
+    sha256: 3351fe587de35303921dc6af5ebf0b919ca9dbe49a74a47c023667b8c277e396
 
 build:
   number: 0

--- a/recipes/gz-fuel-toos/meta.yaml
+++ b/recipes/gz-fuel-toos/meta.yaml
@@ -1,0 +1,85 @@
+{% set component_name = "fuel-tools" %}
+{% set repo_name = "gz-" + component_name %}
+{% set version = "8_8.0.0" %}
+{% set version_package = version.split('_')[1] %}
+{% set major_version = version_package.split('.')[0] %}
+{% set name = repo_name + major_version %}
+{% set component_version = component_name + major_version %}
+{% set cxx_name = "lib" + name %}
+
+package:
+  name: {{ name }}
+  version: {{ version_package }}
+
+source:
+  - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ version }}.tar.gz
+    sha256: af9e5b862e10aa0cedd97d9c5ca3eb9a443b7c9e560a083e8f0399e93e1cfafa
+
+build:
+  number: 1
+
+outputs:
+  - name: {{ cxx_name }}
+    script: build_cxx.sh  # [unix]
+    script: bld_cxx.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage(cxx_name, max_pin='x') }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}
+        - {{ compiler('c') }}
+        - cmake
+        - ninja
+        - pkgconfig
+      host:
+        - libgz-cmake3
+        - libgz-math7
+        - libgz-msgs9
+        - libgz-common5
+        - libgz-tools2
+        - libcurl
+        - jsoncpp
+        - libzip
+        - yaml
+        - tinyxml2
+        - libprotobuf
+    test:
+      commands:
+        - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
+        - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
+
+  - name: {{ name }}
+    build:
+      run_exports:
+        - {{ pin_subpackage(cxx_name, max_pin='x') }}
+    requirements:
+      run:
+        - {{ pin_subpackage(cxx_name, exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/include/gz/{{ component_version }}/gz/{{ component_name }}.hh  # [not win]
+        - test -f ${PREFIX}/lib/lib{{ name }}.so  # [linux]
+        - test -f ${PREFIX}/lib/lib{{ name }}.dylib  # [osx]
+        - test -f ${PREFIX}/lib/cmake/{{ name }}/{{ name }}-config.cmake  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\gz\\{{ component_version }}\\gz\\{{ component_name }}.hh exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\{{ name }}.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\{{ name }}.dll exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\cmake\\{{ name }}\\{{ name }}-config.cmake exit 1  # [win]
+
+about:
+  home: https://github.com/gazebosim/{{ repo_name }}
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: 'A client library and command line tools for interacting with Gazebo Fuel servers.'
+
+extra:
+  recipe-maintainers:
+    - traversaro
+    - Tobias-Fischer


### PR DESCRIPTION
The ignition robotics libraries, that are currently packaged in conda-forge under the `libignition-*`, have been renamed to Gazebo libraries (see https://community.gazebosim.org/t/a-new-era-for-gazebo/1356).

To avoid confusion related to the feedstock name in the future, we are re-submitting all the `libignition-` recipes to conda-forge to have descriptive and coherent names that start with `gz-`, as described in https://github.com/conda-forge/libignition-cmake0-feedstock/issues/26#issuecomment-1255871405 . 

This PR creates a new `gz-fuel-tools-feedstock` to package [`gz-fuel-tools`](https://github.com/gazebosim/gz-fuel-tools), using the recipe already available in https://github.com/conda-forge/libignition-fuel-tools-feedstock .

As discussed in https://github.com/conda-forge/libignition-cmake0-feedstock/issues/26, for consistency with Gazebo/Ignition libraries that have Python bindings also this PRs structured the recipe as a multiple-output one, in which the `gz-fuel-tools5` package is used to install all the outputs. 

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
