### PR TITLE
add r-mclogit

### DIFF
--- a/recipes/r-mclogit/bld.bat
+++ b/recipes/r-mclogit/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mclogit/build.sh
+++ b/recipes/r-mclogit/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mclogit/meta.yaml
+++ b/recipes/r-mclogit/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '0.9.6' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mclogit
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/mclogit_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/mclogit/mclogit_{{ version }}.tar.gz
+  sha256: 9adc5f6d8649960abe009c30d9b4c448ff7d174c455a594cbf104a33d5a36f69
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-matrix
+    - r-memisc
+  run:
+    - r-base
+    - r-matrix
+    - r-memisc
+
+test:
+  commands:
+    - $R -e "library('mclogit')"           # [not win]
+    - "\"%R%\" -e \"library('mclogit')\""  # [win]
+
+about:
+  home: http://mclogit.elff.eu,https://github.com/melff/mclogit/
+  license: GPL-2.0-or-later
+  summary: Provides estimators for multinomial logit models in their conditional logit and baseline
+    logit variants, with or without random effects, with or without overdispersion.
+    Random effects models are estimated using the PQL technique (based on a Laplace
+    approximation) or the MQL technique (based on a Solomon-Cox approximation). Estimates
+    should be treated with caution if the group sizes are small.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: mclogit
+# Type: Package
+# Title: Multinomial Logit Models, with or without Random Effects or Overdispersion
+# Version: 0.9.6
+# Date: 2022-10-27
+# Author: Martin Elff
+# Maintainer: Martin Elff <mclogit@elff.eu>
+# Description: Provides estimators for multinomial logit models in their conditional logit and baseline logit variants, with or without random effects, with or without overdispersion. Random effects models are estimated using the PQL technique (based on a Laplace approximation) or the MQL technique (based on a Solomon-Cox approximation). Estimates should be treated with caution if the group sizes are small.
+# License: GPL-2
+# Depends: stats, Matrix
+# Imports: memisc, methods
+# Suggests: MASS, nnet
+# Enhances: emmeans
+# LazyLoad: Yes
+# URL: http://mclogit.elff.eu,https://github.com/melff/mclogit/
+# BugReports: https://github.com/melff/mclogit/issues
+# RoxygenNote: 7.1.2
+# NeedsCompilation: no
+# Packaged: 2022-10-27 09:17:22 UTC; elff
+# Repository: CRAN
+# Date/Publication: 2022-10-27 10:02:37 UTC

--- a/recipes/r-mclogit/meta.yaml
+++ b/recipes/r-mclogit/meta.yaml
@@ -39,7 +39,8 @@ test:
     - "\"%R%\" -e \"library('mclogit')\""  # [win]
 
 about:
-  home: http://mclogit.elff.eu,https://github.com/melff/mclogit/
+  home: https://www.elff.eu/software/mclogit/
+  dev_url: https://github.com/melff/mclogit/
   license: GPL-2.0-or-later
   summary: Provides estimators for multinomial logit models in their conditional logit and baseline
     logit variants, with or without random effects, with or without overdispersion.
@@ -49,6 +50,7 @@ about:
   license_family: GPL2
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `mclogit`](https://cran.r-project.org/package=mclogit) as `r-mclogit`. Recipe generated with `conda_r_skeleton_helper`, with URLs split and license expanded to match CRAN.

Needed as new dependency of https://github.com/conda-forge/r-projpred-feedstock/pull/10.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
