### PR TITLE
BUG: Missing cuda keys

### DIFF
--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -18,3 +18,5 @@ cuda_compiler:
 - None
 cuda_compiler_version_min:
 - None
+cudnn:
+- undefined

--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -14,3 +14,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler_version:
 - None
+cuda_compiler:
+- None
+cuda_compiler_version_min:
+- None

--- a/.ci_support/linux64_cuda102.yaml
+++ b/.ci_support/linux64_cuda102.yaml
@@ -24,3 +24,5 @@ cuda_compiler:
 - nvcc
 cuda_compiler_version_min:
 - 10.2
+cudnn:
+- 7

--- a/.ci_support/linux64_cuda102.yaml
+++ b/.ci_support/linux64_cuda102.yaml
@@ -20,3 +20,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cos7-cuda:10.2
 cuda_compiler_version:
 - 10.2
+cuda_compiler:
+- nvcc
+cuda_compiler_version_min:
+- 10.2

--- a/.ci_support/linux64_cuda110.yaml
+++ b/.ci_support/linux64_cuda110.yaml
@@ -22,3 +22,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.0
 cuda_compiler_version:
 - 11.0
+cuda_compiler:
+- nvcc
+cuda_compiler_version_min:
+- 10.2

--- a/.ci_support/linux64_cuda110.yaml
+++ b/.ci_support/linux64_cuda110.yaml
@@ -26,3 +26,5 @@ cuda_compiler:
 - nvcc
 cuda_compiler_version_min:
 - 10.2
+cudnn:
+- 8

--- a/.ci_support/linux64_cuda111.yaml
+++ b/.ci_support/linux64_cuda111.yaml
@@ -22,3 +22,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.1
 cuda_compiler_version:
 - 11.1
+cuda_compiler:
+- nvcc
+cuda_compiler_version_min:
+- 10.2

--- a/.ci_support/linux64_cuda111.yaml
+++ b/.ci_support/linux64_cuda111.yaml
@@ -26,3 +26,5 @@ cuda_compiler:
 - nvcc
 cuda_compiler_version_min:
 - 10.2
+cudnn:
+- 8

--- a/.ci_support/linux64_cuda112.yaml
+++ b/.ci_support/linux64_cuda112.yaml
@@ -22,3 +22,7 @@ docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
 cuda_compiler_version:
 - 11.2
+cuda_compiler:
+- nvcc
+cuda_compiler_version_min:
+- 10.2

--- a/.ci_support/linux64_cuda112.yaml
+++ b/.ci_support/linux64_cuda112.yaml
@@ -26,3 +26,5 @@ cuda_compiler:
 - nvcc
 cuda_compiler_version_min:
 - 10.2
+cudnn:
+- 8


### PR DESCRIPTION
The keys `cuda_compiler` and `cuda_compiler_version_min` were added to the conda-forge pinnings, but they are not added here in staged recipes. Without them, CUDA build jobs will try to install the `none_linux-64` package instead of `nvcc_linux-64`. Also added `cuda_compiler_version_min` to be consistent with the pinnings, and since I don't know how it is used.

EDIT: I now realize that the keys in staged recipes override the ones from the pinnings, so the error is due to the overrided keys here disrupting the key zipping from the pinnings. Thus, I should include all cuda related keys that zip with `cuda_compiler_verion`.

~~Also added a line to the build steps to squash an error from running the build-locally script.~~
EDIT: Removed docker permissions related changes

Related to: https://github.com/conda-forge/staged-recipes/pull/22898 , https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4407