### PR TITLE
Adds `r-rgenoud`

### DIFF
--- a/recipes/r-rgenoud/bld.bat
+++ b/recipes/r-rgenoud/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rgenoud/bld.bat
+++ b/recipes/r-rgenoud/bld.bat
@@ -1,2 +1,2 @@
-"%R%" CMD INSTALL --build . %R_ARGS%
+"%R%" CMD INSTALL --install-tests --build . %R_ARGS%
 IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rgenoud/build.sh
+++ b/recipes/r-rgenoud/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rgenoud/build.sh
+++ b/recipes/r-rgenoud/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export DISABLE_AUTOBREW=1
-${R} CMD INSTALL --build . ${R_ARGS}
+${R} CMD INSTALL --install-tests --build . ${R_ARGS}

--- a/recipes/r-rgenoud/meta.yaml
+++ b/recipes/r-rgenoud/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-rgenoud/meta.yaml
+++ b/recipes/r-rgenoud/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = '5.9-0.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rgenoud
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rgenoud_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rgenoud/rgenoud_{{ version }}.tar.gz
+  sha256: 31560a8dad791f9c47a673e90d397b3fc60da1a58be1ae1486ace90d988eb55f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+
+test:
+  commands:
+    - $R -e "library('rgenoud')"           # [not win]
+    - "\"%R%\" -e \"library('rgenoud')\""  # [win]
+
+about:
+  home: https://github.com/JasjeetSekhon/rgenoud
+  license: GPL-3
+  summary: A genetic algorithm plus derivative optimizer.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rgenoud
+# Version: 5.9-0.3
+# Date: 2022-04-19
+# Title: R Version of GENetic Optimization Using Derivatives
+# Authors@R: c( person("Walter", "R. Mebane, Jr", role = "aut", email = "wmebane@umich.edu"), person("Jasjeet", "Singh Sekhon", role = c("aut","cre"), email = "jas.sekhon@yale.edu"), person("Theo", "Saarinen", role = "aut", email = "theo_s@berkeley.edu") )
+# Maintainer: Jasjeet Singh Sekhon <jas.sekhon@yale.edu>
+# Description: A genetic algorithm plus derivative optimizer.
+# Depends: R (>= 2.15), utils
+# Suggests: testthat
+# License: GPL-3
+# URL: https://github.com/JasjeetSekhon/rgenoud
+# NeedsCompilation: yes
+# Packaged: 2022-04-19 16:44:49 UTC; theosaa
+# Author: Walter R. Mebane, Jr [aut], Jasjeet Singh Sekhon [aut, cre], Theo Saarinen [aut]
+# Repository: CRAN
+# Date/Publication: 2022-04-20 12:40:08 UTC

--- a/recipes/r-rgenoud/meta.yaml
+++ b/recipes/r-rgenoud/meta.yaml
@@ -21,10 +21,10 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -38,17 +38,21 @@ requirements:
     - {{ native }}gcc-libs         # [win]
 
 test:
+  requires:
+    - r-testthat
   commands:
-    - $R -e "library('rgenoud')"           # [not win]
-    - "\"%R%\" -e \"library('rgenoud')\""  # [win]
+    - $R -e "library('rgenoud')"                          # [not win]
+    - $R -e "testthat::test_package('rgenoud')"           # [not win]
+    - "\"%R%\" -e \"library('rgenoud')\""                 # [win]
+    - "\"%R%\" -e \"testthat::test_package('rgenoud')\""  # [win]
 
 about:
   home: https://github.com/JasjeetSekhon/rgenoud
-  license: GPL-3
+  license: GPL-3.0-only
   summary: A genetic algorithm plus derivative optimizer.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `rgenoud`](https://cran.r-project.org/web/packages/rgenoud/index.html) as `r-rgenoud`. Recipe generated with `conda_r_skeleton_helper` with `testthat` testing enabled.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
