### PR TITLE
Add realalg

### DIFF
--- a/recipes/realalg/meta.yaml
+++ b/recipes/realalg/meta.yaml
@@ -23,6 +23,10 @@ requirements:
     - numpy >=1.15.1
     - sympy >=1.6
     - cypari2 >=2,<3
+    # We need Cython at runtime since it is an install_requires of our indirect
+    # dependency cysignals, fixed in
+    # https://github.com/conda-forge/cysignals-feedstock/pull/44
+    - cython
 
 test:
   imports:

--- a/recipes/realalg/meta.yaml
+++ b/recipes/realalg/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "realalg" %}
+{% set version = "0.3.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/realalg-{{ version }}.tar.gz
+  sha256: 815137972ca64cf3b579e2b454ab522648c54206dc84d5066101023888ae5d6e
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy >=1.15.1
+    - sympy >=1.6
+    - cypari2 >=2,<3
+
+test:
+  imports:
+    - realalg
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/MarkCBell/realalg
+  summary: Computations with real algebraic numbers
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - saraedum
+

--- a/recipes/realalg/meta.yaml
+++ b/recipes/realalg/meta.yaml
@@ -16,7 +16,7 @@ build:
 
 requirements:
   host:
-    - python >= 3.6
+    - python >=3.6
     - pip
   run:
     - python >=3.6

--- a/recipes/realalg/meta.yaml
+++ b/recipes/realalg/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >= 3.6
     - pip
   run:
-    - python
+    - python >=3.6
     - numpy >=1.15.1
     - sympy >=1.6
     - cypari2 >=2,<3
@@ -45,4 +45,3 @@ about:
 extra:
   recipe-maintainers:
     - saraedum
-


### PR DESCRIPTION
realalg is a Python library for computation with real algebraic numbers.

realalg is a pure Python package. However, it depends on cypari2 which links to the shared libpari library which is not available on Windows; that's why the Windows build fails below.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
