### PR TITLE
Add `r-discrim`

### DIFF
--- a/recipes/r-discrim/bld.bat
+++ b/recipes/r-discrim/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-discrim/build.sh
+++ b/recipes/r-discrim/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-discrim/meta.yaml
+++ b/recipes/r-discrim/meta.yaml
@@ -1,0 +1,86 @@
+{% set version = '1.0.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-discrim
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/discrim_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/discrim/discrim_{{ version }}.tar.gz
+  sha256: a03e862206efc5b99e737a5d6227d842d97f388174ec6b2168b8ad807d100025
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dials
+    - r-parsnip >=0.2.0
+    - r-rlang
+    - r-tibble
+    - r-withr
+  run:
+    - r-base
+    - r-dials
+    - r-parsnip >=0.2.0
+    - r-rlang
+    - r-tibble
+    - r-withr
+
+test:
+  commands:
+    - $R -e "library('discrim')"           # [not win]
+    - "\"%R%\" -e \"library('discrim')\""  # [win]
+
+about:
+  home: https://github.com/tidymodels/discrim, https://discrim.tidymodels.org/
+  license: MIT
+  summary: Bindings for additional classification models for use with the 'parsnip' package.
+    Models include flavors of discriminant analysis, such as linear (Fisher (1936) <doi:10.1111/j.1469-1809.1936.tb02137.x>),
+    regularized (Friedman (1989) <doi:10.1080/01621459.1989.10478752>), and flexible
+    (Hastie, Tibshirani, and Buja (1994) <doi:10.1080/01621459.1994.10476866>), as well
+    as naive Bayes classifiers (Hand and Yu (2007) <doi:10.1111/j.1751-5823.2001.tb00465.x>).
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: discrim
+# Title: Model Wrappers for Discriminant Analysis
+# Version: 1.0.1
+# Authors@R: c( person("Emil", "Hvitfeldt", , "emil.hvitfeldt@posit.co", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-0679-1945")), person("Max", "Kuhn", , "max@posit.co", role = c("aut"), comment = c(ORCID = "0000-0003-2402-136X")), person(given = "Posit Software, PBC", role = c("cph", "fnd")) )
+# Description: Bindings for additional classification models for use with the 'parsnip' package. Models include flavors of discriminant analysis, such as linear (Fisher (1936) <doi:10.1111/j.1469-1809.1936.tb02137.x>), regularized (Friedman (1989) <doi:10.1080/01621459.1989.10478752>), and flexible (Hastie, Tibshirani, and Buja (1994) <doi:10.1080/01621459.1994.10476866>), as well as naive Bayes classifiers (Hand and Yu (2007) <doi:10.1111/j.1751-5823.2001.tb00465.x>).
+# License: MIT + file LICENSE
+# URL: https://github.com/tidymodels/discrim, https://discrim.tidymodels.org/
+# BugReports: https://github.com/tidymodels/discrim/issues
+# Depends: parsnip (>= 0.2.0), R (>= 3.4)
+# Imports: dials, rlang, stats, tibble, withr
+# Suggests: covr, dplyr, earth, ggplot2, klaR, knitr, MASS, mda, mlbench, modeldata, naivebayes, rmarkdown, sda, sparsediscrim (>= 0.3.0), spelling, testthat (>= 3.0.0), xml2
+# Config/Needs/website: tidymodels/tidymodels, tidyverse/tidytemplate
+# Encoding: UTF-8
+# Language: en-US
+# LazyData: true
+# RoxygenNote: 7.2.3
+# Config/testthat/edition: 3
+# NeedsCompilation: no
+# Packaged: 2023-03-08 20:38:54 UTC; emilhvitfeldt
+# Author: Emil Hvitfeldt [aut, cre] (<https://orcid.org/0000-0002-0679-1945>), Max Kuhn [aut] (<https://orcid.org/0000-0003-2402-136X>), Posit Software, PBC [cph, fnd]
+# Maintainer: Emil Hvitfeldt <emil.hvitfeldt@posit.co>
+# Repository: CRAN
+# Date/Publication: 2023-03-08 22:00:15 UTC

--- a/recipes/r-discrim/meta.yaml
+++ b/recipes/r-discrim/meta.yaml
@@ -45,7 +45,8 @@ test:
     - "\"%R%\" -e \"library('discrim')\""  # [win]
 
 about:
-  home: https://github.com/tidymodels/discrim, https://discrim.tidymodels.org/
+  home: https://discrim.tidymodels.org/
+  dev_url: https://github.com/tidymodels/discrim
   license: MIT
   summary: Bindings for additional classification models for use with the 'parsnip' package.
     Models include flavors of discriminant analysis, such as linear (Fisher (1936) <doi:10.1111/j.1469-1809.1936.tb02137.x>),


### PR DESCRIPTION
Adds [CRAN package `discrim`](https://cran.r-project.org/package=discrim) as `r-discrim`. Recipe generated with `conda_r_skeleton_helper`, with URLs split.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
