### PR TITLE
Add sphinx-mdinclude

### DIFF
--- a/recipes/sphinx-mdinclude/meta.yaml
+++ b/recipes/sphinx-mdinclude/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "0.5.3" %}
+
+package:
+  # pypi package uses underscore
+  # https://pypi.org/project/sphinx_mdinclude/
+  name: sphinx_mdinclude
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/s/sphinx_mdinclude/sphinx_mdinclude-{{ version }}.tar.gz
+  sha256: 2998e3d18b3022c9983d1b72191fe37e25ffccd54165cbe3acb22cceedd91af4
+
+build:
+  noarch: python
+  script:
+    # - rm -f pyproject.toml
+    - {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - flit-core
+    # flit seems to import things, so duplicate all dependencies here
+    - mistune >=2.0,<3.0.0.0a
+    - docutils >=0.16,<1.0.0a
+    - pygments >=2.8
+    - docutils
+  run:
+    - python >=3.8
+    - mistune >=2.0,<3.0.0.0a
+    - docutils >=0.16,<1.0.0a
+    - pygments >=2.8
+    - docutils
+
+test:
+  imports:
+    - sphinx_mdinclude
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/omnilib/sphinx-mdinclude
+  summary: Sphinx extension for including or writing pages in Markdown format.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/sphinx-mdinclude/meta.yaml
+++ b/recipes/sphinx-mdinclude/meta.yaml
@@ -1,9 +1,10 @@
 {% set version = "0.5.3" %}
 
 package:
-  # pypi package uses underscore
+  # pypi package uses underscore. however, I believe that conda-forge
+  # prefers dashes
   # https://pypi.org/project/sphinx_mdinclude/
-  name: sphinx_mdinclude
+  name: sphinx-mdinclude
   version: {{ version }}
 
 source:


### PR DESCRIPTION
@conda-forge/help-python upstream publishes as `sphinx_mdinclude` on pypi. However I think that `-` is better for conda-forge. can you provide some input on how to move forward.

Help with `flit` would  be appreciated too. I had to add everything to the host dependencies during the build process.

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
