### PR TITLE
adds r-future.callr

### DIFF
--- a/recipes/r-future.callr/bld.bat
+++ b/recipes/r-future.callr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-future.callr/build.sh
+++ b/recipes/r-future.callr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-future.callr/meta.yaml
+++ b/recipes/r-future.callr/meta.yaml
@@ -39,8 +39,9 @@ test:
     - "\"%R%\" -e \"library('future.callr')\""  # [win]
 
 about:
-  home: https://future.callr.futureverse.org, https://github.com/HenrikBengtsson/future.callr
-  license: LGPL-2.1
+  home: https://future.callr.futureverse.org
+  dev_url: https://github.com/HenrikBengtsson/future.callr
+  license: LGPL-2.1-or-later
   summary: Implementation of the Future API on top of the 'callr' package.  This allows you to
     process futures, as defined by the 'future' package, in parallel out of the box,
     on your local (Linux, macOS, Windows, ...) machine.  Contrary to backends relying

--- a/recipes/r-future.callr/meta.yaml
+++ b/recipes/r-future.callr/meta.yaml
@@ -1,0 +1,76 @@
+{% set version = '0.8.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-future.callr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/future.callr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/future.callr/future.callr_{{ version }}.tar.gz
+  sha256: 33bdfc4b7d41306f0f606c53cb7131255d54444ab02c6d8b50c5c89dadc0fcf0
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-callr >=2.0.3
+    - r-future >=1.23.0
+  run:
+    - r-base
+    - r-callr >=2.0.3
+    - r-future >=1.23.0
+
+test:
+  commands:
+    - $R -e "library('future.callr')"           # [not win]
+    - "\"%R%\" -e \"library('future.callr')\""  # [win]
+
+about:
+  home: https://future.callr.futureverse.org, https://github.com/HenrikBengtsson/future.callr
+  license: LGPL-2.1
+  summary: Implementation of the Future API on top of the 'callr' package.  This allows you to
+    process futures, as defined by the 'future' package, in parallel out of the box,
+    on your local (Linux, macOS, Windows, ...) machine.  Contrary to backends relying
+    on the 'parallel' package (e.g. 'future::multisession') and socket connections,
+    the 'callr' backend provided here can run more than 125 parallel R processes.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: future.callr
+# Version: 0.8.1
+# Depends: R (>= 3.4.0), future (>= 1.23.0)
+# Imports: callr (>= 2.0.3)
+# Suggests: globals, future.apply, listenv, markdown, R.rsp
+# VignetteBuilder: R.rsp
+# Title: A Future API for Parallel Processing using 'callr'
+# Authors@R: c(person("Henrik", "Bengtsson", role=c("aut", "cre", "cph"), email = "henrikb@braju.com"))
+# Description: Implementation of the Future API on top of the 'callr' package.  This allows you to process futures, as defined by the 'future' package, in parallel out of the box, on your local (Linux, macOS, Windows, ...) machine.  Contrary to backends relying on the 'parallel' package (e.g. 'future::multisession') and socket connections, the 'callr' backend provided here can run more than 125 parallel R processes.
+# License: LGPL (>= 2.1)
+# LazyLoad: TRUE
+# URL: https://future.callr.futureverse.org, https://github.com/HenrikBengtsson/future.callr
+# BugReports: https://github.com/HenrikBengtsson/future.callr/issues
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Packaged: 2022-12-13 17:10:30 UTC; hb
+# Author: Henrik Bengtsson [aut, cre, cph]
+# Maintainer: Henrik Bengtsson <henrikb@braju.com>
+# Repository: CRAN
+# Date/Publication: 2022-12-14 17:10:09 UTC


### PR DESCRIPTION
Adds [CRAN package `future.callr`](https://cran.r-project.org/package=future.callr) as `r-future.callr`. Recipe created with `conda_r_skeleton_helper`, with URLs split and license adjusted for SPDX.

Needed as new dependency of `r-tarchetypes` (https://github.com/conda-forge/r-tarchetypes-feedstock/pull/17).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
