### PR TITLE
Draft: Add python-poppler-qt5

### DIFF
--- a/recipes/python-poppler-qt5/bld.bat
+++ b/recipes/python-poppler-qt5/bld.bat
@@ -1,0 +1,2 @@
+set PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig
+sip-install --verbose

--- a/recipes/python-poppler-qt5/bld.bat
+++ b/recipes/python-poppler-qt5/bld.bat
@@ -1,2 +1,2 @@
-set PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig
+set PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig
 sip-install --verbose

--- a/recipes/python-poppler-qt5/bld.bat
+++ b/recipes/python-poppler-qt5/bld.bat
@@ -1,2 +1,2 @@
-set PKG_CONFIG_PATH=$CONDA_PREFIX_1/lib/pkgconfig
+set PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig
 sip-install --verbose

--- a/recipes/python-poppler-qt5/bld.bat
+++ b/recipes/python-poppler-qt5/bld.bat
@@ -1,2 +1,2 @@
-set PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig
+set PKG_CONFIG_PATH=$CONDA_PREFIX_1/lib/pkgconfig
 sip-install --verbose

--- a/recipes/python-poppler-qt5/build.sh
+++ b/recipes/python-poppler-qt5/build.sh
@@ -3,4 +3,4 @@ qmake-settings = [
   \"QMAKE_CXX = $CXX\"
 ]
 " >> pyproject.toml
-PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig sip-install --verbose
+PKG_CONFIG_PATH=$CONDA_PREFIX_1/lib/pkgconfig sip-install --verbose

--- a/recipes/python-poppler-qt5/build.sh
+++ b/recipes/python-poppler-qt5/build.sh
@@ -3,4 +3,4 @@ qmake-settings = [
   \"QMAKE_CXX = $CXX\"
 ]
 " >> pyproject.toml
-PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig sip-install --verbose
+PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig sip-install --verbose

--- a/recipes/python-poppler-qt5/build.sh
+++ b/recipes/python-poppler-qt5/build.sh
@@ -3,4 +3,4 @@ qmake-settings = [
   \"QMAKE_CXX = $CXX\"
 ]
 " >> pyproject.toml
-PKG_CONFIG_PATH=$CONDA_PREFIX_1/lib/pkgconfig sip-install --verbose
+PKG_CONFIG_PATH=$BUILD_PREFIX/lib/pkgconfig sip-install --verbose

--- a/recipes/python-poppler-qt5/build.sh
+++ b/recipes/python-poppler-qt5/build.sh
@@ -1,0 +1,6 @@
+echo "[tool.sip.builder]
+qmake-settings = [
+  \"QMAKE_CXX = $CXX\"
+]
+" >> pyproject.toml
+PKG_CONFIG_PATH=$CONDA_PREFIX/lib/pkgconfig sip-install --verbose

--- a/recipes/python-poppler-qt5/meta.yaml
+++ b/recipes/python-poppler-qt5/meta.yaml
@@ -16,6 +16,9 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: b477e8841f0ea0e09fdab6f2f305cf38df977d9e142e5693a374605d75dd6fe0
 
+build:
+  number: 0
+
 requirements:
   build:
     - {{ compiler('cxx') }}
@@ -39,10 +42,7 @@ requirements:
     # pinned by pin_run_as_build in conda-forge's conda_build_config.yaml
     - poppler-qt
 
-build:
-  number: 0
-
-tests:
+test:
   imports:
     - popplerqt5
   requires:

--- a/recipes/python-poppler-qt5/meta.yaml
+++ b/recipes/python-poppler-qt5/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "python-poppler-qt5" %}
+{% set version = "21.3.0" %}
+
+# Note: python-poppler-qt5 versions follow Poppler versions. However,
+# poppler is pinned in conda-forge
+# (https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml).
+# We just build the binding with a higher version of Poppler, which is fine
+# -- it just exposes the API subset that was already in the older Poppler version
+# corresponding to the python-poppler-qt5 version.
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b477e8841f0ea0e09fdab6f2f305cf38df977d9e142e5693a374605d75dd6fe0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - python
+    - sip
+    - setuptools
+    - pyqt-builder
+    - pyqt
+    - poppler-qt {{ poppler }}
+  host:
+    - {{ compiler('cxx') }}
+    - python
+    - sip
+    - setuptools
+    - pyqt-builder
+    - pyqt
+    - poppler-qt {{ poppler }}
+  run:
+    - python
+    - pyqt
+    # pinned by pin_run_as_build in conda-forge's conda_build_config.yaml
+    - poppler-qt
+
+build:
+  number: 0
+
+tests:
+  imports:
+    - popplerqt5
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/frescobaldi/python-poppler-qt5
+  summary: 'Python binding to libpoppler-qt5'
+  license: GPL-2.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - jeanas

--- a/recipes/python-poppler-qt5/meta.yaml
+++ b/recipes/python-poppler-qt5/meta.yaml
@@ -22,20 +22,13 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - python
-    - sip
-    - setuptools
-    - pyqt-builder
-    - pyqt
-    - poppler-qt {{ poppler }}
   host:
-    - {{ compiler('cxx') }}
     - python
     - sip
     - setuptools
     - pyqt-builder
     - pyqt
-    - poppler-qt {{ poppler }}
+    - poppler-qt
   run:
     - python
     - pyqt
@@ -60,3 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - jeanas
+    - fedelibre


### PR DESCRIPTION
This is a Python binding to poppler-qt5, for which conda-forge already has a package.

https://github.com/frescobaldi/python-poppler-qt5

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


-----------------


This PR is a draft and I could use some help.

Right now, the build fails with

```
$BUILD_PREFIX/bin/qmake -recursive python-poppler-qt5.pro
Project ERROR: Cannot run compiler 'g++'. Output:
===================
===================
Maybe you forgot to setup the environment?
```

The solution I tried didn't work. I'm willing to debug that, but I have trouble understanding how.

When I run `python build-locally.py`, it shows the failure, but each run takes quite long (8 minutes), making it difficult to inspect the environment.

When I run `conda build .`, I get an error due to `{{ poppler }}` not being defined. IIUC, it's defined by conda-forge's `conda_build_config.yaml`. So I did this:

```diff
diff --git a/recipes/python-poppler-qt5/meta.yaml b/recipes/python-poppler-qt5/meta.yaml
index 0727b1a32a..591db2d2ae 100644
--- a/recipes/python-poppler-qt5/meta.yaml
+++ b/recipes/python-poppler-qt5/meta.yaml
@@ -1,6 +1,8 @@
 {% set name = "python-poppler-qt5" %}
 {% set version = "21.3.0" %}
 
+{% set poppler = "23.05.0" %}
+
 # Note: python-poppler-qt5 versions follow Poppler versions. However,
 # poppler is pinned in conda-forge
 # (https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml).
@@ -24,7 +26,7 @@ requirements:
     - setuptools
     - pyqt-builder
     - pyqt
-    - poppler-qt {{ poppler }}
+    - poppler-qt =={{ poppler }}
   host:
     - {{ compiler('cxx') }}
     - python
@@ -32,7 +34,7 @@ requirements:
     - setuptools
     - pyqt-builder
     - pyqt
-    - poppler-qt {{ poppler }}
+    - poppler-qt =={{ poppler }}
   run:
     - python
     - pyqt
```

but now I get this error which I don't understand:

```
[...]
conda.exceptions.ResolvePackageNotFound: 
  - poppler-qt==23.05.0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
[...]
Unsatisfiable dependencies for platform linux-64: {'poppler-qt==23.05.0'}
```

23.05.0 is the latest version of poppler-qt5 on conda-forge.

CC @h-vetinari 