### PR TITLE
adds r-modelenv

### DIFF
--- a/recipes/r-modelenv/bld.bat
+++ b/recipes/r-modelenv/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-modelenv/build.sh
+++ b/recipes/r-modelenv/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-modelenv/meta.yaml
+++ b/recipes/r-modelenv/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-modelenv
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/modelenv_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/modelenv/modelenv_{{ version }}.tar.gz
+  sha256: a4c5eca4eb71f4cd1563c1e823cefafd435b2e0925a4a5d027986faae1a08fa3
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-glue
+    - r-rlang
+    - r-tibble
+    - r-vctrs
+  run:
+    - r-base
+    - r-glue
+    - r-rlang
+    - r-tibble
+    - r-vctrs
+
+test:
+  commands:
+    - $R -e "library('modelenv')"           # [not win]
+    - "\"%R%\" -e \"library('modelenv')\""  # [win]
+
+about:
+  home: https://github.com/tidymodels/modelenv
+  license: MIT
+  summary: An developer focused, low dependency package in 'tidymodels' that provides functions
+    to register how models are to be used. Functions to register models are complimented
+    with accessor functions to retrieve registered model information to aid in model
+    fitting and error handling.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: modelenv
+# Title: Provide Tools to Register Models for Use in 'tidymodels'
+# Version: 0.1.0
+# Authors@R: person("Emil", "Hvitfeldt", , "emilhhvitfeldt@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0679-1945"))
+# Description: An developer focused, low dependency package in 'tidymodels' that provides functions to register how models are to be used. Functions to register models are complimented with accessor functions to retrieve registered model information to aid in model fitting and error handling.
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# RoxygenNote: 7.2.1.9000
+# Imports: glue, rlang, tibble, vctrs
+# Suggests: covr, testthat (>= 3.0.0)
+# Config/Needs/website: tidyverse/tidytemplate
+# Config/testthat/edition: 3
+# URL: https://github.com/tidymodels/modelenv
+# BugReports: https://github.com/tidymodels/modelenv/issues
+# NeedsCompilation: no
+# Packaged: 2022-10-15 19:07:03 UTC; emilhvitfeldt
+# Author: Emil Hvitfeldt [aut, cre] (<https://orcid.org/0000-0002-0679-1945>)
+# Maintainer: Emil Hvitfeldt <emilhhvitfeldt@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-10-17 12:00:07 UTC


### PR DESCRIPTION
Adds [CRAN package `modelenv`](https://cran.r-project.org/package=modelenv) as `r-modelenv`. Recipe generated with `conda_r_skeleton_helper`.

Needed as [new dependency of `r-workflows`](https://github.com/conda-forge/r-workflows-feedstock/pull/16).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
