### PR TITLE
add r-tlmoments

### DIFF
--- a/recipes/r-tlmoments/bld.bat
+++ b/recipes/r-tlmoments/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tlmoments/build.sh
+++ b/recipes/r-tlmoments/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tlmoments/meta.yaml
+++ b/recipes/r-tlmoments/meta.yaml
@@ -21,10 +21,10 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -58,6 +58,7 @@ about:
   license_family: GPL2
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 
 extra:
   recipe-maintainers:

--- a/recipes/r-tlmoments/meta.yaml
+++ b/recipes/r-tlmoments/meta.yaml
@@ -1,0 +1,85 @@
+{% set version = '0.7.5.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tlmoments
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/TLMoments_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/TLMoments/TLMoments_{{ version }}.tar.gz
+  sha256: d0485f000bf03af6e1b8f1c401e8ec9a4c59017fbf98c2bad28ec24d24c8da24
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp >=0.12.12
+    - r-ggplot2
+    - r-hypergeo
+    - r-lmomco
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp >=0.12.12
+    - r-ggplot2
+    - r-hypergeo
+    - r-lmomco
+
+test:
+  commands:
+    - $R -e "library('TLMoments')"           # [not win]
+    - "\"%R%\" -e \"library('TLMoments')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=TLMoments
+  license: GPL-2.0-or-later
+  summary: Calculates empirical TL-moments (trimmed L-moments) of arbitrary order and trimming,
+    and converts them to distribution parameters.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: TLMoments
+# Type: Package
+# Title: Calculate TL-Moments and Convert Them to Distribution Parameters
+# Version: 0.7.5.3
+# Date: 2022-03-27
+# Author: Jona Lilienthal
+# Maintainer: Jona Lilienthal <lilienthal@statistik.tu-dortmund.de>
+# Description: Calculates empirical TL-moments (trimmed L-moments) of arbitrary order and trimming, and converts them to distribution parameters.
+# License: GPL (>= 2)
+# Depends: R (>= 2.10), Rcpp (>= 0.12.12)
+# Imports: hypergeo, ggplot2, stats, lmomco
+# Suggests: evd, knitr, magrittr, lmom, Lmoments, rmarkdown
+# VignetteBuilder: knitr
+# LinkingTo: Rcpp
+# Encoding: UTF-8
+# RoxygenNote: 7.1.2
+# NeedsCompilation: yes
+# Packaged: 2022-03-27 12:53:31 UTC; jona
+# Repository: CRAN
+# Date/Publication: 2022-03-27 13:20:02 UTC


### PR DESCRIPTION
Adds [CRAN package `TLMoments`](https://cran.r-project.org/package=TLMoments) as `r-tlmoments`. Recipe created with `conda_r_skeleton_helper`.

Needed as [new dependency of `r-spei`](https://github.com/conda-forge/r-spei-feedstock/pull/3).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
