### PR TITLE
Adds `r-smdocker`

### DIFF
--- a/recipes/r-smdocker/bld.bat
+++ b/recipes/r-smdocker/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-smdocker/build.sh
+++ b/recipes/r-smdocker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-smdocker/meta.yaml
+++ b/recipes/r-smdocker/meta.yaml
@@ -1,0 +1,89 @@
+{% set version = '0.1.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-smdocker
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/smdocker_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/smdocker/smdocker_{{ version }}.tar.gz
+  sha256: 07ce3397f134b4589d48e54294fd3321c0e38a1aabd39eee2160fd0e991e2d51
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-jsonlite
+    - r-paws.compute
+    - r-paws.developer.tools
+    - r-paws.machine.learning
+    - r-paws.management
+    - r-paws.security.identity
+    - r-paws.storage
+    - r-uuid
+    - r-zip
+  run:
+    - r-base
+    - r-jsonlite
+    - r-paws.compute
+    - r-paws.developer.tools
+    - r-paws.machine.learning
+    - r-paws.management
+    - r-paws.security.identity
+    - r-paws.storage
+    - r-uuid
+    - r-zip
+
+test:
+  commands:
+    - $R -e "library('smdocker')"           # [not win]
+    - "\"%R%\" -e \"library('smdocker')\""  # [win]
+
+about:
+  home: https://github.com/DyfanJones/sm-docker
+  license: MIT
+  summary: Allows users to easily build custom 'docker images' <https://docs.docker.com/> from
+    'Amazon Web Service Sagemaker' <https://aws.amazon.com/sagemaker/> using 'Amazon
+    Web Service CodeBuild' <https://aws.amazon.com/codebuild/>.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: smdocker
+# Title: Build 'Docker Images' in 'Amazon SageMaker Studio' using 'Amazon Web Service CodeBuild'
+# Version: 0.1.3
+# Authors@R: c(person("Dyfan", "Jones", email="dyfan.r.jones@gmail.com", role= c("aut", "cre")))
+# Description: Allows users to easily build custom 'docker images' <https://docs.docker.com/> from 'Amazon Web Service Sagemaker' <https://aws.amazon.com/sagemaker/> using 'Amazon Web Service CodeBuild' <https://aws.amazon.com/codebuild/>.
+# License: MIT + file LICENSE
+# URL: https://github.com/DyfanJones/sm-docker
+# BugReports: https://github.com/DyfanJones/sm-docker/issues
+# Encoding: UTF-8
+# Imports: jsonlite, paws.compute, paws.developer.tools, paws.machine.learning, paws.management, paws.storage, paws.security.identity, zip, stats, utils, uuid
+# Suggests: covr, crayon, mockery, testthat (>= 3.0.0)
+# RoxygenNote: 7.2.3
+# Collate: 'utils.R' 'logs.R' 'code_build.R' 'builder.R' 'config.R' 'logging.R' 'sm_role.R' 'main.R' 'zzz.R'
+# Config/testthat/edition: 3
+# NeedsCompilation: no
+# Packaged: 2023-05-15 17:13:47 UTC; dyfanjones
+# Author: Dyfan Jones [aut, cre]
+# Maintainer: Dyfan Jones <dyfan.r.jones@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-05-15 17:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `smdocker`](https://cran.r-project.org/package=smdocker) as `r-smdocker`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
