### PR TITLE
adds r-hotelling

### DIFF
--- a/recipes/r-hotelling/bld.bat
+++ b/recipes/r-hotelling/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-hotelling/build.sh
+++ b/recipes/r-hotelling/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-hotelling/meta.yaml
+++ b/recipes/r-hotelling/meta.yaml
@@ -1,0 +1,70 @@
+{% set version = '1.0-8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-hotelling
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/Hotelling_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/Hotelling/Hotelling_{{ version }}.tar.gz
+  sha256: 51239a4617852ea8bd8e5b0106b5f6cf9fa93d02def4535b388d386ed5e8a213
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-corpcor
+  run:
+    - r-base
+    - r-corpcor
+
+test:
+  commands:
+    - $R -e "library('Hotelling')"           # [not win]
+    - "\"%R%\" -e \"library('Hotelling')\""  # [win]
+
+about:
+  home: https://github.com/jmcurran/Hotelling
+  license: GPL-2.0-or-later
+  summary: A set of R functions which implements Hotelling's T^2 test and some variants of it.
+    Functions are also included for Aitchison's additive log ratio and centred log ratio
+    transformations.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: Hotelling
+# Version: 1.0-8
+# Date: 2021-09-09
+# Title: Hotelling's T^2 Test and Variants
+# Authors@R: c(person("James", "Curran", email = "j.curran@auckland.ac.nz", role = c("aut", "cre")), person("Taylor", "Hersh", email = "taylor.hersh@dal.ca", role = c("aut")))
+# Maintainer: James Curran <j.curran@auckland.ac.nz>
+# Description: A set of R functions which implements Hotelling's T^2 test and some variants of it. Functions are also included for Aitchison's additive log ratio and centred log ratio transformations.
+# Depends: corpcor
+# License: GPL (>= 2)
+# URL: https://github.com/jmcurran/Hotelling
+# BugReports: https://github.com/jmcurran/Hotelling/issues
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2021-09-09 01:31:33 UTC; jcur002
+# Author: James Curran [aut, cre], Taylor Hersh [aut]
+# Repository: CRAN
+# Date/Publication: 2021-09-09 04:30:05 UTC

--- a/recipes/r-hotelling/meta.yaml
+++ b/recipes/r-hotelling/meta.yaml
@@ -45,6 +45,7 @@ about:
   license_family: GPL2
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `Hotelling`](https://cran.r-project.org/package=Hotelling) as `r-hotelling`. Recipe generate with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
