### PR TITLE
add r-ggstats

### DIFF
--- a/recipes/r-ggstats/bld.bat
+++ b/recipes/r-ggstats/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ggstats/build.sh
+++ b/recipes/r-ggstats/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ggstats/meta.yaml
+++ b/recipes/r-ggstats/meta.yaml
@@ -1,0 +1,93 @@
+{% set version = '0.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggstats
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggstats_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggstats/ggstats_{{ version }}.tar.gz
+  sha256: a68cbe467f688e12e43cb5640173bcc2e6301e9f3d80c385649c98e79fd44ae6
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-broom.helpers
+    - r-cli
+    - r-dplyr
+    - r-forcats
+    - r-ggplot2
+    - r-lifecycle
+    - r-magrittr
+    - r-scales
+    - r-tidyr
+  run:
+    - r-base
+    - r-broom.helpers
+    - r-cli
+    - r-dplyr
+    - r-forcats
+    - r-ggplot2
+    - r-lifecycle
+    - r-magrittr
+    - r-scales
+    - r-tidyr
+
+test:
+  commands:
+    - $R -e "library('ggstats')"           # [not win]
+    - "\"%R%\" -e \"library('ggstats')\""  # [win]
+
+about:
+  home: https://larmarange.github.io/ggstats/
+  dev_url: https://github.com/larmarange/ggstats/
+  doc_url: https://larmarange.github.io/ggstats/reference/index.html
+  license: GPL-3.0-only
+  summary: Provides suite of functions to plot regression model coefficients ("forest plots").
+    The suite also includes new statistics to compute proportions, weighted mean and
+    cross-tabulation statistics, as well as new geometries to add alternative background
+    color to a plot.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ggstats
+# Type: Package
+# Title: Extension to 'ggplot2' for Plotting Stats
+# Version: 0.1.1
+# Authors@R: c( person("Joseph", "Larmarange", , "joseph@larmarange.net", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7097-700X")) )
+# Description: Provides suite of functions to plot regression model coefficients ("forest plots"). The suite also includes new statistics to compute proportions, weighted mean and cross-tabulation statistics, as well as new geometries to add alternative background color to a plot.
+# License: GPL-3
+# URL: https://larmarange.github.io/ggstats/
+# BugReports: https://github.com/larmarange/ggstats/issues
+# Imports: broom.helpers, cli, dplyr, forcats, ggplot2, lifecycle, magrittr, scales, stats, tidyr
+# Suggests: broom, emmeans, glue, knitr, labelled, reshape, rmarkdown, nnet, testthat (>= 3.0.0), spelling, survey, survival, vdiffr
+# Encoding: UTF-8
+# RoxygenNote: 7.2.1
+# Config/testthat/edition: 3
+# Language: en-US
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2022-11-19 12:10:28 UTC; josep
+# Author: Joseph Larmarange [aut, cre] (<https://orcid.org/0000-0001-7097-700X>)
+# Maintainer: Joseph Larmarange <joseph@larmarange.net>
+# Repository: CRAN
+# Date/Publication: 2022-11-24 00:20:08 UTC

--- a/recipes/r-ggstats/meta.yaml
+++ b/recipes/r-ggstats/meta.yaml
@@ -68,26 +68,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-
-# Package: ggstats
-# Type: Package
-# Title: Extension to 'ggplot2' for Plotting Stats
-# Version: 0.1.1
-# Authors@R: c( person("Joseph", "Larmarange", , "joseph@larmarange.net", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-7097-700X")) )
-# Description: Provides suite of functions to plot regression model coefficients ("forest plots"). The suite also includes new statistics to compute proportions, weighted mean and cross-tabulation statistics, as well as new geometries to add alternative background color to a plot.
-# License: GPL-3
-# URL: https://larmarange.github.io/ggstats/
-# BugReports: https://github.com/larmarange/ggstats/issues
-# Imports: broom.helpers, cli, dplyr, forcats, ggplot2, lifecycle, magrittr, scales, stats, tidyr
-# Suggests: broom, emmeans, glue, knitr, labelled, reshape, rmarkdown, nnet, testthat (>= 3.0.0), spelling, survey, survival, vdiffr
-# Encoding: UTF-8
-# RoxygenNote: 7.2.1
-# Config/testthat/edition: 3
-# Language: en-US
-# VignetteBuilder: knitr
-# NeedsCompilation: no
-# Packaged: 2022-11-19 12:10:28 UTC; josep
-# Author: Joseph Larmarange [aut, cre] (<https://orcid.org/0000-0001-7097-700X>)
-# Maintainer: Joseph Larmarange <joseph@larmarange.net>
-# Repository: CRAN
-# Date/Publication: 2022-11-24 00:20:08 UTC


### PR DESCRIPTION
Adds [CRAN package `ggstats`](https://cran.r-project.org/package=ggstats) as `r-ggstats`. Recipe generated with `conda_r_skeleton_helper`.

Needed as [new test dependency of `r-gtsummary`](https://github.com/conda-forge/r-gtsummary-feedstock/pull/25).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
