### PR TITLE
Adds `r-clustmixtype`

### DIFF
--- a/recipes/r-clustmixtype/bld.bat
+++ b/recipes/r-clustmixtype/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-clustmixtype/build.sh
+++ b/recipes/r-clustmixtype/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-clustmixtype/meta.yaml
+++ b/recipes/r-clustmixtype/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '0.3-9' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-clustmixtype
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/clustMixType_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/clustMixType/clustMixType_{{ version }}.tar.gz
+  sha256: a237359f566abdd01cc9ca3056bc83b0f77b189a9f4e4a8586ac94e51bb55146
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcolorbrewer
+    - r-tibble
+  run:
+    - r-base
+    - r-rcolorbrewer
+    - r-tibble
+
+test:
+  commands:
+    - $R -e "library('clustMixType')"           # [not win]
+    - "\"%R%\" -e \"library('clustMixType')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=clustMixType
+  license: GPL-2.0-only
+  summary: 'Functions to perform k-prototypes partitioning clustering for mixed variable-type
+    data according to Z.Huang (1998): Extensions to the k-Means Algorithm for Clustering
+    Large Data Sets with Categorical Variables, Data Mining and Knowledge Discovery
+    2, 283-304.'
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: clustMixType
+# Version: 0.3-9
+# Date: 2022-12-13
+# Title: k-Prototypes Clustering for Mixed Variable-Type Data
+# Author: Gero Szepannek [aut, cre], Rabea Aschenbruck [aut]
+# Maintainer: Gero Szepannek <gero.szepannek@web.de>
+# Imports: RColorBrewer, tibble
+# Suggests: testthat
+# Description: Functions to perform k-prototypes partitioning clustering for mixed variable-type data according to Z.Huang (1998): Extensions to the k-Means Algorithm for Clustering Large Data Sets with Categorical Variables, Data Mining and Knowledge Discovery 2, 283-304.
+# License: GPL (>= 2)
+# RoxygenNote: 7.2.0
+# NeedsCompilation: no
+# Packaged: 2022-12-13 18:18:19 UTC; szepannek
+# Encoding: UTF-8
+# Repository: CRAN
+# Date/Publication: 2022-12-14 19:50:02 UTC

--- a/recipes/r-clustmixtype/meta.yaml
+++ b/recipes/r-clustmixtype/meta.yaml
@@ -40,14 +40,15 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=clustMixType
-  license: GPL-2.0-only
+  license: GPL-2.0-or-later
   summary: 'Functions to perform k-prototypes partitioning clustering for mixed variable-type
     data according to Z.Huang (1998): Extensions to the k-Means Algorithm for Clustering
     Large Data Sets with Categorical Variables, Data Mining and Knowledge Discovery
     2, 283-304.'
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `clustMixType`](https://cran.r-project.org/package=clustMixType) as `r-clustmixtype`. Recipe generated with `conda_r_skeleton_helper`, with license adjusted.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
