### PR TITLE
Added recipe for dpct

### DIFF
--- a/recipes/dpct/bld.bat
+++ b/recipes/dpct/bld.bat
@@ -1,0 +1,21 @@
+mkdir build
+cd build
+
+set CONFIGURATION=Release
+
+cmake .. -G "NMake Makefiles" ^
+         -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+         -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+         -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+         -DPYTHON_EXECUTABLE="%PYTHON%" ^
+         -DWITH_LOG="OFF" ^
+         -DBoost_NO_BOOST_CMAKE=ON
+
+
+if errorlevel 1 exit 1
+
+nmake all
+if errorlevel 1 exit 1
+
+nmake install
+if errorlevel 1 exit 1

--- a/recipes/dpct/build.sh
+++ b/recipes/dpct/build.sh
@@ -1,0 +1,25 @@
+mkdir build
+cd build
+
+if [ $(uname) == "Darwin" ]; then
+    LDFLAGS="-undefined dynamic_lookup -L${PREFIX}/lib ${LDFLAGS}"
+else
+    LDFLAGS="-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib ${LDFLAGS}"
+fi
+
+cmake .. \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DPYTHON_EXECUTABLE=${PYTHON} \
+    -DPYTHON_INCLUDE_DIRS=${PREFIX}/include/python${CONDA_PY} \
+    -DWITH_LOG=OFF \
+    -DCMAKE_CXX_LINK_FLAGS="${LDFLAGS}" \
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+    -DBoost_INCLUDE_DIR=${PREFIX}/include \
+    -DBoost_LIBRARY_DIRS=${PREFIX}/lib \
+    -DBoost_PYTHON_LIBRARY=${PREFIX}/lib/libboost_python${CONDA_PY}${SHLIB_EXT} \
+    -DBoost_NO_BOOST_CMAKE=ON \
+
+make -j${CPU_COUNT}
+make install

--- a/recipes/dpct/meta.yaml
+++ b/recipes/dpct/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "dpct" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ilastik/dpct/archive/{{ version }}.tar.gz
+  sha256: 7980d98ffb57134d20cc1ed6a5460d1b87bf3b04c0fd33cfade86ae3f22b4272
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - make  # [not win]
+    - {{ compiler("c") }}
+    - {{ compiler("cxx") }}
+  host:
+    - boost
+    - boost-cpp
+    - lemon
+    - python
+  run:
+    - boost
+    - boost-cpp
+    - lemon
+    - python
+
+test:
+  imports:
+    - dpct
+
+about:
+  home: https://github.com/ilastik/dpct
+  summary: 'Python package for running tracking of divisible objects using a modified successive shortest paths solver'
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/ilastik/dpct
+
+extra:
+  recipe-maintainers:
+    - k-dominik


### PR DESCRIPTION
Dear Conda-Forge team,

I would like to add a recipe for the `dpct` package - a library for solving tracking problems with divisible objects, originally developed by @chaubold. The [original repo](https://github.com/chaubold/dpct) is archived, and the fork on the ilastik org is considered the main fork.

I would have _two_ tiny questions:

1. I could get it to work with github releases like `https://github.com/ilastik/dpct/releases/download/{{ version }}/dpct-{{ version }}.tar.gz` - so I had to go with the "fallback" solution of `https://github.com/ilastik/dpct/archive/{{ version }}.tar.gz`. Is there anything special one needs to do in github to allow this?
2. is there a way to enable `osx-arm64` builds right from the start (when submitting a recipe), or is this better done afterwards via migration?


Happy to clarify any questions!

Thank you :)

Cheers
Dominik

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
