### PR TITLE
adds r-tgp

### DIFF
--- a/recipes/r-tgp/bld.bat
+++ b/recipes/r-tgp/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tgp/build.sh
+++ b/recipes/r-tgp/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tgp/meta.yaml
+++ b/recipes/r-tgp/meta.yaml
@@ -1,0 +1,83 @@
+{% set version = '2.4-21' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tgp
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/tgp_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/tgp/tgp_{{ version }}.tar.gz
+  sha256: 88f3383bdccbcc567194c147807dfe5de537be487f3b68ef8253f351f3692e8a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-maptree
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-maptree
+
+test:
+  commands:
+    - $R -e "library('tgp')"           # [not win]
+    - "\"%R%\" -e \"library('tgp')\""  # [win]
+
+about:
+  home: https://bobby.gramacy.com/r_packages/tgp/
+  license: LGPL-3
+  summary: Bayesian nonstationary, semiparametric nonlinear regression and design by treed Gaussian
+    processes (GPs) with jumps to the limiting linear model (LLM).  Special cases also
+    implemented include Bayesian linear models, CART, treed linear models, stationary
+    separable and isotropic GPs, and GP single-index models.  Provides 1-d and 2-d plotting
+    functions (with projection and slice capabilities) and tree drawing, designed for
+    visualization of tgp-class output.  Sensitivity analysis and multi-resolution models
+    are supported. Sequential experimental design and adaptive sampling functions are
+    also provided, including ALM, ALC, and expected improvement.  The latter supports
+    derivative-free optimization of noisy black-box functions.  For details and tutorials,
+    see Gramacy (2007) <doi:10.18637/jss.v019.i09> and Gramacy & Taddy (2010) <doi:10.18637/jss.v033.i06>.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: tgp
+# Title: Bayesian Treed Gaussian Process Models
+# Version: 2.4-21
+# Date: 2023-01-06
+# Author: Robert B. Gramacy <rbg@vt.edu> and Matt A. Taddy
+# Depends: R (>= 2.14.0)
+# Imports: maptree
+# Suggests: MASS
+# Description: Bayesian nonstationary, semiparametric nonlinear regression and design by treed Gaussian processes (GPs) with jumps to the limiting linear model (LLM).  Special cases also implemented include Bayesian linear models, CART, treed linear models, stationary separable and isotropic GPs, and GP single-index models.  Provides 1-d and 2-d plotting functions (with projection and slice capabilities) and tree drawing, designed for visualization of tgp-class output.  Sensitivity analysis and multi-resolution models are supported. Sequential experimental design and adaptive sampling functions are also provided, including ALM, ALC, and expected improvement.  The latter supports derivative-free optimization of noisy black-box functions.  For details and tutorials, see Gramacy (2007) <doi:10.18637/jss.v019.i09> and Gramacy & Taddy (2010) <doi:10.18637/jss.v033.i06>.
+# Maintainer: Robert B. Gramacy  <rbg@vt.edu>
+# License: LGPL
+# URL: https://bobby.gramacy.com/r_packages/tgp/
+# NeedsCompilation: yes
+# Packaged: 2022-12-31 01:23:04 UTC; bobby
+# Repository: CRAN
+# Date/Publication: 2023-01-06 18:50:16 UTC

--- a/recipes/r-tgp/meta.yaml
+++ b/recipes/r-tgp/meta.yaml
@@ -21,19 +21,22 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - r-maptree                    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-maptree
+    - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
@@ -46,7 +49,7 @@ test:
 
 about:
   home: https://bobby.gramacy.com/r_packages/tgp/
-  license: LGPL-3
+  license: LGPL-2.0-or-later
   summary: Bayesian nonstationary, semiparametric nonlinear regression and design by treed Gaussian
     processes (GPs) with jumps to the limiting linear model (LLM).  Special cases also
     implemented include Bayesian linear models, CART, treed linear models, stationary
@@ -59,6 +62,8 @@ about:
     see Gramacy (2007) <doi:10.18637/jss.v019.i09> and Gramacy & Taddy (2010) <doi:10.18637/jss.v033.i06>.
   license_family: LGPL
   license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
 
 extra:


### PR DESCRIPTION
Adds [CRAN package `tgp`](https://cran.r-project.org/package=tgp) as `r-tgp`. Recipe generated with `conda_r_skeleton_helper`, expanding "LGPL" license consistent  with CRAN's interpretation (`LGPL-2.0-or-later`) and adding linking dependencies.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
