### PR TITLE
add pyodide-build 0.22.1 and dependencies

### DIFF
--- a/recipes/auditwheel-emscripten/meta.yaml
+++ b/recipes/auditwheel-emscripten/meta.yaml
@@ -1,16 +1,12 @@
-{% set version = "0.0.11" %}
+{% set version = "0.0.12" %}
 
 package:
   name: auditwheel-emscripten
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/a/auditwheel-emscripten/auditwheel_emscripten-{{ version }}.tar.gz
-    sha256: 0bacaf0e800e18b04ce19d89c91a82243d86445d1758421ff02d715736455c1b
-  # TODO: remove after https://github.com/ryanking13/auditwheel-emscripten/pull/10
-  - fn: LICENSE-auditwheel-emscripten-{{ version }}
-    url: https://raw.githubusercontent.com/ryanking13/auditwheel-emscripten/{{ version }}/LICENSE
-    sha256: 1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5
+  url: https://pypi.io/packages/source/a/auditwheel-emscripten/auditwheel_emscripten-{{ version }}.tar.gz
+  sha256: c83ef2c16f6bcc4ae1674bd09967d9c635c2c991dcd6ef9f267dcb10175f342e
 
 build:
   noarch: python
@@ -43,7 +39,7 @@ about:
   home: https://pypi.org/project/auditwheel-emscripten
   summary: auditwheel-like tool for Pyodide
   license: MPL-2.0
-  license_file: LICENSE-auditwheel-emscripten-{{ version }}
+  license_file: LICENSE
   dev_url: https://github.com/ryanking13/auditwheel-emscripten
 
 extra:

--- a/recipes/auditwheel-emscripten/meta.yaml
+++ b/recipes/auditwheel-emscripten/meta.yaml
@@ -19,14 +19,14 @@ build:
 
 requirements:
   host:
-    - python >=3.8
-    - pip
     - flit-core >=3.2,<4
-  run:
+    - pip
     - python >=3.8
+  run:
     - leb128
     - packaging
     - pyodide-cli
+    - python >=3.8
     - typer
     - wheel
 

--- a/recipes/auditwheel-emscripten/meta.yaml
+++ b/recipes/auditwheel-emscripten/meta.yaml
@@ -1,0 +1,50 @@
+{% set version = "0.0.11" %}
+
+package:
+  name: auditwheel-emscripten
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/a/auditwheel-emscripten/auditwheel_emscripten-{{ version }}.tar.gz
+    sha256: 0bacaf0e800e18b04ce19d89c91a82243d86445d1758421ff02d715736455c1b
+  # TODO: upstream PR for license
+  - fn: LICENSE-auditwheel-emscripten-{{ version }}
+    url: https://raw.githubusercontent.com/ryanking13/auditwheel-emscripten/{{ version }}/LICENSE
+    sha256: 1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - flit-core >=3.2,<4
+  run:
+    - python >=3.8
+    - leb128
+    - packaging
+    - pyodide-cli
+    - typer
+    - wheel
+
+test:
+  imports:
+    - auditwheel_emscripten
+  commands:
+    - pip check
+    - pyodide auditwheel --help
+  requires:
+    - pip
+
+about:
+  home: https://pypi.org/project/auditwheel-emscripten
+  summary: auditwheel-like tool for Pyodide
+  license: MPL-2.0
+  license_file: LICENSE-auditwheel-emscripten-{{ version }}
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/auditwheel-emscripten/meta.yaml
+++ b/recipes/auditwheel-emscripten/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   - url: https://pypi.io/packages/source/a/auditwheel-emscripten/auditwheel_emscripten-{{ version }}.tar.gz
     sha256: 0bacaf0e800e18b04ce19d89c91a82243d86445d1758421ff02d715736455c1b
-  # TODO: upstream PR for license
+  # TODO: remove after https://github.com/ryanking13/auditwheel-emscripten/pull/10
   - fn: LICENSE-auditwheel-emscripten-{{ version }}
     url: https://raw.githubusercontent.com/ryanking13/auditwheel-emscripten/{{ version }}/LICENSE
     sha256: 1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5
@@ -44,6 +44,7 @@ about:
   summary: auditwheel-like tool for Pyodide
   license: MPL-2.0
   license_file: LICENSE-auditwheel-emscripten-{{ version }}
+  dev_url: https://github.com/ryanking13/auditwheel-emscripten
 
 extra:
   recipe-maintainers:

--- a/recipes/leb128/meta.yaml
+++ b/recipes/leb128/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   - url: https://pypi.io/packages/source/l/leb128/leb128-{{ version }}.tar.gz
     sha256: 3552deeae400b835f86e0d32eb7c737a75eb167c0eb551b70268d522633581af
-  # TODO: upstream PR to include license
+  # TODO: remove after https://github.com/mohanson/leb128/pull/6
   - fn: LICENSE-leb128-{{ version }}
     url: https://raw.githubusercontent.com/mohanson/leb128/v{{ version }}/LICENSE
     sha256: 6d21d47a22d95b919ddeaf8b49a4697909b47310472cb7fe3ad14cf6810d3208

--- a/recipes/leb128/meta.yaml
+++ b/recipes/leb128/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "1.0.4" %}
+
+package:
+  name: leb128
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/l/leb128/leb128-{{ version }}.tar.gz
+    sha256: 3552deeae400b835f86e0d32eb7c737a75eb167c0eb551b70268d522633581af
+  # TODO: upstream PR to include license
+  - fn: LICENSE-leb128-{{ version }}
+    url: https://raw.githubusercontent.com/mohanson/leb128/v{{ version }}/LICENSE
+    sha256: 6d21d47a22d95b919ddeaf8b49a4697909b47310472cb7fe3ad14cf6810d3208
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  number: 0
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+
+test:
+  imports:
+    - leb128
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/mohanson/leb128
+  summary: LEB128(Little Endian Base 128)
+  license: MIT
+  license_file: LICENSE-leb128-{{ version }}
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/leb128/meta.yaml
+++ b/recipes/leb128/meta.yaml
@@ -1,16 +1,12 @@
-{% set version = "1.0.4" %}
+{% set version = "1.0.5" %}
 
 package:
   name: leb128
   version: {{ version }}
 
 source:
-  - url: https://pypi.io/packages/source/l/leb128/leb128-{{ version }}.tar.gz
-    sha256: 3552deeae400b835f86e0d32eb7c737a75eb167c0eb551b70268d522633581af
-  # TODO: remove after https://github.com/mohanson/leb128/pull/6
-  - fn: LICENSE-leb128-{{ version }}
-    url: https://raw.githubusercontent.com/mohanson/leb128/v{{ version }}/LICENSE
-    sha256: 6d21d47a22d95b919ddeaf8b49a4697909b47310472cb7fe3ad14cf6810d3208
+  url: https://pypi.io/packages/source/l/leb128/leb128-{{ version }}.tar.gz
+  sha256: cb16001f0087b499ab51f6b8e3ef8377ba14a0c9990db85316dedf0ad4a54e80
 
 build:
   noarch: python
@@ -36,7 +32,7 @@ about:
   home: https://github.com/mohanson/leb128
   summary: LEB128(Little Endian Base 128)
   license: MIT
-  license_file: LICENSE-leb128-{{ version }}
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipes/pyodide-build/0000-no-cmake-from-pip.patch
+++ b/recipes/pyodide-build/0000-no-cmake-from-pip.patch
@@ -1,0 +1,11 @@
+--- setup.cfg	2023-02-11 13:22:04.989379640 -0600
++++ setup.cfg	2023-02-11 13:22:14.693162999 -0600
+@@ -30,7 +30,7 @@
+ 	virtualenv
+ 	pydantic>=1.10.2
+ 	pyodide-cli~=0.2.1
+-	cmake>=3.24
++	# cmake>=3.24
+ 	unearth~=0.6
+ 	requests
+ 	types-requests

--- a/recipes/pyodide-build/meta.yaml
+++ b/recipes/pyodide-build/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = "0.22.1" %}
+
+package:
+  name: pyodide-build
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/p/pyodide-build/pyodide-build-{{ version }}.tar.gz
+    sha256: b758be86dee0559dac99d11fc7f32e99e81da847fb3869d4294b5ed04c10ca30
+    patches:
+      # this _should_ fail if the version of cmake changes below
+      - 0000-no-cmake-from-pip.patch
+  # TODO: remove after https://github.com/pyodide/pyodide/pull/3574
+  - fn: LICENSE-pyodide-build-{{ version }}
+    url: https://raw.githubusercontent.com/pyodide/pyodide/{{ version }}/LICENSE
+    sha256: 1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5
+
+build:
+  entry_points:
+    - pyodide-build = pyodide_build.__main__:main
+    - _pywasmcross = pyodide_build.pywasmcross:compiler_main
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >=3.10
+  run:
+    - auditwheel-emscripten >=0.0.9,<0.1.0
+    - cmake >=3.24
+    - cython <3.0
+    - packaging
+    - pydantic >=1.10.2
+    - pyodide-cli >=0.2.1,<0.3.0
+    - python >=3.10
+    - python-build ==0.7.0
+    - pyyaml
+    - requests
+    - ruamel.yaml
+    - tomli
+    - typer
+    - types-requests
+    - unearth >=0.6,<1.0.0
+    - virtualenv
+    - wheel
+
+test:
+  files:
+    - test_pyodide_cli.py
+  imports:
+    - pyodide_build
+  requires:
+    - pip
+  commands:
+    - pip check
+    # TODO: deprecated, but maybe figure out all the env vars needed for this to actually run
+    # - pyodide-build --help
+    - which pyodide-build || where pyodide-build
+    - pyodide build-recipes --help
+    - pyodide skeleton --help
+    - pyodide config --help
+
+about:
+  home: https://github.com/pyodide/pyodide
+  summary: Tools for building Pyodide
+  license: MPL-2.0
+  license_file: LICENSE-pyodide-build-{{ version }}
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/pyodide-build/meta.yaml
+++ b/recipes/pyodide-build/meta.yaml
@@ -16,6 +16,7 @@ source:
     sha256: 1f256ecad192880510e84ad60474eab7589218784b9a50bc7ceee34c2b91f1d5
 
 build:
+  noarch: python
   entry_points:
     - pyodide-build = pyodide_build.__main__:main
     - _pywasmcross = pyodide_build.pywasmcross:compiler_main

--- a/recipes/pyodide-cli/meta.yaml
+++ b/recipes/pyodide-cli/meta.yaml
@@ -17,13 +17,13 @@ build:
 
 requirements:
   host:
-    - python >=3.10
     - pip
+    - python >=3.10
     - setuptools_scm >=6.2
   run:
     - python >=3.10
-    - typer >=0.6.0
     - rich
+    - typer >=0.6.0
 
 test:
   imports:

--- a/recipes/pyodide-cli/meta.yaml
+++ b/recipes/pyodide-cli/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.2.3" %}
+
+package:
+  name: pyodide-cli
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/pyodide-cli/pyodide-cli-{{ version }}.tar.gz
+  sha256: b97c891bcd72bd42232e2e2674005c30ad9ea6ff1a0445820081f004b131173d
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  entry_points:
+    - pyodide = pyodide_cli.__main__:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools_scm >=6.2
+  run:
+    - python >=3.10
+    - typer >=0.6.0
+    - rich
+
+test:
+  imports:
+    - pyodide_cli
+  commands:
+    - pip check
+    - pyodide --version
+    - pyodide --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pyodide/pyodide-cli
+  summary: The command line interface for the Pyodide project
+  license: MPL-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

The dependency tree:

- `pyodide-build`
  - `auditwheel-emscripten 0.0.12`
  - `pyodide-cli 0.2.3`
    - `leb128 1.0.5`