### PR TITLE
adds r-spatstat.explore

### DIFF
--- a/recipes/r-spatstat.explore/bld.bat
+++ b/recipes/r-spatstat.explore/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-spatstat.explore/build.sh
+++ b/recipes/r-spatstat.explore/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-spatstat.explore/meta.yaml
+++ b/recipes/r-spatstat.explore/meta.yaml
@@ -1,0 +1,105 @@
+{% set version = '3.0-3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-spatstat.explore
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/spatstat.explore_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/spatstat.explore/spatstat.explore_{{ version }}.tar.gz
+  sha256: 137444a46d26d88241336feece63ed7b006a9328cfe3861d4b8ab7b4bed963a7
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+  host:
+    - r-base
+    - r-matrix
+    - r-abind
+    - r-goftest >=1.2_2
+    - r-nlme
+    - r-spatstat.data >=3.0
+    - r-spatstat.geom >=3.0
+    - r-spatstat.random >=3.0
+    - r-spatstat.sparse >=3.0
+    - r-spatstat.utils >=3.0
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-matrix
+    - r-abind
+    - r-goftest >=1.2_2
+    - r-nlme
+    - r-spatstat.data >=3.0
+    - r-spatstat.geom >=3.0
+    - r-spatstat.random >=3.0
+    - r-spatstat.sparse >=3.0
+    - r-spatstat.utils >=3.0
+
+test:
+  commands:
+    - $R -e "library('spatstat.explore')"           # [not win]
+    - "\"%R%\" -e \"library('spatstat.explore')\""  # [win]
+
+about:
+  home: http://spatstat.org/
+  url_dev: https://github.com/spatstat/spatstat.explore
+  license: GPL-2.0-or-later
+  summary: Functionality for exploratory data analysis and nonparametric analysis of spatial
+    data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes
+    analysis of spatial data on a linear network, which is covered by the separate package
+    'spatstat.linnet'.) Methods include quadrat counts, K-functions and their simulation
+    envelopes, nearest neighbour distance and empty space statistics, Fry plots, pair
+    correlation function, kernel smoothed intensity, relative risk estimation with cross-validated
+    bandwidth selection, mark correlation functions, segregation indices, mark dependence
+    diagnostics, and kernel estimates of covariate effects. Formal hypothesis tests
+    of random pattern (chi-squared, Kolmogorov-Smirnov, Monte Carlo, Diggle-Cressie-Loosmore-Ford,
+    Dao-Genton, two-stage Monte Carlo) and tests for covariate effects (Cox-Berman-Waller-Lawson,
+    Kolmogorov-Smirnov, ANOVA) are also supported.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - mfansler
+
+# Package: spatstat.explore
+# Version: 3.0-3
+# Date: 2022-11-04
+# Title: Exploratory Data Analysis for the 'spatstat' Family
+# Authors@R: c(person("Adrian", "Baddeley", role = c("aut", "cre", "cph"), email = "Adrian.Baddeley@curtin.edu.au", comment = c(ORCID="0000-0001-9499-8382")), person("Rolf", "Turner", role = c("aut", "cph"), email="r.turner@auckland.ac.nz", comment=c(ORCID="0000-0001-5521-5218")), person("Ege",   "Rubak", role = c("aut", "cph"), email = "rubak@math.aau.dk", comment=c(ORCID="0000-0002-6675-533X")), person("Kasper", "Klitgaard Berthelsen", role = "ctb"), person("Warick", "Brown", role = "cph"), person("Achmad", "Choiruddin", role = "ctb"), person("Jean-Francois", "Coeurjolly", role = "ctb"), person("Ottmar", "Cronie", role = "ctb"), person("Tilman", "Davies", role = c("ctb", "cph")), person("Julian", "Gilbey", role = "ctb"), person("Yongtao", "Guan", role = "ctb"), person("Ute", "Hahn", role = "ctb"), person("Kassel", "Hingee", role = c("ctb", "cph")), person("Abdollah", "Jalilian", role = "ctb"), person("Frederic", "Lavancier", role = "ctb"), person("Marie-Colette", "van Lieshout", role = c("ctb", "cph")), person("Greg", "McSwiggan", role = "ctb"), person("Robin K", "Milne", role = "cph"), person("Tuomas", "Rajala", role = "ctb"), person("Suman", "Rakshit", role = c("ctb", "cph")), person("Dominic", "Schuhmacher", role = "ctb"), person("Rasmus", "Plenge Waagepetersen", role = "ctb"), person("Hangsheng", "Wang", role = "ctb"))
+# Maintainer: Adrian Baddeley <Adrian.Baddeley@curtin.edu.au>
+# Depends: R (>= 3.5.0), spatstat.data (>= 3.0), spatstat.geom (>= 3.0), spatstat.random (>= 3.0), stats, graphics, grDevices, utils, methods, nlme
+# Imports: spatstat.utils (>= 3.0), spatstat.sparse (>= 3.0), goftest (>= 1.2-2), Matrix, abind
+# Suggests: sm, maptools (>= 0.9-9), gsl, locfit, spatial, fftwtools (>= 0.9-8), spatstat.linnet (>= 3.0), spatstat.model (>= 3.0), spatstat (>= 3.0)
+# Additional_repositories: https://spatstat.r-universe.dev
+# Description: Functionality for exploratory data analysis and nonparametric analysis of spatial data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes analysis of spatial data on a linear network, which is covered by the separate package 'spatstat.linnet'.) Methods include quadrat counts, K-functions and their simulation envelopes, nearest neighbour distance and empty space statistics, Fry plots, pair correlation function, kernel smoothed intensity, relative risk estimation with cross-validated bandwidth selection, mark correlation functions, segregation indices, mark dependence diagnostics, and kernel estimates of covariate effects. Formal hypothesis tests of random pattern (chi-squared, Kolmogorov-Smirnov, Monte Carlo, Diggle-Cressie-Loosmore-Ford, Dao-Genton, two-stage Monte Carlo) and tests for covariate effects (Cox-Berman-Waller-Lawson, Kolmogorov-Smirnov, ANOVA) are also supported.
+# License: GPL (>= 2)
+# URL: http://spatstat.org/
+# NeedsCompilation: yes
+# ByteCompile: true
+# BugReports: https://github.com/spatstat/spatstat.explore/issues
+# Packaged: 2022-11-04 10:09:42 UTC; adrian
+# Author: Adrian Baddeley [aut, cre, cph] (<https://orcid.org/0000-0001-9499-8382>), Rolf Turner [aut, cph] (<https://orcid.org/0000-0001-5521-5218>), Ege Rubak [aut, cph] (<https://orcid.org/0000-0002-6675-533X>), Kasper Klitgaard Berthelsen [ctb], Warick Brown [cph], Achmad Choiruddin [ctb], Jean-Francois Coeurjolly [ctb], Ottmar Cronie [ctb], Tilman Davies [ctb, cph], Julian Gilbey [ctb], Yongtao Guan [ctb], Ute Hahn [ctb], Kassel Hingee [ctb, cph], Abdollah Jalilian [ctb], Frederic Lavancier [ctb], Marie-Colette van Lieshout [ctb, cph], Greg McSwiggan [ctb], Robin K Milne [cph], Tuomas Rajala [ctb], Suman Rakshit [ctb, cph], Dominic Schuhmacher [ctb], Rasmus Plenge Waagepetersen [ctb], Hangsheng Wang [ctb]
+# Repository: CRAN
+# Date/Publication: 2022-11-04 15:30:05 UTC

--- a/recipes/r-spatstat.explore/meta.yaml
+++ b/recipes/r-spatstat.explore/meta.yaml
@@ -60,7 +60,7 @@ test:
 
 about:
   home: http://spatstat.org/
-  url_dev: https://github.com/spatstat/spatstat.explore
+  dev_url: https://github.com/spatstat/spatstat.explore
   license: GPL-2.0-or-later
   summary: Functionality for exploratory data analysis and nonparametric analysis of spatial
     data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes

--- a/recipes/r-spatstat.explore/meta.yaml
+++ b/recipes/r-spatstat.explore/meta.yaml
@@ -81,25 +81,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-    - mfansler
-
-# Package: spatstat.explore
-# Version: 3.0-3
-# Date: 2022-11-04
-# Title: Exploratory Data Analysis for the 'spatstat' Family
-# Authors@R: c(person("Adrian", "Baddeley", role = c("aut", "cre", "cph"), email = "Adrian.Baddeley@curtin.edu.au", comment = c(ORCID="0000-0001-9499-8382")), person("Rolf", "Turner", role = c("aut", "cph"), email="r.turner@auckland.ac.nz", comment=c(ORCID="0000-0001-5521-5218")), person("Ege",   "Rubak", role = c("aut", "cph"), email = "rubak@math.aau.dk", comment=c(ORCID="0000-0002-6675-533X")), person("Kasper", "Klitgaard Berthelsen", role = "ctb"), person("Warick", "Brown", role = "cph"), person("Achmad", "Choiruddin", role = "ctb"), person("Jean-Francois", "Coeurjolly", role = "ctb"), person("Ottmar", "Cronie", role = "ctb"), person("Tilman", "Davies", role = c("ctb", "cph")), person("Julian", "Gilbey", role = "ctb"), person("Yongtao", "Guan", role = "ctb"), person("Ute", "Hahn", role = "ctb"), person("Kassel", "Hingee", role = c("ctb", "cph")), person("Abdollah", "Jalilian", role = "ctb"), person("Frederic", "Lavancier", role = "ctb"), person("Marie-Colette", "van Lieshout", role = c("ctb", "cph")), person("Greg", "McSwiggan", role = "ctb"), person("Robin K", "Milne", role = "cph"), person("Tuomas", "Rajala", role = "ctb"), person("Suman", "Rakshit", role = c("ctb", "cph")), person("Dominic", "Schuhmacher", role = "ctb"), person("Rasmus", "Plenge Waagepetersen", role = "ctb"), person("Hangsheng", "Wang", role = "ctb"))
-# Maintainer: Adrian Baddeley <Adrian.Baddeley@curtin.edu.au>
-# Depends: R (>= 3.5.0), spatstat.data (>= 3.0), spatstat.geom (>= 3.0), spatstat.random (>= 3.0), stats, graphics, grDevices, utils, methods, nlme
-# Imports: spatstat.utils (>= 3.0), spatstat.sparse (>= 3.0), goftest (>= 1.2-2), Matrix, abind
-# Suggests: sm, maptools (>= 0.9-9), gsl, locfit, spatial, fftwtools (>= 0.9-8), spatstat.linnet (>= 3.0), spatstat.model (>= 3.0), spatstat (>= 3.0)
-# Additional_repositories: https://spatstat.r-universe.dev
-# Description: Functionality for exploratory data analysis and nonparametric analysis of spatial data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes analysis of spatial data on a linear network, which is covered by the separate package 'spatstat.linnet'.) Methods include quadrat counts, K-functions and their simulation envelopes, nearest neighbour distance and empty space statistics, Fry plots, pair correlation function, kernel smoothed intensity, relative risk estimation with cross-validated bandwidth selection, mark correlation functions, segregation indices, mark dependence diagnostics, and kernel estimates of covariate effects. Formal hypothesis tests of random pattern (chi-squared, Kolmogorov-Smirnov, Monte Carlo, Diggle-Cressie-Loosmore-Ford, Dao-Genton, two-stage Monte Carlo) and tests for covariate effects (Cox-Berman-Waller-Lawson, Kolmogorov-Smirnov, ANOVA) are also supported.
-# License: GPL (>= 2)
-# URL: http://spatstat.org/
-# NeedsCompilation: yes
-# ByteCompile: true
-# BugReports: https://github.com/spatstat/spatstat.explore/issues
-# Packaged: 2022-11-04 10:09:42 UTC; adrian
-# Author: Adrian Baddeley [aut, cre, cph] (<https://orcid.org/0000-0001-9499-8382>), Rolf Turner [aut, cph] (<https://orcid.org/0000-0001-5521-5218>), Ege Rubak [aut, cph] (<https://orcid.org/0000-0002-6675-533X>), Kasper Klitgaard Berthelsen [ctb], Warick Brown [cph], Achmad Choiruddin [ctb], Jean-Francois Coeurjolly [ctb], Ottmar Cronie [ctb], Tilman Davies [ctb, cph], Julian Gilbey [ctb], Yongtao Guan [ctb], Ute Hahn [ctb], Kassel Hingee [ctb, cph], Abdollah Jalilian [ctb], Frederic Lavancier [ctb], Marie-Colette van Lieshout [ctb, cph], Greg McSwiggan [ctb], Robin K Milne [cph], Tuomas Rajala [ctb], Suman Rakshit [ctb, cph], Dominic Schuhmacher [ctb], Rasmus Plenge Waagepetersen [ctb], Hangsheng Wang [ctb]
-# Repository: CRAN
-# Date/Publication: 2022-11-04 15:30:05 UTC


### PR DESCRIPTION
Adds [CRAN package `spatstat.explore`](https://cran.r-project.org/package=spatstat.explore) as `r-spatstat.explore`. Recipe generated with `conda_r_skeleton_helper`.

Needed as [new dependency of `r-seurat`](https://github.com/conda-forge/r-seurat-feedstock/pull/27).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
