### PR TITLE
adds r-tidyseurat

### DIFF
--- a/recipes/r-tidyseurat/bld.bat
+++ b/recipes/r-tidyseurat/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tidyseurat/build.sh
+++ b/recipes/r-tidyseurat/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tidyseurat/meta.yaml
+++ b/recipes/r-tidyseurat/meta.yaml
@@ -82,33 +82,7 @@ about:
   license_family: GPL3
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
-# Type: Package
-# biocViews: AssayDomain, Infrastructure, RNASeq, DifferentialExpression, GeneExpression, Normalization, Clustering, QualityControl, Sequencing, Transcription, Transcriptomics
 
 extra:
   recipe-maintainers:
     - conda-forge/r
-
-# Package: tidyseurat
-# Title: Brings Seurat to the Tidyverse
-# Version: 0.5.3
-# Authors@R: c(person("Stefano", "Mangiola", email = "mangiolastefano@gmail.com", role = c("aut", "cre")), person("Maria", "Doyle", email = "Maria.Doyle@petermac.org", role = c("ctb")) )
-# Description: It creates an invisible layer that allow to see the 'Seurat' object as tibble and interact seamlessly with the tidyverse.
-# License: GPL-3
-# Depends: R (>= 4.0.0), ttservice, SeuratObject
-# Imports: Seurat, tibble, dplyr, magrittr, tidyr (>= 1.2.0), ggplot2, rlang, purrr, lifecycle, methods, plotly, tidyselect, utils, ellipsis, vctrs, pillar, stringr, cli, fansi
-# Suggests: testthat, knitr, GGally, markdown, SingleR
-# VignetteBuilder: knitr
-# RdMacros: lifecycle
-# Biarch: true
-# Encoding: UTF-8
-# LazyData: true
-# RoxygenNote: 7.1.2
-# URL: https://github.com/stemangiola/tidyseurat
-# BugReports: https://github.com/stemangiola/tidyseurat/issues
-# NeedsCompilation: no
-# Packaged: 2022-05-20 12:27:37 UTC; mangiola.s
-# Author: Stefano Mangiola [aut, cre], Maria Doyle [ctb]
-# Maintainer: Stefano Mangiola <mangiolastefano@gmail.com>
-# Repository: CRAN
-# Date/Publication: 2022-05-20 12:50:02 UTC

--- a/recipes/r-tidyseurat/meta.yaml
+++ b/recipes/r-tidyseurat/meta.yaml
@@ -76,7 +76,7 @@ about:
   home: https://stemangiola.github.io/tidyseurat/
   dev_url: https://github.com/stemangiola/tidyseurat
   doc_url: https://stemangiola.github.io/tidyseurat/reference/index.html
-  license: GPL-3
+  license: GPL-3.0-only
   summary: It creates an invisible layer that allow to see the 'Seurat' object as tibble and
     interact seamlessly with the tidyverse.
   license_family: GPL3

--- a/recipes/r-tidyseurat/meta.yaml
+++ b/recipes/r-tidyseurat/meta.yaml
@@ -1,0 +1,114 @@
+{% set version = '0.5.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tidyseurat
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/tidyseurat_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/tidyseurat/tidyseurat_{{ version }}.tar.gz
+  sha256: 33dc7cd324884b5db6eb950b14fbcabbf047d0765f92e454a446ec95da35b310
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-seurat
+    - r-seuratobject
+    - r-cli
+    - r-dplyr
+    - r-ellipsis
+    - r-fansi
+    - r-ggplot2
+    - r-lifecycle
+    - r-magrittr
+    - r-pillar
+    - r-plotly
+    - r-purrr
+    - r-rlang
+    - r-stringr
+    - r-tibble
+    - r-tidyr >=1.2.0
+    - r-tidyselect
+    - r-ttservice
+    - r-vctrs
+  run:
+    - r-base
+    - r-seurat
+    - r-seuratobject
+    - r-cli
+    - r-dplyr
+    - r-ellipsis
+    - r-fansi
+    - r-ggplot2
+    - r-lifecycle
+    - r-magrittr
+    - r-pillar
+    - r-plotly
+    - r-purrr
+    - r-rlang
+    - r-stringr
+    - r-tibble
+    - r-tidyr >=1.2.0
+    - r-tidyselect
+    - r-ttservice
+    - r-vctrs
+
+test:
+  commands:
+    - $R -e "library('tidyseurat')"           # [not win]
+    - "\"%R%\" -e \"library('tidyseurat')\""  # [win]
+
+about:
+  home: https://stemangiola.github.io/tidyseurat/
+  dev_url: https://github.com/stemangiola/tidyseurat
+  doc_url: https://stemangiola.github.io/tidyseurat/reference/index.html
+  license: GPL-3
+  summary: It creates an invisible layer that allow to see the 'Seurat' object as tibble and
+    interact seamlessly with the tidyverse.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+# Type: Package
+# biocViews: AssayDomain, Infrastructure, RNASeq, DifferentialExpression, GeneExpression, Normalization, Clustering, QualityControl, Sequencing, Transcription, Transcriptomics
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: tidyseurat
+# Title: Brings Seurat to the Tidyverse
+# Version: 0.5.3
+# Authors@R: c(person("Stefano", "Mangiola", email = "mangiolastefano@gmail.com", role = c("aut", "cre")), person("Maria", "Doyle", email = "Maria.Doyle@petermac.org", role = c("ctb")) )
+# Description: It creates an invisible layer that allow to see the 'Seurat' object as tibble and interact seamlessly with the tidyverse.
+# License: GPL-3
+# Depends: R (>= 4.0.0), ttservice, SeuratObject
+# Imports: Seurat, tibble, dplyr, magrittr, tidyr (>= 1.2.0), ggplot2, rlang, purrr, lifecycle, methods, plotly, tidyselect, utils, ellipsis, vctrs, pillar, stringr, cli, fansi
+# Suggests: testthat, knitr, GGally, markdown, SingleR
+# VignetteBuilder: knitr
+# RdMacros: lifecycle
+# Biarch: true
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.1.2
+# URL: https://github.com/stemangiola/tidyseurat
+# BugReports: https://github.com/stemangiola/tidyseurat/issues
+# NeedsCompilation: no
+# Packaged: 2022-05-20 12:27:37 UTC; mangiola.s
+# Author: Stefano Mangiola [aut, cre], Maria Doyle [ctb]
+# Maintainer: Stefano Mangiola <mangiolastefano@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-05-20 12:50:02 UTC


### PR DESCRIPTION
Adds [CRAN package `tidyseurat`](https://cran.r-project.org/package=tidyseurat) as `r-tidyseurat`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
