### PR TITLE
adds twarc

### DIFF
--- a/recipes/twarc/meta.yaml
+++ b/recipes/twarc/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "twarc" %}
+{% set version = "2.12.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/twarc-{{ version }}.tar.gz
+  sha256: bc64d6765d9b98ef9d8b79aa69dbf9615f3b24bc29b7a659d42d25208e48d618
+
+build:
+  entry_points:
+    - twarc = twarc.command:main
+    - twarc2 = twarc.command2:twarc2
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.3
+    - pytest-runner
+    - pip
+  run:
+    - python >=3.3
+    - click >=7,<9
+    - click-config-file >=0.6
+    - click-plugins >=1
+    - humanize >=3.9
+    - python-dateutil >=2.8
+    - requests-oauthlib >=1.3
+    - tqdm >=4.62
+
+test:
+  imports:
+    - twarc
+  commands:
+    - pip check
+    - twarc --help
+    - twarc2 --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/docnow/twarc
+  summary: Archive tweets from the command line
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mfansler


### PR DESCRIPTION
Adds PyPI package `twarc`. Recipe generated with `grayskull` v1.8.4.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
