### PR TITLE
Add home-assistant-bluetooth

### DIFF
--- a/recipes/home-assistant-bluetooth/meta.yaml
+++ b/recipes/home-assistant-bluetooth/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "home_assistant_bluetooth" %}
+{% set version = "1.6.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 82487a7e6bdcf59a703def06b1659c9d7ed1bd8d8742129f5bc198d00360c8c7
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.0
+    - pip
+    - poetry
+  run:
+    - python >=3.9
+    - bleak >=0.19.0
+
+test:
+  imports:
+    - home_assistant_bluetooth
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/home-assistant-libs/home-assistant-bluetooth
+  summary: Home Assistant Bluetooth Models and Helpers
+  description: |
+    This library is for accessing Home Assistant Bluetooth models. Libraries use these models to receive and parse Bluetooth advertisement data.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  doc_url: https://github.com/home-assistant-libs/home-assistant-bluetooth
+  dev_url: https://github.com/home-assistant-libs/home-assistant-bluetooth
+
+extra:
+  recipe-maintainers:
+    - SylvainCorlay


### PR DESCRIPTION
I am starting from 1.6.0 (and not 1.8.1) because 1.6 is the version currently required for the stable version of homeassistant.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
