### PR TITLE
Add trame

### DIFF
--- a/recipes/trame-client/meta.yaml
+++ b/recipes/trame-client/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.7
     - pip
   run:
-    - python
+    - python >=3.7
 
 test:
   imports:

--- a/recipes/trame-client/meta.yaml
+++ b/recipes/trame-client/meta.yaml
@@ -42,3 +42,6 @@ extra:
   recipe-maintainers:
     - larsoner
     - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-client/meta.yaml
+++ b/recipes/trame-client/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "trame-client" %}
+{% set version = "2.5.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-client-{{ version }}.tar.gz
+  sha256: ae7f08b6927ea69b7ab3dab71813da3fb4da5955cb037933554f9825f91ff92b
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - trame
+    - trame_client
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-client/
+  summary: Internal client of trame
+  license: MIT
+  license_file:
+    - LICENSE
+    - trame_client/LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner

--- a/recipes/trame-client/meta.yaml
+++ b/recipes/trame-client/meta.yaml
@@ -41,3 +41,4 @@ about:
 extra:
   recipe-maintainers:
     - larsoner
+    - banesullivan

--- a/recipes/trame-components/meta.yaml
+++ b/recipes/trame-components/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-components" %}
+{% set version = "2.1.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-components-{{ version }}.tar.gz
+  sha256: b8d4ad2a8a60db00c713db3404fc45171646ef825cfe031e8d8336237ec724f5
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-components/
+  summary: Core components for trame widgets
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-deckgl/meta.yaml
+++ b/recipes/trame-deckgl/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-deckgl" %}
+{% set version = "2.0.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-deckgl-{{ version }}.tar.gz
+  sha256: f01b1c88350f324cbedc26af6e8ea3f55dd60389d39b726275461add1bf8d06a
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-deckgl/
+  summary: Deck.gl widget for trame
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-markdown/meta.yaml
+++ b/recipes/trame-markdown/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-markdown" %}
+{% set version = "2.0.2" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-markdown-{{ version }}.tar.gz
+  sha256: 7d4979acb0b2382c144aaa461825b76bde4dc4120869c1a7dda41543485cafc6
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-markdown/
+  summary: Markdown widget for trame
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-matplotlib/meta.yaml
+++ b/recipes/trame-matplotlib/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-matplotlib" %}
+{% set version = "2.0.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-matplotlib-{{ version }}.tar.gz
+  sha256: 91191277723f3c4077e55dc98c67326d599a9c449c5e753c4e674348ba0bd728
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-matplotlib/
+  summary: Markdown widget for trame
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-plotly/meta.yaml
+++ b/recipes/trame-plotly/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-plotly" %}
+{% set version = "2.1.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-plotly-{{ version }}.tar.gz
+  sha256: 035c2983fa296149449553530021c3117f3efad65f6b5f0d63cdf6f79ed4d690
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-plotly/
+  summary: Plotly figure widget for trame
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-rca/meta.yaml
+++ b/recipes/trame-rca/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "trame-rca" %}
+{% set version = "0.3.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-rca-{{ version }}.tar.gz
+  sha256: 174fac99951e7107a06b39c475b964b41af6567de57879702f1bfabfea82414a
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+    - wslink
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-rca/
+  summary: Remote Controlled Area widget for trame
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-router/meta.yaml
+++ b/recipes/trame-router/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-router" %}
+{% set version = "2.0.1" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-router-{{ version }}.tar.gz
+  sha256: 3b9fb37c0cdd0014a619d85c7e5480b42242fb4bc52006cb3e63d93447444256
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-router/
+  summary: Vue Router widgets for trame
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-server/meta.yaml
+++ b/recipes/trame-server/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-server" %}
+{% set version = "2.8.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-server-{{ version }}.tar.gz
+  sha256: 0944ea964af734e503021801044072f1f5a58a359361369c3fc8dfae58c6b6ce
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - wslink >=1.9.0
+
+test:
+  imports:
+    - trame_server
+    - trame_server.utils
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-server/
+  summary: Internal server side implementation of trame
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-simput/meta.yaml
+++ b/recipes/trame-simput/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "trame-simput" %}
+{% set version = "2.2.5" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-simput-{{ version }}.tar.gz
+  sha256: b344bf93c3c0eaf5378dea7210c26949c62dc0deddeaf53bd74f3486fa3ac01b
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - pyyaml
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-simput/
+  summary: Simput implementation for trame
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-vega/meta.yaml
+++ b/recipes/trame-vega/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-vega" %}
+{% set version = "2.0.2" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-vega-{{ version }}.tar.gz
+  sha256: 734ac93b51950d49aa20cccf0b332232c74f14d26ef5f981dde56d41de1fa6b4
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-vega/
+  summary: Vega widget for trame
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-vtk/meta.yaml
+++ b/recipes/trame-vtk/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-vtk" %}
+{% set version = "2.0.15" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-vtk-{{ version }}.tar.gz
+  sha256: 0ffb4240bc7faf650d1b0f506bb8b274f6b63cdbb7fec4cd7cb0ddca4f81d1f8
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-vtk/
+  summary: VTK widgets for trame
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame-vuetify/meta.yaml
+++ b/recipes/trame-vuetify/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "trame-vuetify" %}
+{% set version = "2.1.0" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-vuetify-{{ version }}.tar.gz
+  sha256: 4577872758d3a1c971f720af74c286cca7e0d08fb86dc8618f3d0d1bfceca2a5
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client
+
+test:
+  imports:
+    - trame
+    - trame.modules
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame-vuetify/
+  summary: Vuetify widgets for trame
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot

--- a/recipes/trame/meta.yaml
+++ b/recipes/trame/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "trame" %}
+{% set version = "2.2.6" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/trame-{{ version }}.tar.gz
+  sha256: f64a83937b5804b6461036b9314ce05d5d28e71ef5e136d953d33ae9cc556e9f
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - pip
+    - python >=3.7
+  run:
+    - python >=3.7
+    - trame-client >=2.1.0
+    - trame-components
+    - trame-deckgl
+    - trame-markdown
+    - trame-matplotlib
+    - trame-plotly
+    - trame-rca
+    - trame-router
+    - trame-server >=2.1.0
+    - trame-simput
+    - trame-vega
+    - trame-vtk
+    - trame-vuetify
+
+test:
+  imports:
+    - trame
+    - trame.app
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/trame/
+  summary: Trame, a framework to build applications in plain Python
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - larsoner
+    - banesullivan
+    - jourdain
+    - psavery
+    - kwrobot


### PR DESCRIPTION
The goal is to add `trame` support. There are a total of 14 `trame` feedstocks that are needed:
```
	trame-client/
	trame-components/
	trame-deckgl/
	trame-markdown/
	trame-matplotlib/
	trame-plotly/
	trame-rca/
	trame-router/
	trame-server/
	trame-simput/
	trame-vega/
	trame-vtk/
	trame-vuetify/
	trame/
```

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
