### PR TITLE
add r-bde

### DIFF
--- a/recipes/r-bde/bld.bat
+++ b/recipes/r-bde/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-bde/build.sh
+++ b/recipes/r-bde/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-bde/meta.yaml
+++ b/recipes/r-bde/meta.yaml
@@ -48,7 +48,6 @@ about:
   license_family: GPL2
   license_file:
     - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
-    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-bde/meta.yaml
+++ b/recipes/r-bde/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=bde
-  license: GPL-2.0-or-later
+  license: GPL-2.0-only
   summary: A collection of S4 classes which implements different methods to estimate and deal
     with densities in bounded domains. That is, densities defined within the interval
     [lower.limit, upper.limit], where lower.limit and upper.limit are values that can

--- a/recipes/r-bde/meta.yaml
+++ b/recipes/r-bde/meta.yaml
@@ -47,7 +47,8 @@ about:
     be set by the user.
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-bde/meta.yaml
+++ b/recipes/r-bde/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = '1.0.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-bde
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/bde_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/bde/bde_{{ version }}.tar.gz
+  sha256: 69d9bf5757ee7cf9fe1f5cf4d603570ae1d0b8210968e6ac5dfe7c3cbde6aa45
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-ggplot2
+    - r-shiny
+  run:
+    - r-base
+    - r-ggplot2
+    - r-shiny
+
+test:
+  commands:
+    - $R -e "library('bde')"           # [not win]
+    - "\"%R%\" -e \"library('bde')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=bde
+  license: GPL-2.0-or-later
+  summary: A collection of S4 classes which implements different methods to estimate and deal
+    with densities in bounded domains. That is, densities defined within the interval
+    [lower.limit, upper.limit], where lower.limit and upper.limit are values that can
+    be set by the user.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: bde
+# Type: Package
+# Title: Bounded Density Estimation
+# Version: 1.0.1.1
+# Date: 2013-06-19
+# Author: Guzman Santafe, Borja Calvo, Aritz Perez and Jose A. Lozano
+# Maintainer: Guzman Santafe <guzman.santafe@unavarra.es>
+# Depends: R (>= 2.10), shiny, ggplot2
+# Imports: methods
+# Description: A collection of S4 classes which implements different methods to estimate and deal with densities in bounded domains. That is, densities defined within the interval [lower.limit, upper.limit], where lower.limit and upper.limit are values that can be set by the user.
+# License: GPL-2
+# LazyData: TRUE
+# Collate: BoundedDensity.R KernelDensity.R Chen99Kernel.R MicroBetaChen99Kernel.R MacroBetaChen99Kernel.R BoundaryKernel.R NoBoundaryKernel.R NormalizedBoundaryKernel.R Muller91BoundaryKernel.R JonesCorrectionMuller91BoundaryKernel.R Muller94BoundaryKernel.R JonesCorrectionMuller94BoundaryKernel.R BernsteinPolynomials.R Vitale.R BrVitale.R KakizawaB1.R KakizawaB2.R KakizawaB3.R HirukawaJLNKernel.R HirukawaTSKernel.R MacroBetaHirukawaJLNKernel.R MacroBetaHirukawaTSKernel.R utils.R bde.R
+# Packaged: 2022-06-10 14:29:44 UTC; hornik
+# NeedsCompilation: no
+# Repository: CRAN
+# Date/Publication: 2022-06-10 14:39:25 UTC


### PR DESCRIPTION
Adds [CRAN package `bde`](https://cran.r-project.org/package=bde) as `r-bde`. Generated with `conda_r_skeleton_helper`.

Required as [new dependency of `r-jfa`](https://github.com/conda-forge/r-jfa-feedstock/pull/8).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
