### PR TITLE
CI: Remove token from automated label workflow

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -90,36 +90,9 @@
           id: check_team_review
           uses: actions/github-script@v6
           with:
-            github-token: ${{ secrets.CF_ADMIN_GITHUB_TOKEN }}
             script: |
               console.log(`Label was removed by ${context.payload.sender.login}`);
-              let memberships = [];
-              for (const team of ['staged-recipes', 'core']) {
-                  const membership = github.rest.teams.getMembershipForUserInOrg({
-                      org: 'conda-forge',
-                      team_slug: team,
-                      username: context.payload.sender.login,
-                  });
-                  memberships.push(membership.then((result) => {
-                      if (result.status == 200 && result.data.state == 'active') {
-                          console.log('User is authorized');
-                          return true;
-                      } else {
-                          console.log('User is nonactive');
-                          return false;
-                      }
-                  }).catch((error) => {
-                      // Non-membership raises an HttpError
-                      return false;
-                  }));
-              }
-              return Promise.all(memberships).then((values) => {
-                  let is_authorized = false;
-                  for (const m of values) {
-                      is_authorized = is_authorized || m;
-                  }
-                  return is_authorized;
-              });
+              return true;
         - name: add-labels
           if: >
             (steps.check_team_review.outputs.result == 'true')


### PR DESCRIPTION
For reasons, the GitHub actions on this repo will soon no longer have a token with the priviledge necesssary to check user team membership, so now the semi-automated review labels should respond to anyone who tries to relabel a PR.

This PR does the simplest thing which is to just replace the membership checking step with a function that always returns true. This will prevent the workflow from breaking once the token is invalidated.

Still need to consider transitioning this workflow to a CRON-based check of whether there are recently completed reviewd as discussed https://github.com/conda-forge/staged-recipes/issues/21161