### PR TITLE
Adds `r-mlr3mbo`

### DIFF
--- a/recipes/r-mlr3mbo/bld.bat
+++ b/recipes/r-mlr3mbo/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mlr3mbo/bld.bat
+++ b/recipes/r-mlr3mbo/bld.bat
@@ -1,2 +1,2 @@
-"%R%" CMD INSTALL --build . %R_ARGS%
+"%R%" CMD INSTALL --install-tests --build . %R_ARGS%
 IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mlr3mbo/build.sh
+++ b/recipes/r-mlr3mbo/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mlr3mbo/build.sh
+++ b/recipes/r-mlr3mbo/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export DISABLE_AUTOBREW=1
-${R} CMD INSTALL --build . ${R_ARGS}
+${R} CMD INSTALL install-tests --build . ${R_ARGS}

--- a/recipes/r-mlr3mbo/meta.yaml
+++ b/recipes/r-mlr3mbo/meta.yaml
@@ -54,9 +54,19 @@ requirements:
     - r-r6 >=2.4.1
 
 test:
+  requires:
+    - r-dicekriging
+    - r-fastghquad
+    - r-mlr3learners
+    - r-mlr3pipelines
+    - r-ranger
+    - r-rpart
+    - r-testthat
   commands:
-    - $R -e "library('mlr3mbo')"           # [not win]
-    - "\"%R%\" -e \"library('mlr3mbo')\""  # [win]
+    - $R -e "library('mlr3mbo')"                          # [not win]
+    - $R -e "testthat::test_package('mlr3mbo')"           # [not win]
+    - "\"%R%\" -e \"library('mlr3mbo')\""                 # [win]
+    - "\"%R%\" -e \"testthat::test_package('mlr3mbo')\""  # [win]
 
 about:
   home: https://mlr3mbo.mlr-org.com

--- a/recipes/r-mlr3mbo/meta.yaml
+++ b/recipes/r-mlr3mbo/meta.yaml
@@ -1,0 +1,106 @@
+{% set version = '0.1.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mlr3mbo
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/mlr3mbo_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/mlr3mbo/mlr3mbo_{{ version }}.tar.gz
+  sha256: dcf61b5d249dd0a604256bbffb81b64cc3ad89517f3c4ffb22f35a5dbda2d5c2
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-r6 >=2.4.1
+    - r-bbotk >=0.5.4
+    - r-checkmate >=2.0.0
+    - r-data.table
+    - r-lgr >=0.3.4
+    - r-mlr3 >=0.14.0
+    - r-mlr3misc >=0.11.0
+    - r-mlr3tuning >=0.14.0
+    - r-paradox >=0.10.0
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-r6 >=2.4.1
+    - r-bbotk >=0.5.4
+    - r-checkmate >=2.0.0
+    - r-data.table
+    - r-lgr >=0.3.4
+    - r-mlr3 >=0.14.0
+    - r-mlr3misc >=0.11.0
+    - r-mlr3tuning >=0.14.0
+    - r-paradox >=0.10.0
+
+test:
+  commands:
+    - $R -e "library('mlr3mbo')"           # [not win]
+    - "\"%R%\" -e \"library('mlr3mbo')\""  # [win]
+
+about:
+  home: https://mlr3mbo.mlr-org.com, https://github.com/mlr-org/mlr3mbo
+  license: LGPL-3
+  summary: A modern and flexible approach to Bayesian Optimization / Model Based Optimization
+    building on the 'bbotk' package. 'mlr3mbo' is a toolbox providing both ready-to-use
+    optimization algorithms as well as their fundamental building blocks allowing for
+    straightforward implementation of custom algorithms. Single- and multi-objective
+    optimization is supported as well as mixed continuous, categorical and conditional
+    search spaces. Moreover, using 'mlr3mbo' for hyperparameter optimization of machine
+    learning models within the 'mlr3' ecosystem is straightforward via 'mlr3tuning'.
+    Examples of ready-to-use optimization algorithms include Efficient Global Optimization
+    by Jones et al. (1998) <doi:10.1023/A:1008306431147>, ParEGO by Knowles (2006) <doi:10.1109/TEVC.2005.851274>
+    and SMS-EGO by Ponweiser et al. (2008) <doi:10.1007/978-3-540-87700-4_78>.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
+# Type: Package
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: mlr3mbo
+# Title: Flexible Bayesian Optimization
+# Version: 0.1.2
+# Authors@R: c( person("Lennart", "Schneider", , "lennart.sch@web.de", role = c("cre", "aut"), comment = c(ORCID = "0000-0003-4152-5308")), person("Jakob", "Richter", , "jakob1richter@gmail.com", role = "aut", comment = c(ORCID = "0000-0003-4481-5554")), person("Marc", "Becker", , "marcbecker@posteo.de", role = "aut", comment = c(ORCID = "0000-0002-8115-0400")), person("Michel", "Lang", , "michellang@gmail.com", role = "aut", comment = c(ORCID = "0000-0001-9754-0393")), person("Bernd", "Bischl", , "bernd_bischl@gmx.net", role = "aut", comment = c(ORCID = "0000-0001-6002-6980")), person("Florian", "Pfisterer", , "pfistererf@googlemail.com", role = "aut", comment = c(ORCID = "0000-0001-8867-762X")), person("Martin", "Binder", , "mlr.developer@mb706.com", role = "aut"), person("Sebastian", "Fischer", , "sebf.fischer@gmail.com", role = "aut", comment = c(ORCID = "0000-0002-9609-3197")), person("Michael H.", "Buselli", role = "cph"), person("Wessel", "Dankers", role = "cph"), person("Carlos", "Fonseca", role = "cph"), person("Manuel", "Lopez-Ibanez", role = "cph"), person("Luis", "Paquete", role = "cph"))
+# Description: A modern and flexible approach to Bayesian Optimization / Model Based Optimization building on the 'bbotk' package. 'mlr3mbo' is a toolbox providing both ready-to-use optimization algorithms as well as their fundamental building blocks allowing for straightforward implementation of custom algorithms. Single- and multi-objective optimization is supported as well as mixed continuous, categorical and conditional search spaces. Moreover, using 'mlr3mbo' for hyperparameter optimization of machine learning models within the 'mlr3' ecosystem is straightforward via 'mlr3tuning'. Examples of ready-to-use optimization algorithms include Efficient Global Optimization by Jones et al. (1998) <doi:10.1023/A:1008306431147>, ParEGO by Knowles (2006) <doi:10.1109/TEVC.2005.851274> and SMS-EGO by Ponweiser et al. (2008) <doi:10.1007/978-3-540-87700-4_78>.
+# License: LGPL-3
+# URL: https://mlr3mbo.mlr-org.com, https://github.com/mlr-org/mlr3mbo
+# BugReports: https://github.com/mlr-org/mlr3mbo/issues
+# Depends: mlr3tuning (>= 0.14.0), R (>= 3.1.0)
+# Imports: bbotk (>= 0.5.4), checkmate (>= 2.0.0), data.table, lgr (>= 0.3.4), mlr3 (>= 0.14.0), mlr3misc (>= 0.11.0), paradox (>= 0.10.0), R6 (>= 2.4.1)
+# Suggests: DiceKriging, knitr, lhs, mlr3learners (>= 0.5.4), mlr3pipelines (>= 0.4.2), nloptr, ranger, rgenoud, rmarkdown, rpart, spacefillr, stringi, testthat (>= 3.0.0),
+# ByteCompile: no
+# Encoding: UTF-8
+# Config/testthat/edition: 3
+# Config/testthat/parallel: false
+# NeedsCompilation: yes
+# RoxygenNote: 7.2.3
+# Collate: 'mlr_acqfunctions.R' 'AcqFunction.R' 'AcqFunctionAEI.R' 'AcqFunctionCB.R' 'AcqFunctionEI.R' 'AcqFunctionEIPS.R' 'AcqFunctionMean.R' 'AcqFunctionPI.R' 'AcqFunctionSmsEgo.R' 'AcqOptimizer.R' 'aaa.R' 'OptimizerMbo.R' 'Surrogate.R' 'SurrogateLearner.R' 'SurrogateLearnerCollection.R' 'TunerMbo.R' 'mlr_loop_functions.R' 'bayesopt_ego.R' 'bayesopt_mpcl.R' 'bayesopt_parego.R' 'bayesopt_smsego.R' 'bibentries.R' 'helper.R' 'loop_function.R' 'mbo_defaults.R' 'result_by_default.R' 'result_by_surrogate_design.R' 'sugar.R' 'zzz.R'
+# VignetteBuilder: knitr
+# Packaged: 2023-03-02 23:54:07 UTC; lps
+# Author: Lennart Schneider [cre, aut] (<https://orcid.org/0000-0003-4152-5308>), Jakob Richter [aut] (<https://orcid.org/0000-0003-4481-5554>), Marc Becker [aut] (<https://orcid.org/0000-0002-8115-0400>), Michel Lang [aut] (<https://orcid.org/0000-0001-9754-0393>), Bernd Bischl [aut] (<https://orcid.org/0000-0001-6002-6980>), Florian Pfisterer [aut] (<https://orcid.org/0000-0001-8867-762X>), Martin Binder [aut], Sebastian Fischer [aut] (<https://orcid.org/0000-0002-9609-3197>), Michael H. Buselli [cph], Wessel Dankers [cph], Carlos Fonseca [cph], Manuel Lopez-Ibanez [cph], Luis Paquete [cph]
+# Maintainer: Lennart Schneider <lennart.sch@web.de>
+# Repository: CRAN
+# Date/Publication: 2023-03-03 00:20:02 UTC

--- a/recipes/r-mlr3mbo/meta.yaml
+++ b/recipes/r-mlr3mbo/meta.yaml
@@ -21,8 +21,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -31,7 +31,6 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-r6 >=2.4.1
     - r-bbotk >=0.5.4
     - r-checkmate >=2.0.0
     - r-data.table
@@ -40,10 +39,10 @@ requirements:
     - r-mlr3misc >=0.11.0
     - r-mlr3tuning >=0.14.0
     - r-paradox >=0.10.0
+    - r-r6 >=2.4.1
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
-    - r-r6 >=2.4.1
     - r-bbotk >=0.5.4
     - r-checkmate >=2.0.0
     - r-data.table
@@ -52,6 +51,7 @@ requirements:
     - r-mlr3misc >=0.11.0
     - r-mlr3tuning >=0.14.0
     - r-paradox >=0.10.0
+    - r-r6 >=2.4.1
 
 test:
   commands:
@@ -59,7 +59,8 @@ test:
     - "\"%R%\" -e \"library('mlr3mbo')\""  # [win]
 
 about:
-  home: https://mlr3mbo.mlr-org.com, https://github.com/mlr-org/mlr3mbo
+  home: https://mlr3mbo.mlr-org.com
+  dev_url: https://github.com/mlr-org/mlr3mbo
   license: LGPL-3
   summary: A modern and flexible approach to Bayesian Optimization / Model Based Optimization
     building on the 'bbotk' package. 'mlr3mbo' is a toolbox providing both ready-to-use
@@ -73,8 +74,7 @@ about:
     and SMS-EGO by Ponweiser et al. (2008) <doi:10.1007/978-3-540-87700-4_78>.
   license_family: LGPL
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
-# Type: Package
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `mlr3mbo`](https://cran.r-project.org/package=mlr3mbo) as `r-mlr3mbo`. Recipe created with `conda_r_skeleton_helper` with `testthat` testing added.

Needed as [new dependency of `r-mlr3verse`](https://github.com/conda-forge/r-mlr3verse-feedstock/pull/10).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
