### PR TITLE
follow rest of conda-forge to use windows-2022 image

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,4 +2,4 @@ channel_priority: strict
 azure:
   settings_win:
     pool:
-      vmImage: windows-2019
+      vmImage: windows-2022


### PR DESCRIPTION
Inspired by https://github.com/conda-forge/staged-recipes/issues/22620 I had a look at the setup here and noticed that staged-recipes has not followed the [switch](https://github.com/conda-forge/conda-smithy/pull/1720) to windows-2022.