### PR TITLE
Adds `r-plottools`

### DIFF
--- a/recipes/r-plottools/bld.bat
+++ b/recipes/r-plottools/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-plottools/build.sh
+++ b/recipes/r-plottools/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-plottools/meta.yaml
+++ b/recipes/r-plottools/meta.yaml
@@ -35,13 +35,15 @@ test:
     - "\"%R%\" -e \"library('PlotTools')\""  # [win]
 
 about:
-  home: https://ms609.github.io/PlotTools/, https://github.com/ms609/PlotTools/
+  home: https://ms609.github.io/PlotTools/
+  dev_url: https://github.com/ms609/PlotTools/
   license: GPL-2.0-or-later
   summary: Annotate plots with legends for continuous variables and colour spectra using the
     base graphics plotting tools.
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-plottools/meta.yaml
+++ b/recipes/r-plottools/meta.yaml
@@ -1,0 +1,75 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-plottools
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/PlotTools_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/PlotTools/PlotTools_{{ version }}.tar.gz
+  sha256: 9b7b664b134418d9c2d471cd09a6963a9db6d4964478af261c36ffa32bbc9eb7
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('PlotTools')"           # [not win]
+    - "\"%R%\" -e \"library('PlotTools')\""  # [win]
+
+about:
+  home: https://ms609.github.io/PlotTools/, https://github.com/ms609/PlotTools/
+  license: GPL-2.0-or-later
+  summary: Annotate plots with legends for continuous variables and colour spectra using the
+    base graphics plotting tools.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: PlotTools
+# Title: Add Continuous Legends to Plots
+# Version: 0.1.0
+# URL: https://ms609.github.io/PlotTools/, https://github.com/ms609/PlotTools/
+# BugReports: https://github.com/ms609/PlotTools/issues/
+# Authors@R: c(person("Martin R.", "Smith", email = "martin.smith@durham.ac.uk", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0001-5660-1727") ) )
+# License: GPL (>= 2)
+# Language: en-GB
+# Depends: R (>= 3.2.0)
+# Description: Annotate plots with legends for continuous variables and colour spectra using the base graphics plotting tools.
+# Suggests: spelling, knitr, rmarkdown, testthat (>= 3.0), vdiffr (>= 1.0.0),
+# Config/Needs/check: rcmdcheck
+# Config/Needs/coverage: covr
+# Config/Needs/metadata: codemeta
+# Config/Needs/revdeps: revdepcheck
+# Config/Needs/website: pkgdown
+# Config/testthat/edition: 3
+# Config/testthat/parallel: false
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Packaged: 2023-04-17 09:12:09 UTC; pjjg18
+# Author: Martin R. Smith [aut, cre, cph] (<https://orcid.org/0000-0001-5660-1727>)
+# Maintainer: Martin R. Smith <martin.smith@durham.ac.uk>
+# Repository: CRAN
+# Date/Publication: 2023-04-18 14:30:13 UTC


### PR DESCRIPTION
Adds [CRAN package `PlotTools`](https://cran.r-project.org/package=PlotTools) as `r-plottools`. Generated with `conda_r_skeleton_helper`.

Needed as [new dependency of `r-treetools`](https://github.com/conda-forge/r-treetools-feedstock/pull/21).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
