### PR TITLE
adds r-xefun

### DIFF
--- a/recipes/r-xefun/bld.bat
+++ b/recipes/r-xefun/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-xefun/build.sh
+++ b/recipes/r-xefun/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-xefun/meta.yaml
+++ b/recipes/r-xefun/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = '0.1.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-xefun
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/xefun_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/xefun/xefun_{{ version }}.tar.gz
+  sha256: 7163568bb66d241b2bc5f88b7650082861bf6f508650e14e4092f5940c321fa7
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-data.table
+  run:
+    - r-base
+    - r-data.table
+
+test:
+  commands:
+    - $R -e "library('xefun')"           # [not win]
+    - "\"%R%\" -e \"library('xefun')\""  # [win]
+
+about:
+  home: https://github.com/ShichenXie/xefun
+  license: MIT
+  summary: Miscellaneous functions used for x-engineering (feature engineering) or for supporting
+    in other packages maintained by 'Shichen Xie'.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: xefun
+# Version: 0.1.3
+# Title: X-Engineering or Supporting Functions
+# Description: Miscellaneous functions used for x-engineering (feature engineering) or for supporting in other packages maintained by 'Shichen Xie'.
+# Authors@R: person("Shichen", "Xie", , "xie@shichen.name", c("aut", "cre"))
+# Imports: data.table
+# License: MIT + file LICENSE
+# URL: https://github.com/ShichenXie/xefun
+# BugReports: https://github.com/ShichenXie/xefun/issues
+# Encoding: UTF-8
+# RoxygenNote: 7.2.1
+# NeedsCompilation: no
+# Packaged: 2022-12-25 04:23:43 UTC; shichenxie
+# Author: Shichen Xie [aut, cre]
+# Maintainer: Shichen Xie <xie@shichen.name>
+# Repository: CRAN
+# Date/Publication: 2022-12-25 04:40:02 UTC


### PR DESCRIPTION
Adds [CRAN package `xefun`](https://cran.r-project.org/package=xefun) as `r-xefun`. Recipe generate with `conda_r_skeleton_helper`.

Needed as new dependency for https://github.com/conda-forge/r-scorecard-feedstock/pull/16.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
