### PR TITLE
add r-ggbreak

### DIFF
--- a/recipes/r-ggbreak/bld.bat
+++ b/recipes/r-ggbreak/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ggbreak/build.sh
+++ b/recipes/r-ggbreak/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ggbreak/meta.yaml
+++ b/recipes/r-ggbreak/meta.yaml
@@ -1,0 +1,78 @@
+{% set version = '0.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggbreak
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggbreak_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggbreak/ggbreak_{{ version }}.tar.gz
+  sha256: 9a9dcc3b2861f7b0a70f69aaab5e9ee84e3b95c2add7b4163d037509afdf4ccb
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-aplot >=0.1.5
+    - r-ggfun >=0.0.4
+    - r-ggplot2
+    - r-ggplotify >=0.0.7
+    - r-rlang
+  run:
+    - r-base
+    - r-aplot >=0.1.5
+    - r-ggfun >=0.0.4
+    - r-ggplot2
+    - r-ggplotify >=0.0.7
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('ggbreak')"           # [not win]
+    - "\"%R%\" -e \"library('ggbreak')\""  # [win]
+
+about:
+  home: https://github.com/YuLab-SMU/ggbreak
+  doc_url: https://www.frontiersin.org/articles/10.3389/fgene.2021.774846/full
+  license: Artistic-2.0
+  summary: An implementation of scale functions for setting axis breaks of a 'gg' plot.
+  license_family: OTHER
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/Artistic-2.0'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ggbreak
+# Title: Set Axis Break for 'ggplot2'
+# Version: 0.1.1
+# Authors@R: c( person("Guangchuang", "Yu",     email = "guangchuangyu@gmail.com", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")), person("Shuangbin", "Xu",       email = "xshuangbin@163.com",      role = "aut", comment = c(ORCID="0000-0003-3513-5362")) )
+# Description: An implementation of scale functions for setting axis breaks of a 'gg' plot.
+# Imports: ggfun (>= 0.0.4), grid, ggplot2, ggplotify (>= 0.0.7), aplot (>= 0.1.5), rlang, stats
+# Suggests: cowplot, ggimage, knitr, patchwork, pillar, prettydoc, rmarkdown
+# VignetteBuilder: knitr
+# License: Artistic-2.0
+# Encoding: UTF-8
+# URL: https://github.com/YuLab-SMU/ggbreak (devel), https://www.frontiersin.org/articles/10.3389/fgene.2021.774846/full (article)
+# BugReports: https://github.com/YuLab-SMU/ggbreak/issues
+# RoxygenNote: 7.2.1
+# NeedsCompilation: no
+# Packaged: 2022-10-15 06:25:39 UTC; ygc
+# Author: Guangchuang Yu [aut, cre, cph] (<https://orcid.org/0000-0002-6485-8781>), Shuangbin Xu [aut] (<https://orcid.org/0000-0003-3513-5362>)
+# Maintainer: Guangchuang Yu <guangchuangyu@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-10-16 00:23:32 UTC


### PR DESCRIPTION
Adds [CRAN package `ggbreak`](https://cran.r-project.org/package=ggbreak) as `r-ggbreak`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
