### PR TITLE
add `r-ggblend`

### DIFF
--- a/recipes/r-ggblend/bld.bat
+++ b/recipes/r-ggblend/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ggblend/build.sh
+++ b/recipes/r-ggblend/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ggblend/conda_build_config.yaml
+++ b/recipes/r-ggblend/conda_build_config.yaml
@@ -1,0 +1,2 @@
+r_base:
+  - 4.2  # [not win]

--- a/recipes/r-ggblend/meta.yaml
+++ b/recipes/r-ggblend/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ggblend
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ggblend_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ggblend/ggblend_{{ version }}.tar.gz
+  sha256: df144daf350899adf95a28e01ee68669c27dbb353ecc1d42195476bc2d4dfe73
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-ggplot2 >=3.4.0
+    - r-rlang
+  run:
+    - r-base
+    - r-ggplot2 >=3.4.0
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('ggblend')"           # [not win]
+    - "\"%R%\" -e \"library('ggblend')\""  # [win]
+
+about:
+  home: https://mjskay.github.io/ggblend/, https://github.com/mjskay/ggblend/
+  license: MIT
+  summary: Algebra of operations for blending, copying, adjusting, and compositing layers in
+    'ggplot2'. Supports copying and adjusting the aesthetics or parameters of an existing
+    layer, partitioning a layer into multiple pieces for re-composition, applying affine
+    transformations to layers, and combining layers (or partitions of layers) using
+    blend modes (including commutative blend modes, like multiply and darken). Blend
+    mode support is particularly useful for creating plots with overlapping groups where
+    the layer drawing order does not change the output; see Kindlmann and Scheidegger
+    (2014) <doi:10.1109/TVCG.2014.2346325>.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ggblend
+# Title: Blending and Compositing Algebra for 'ggplot2'
+# Version: 0.1.0
+# Authors@R: person("Matthew", "Kay", , "mjskay@northwestern.edu", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0001-9446-0419"))
+# Description: Algebra of operations for blending, copying, adjusting, and compositing layers in 'ggplot2'. Supports copying and adjusting the aesthetics or parameters of an existing layer, partitioning a layer into multiple pieces for re-composition, applying affine transformations to layers, and combining layers (or partitions of layers) using blend modes (including commutative blend modes, like multiply and darken). Blend mode support is particularly useful for creating plots with overlapping groups where the layer drawing order does not change the output; see Kindlmann and Scheidegger (2014) <doi:10.1109/TVCG.2014.2346325>.
+# License: MIT + file LICENSE
+# Language: en-US
+# Depends: R (>= 4.2)
+# Imports: methods, grid, ggplot2 (>= 3.4.0), rlang
+# Suggests: covr, testthat (>= 3.0.0), fontquiver, showtext, sysfonts, ggnewscale
+# Config/testthat/edition: 3
+# BugReports: https://github.com/mjskay/ggblend/issues/new
+# URL: https://mjskay.github.io/ggblend/, https://github.com/mjskay/ggblend/
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Packaged: 2023-05-21 04:21:44 UTC; matth
+# Author: Matthew Kay [aut, cre, cph] (<https://orcid.org/0000-0001-9446-0419>)
+# Maintainer: Matthew Kay <mjskay@northwestern.edu>
+# Repository: CRAN
+# Date/Publication: 2023-05-22 08:30:05 UTC

--- a/recipes/r-ggblend/meta.yaml
+++ b/recipes/r-ggblend/meta.yaml
@@ -39,7 +39,8 @@ test:
     - "\"%R%\" -e \"library('ggblend')\""  # [win]
 
 about:
-  home: https://mjskay.github.io/ggblend/, https://github.com/mjskay/ggblend/
+  home: https://mjskay.github.io/ggblend
+  dev_url: https://github.com/mjskay/ggblend/
   license: MIT
   summary: Algebra of operations for blending, copying, adjusting, and compositing layers in
     'ggplot2'. Supports copying and adjusting the aesthetics or parameters of an existing


### PR DESCRIPTION
Adds [CRAN package `ggblend`](https://cran.r-project.org/package=ggblend) as `r-ggblend`. Recipe generate with `conda_r_skeleton_helper`, with URLs split.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
