### PR TITLE
adds r-ggsurvfit

### DIFF
--- a/recipes/r-ggsurvfit/bld.bat
+++ b/recipes/r-ggsurvfit/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ggsurvfit/build.sh
+++ b/recipes/r-ggsurvfit/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ggsurvfit/meta.yaml
+++ b/recipes/r-ggsurvfit/meta.yaml
@@ -1,0 +1,97 @@
+{% set version = '0.2.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggsurvfit
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggsurvfit_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggsurvfit/ggsurvfit_{{ version }}.tar.gz
+  sha256: 939acc42daa8e747eacf06bdd9e48a55ccafdfaf8b24bc24d6eb44d5345a2f08
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-broom >=1.0.0
+    - r-cli >=3.0.0
+    - r-dplyr >=1.0.3
+    - r-ggplot2 >=3.4.0
+    - r-glue >=1.6.0
+    - r-gtable
+    - r-patchwork >=1.1.0
+    - r-rlang >=1.0.0
+    - r-survival >=3.4_0
+    - r-tidyr >=1.0.0
+  run:
+    - r-base
+    - r-broom >=1.0.0
+    - r-cli >=3.0.0
+    - r-dplyr >=1.0.3
+    - r-ggplot2 >=3.4.0
+    - r-glue >=1.6.0
+    - r-gtable
+    - r-patchwork >=1.1.0
+    - r-rlang >=1.0.0
+    - r-survival >=3.4_0
+    - r-tidyr >=1.0.0
+
+test:
+  commands:
+    - $R -e "library('ggsurvfit')"           # [not win]
+    - "\"%R%\" -e \"library('ggsurvfit')\""  # [win]
+
+about:
+  home: https://github.com/ddsjoberg/ggsurvfit, http://www.danieldsjoberg.com/ggsurvfit/
+  license: MIT
+  summary: Ease the creation of time-to-event (i.e. survival) endpoint figures. The modular functions
+    create figures ready for publication. Each of the functions that add to or modify
+    the figure are written as proper 'ggplot2' geoms or stat methods, allowing the functions
+    from this package to be combined with any function or customization from 'ggplot2'
+    and other 'ggplot2' extension packages.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ggsurvfit
+# Title: Flexible Time-to-Event Figures
+# Version: 0.2.1
+# Authors@R: c( person("Daniel D.", "Sjoberg", , "danield.sjoberg@gmail.com", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0003-0862-2018")), person("Mark", "Baillie", , "bailliem@gmail.com", role = "aut"), person("Steven", "Haesendonckx", , "shaesen2@its.jnj.com", role = "aut", comment = c(ORCID = "0000-0001-8222-3686")), person("Tim", "Treis", , "tim.treis@outlook.de", role = "aut", comment = c(ORCID = "0000-0002-9686-4799")) )
+# Description: Ease the creation of time-to-event (i.e. survival) endpoint figures. The modular functions create figures ready for publication. Each of the functions that add to or modify the figure are written as proper 'ggplot2' geoms or stat methods, allowing the functions from this package to be combined with any function or customization from 'ggplot2' and other 'ggplot2' extension packages.
+# License: MIT + file LICENSE
+# URL: https://github.com/ddsjoberg/ggsurvfit, http://www.danieldsjoberg.com/ggsurvfit/
+# BugReports: https://github.com/ddsjoberg/ggsurvfit/issues
+# Depends: R (>= 3.5)
+# Imports: broom (>= 1.0.0), cli (>= 3.0.0), dplyr (>= 1.0.3), ggplot2 (>= 3.4.0), glue (>= 1.6.0), gtable, patchwork (>= 1.1.0), rlang (>= 1.0.0), survival (>= 3.4-0), tidyr (>= 1.0.0)
+# Suggests: covr, knitr, rmarkdown, scales (>= 1.1.0), spelling, testthat (>= 3.0.0), tidycmprsk (>= 0.2.0), vdiffr (>= 1.0.0)
+# VignetteBuilder: knitr
+# Config/testthat/edition: 3
+# Config/Needs/website: cowplot, ggeasy, gghighlight
+# Encoding: UTF-8
+# Language: en-US
+# LazyData: true
+# RoxygenNote: 7.2.1
+# NeedsCompilation: no
+# Packaged: 2022-12-06 17:46:02 UTC; SjobergD
+# Author: Daniel D. Sjoberg [aut, cre, cph] (<https://orcid.org/0000-0003-0862-2018>), Mark Baillie [aut], Steven Haesendonckx [aut] (<https://orcid.org/0000-0001-8222-3686>), Tim Treis [aut] (<https://orcid.org/0000-0002-9686-4799>)
+# Maintainer: Daniel D. Sjoberg <danield.sjoberg@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-12-06 18:30:02 UTC

--- a/recipes/r-ggsurvfit/meta.yaml
+++ b/recipes/r-ggsurvfit/meta.yaml
@@ -55,7 +55,9 @@ test:
     - "\"%R%\" -e \"library('ggsurvfit')\""  # [win]
 
 about:
-  home: https://github.com/ddsjoberg/ggsurvfit, http://www.danieldsjoberg.com/ggsurvfit/
+  home: https://www.danieldsjoberg.com/ggsurvfit/
+  dev_url: https://github.com/ddsjoberg/ggsurvfit
+  doc_url: https://www.danieldsjoberg.com/ggsurvfit/reference/index.html
   license: MIT
   summary: Ease the creation of time-to-event (i.e. survival) endpoint figures. The modular functions
     create figures ready for publication. Each of the functions that add to or modify


### PR DESCRIPTION
Adds [CRAN package `ggsurvfit`](https://cran.r-project.org/web/packages/ggsurvfit/index.html) as `r-ggsurvfit`. Recipe generated with `conda_r_skeleton_helper`.

# Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
