### PR TITLE
Add `r-finetune`

### DIFF
--- a/recipes/r-finetune/bld.bat
+++ b/recipes/r-finetune/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-finetune/build.sh
+++ b/recipes/r-finetune/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-finetune/meta.yaml
+++ b/recipes/r-finetune/meta.yaml
@@ -1,0 +1,101 @@
+{% set version = '1.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-finetune
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/finetune_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/finetune/finetune_{{ version }}.tar.gz
+  sha256: d18fa031546241b4a9d0a8e3aa0a5388eafeeb8fdc93e03230dd5dd8a674acab
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-cli
+    - r-dials >=0.1.0
+    - r-dplyr >=1.1.1
+    - r-ggplot2
+    - r-parsnip >=1.1.0
+    - r-purrr
+    - r-rlang
+    - r-tibble
+    - r-tidyr
+    - r-tidyselect
+    - r-tune >=1.1.1
+    - r-vctrs
+    - r-workflows >=0.2.6
+  run:
+    - r-base
+    - r-cli
+    - r-dials >=0.1.0
+    - r-dplyr >=1.1.1
+    - r-ggplot2
+    - r-parsnip >=1.1.0
+    - r-purrr
+    - r-rlang
+    - r-tibble
+    - r-tidyr
+    - r-tidyselect
+    - r-tune >=1.1.1
+    - r-vctrs
+    - r-workflows >=0.2.6
+
+test:
+  commands:
+    - $R -e "library('finetune')"           # [not win]
+    - "\"%R%\" -e \"library('finetune')\""  # [win]
+
+about:
+  home: https://github.com/tidymodels/finetune, https://finetune.tidymodels.org
+  license: MIT
+  summary: The ability to tune models is important. 'finetune' enhances the 'tune' package by
+    providing more specialized methods for finding reasonable values of model tuning
+    parameters.  Two racing methods described by Kuhn (2014) <arXiv:1405.6974> are included.
+    An iterative search method using generalized simulated annealing (Bohachevsky, Johnson
+    and Stein, 1986) <doi:10.1080/00401706.1986.10488128> is also included.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: finetune
+# Title: Additional Functions for Model Tuning
+# Version: 1.1.0
+# Authors@R: c( person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2402-136X")), person("Posit Software, PBC", role = c("cph", "fnd")) )
+# Description: The ability to tune models is important. 'finetune' enhances the 'tune' package by providing more specialized methods for finding reasonable values of model tuning parameters.  Two racing methods described by Kuhn (2014) <arXiv:1405.6974> are included. An iterative search method using generalized simulated annealing (Bohachevsky, Johnson and Stein, 1986) <doi:10.1080/00401706.1986.10488128> is also included.
+# License: MIT + file LICENSE
+# URL: https://github.com/tidymodels/finetune, https://finetune.tidymodels.org
+# BugReports: https://github.com/tidymodels/finetune/issues
+# Depends: R (>= 3.5), tune (>= 1.1.1)
+# Imports: cli, dials (>= 0.1.0), dplyr (>= 1.1.1), ggplot2, parsnip (>= 1.1.0), purrr, rlang, tibble, tidyr, tidyselect, utils, vctrs, workflows (>= 0.2.6)
+# Suggests: BradleyTerry2, covr, discrim, kknn, klaR, lme4, modeldata, ranger, recipes (>= 0.2.0), rpart, rsample, spelling, testthat, yardstick
+# Config/Needs/website: tidyverse/tidytemplate
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# Language: en-US
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Packaged: 2023-04-18 23:16:32 UTC; max
+# Author: Max Kuhn [aut, cre] (<https://orcid.org/0000-0003-2402-136X>), Posit Software, PBC [cph, fnd]
+# Maintainer: Max Kuhn <max@posit.co>
+# Repository: CRAN
+# Date/Publication: 2023-04-19 07:40:02 UTC

--- a/recipes/r-finetune/meta.yaml
+++ b/recipes/r-finetune/meta.yaml
@@ -61,7 +61,8 @@ test:
     - "\"%R%\" -e \"library('finetune')\""  # [win]
 
 about:
-  home: https://github.com/tidymodels/finetune, https://finetune.tidymodels.org
+  home: https://finetune.tidymodels.org
+  dev_url: https://github.com/tidymodels/finetune
   license: MIT
   summary: The ability to tune models is important. 'finetune' enhances the 'tune' package by
     providing more specialized methods for finding reasonable values of model tuning
@@ -70,7 +71,7 @@ about:
     and Stein, 1986) <doi:10.1080/00401706.1986.10488128> is also included.
   license_family: MIT
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
     - LICENSE
 
 extra:


### PR DESCRIPTION
Adds [CRAN package `finetune`](https://cran.r-project.org/package=finetune) as `r-finetune`. Recipe generated with `conda_r_skeleton_helper`, plus splitting URLs.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
