### PR TITLE
Adds `r-emoa`

### DIFF
--- a/recipes/r-emoa/bld.bat
+++ b/recipes/r-emoa/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-emoa/build.sh
+++ b/recipes/r-emoa/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-emoa/meta.yaml
+++ b/recipes/r-emoa/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-emoa/meta.yaml
+++ b/recipes/r-emoa/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.5-0.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-emoa
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/emoa_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/emoa/emoa_{{ version }}.tar.gz
+  sha256: bff6c84274e9bdcbdb82d6edd90265844f7cd23f22abbf68d6b563ef48237966
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+
+test:
+  commands:
+    - $R -e "library('emoa')"           # [not win]
+    - "\"%R%\" -e \"library('emoa')\""  # [win]
+
+about:
+  home: http://www.statistik.tu-dortmund.de/~olafm/software/emoa/
+  license: GPL-2.0-or-later
+  summary: Collection of building blocks for the design and analysis of evolutionary multiobjective
+    optimization algorithms.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: emoa
+# Title: Evolutionary Multiobjective Optimization Algorithms
+# Description: Collection of building blocks for the design and analysis of evolutionary multiobjective optimization algorithms.
+# Author: Olaf Mersmann <olafm@statistik.tu-dortmund.de>
+# Maintainer: Olaf Mersmann <olafm@statistik.tu-dortmund.de>
+# License: GPL-2
+# URL: http://www.statistik.tu-dortmund.de/~olafm/software/emoa/
+# LazyData: yes
+# Version: 0.5-0.1
+# Suggests: RUnit
+# Collate: 'cec2009.r' 'control.R' 'crowding_distance.r' 'dominance.r' 'emoa.r' 'front_edge.R' 'hypervolume.r' 'indicators.r' 'logger.R' 'poly_mutation.r' 'sb_crossover.r' 'selection.r' 'sympart.r' 'utilities.r'
+# Date:
+# Packaged: 2020-03-06 17:24:20 UTC; hornik
+# Repository: CRAN
+# Date/Publication: 2020-03-06 17:31:53 UTC
+# NeedsCompilation: yes

--- a/recipes/r-emoa/meta.yaml
+++ b/recipes/r-emoa/meta.yaml
@@ -21,8 +21,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -41,13 +41,13 @@ test:
     - "\"%R%\" -e \"library('emoa')\""  # [win]
 
 about:
-  home: http://www.statistik.tu-dortmund.de/~olafm/software/emoa/
-  license: GPL-2.0-or-later
+  home: https://cran.r-project.org/package=emoa
+  license: GPL-2.0-only
   summary: Collection of building blocks for the design and analysis of evolutionary multiobjective
     optimization algorithms.
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `emoa`](https://cran.r-project.org/package=emoa) as `r-emoa`. Recipe generated with `conda_r_skeleton_helper` with license adjusted. URL in `DESCRIPTION` was 404, so replaced with CRAN link.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
