### PR TITLE
add r-groupdata2

### DIFF
--- a/recipes/r-groupdata2/bld.bat
+++ b/recipes/r-groupdata2/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-groupdata2/build.sh
+++ b/recipes/r-groupdata2/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-groupdata2/meta.yaml
+++ b/recipes/r-groupdata2/meta.yaml
@@ -1,0 +1,92 @@
+{% set version = '2.0.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-groupdata2
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/groupdata2_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/groupdata2/groupdata2_{{ version }}.tar.gz
+  sha256: 85bee0a66d777414c1873bf661a95fdba88aad5a8bab1a157187f30e5ef198c5
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-checkmate >=2.0.0
+    - r-dplyr >=0.8.4
+    - r-lifecycle
+    - r-numbers >=0.7_5
+    - r-plyr >=1.8.5
+    - r-purrr
+    - r-rearrr >=0.3.0
+    - r-rlang >=0.4.4
+    - r-tibble >=2.1.3
+    - r-tidyr
+  run:
+    - r-base
+    - r-checkmate >=2.0.0
+    - r-dplyr >=0.8.4
+    - r-lifecycle
+    - r-numbers >=0.7_5
+    - r-plyr >=1.8.5
+    - r-purrr
+    - r-rearrr >=0.3.0
+    - r-rlang >=0.4.4
+    - r-tibble >=2.1.3
+    - r-tidyr
+
+test:
+  commands:
+    - $R -e "library('groupdata2')"           # [not win]
+    - "\"%R%\" -e \"library('groupdata2')\""  # [win]
+
+about:
+  home: https://github.com/ludvigolsen/groupdata2
+  license: MIT
+  summary: Methods for dividing data into groups. Create balanced partitions and cross-validation
+    folds. Perform time series windowing and general grouping and splitting of data.
+    Balance existing groups with up- and downsampling or collapse them to fewer groups.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: groupdata2
+# Title: Creating Groups from Data
+# Version: 2.0.2
+# Authors@R: person("Ludvig Renbo", "Olsen", email = "r-pkgs@ludvigolsen.dk", role = c("aut", "cre"))
+# Description: Methods for dividing data into groups. Create balanced partitions and cross-validation folds. Perform time series windowing and general grouping and splitting of data. Balance existing groups with up- and downsampling or collapse them to fewer groups.
+# Depends: R (>= 3.5)
+# License: MIT + file LICENSE
+# URL: https://github.com/ludvigolsen/groupdata2
+# BugReports: https://github.com/ludvigolsen/groupdata2/issues
+# Encoding: UTF-8
+# Imports: checkmate (>= 2.0.0), dplyr (>= 0.8.4), numbers (>= 0.7-5), lifecycle, plyr (>= 1.8.5), purrr, rearrr (>= 0.3.0), rlang (>= 0.4.4), stats, tibble (>= 2.1.3), tidyr, utils
+# RoxygenNote: 7.2.2
+# Suggests: broom, covr, ggplot2, knitr, lmerTest, rmarkdown, testthat, xpectr (>= 0.4.1)
+# RdMacros: lifecycle
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2022-11-19 17:52:25 UTC; au547627
+# Author: Ludvig Renbo Olsen [aut, cre]
+# Maintainer: Ludvig Renbo Olsen <r-pkgs@ludvigolsen.dk>
+# Repository: CRAN
+# Date/Publication: 2022-11-24 09:50:02 UTC

--- a/recipes/r-groupdata2/meta.yaml
+++ b/recipes/r-groupdata2/meta.yaml
@@ -68,25 +68,3 @@ about:
 extra:
   recipe-maintainers:
     - conda-forge/r
-
-# Package: groupdata2
-# Title: Creating Groups from Data
-# Version: 2.0.2
-# Authors@R: person("Ludvig Renbo", "Olsen", email = "r-pkgs@ludvigolsen.dk", role = c("aut", "cre"))
-# Description: Methods for dividing data into groups. Create balanced partitions and cross-validation folds. Perform time series windowing and general grouping and splitting of data. Balance existing groups with up- and downsampling or collapse them to fewer groups.
-# Depends: R (>= 3.5)
-# License: MIT + file LICENSE
-# URL: https://github.com/ludvigolsen/groupdata2
-# BugReports: https://github.com/ludvigolsen/groupdata2/issues
-# Encoding: UTF-8
-# Imports: checkmate (>= 2.0.0), dplyr (>= 0.8.4), numbers (>= 0.7-5), lifecycle, plyr (>= 1.8.5), purrr, rearrr (>= 0.3.0), rlang (>= 0.4.4), stats, tibble (>= 2.1.3), tidyr, utils
-# RoxygenNote: 7.2.2
-# Suggests: broom, covr, ggplot2, knitr, lmerTest, rmarkdown, testthat, xpectr (>= 0.4.1)
-# RdMacros: lifecycle
-# VignetteBuilder: knitr
-# NeedsCompilation: no
-# Packaged: 2022-11-19 17:52:25 UTC; au547627
-# Author: Ludvig Renbo Olsen [aut, cre]
-# Maintainer: Ludvig Renbo Olsen <r-pkgs@ludvigolsen.dk>
-# Repository: CRAN
-# Date/Publication: 2022-11-24 09:50:02 UTC


### PR DESCRIPTION
Adds [CRAN package `groupdata2`](https://cran.r-project.org/package=groupdata2) as `r-groupdata2`. Recipe generated with `conda_r_skeleton_helper`.

Package required as [new dependency of `r-cvms`](https://github.com/conda-forge/r-cvms-feedstock/pull/1).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
