### PR TITLE
adds r-spatstat.model

### DIFF
--- a/recipes/r-spatstat.model/bld.bat
+++ b/recipes/r-spatstat.model/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-spatstat.model/build.sh
+++ b/recipes/r-spatstat.model/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-spatstat.model/meta.yaml
+++ b/recipes/r-spatstat.model/meta.yaml
@@ -1,0 +1,111 @@
+{% set version = '3.0-2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-spatstat.model
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/spatstat.model_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/spatstat.model/spatstat.model_{{ version }}.tar.gz
+  sha256: e923f5608bcc571b14ac183af2d8568772dd6b769c5b0a34307084097c71d428
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+  host:
+    - r-base
+    - r-matrix
+    - r-abind
+    - r-goftest >=1.2_2
+    - r-mgcv
+    - r-nlme
+    - r-rpart
+    - r-spatstat.data >=3.0
+    - r-spatstat.explore >=3.0
+    - r-spatstat.geom >=3.0
+    - r-spatstat.random >=3.0
+    - r-spatstat.sparse >=3.0
+    - r-spatstat.utils >=3.0
+    - r-tensor
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-matrix
+    - r-abind
+    - r-goftest >=1.2_2
+    - r-mgcv
+    - r-nlme
+    - r-rpart
+    - r-spatstat.data >=3.0
+    - r-spatstat.explore >=3.0
+    - r-spatstat.geom >=3.0
+    - r-spatstat.random >=3.0
+    - r-spatstat.sparse >=3.0
+    - r-spatstat.utils >=3.0
+    - r-tensor
+
+test:
+  commands:
+    - $R -e "library('spatstat.model')"           # [not win]
+    - "\"%R%\" -e \"library('spatstat.model')\""  # [win]
+
+about:
+  home: http://spatstat.org/
+  license: GPL-2.0-or-later
+  summary: Functionality for exploratory data analysis and nonparametric analysis of spatial
+    data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes
+    analysis of spatial data on a linear network, which is covered by the separate package
+    'spatstat.linnet'.) Methods include quadrat counts, K-functions and their simulation
+    envelopes, nearest neighbour distance and empty space statistics, Fry plots, pair
+    correlation function, kernel smoothed intensity, relative risk estimation with cross-validated
+    bandwidth selection, mark correlation functions, segregation indices, mark dependence
+    diagnostics, and kernel estimates of covariate effects. Formal hypothesis tests
+    of random pattern (chi-squared, Kolmogorov-Smirnov, Monte Carlo, Diggle-Cressie-Loosmore-Ford,
+    Dao-Genton, two-stage Monte Carlo) and tests for covariate effects (Cox-Berman-Waller-Lawson,
+    Kolmogorov-Smirnov, ANOVA) are also supported.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: spatstat.model
+# Version: 3.0-2
+# Date: 2022-11-04
+# Title: Parametric Statistical Modelling for the 'spatstat' Family
+# Authors@R: c(person("Adrian", "Baddeley", role = c("aut", "cre", "cph"), email = "Adrian.Baddeley@curtin.edu.au", comment = c(ORCID="0000-0001-9499-8382")), person("Rolf", "Turner", role = c("aut", "cph"), email="r.turner@auckland.ac.nz", comment=c(ORCID="0000-0001-5521-5218")), person("Ege",   "Rubak", role = c("aut", "cph"), email = "rubak@math.aau.dk", comment=c(ORCID="0000-0002-6675-533X")), person("Kasper", "Klitgaard Berthelsen", role = "ctb"), person("Achmad", "Choiruddin", role = c("ctb", "cph")), person("Jean-Francois", "Coeurjolly", role = "ctb"), person("Ottmar", "Cronie", role = "ctb"), person("Tilman", "Davies", role = "ctb"), person("Julian", "Gilbey", role = "ctb"), person("Yongtao", "Guan", role = "ctb"), person("Ute", "Hahn", role = "ctb"), person("Kassel", "Hingee", role = "ctb"), person("Abdollah", "Jalilian", role = "ctb"), person("Frederic", "Lavancier", role = "ctb"), person("Marie-Colette", "van Lieshout", role = "ctb"), person("Greg", "McSwiggan", role = "ctb"), person("Tuomas", "Rajala", role = "ctb"), person("Suman", "Rakshit", role = c("ctb", "cph")), person("Dominic", "Schuhmacher", role = "ctb"), person("Rasmus", "Plenge Waagepetersen", role = "ctb"), person("Hangsheng", "Wang", role = "ctb"))
+# Maintainer: Adrian Baddeley <Adrian.Baddeley@curtin.edu.au>
+# Depends: R (>= 3.5.0), spatstat.data (>= 3.0), spatstat.geom (>= 3.0), spatstat.random (>= 3.0), spatstat.explore (>= 3.0), stats, graphics, grDevices, utils, methods, nlme, rpart
+# Imports: spatstat.utils (>= 3.0), spatstat.sparse (>= 3.0), mgcv, Matrix, abind, tensor, goftest (>= 1.2-2)
+# Suggests: sm, maptools (>= 0.9-9), gsl, locfit, spatial, RandomFields (>= 3.1.24.1), RandomFieldsUtils(>= 0.3.3.1), fftwtools (>= 0.9-8), nleqslv, glmnet, spatstat.linnet (>= 3.0), spatstat (>= 3.0)
+# Additional_repositories: https://spatstat.r-universe.dev
+# Description: Functionality for exploratory data analysis and nonparametric analysis of spatial data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes analysis of spatial data on a linear network, which is covered by the separate package 'spatstat.linnet'.) Methods include quadrat counts, K-functions and their simulation envelopes, nearest neighbour distance and empty space statistics, Fry plots, pair correlation function, kernel smoothed intensity, relative risk estimation with cross-validated bandwidth selection, mark correlation functions, segregation indices, mark dependence diagnostics, and kernel estimates of covariate effects. Formal hypothesis tests of random pattern (chi-squared, Kolmogorov-Smirnov, Monte Carlo, Diggle-Cressie-Loosmore-Ford, Dao-Genton, two-stage Monte Carlo) and tests for covariate effects (Cox-Berman-Waller-Lawson, Kolmogorov-Smirnov, ANOVA) are also supported.
+# License: GPL (>= 2)
+# URL: http://spatstat.org/
+# NeedsCompilation: yes
+# ByteCompile: true
+# BugReports: https://github.com/spatstat/spatstat.core/issues
+# Packaged: 2022-11-04 11:23:44 UTC; adrian
+# Author: Adrian Baddeley [aut, cre, cph] (<https://orcid.org/0000-0001-9499-8382>), Rolf Turner [aut, cph] (<https://orcid.org/0000-0001-5521-5218>), Ege Rubak [aut, cph] (<https://orcid.org/0000-0002-6675-533X>), Kasper Klitgaard Berthelsen [ctb], Achmad Choiruddin [ctb, cph], Jean-Francois Coeurjolly [ctb], Ottmar Cronie [ctb], Tilman Davies [ctb], Julian Gilbey [ctb], Yongtao Guan [ctb], Ute Hahn [ctb], Kassel Hingee [ctb], Abdollah Jalilian [ctb], Frederic Lavancier [ctb], Marie-Colette van Lieshout [ctb], Greg McSwiggan [ctb], Tuomas Rajala [ctb], Suman Rakshit [ctb, cph], Dominic Schuhmacher [ctb], Rasmus Plenge Waagepetersen [ctb], Hangsheng Wang [ctb]
+# Repository: CRAN
+# Date/Publication: 2022-11-07 09:40:02 UTC

--- a/recipes/r-spatstat.model/meta.yaml
+++ b/recipes/r-spatstat.model/meta.yaml
@@ -88,24 +88,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-
-# Package: spatstat.model
-# Version: 3.0-2
-# Date: 2022-11-04
-# Title: Parametric Statistical Modelling for the 'spatstat' Family
-# Authors@R: c(person("Adrian", "Baddeley", role = c("aut", "cre", "cph"), email = "Adrian.Baddeley@curtin.edu.au", comment = c(ORCID="0000-0001-9499-8382")), person("Rolf", "Turner", role = c("aut", "cph"), email="r.turner@auckland.ac.nz", comment=c(ORCID="0000-0001-5521-5218")), person("Ege",   "Rubak", role = c("aut", "cph"), email = "rubak@math.aau.dk", comment=c(ORCID="0000-0002-6675-533X")), person("Kasper", "Klitgaard Berthelsen", role = "ctb"), person("Achmad", "Choiruddin", role = c("ctb", "cph")), person("Jean-Francois", "Coeurjolly", role = "ctb"), person("Ottmar", "Cronie", role = "ctb"), person("Tilman", "Davies", role = "ctb"), person("Julian", "Gilbey", role = "ctb"), person("Yongtao", "Guan", role = "ctb"), person("Ute", "Hahn", role = "ctb"), person("Kassel", "Hingee", role = "ctb"), person("Abdollah", "Jalilian", role = "ctb"), person("Frederic", "Lavancier", role = "ctb"), person("Marie-Colette", "van Lieshout", role = "ctb"), person("Greg", "McSwiggan", role = "ctb"), person("Tuomas", "Rajala", role = "ctb"), person("Suman", "Rakshit", role = c("ctb", "cph")), person("Dominic", "Schuhmacher", role = "ctb"), person("Rasmus", "Plenge Waagepetersen", role = "ctb"), person("Hangsheng", "Wang", role = "ctb"))
-# Maintainer: Adrian Baddeley <Adrian.Baddeley@curtin.edu.au>
-# Depends: R (>= 3.5.0), spatstat.data (>= 3.0), spatstat.geom (>= 3.0), spatstat.random (>= 3.0), spatstat.explore (>= 3.0), stats, graphics, grDevices, utils, methods, nlme, rpart
-# Imports: spatstat.utils (>= 3.0), spatstat.sparse (>= 3.0), mgcv, Matrix, abind, tensor, goftest (>= 1.2-2)
-# Suggests: sm, maptools (>= 0.9-9), gsl, locfit, spatial, RandomFields (>= 3.1.24.1), RandomFieldsUtils(>= 0.3.3.1), fftwtools (>= 0.9-8), nleqslv, glmnet, spatstat.linnet (>= 3.0), spatstat (>= 3.0)
-# Additional_repositories: https://spatstat.r-universe.dev
-# Description: Functionality for exploratory data analysis and nonparametric analysis of spatial data, mainly spatial point patterns, in the 'spatstat' family of packages. (Excludes analysis of spatial data on a linear network, which is covered by the separate package 'spatstat.linnet'.) Methods include quadrat counts, K-functions and their simulation envelopes, nearest neighbour distance and empty space statistics, Fry plots, pair correlation function, kernel smoothed intensity, relative risk estimation with cross-validated bandwidth selection, mark correlation functions, segregation indices, mark dependence diagnostics, and kernel estimates of covariate effects. Formal hypothesis tests of random pattern (chi-squared, Kolmogorov-Smirnov, Monte Carlo, Diggle-Cressie-Loosmore-Ford, Dao-Genton, two-stage Monte Carlo) and tests for covariate effects (Cox-Berman-Waller-Lawson, Kolmogorov-Smirnov, ANOVA) are also supported.
-# License: GPL (>= 2)
-# URL: http://spatstat.org/
-# NeedsCompilation: yes
-# ByteCompile: true
-# BugReports: https://github.com/spatstat/spatstat.core/issues
-# Packaged: 2022-11-04 11:23:44 UTC; adrian
-# Author: Adrian Baddeley [aut, cre, cph] (<https://orcid.org/0000-0001-9499-8382>), Rolf Turner [aut, cph] (<https://orcid.org/0000-0001-5521-5218>), Ege Rubak [aut, cph] (<https://orcid.org/0000-0002-6675-533X>), Kasper Klitgaard Berthelsen [ctb], Achmad Choiruddin [ctb, cph], Jean-Francois Coeurjolly [ctb], Ottmar Cronie [ctb], Tilman Davies [ctb], Julian Gilbey [ctb], Yongtao Guan [ctb], Ute Hahn [ctb], Kassel Hingee [ctb], Abdollah Jalilian [ctb], Frederic Lavancier [ctb], Marie-Colette van Lieshout [ctb], Greg McSwiggan [ctb], Tuomas Rajala [ctb], Suman Rakshit [ctb, cph], Dominic Schuhmacher [ctb], Rasmus Plenge Waagepetersen [ctb], Hangsheng Wang [ctb]
-# Repository: CRAN
-# Date/Publication: 2022-11-07 09:40:02 UTC


### PR DESCRIPTION
Adds [CRAN package `spatstat.model`](https://cran.r-project.org/package=spatstat.model) as `r-spatstat.model`. Recipe generated with `conda_r_skeleton_helper`.

Needed as [new dependency of `r-spatstat.linnet`](https://github.com/conda-forge/r-spatstat.linnet-feedstock/pull/9).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
