### PR TITLE
add py-serializable 0.12.0

### DIFF
--- a/recipes/py-serializable/meta.yaml
+++ b/recipes/py-serializable/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "0.12.0" %}
+
+package:
+  name: py-serializable
+  version: {{ version }}
+
+source:
+  - folder: dist
+    url: https://pypi.io/packages/source/p/py-serializable/py-serializable-{{ version }}.tar.gz
+    sha256: 1771811289b919062fdc0a26c02b79cfedeeaa7fbc97ac2d862ee7f8eaf13dee
+  - folder: src
+    url: https://github.com/madpah/serializable/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 2090b6c6b80aeb03895b61fb221eb51176acb0bec2de0418c30772f9ec9a96be
+
+build:
+  noarch: python
+  script: cd dist && {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - poetry-core >=1.0.0
+    - python >=3.7
+  run:
+    - defusedxml >=0.7.1,<1.0.0
+    - python >=3.7
+
+test:
+  source_files:
+    - src/tests
+  imports:
+    - serializable
+  commands:
+    - pip check
+    - mypy -p serializable
+    - cd src && pytest -vv --cov=serializable --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=82
+  requires:
+    - lxml
+    - mypy
+    - pip
+    - pytest-cov
+    - xmldiff
+
+about:
+  home: https://github.com/madpah/serializable
+  summary: Library for serializing and deserializing Python Objects to and from JSON and XML.
+  license: Apache-2.0
+  license_file: dist/LICENSE
+  doc_url: https://py-serializable.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

References:
- blocks https://github.com/conda-forge/cyclonedx-python-lib-feedstock/pull/35