### PR TITLE
Adding oasis-deconv 0.2.0

### DIFF
--- a/recipes/oasis-deconv/meta.yaml
+++ b/recipes/oasis-deconv/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "oasis-deconv" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/j-friedrich/OASIS
+  git_depth: 1
+  git_rev: v0.2.0
+  sha256: 3be3de589b0d070e0e0af4f215b2a16d41389be9206e90720827cec66af602b1
+
+build:
+  script: {{ PYTHON }} setup.py build_ext -i
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+  host:
+    - python
+    - setuptools
+    - numpy
+    - cython
+  run:
+    - python
+    - scipy
+    - matplotlib-base
+    - cython
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - oasis
+  requires:
+    - pytest
+    - setuptools<=64.0.2
+    - cvxpy
+  source_files:
+    - tests
+  commands:
+    - pytest tests
+
+about:
+  home: https://github.com/j-friedrich/OASIS
+  summary: Fast algorithm for deconvolution of neural calcium imaging traces
+  license: GPL-3.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - JohannesFriedrich


### PR DESCRIPTION
@conda-forge-admin, please ping conda-forge/help-python-c

This package is also on PyPI, but the unit-tests aren't, thus this recipe builds from GitHub instead of PyPI.





