### PR TITLE
add autocommand package

### DIFF
--- a/recipes/autocommand/meta.yaml
+++ b/recipes/autocommand/meta.yaml
@@ -35,9 +35,9 @@ about:
     Autocommand turns a function into a command-line program. It converts 
     the function's parameter signature into command-line arguments, and 
     automatically runs the function if the module was called as ``__main__``.
-  license: LGPL-3.0
+  license: LGPL-3.0-only
   license_family: LGPL
-  license_file: LICENSE.txt
+  license_file: LICENSE
   doc_url: https://github.com/Lucretiel/autocommand
   dev_url: https://github.com/simplejson/simplejson
 

--- a/recipes/autocommand/meta.yaml
+++ b/recipes/autocommand/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "autocommand" %}
+{% set version = "2.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: fed420e9d02745821a782971b583c6970259ee0b229be2a0a401e1467a4f170f
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3
+    - pip
+  run:
+    - python >=3
+
+test:
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "from autocommand import autocommand"
+
+about:
+  home: https://github.com/Lucretiel/autocommand
+  summary: 'A library to automatically generate and run simple argparse parsers from function signatures.'
+  description: |
+    Autocommand turns a function into a command-line program. It converts 
+    the function's parameter signature into command-line arguments, and 
+    automatically runs the function if the module was called as ``__main__``.
+  license: LGPL-3.0
+  license_family: LGPL
+  license_file: LICENSE.txt
+  doc_url: https://github.com/Lucretiel/autocommand
+  dev_url: https://github.com/simplejson/simplejson
+
+extra:
+  recipe-maintainers:
+    - carlodri


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

https://github.com/Lucretiel/autocommand

Required by https://github.com/conda-forge/jaraco.text-feedstock/pull/27
