### PR TITLE
adds r-cvar and r-gbutils

### DIFF
--- a/recipes/r-cvar/bld.bat
+++ b/recipes/r-cvar/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-cvar/build.sh
+++ b/recipes/r-cvar/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-cvar/meta.yaml
+++ b/recipes/r-cvar/meta.yaml
@@ -1,0 +1,78 @@
+{% set version = '0.5' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-cvar
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/cvar_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/cvar/cvar_{{ version }}.tar.gz
+  sha256: 7e721a68a321acbc74149d6ae9c6e3b0c1f896df9fa7786b8b40264e1db2db18
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rdpack >=0.8
+    - r-gbutils
+  run:
+    - r-base
+    - r-rdpack >=0.8
+    - r-gbutils
+
+test:
+  commands:
+    - $R -e "library('cvar')"           # [not win]
+    - "\"%R%\" -e \"library('cvar')\""  # [win]
+
+about:
+  home: https://geobosh.github.io/cvar/ (doc), https://github.com/GeoBosh/cvar (devel)
+  license: GPL-2.0-or-later
+  summary: Compute expected shortfall (ES) and Value at Risk (VaR) from a quantile function,
+    distribution function, random number generator or probability density function.  ES
+    is also known as Conditional Value at Risk (CVaR). Virtually any continuous distribution
+    can be specified. The functions are vectorized over the arguments. The computations
+    are done directly from the definitions, see e.g. Acerbi and Tasche (2002) <doi:10.1111/1468-0300.00091>.
+    Some support for GARCH models is provided, as well.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: cvar
+# Type: Package
+# Title: Compute Expected Shortfall and Value at Risk for Continuous Distributions
+# Version: 0.5
+# Authors@R: person(given = c("Georgi", "N."), family = "Boshnakov", role = c("aut", "cre"), email = "georgi.boshnakov@manchester.ac.uk")
+# Description: Compute expected shortfall (ES) and Value at Risk (VaR) from a quantile function, distribution function, random number generator or probability density function.  ES is also known as Conditional Value at Risk (CVaR). Virtually any continuous distribution can be specified. The functions are vectorized over the arguments. The computations are done directly from the definitions, see e.g. Acerbi and Tasche (2002) <doi:10.1111/1468-0300.00091>. Some support for GARCH models is provided, as well.
+# URL: https://geobosh.github.io/cvar/ (doc), https://github.com/GeoBosh/cvar (devel)
+# BugReports: https://github.com/GeoBosh/cvar/issues
+# Imports: gbutils, Rdpack (>= 0.8)
+# RdMacros: Rdpack
+# License: GPL (>= 2)
+# Collate: VaR.R cvar-package.R garch.R
+# RoxygenNote: 7.2.0
+# Suggests: testthat, fGarch, PerformanceAnalytics
+# NeedsCompilation: no
+# Packaged: 2022-11-03 09:30:19 UTC; georgi
+# Author: Georgi N. Boshnakov [aut, cre]
+# Maintainer: Georgi N. Boshnakov <georgi.boshnakov@manchester.ac.uk>
+# Repository: CRAN
+# Date/Publication: 2022-11-03 10:00:06 UTC

--- a/recipes/r-cvar/meta.yaml
+++ b/recipes/r-cvar/meta.yaml
@@ -39,7 +39,8 @@ test:
     - "\"%R%\" -e \"library('cvar')\""  # [win]
 
 about:
-  home: https://geobosh.github.io/cvar/ (doc), https://github.com/GeoBosh/cvar (devel)
+  home: https://geobosh.github.io/cvar/
+  dev_url: https://github.com/GeoBosh/cvar/
   license: GPL-2.0-or-later
   summary: Compute expected shortfall (ES) and Value at Risk (VaR) from a quantile function,
     distribution function, random number generator or probability density function.  ES

--- a/recipes/r-gbutils/bld.bat
+++ b/recipes/r-gbutils/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-gbutils/build.sh
+++ b/recipes/r-gbutils/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-gbutils/meta.yaml
+++ b/recipes/r-gbutils/meta.yaml
@@ -37,7 +37,8 @@ test:
     - "\"%R%\" -e \"library('gbutils')\""  # [win]
 
 about:
-  home: https://github.com/GeoBosh/gbutils (devel), https://geobosh.github.io/gbutils/ (website)
+  home: https://geobosh.github.io/gbutils/
+  dev_url: https://github.com/GeoBosh/gbutils
   license: GPL-2.0-or-later
   summary: 'Plot density and distribution functions with automatic selection of suitable regions.
     Numerically invert (compute quantiles) distribution functions. Simulate real and

--- a/recipes/r-gbutils/meta.yaml
+++ b/recipes/r-gbutils/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '0.5' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-gbutils
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/gbutils_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/gbutils/gbutils_{{ version }}.tar.gz
+  sha256: ae53356b4e039d937bdd66ec5dd1f061d651b574fa2671997cb0c7e26265c6be
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rdpack >=0.9
+  run:
+    - r-base
+    - r-rdpack >=0.9
+
+test:
+  commands:
+    - $R -e "library('gbutils')"           # [not win]
+    - "\"%R%\" -e \"library('gbutils')\""  # [win]
+
+about:
+  home: https://github.com/GeoBosh/gbutils (devel), https://geobosh.github.io/gbutils/ (website)
+  license: GPL-2.0-or-later
+  summary: 'Plot density and distribution functions with automatic selection of suitable regions.
+    Numerically invert (compute quantiles) distribution functions. Simulate real and
+    complex numbers from distributions of their magnitude and arguments. Optionally,
+    the magnitudes and/or arguments may be fixed in almost arbitrary ways. Create polynomials
+    from roots given in Cartesian or polar form. Small programming utilities: check
+    if an object is identical to NA, count positional arguments in a call, set intersection
+    of more than two sets, check if an argument is unnamed, compute the graph of S4
+    classes in packages.'
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: gbutils
+# Type: Package
+# Title: Utilities for Simulation, Plots, Quantile Functions and Programming
+# Version: 0.5
+# Date: 2022-05-27
+# Depends: methods
+# Imports: stats, utils, Rdpack (>= 0.9)
+# Suggests: testthat (>= 3.0.0), classGraph, graph, Rgraphviz
+# RdMacros: Rdpack
+# Authors@R: person(given = c("Georgi", "N."), family = "Boshnakov", role = c("aut", "cre"), email = "georgi.boshnakov@manchester.ac.uk")
+# Description: Plot density and distribution functions with automatic selection of suitable regions. Numerically invert (compute quantiles) distribution functions. Simulate real and complex numbers from distributions of their magnitude and arguments. Optionally, the magnitudes and/or arguments may be fixed in almost arbitrary ways. Create polynomials from roots given in Cartesian or polar form. Small programming utilities: check if an object is identical to NA, count positional arguments in a call, set intersection of more than two sets, check if an argument is unnamed, compute the graph of S4 classes in packages.
+# URL: https://github.com/GeoBosh/gbutils (devel), https://geobosh.github.io/gbutils/ (website)
+# BugReports: https://github.com/GeoBosh/gbutils/issues
+# License: GPL (>= 2)
+# Encoding: UTF-8
+# Collate: parse_text.R sim_numbers.R isNA.R mintersect.R pad.R args.R history.R cdf2qf.R S4utils.R pseudoInverse.R rpoly.R
+# Config/testthat/edition: 3
+# NeedsCompilation: no
+# Packaged: 2022-05-27 07:31:07 UTC; georgi
+# Author: Georgi N. Boshnakov [aut, cre]
+# Maintainer: Georgi N. Boshnakov <georgi.boshnakov@manchester.ac.uk>
+# Repository: CRAN
+# Date/Publication: 2022-05-27 09:30:07 UTC


### PR DESCRIPTION
Adds [CRAN package `cvar`](https://cran.r-project.org/package=cvar) as `r-cvar` and dependency [`gbutils`](https://cran.r-project.org/package=gbutils) as `r-gbutils`. Recipe generated with `conda_r_skeleton_helper`.

New dependency of [`r-fgarch`](https://github.com/conda-forge/r-fgarch-feedstock/pull/9).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
