### PR TITLE
add KaHIP graph partitioner

### DIFF
--- a/recipes/kahip/0001-install-python-component.patch
+++ b/recipes/kahip/0001-install-python-component.patch
@@ -1,0 +1,35 @@
+From f763f968e60e16dac5a216dad891acb61995f0d5 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Thu, 12 Jan 2023 15:47:20 +0100
+Subject: [PATCH] install python component
+
+---
+ CMakeLists.txt | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8a9a7e4..91b763c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -357,8 +357,18 @@ endif()
+ # pybind11 module
+ option(BUILDPYTHONMODULE "Build Python binding." OFF)
+ if (BUILDPYTHONMODULE)
+-  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/misc/pymodule/pybind11)
++  find_package(
++    Python3
++    COMPONENTS Interpreter Development.Module
++    REQUIRED
++  )
++  find_package(pybind11 REQUIRED)
+   pybind11_add_module(kahip_python_binding ${CMAKE_CURRENT_SOURCE_DIR}/misc/pymodule/kahip.cpp)
+   target_link_libraries(kahip_python_binding PUBLIC kahip_static)
+   set_target_properties(kahip_python_binding PROPERTIES OUTPUT_NAME "kahip")
++  install(TARGETS kahip_python_binding
++    LIBRARY DESTINATION "${Python3_SITELIB}"
++    COMPONENT python
++    EXCLUDE_FROM_ALL
++  )
+ endif ()
+--
+2.39.0

--- a/recipes/kahip/build-kahip-python.sh
+++ b/recipes/kahip/build-kahip-python.sh
@@ -1,0 +1,16 @@
+cmake \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILDPYTHONMODULE=ON \
+  -DPython3_FIND_STRATEGY=LOCATION \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS} \
+  -B build \
+  .
+
+cmake \
+  --build \
+  build \
+  --target kahip_python_binding \
+  -j${CPU_COUNT:-2}
+
+cmake --install build --component python

--- a/recipes/kahip/build-kahip.sh
+++ b/recipes/kahip/build-kahip.sh
@@ -1,0 +1,22 @@
+# also explcitily build shared libs,
+# which makes libkahip_static a _shared_ library,
+# which mostly bundles references to libkahip and friends
+# but don't remove it, since some things (e.g. kahip-python) link it.
+
+# don't build Python in the first go
+# we'll do that in build-kahip-python
+
+cmake \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILDPYTHONMODULE=OFF \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS} \
+  -B build \
+  .
+
+cmake \
+  --build \
+  build \
+  -j${CPU_COUNT:-2}
+
+cmake --install build

--- a/recipes/kahip/conda_build_config.yaml
+++ b/recipes/kahip/conda_build_config.yaml
@@ -1,0 +1,3 @@
+mpi:
+  - mpich
+  # TODO: add openmpi after merge

--- a/recipes/kahip/meta.yaml
+++ b/recipes/kahip/meta.yaml
@@ -1,0 +1,97 @@
+{% set name = "kahip" %}
+{% set version = "3.14" %}
+
+package:
+  name: {{ name }}-split
+  version: {{ version }}
+
+source:
+  url: https://github.com/KaHIP/KaHIP/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 9da04f3b0ea53b50eae670d6014ff54c0df2cb40f6679b2f6a96840c1217f242
+  patches:
+    - 0001-install-python-component.patch
+build:
+  number: 0
+  skip: true  # [win]
+
+outputs:
+  - name: kahip
+    build:
+      script: bash ${RECIPE_DIR}/build-kahip.sh
+      run_exports:
+        - {{ pin_subpackage("kahip", max_pin="x.x.x") }}
+
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - {{ mpi }}  # [mpi == "openmpi"]
+      host:
+        - {{ mpi }}
+        - libgomp  # [linux]
+        - llvm-openmp  # [osx]
+        - metis
+      run:
+        - {{ mpi }}
+        - metis
+
+    test:
+      source_files:
+        - examples
+      commands:
+        # main kahip lib exists
+        - test -f $PREFIX/lib/libkahip${SHLIB_EXT}
+        # 'static' bundle lib is actually shared
+        - test -f $PREFIX/lib/libkahip_static${SHLIB_EXT}
+        - kaffpa examples/delaunay_n15.graph --k 2 --preconfiguration=strong
+
+  - name: kahip-python
+    build:
+      script: bash ${RECIPE_DIR}/build-kahip-python.sh
+
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - python  # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}  # [build_platform != target_platform]
+      host:
+        - python
+        - pybind11
+        - {{ pin_subpackage('kahip', exact=True) }}
+      run:
+        - python
+        - {{ pin_subpackage('kahip', exact=True) }}
+
+    test:
+      commands:
+        - "python -c 'import kahip'"
+
+about:
+  home: https://kahip.github.io
+  summary: 'The graph partitioning framework KaHIP -- Karlsruhe High Quality Partitioning'
+  description: |
+    KaHIP is a family of graph partitioning programs.
+    It includes KaFFPa (Karlsruhe Fast Flow Partitioner),
+    which is a multilevel graph partitioning algorithm,
+    in its variants Strong, Eco and Fast,
+    KaFFPaE (KaFFPaEvolutionary) which is a parallel evolutionary algorithm
+    that uses KaFFPa to provide combine and mutation operations,
+    as well as KaBaPE which extends the evolutionary algorithm.
+    Moreover, specialized techniques are included to partition road networks (Buffoon),
+    to output a vertex separator from a given partition
+    as well as techniques geared towards the efficient partitioning of social networks.
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - extern/argtable3-3.2.1/LICENSE
+  doc_url: https://kahip.github.io
+  dev_url: https://github.com/KaHIP/KaHIP
+
+extra:
+  feedstock-name: kahip
+  recipe-maintainers:
+    - minrk

--- a/recipes/kahip/meta.yaml
+++ b/recipes/kahip/meta.yaml
@@ -26,6 +26,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake
+        - make
         - {{ mpi }}  # [mpi == "openmpi"]
       host:
         - {{ mpi }}
@@ -55,6 +56,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake
+        - make
         - python  # [build_platform != target_platform]
         - cross-python_{{ target_platform }}  # [build_platform != target_platform]
       host:

--- a/recipes/kahip/meta.yaml
+++ b/recipes/kahip/meta.yaml
@@ -89,7 +89,7 @@ about:
   license_family: MIT
   license_file:
     - LICENSE
-    - extern/argtable3-3.2.1/LICENSE
+    - extern/argtable3-3.0.3/LICENSE
   doc_url: https://kahip.github.io
   dev_url: https://github.com/KaHIP/KaHIP
 


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

kahip vendors argtable3 (included in sources, no library), which is the [recommended way to use argtable3](https://github.com/argtable/argtable3/blob/f46ef208a7ebc941c9f56027112b6894baa4c3f9/README.md?plain=1#L35-L38). I could pull argtable3 out into a separate package, if folks need it to be that way. It hasn't been packaged on conda-forge, yet, though the previous [argtable2](https://github.com/conda-forge/argtable2-feedstock) is.

I patched kahip's build so that the Python packages can be installed separately, so there are:

1. `kahip` (shared libs and binaries)
2. `kahip-python` (Python bindings)

Arguably, kahip could be _3_ packages:

- libkahip (libs only)
- kahip (binaries, depends on libkahip)
- kahip-python (Python bindings, depends on libkahip)

but I don't think there's a huge benefit to that at the moment.

xref https://github.com/conda-forge/fenics-dolfinx-feedstock/issues/7