### PR TITLE
add unishox2-py3 recipe

### DIFF
--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   skip: True  # [win or arm64]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -16,10 +16,11 @@ build:
 
 requirements:
   build:
+    - python
+    - pip
     - {{ compiler('cxx') }}
   host:
     - python
-    - pip
   run:
     - python
 

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "unishox2-py3" %}
-{% set version = "0.9.9" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -14,6 +14,8 @@ build:
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('cxx') }}
   host:
     - python
     - pip

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unishox2-py3-{{ version }}.tar.gz
-  sha256: 061ed8a2547c1d85be0cc74f320a5af4f40a10650087d6f62463cba5b9fa3088
+  sha256: cd2595de196ffd8b93bea7a76f5796d8293f32d1f7c9d3660af0b764ab917963
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
+    - pip
   run:
     - python
 

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   skip: True  # [win or arm64]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "unishox2-py3" %}
+{% set version = "0.9.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/unishox2-py3-{{ version }}.tar.gz
+  sha256: 061ed8a2547c1d85be0cc74f320a5af4f40a10650087d6f62463cba5b9fa3088
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - unishox2_py3
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/tweedge/unishox2-py3
+  summary: A package for Unicode-friendly string compression using Unishox2
+  dev_url: https://github.com/tweedge/unishox2-py3
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - tweedge

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [win or arm64]
   number: 0
 
 requirements:

--- a/recipes/unishox2-py3/meta.yaml
+++ b/recipes/unishox2-py3/meta.yaml
@@ -22,7 +22,7 @@ requirements:
 
 test:
   imports:
-    - unishox2_py3
+    - unishox2
   commands:
     - pip check
   requires:


### PR DESCRIPTION
This PR adds [Unishox2-py3](https://github.com/tweedge/unishox2-py3) as a Python binding to the original [Unishox2](https://github.com/siara-cc/Unishox2/tree/cb4a69247ab3171185d3f78290d5ce73c10d28b0) string compression C library.

The original and main developer @tweedge is informed (https://github.com/tweedge/unishox2-py3/issues/7) and agreed to be mentioned as a package maintainer. 

Since I'm not a Python/C hybrid expert and not involved in the development of either Unishox2 or unishox2-py3, all statements below are made to the best of my knowledge. Certainly, @tweedge can provide much better answers to all questions related to the static Unishox2 library which is part of this Python binding library.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
