### PR TITLE
add `r-ergm.multi`

### DIFF
--- a/recipes/r-ergm.multi/bld.bat
+++ b/recipes/r-ergm.multi/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ergm.multi/build.sh
+++ b/recipes/r-ergm.multi/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ergm.multi/meta.yaml
+++ b/recipes/r-ergm.multi/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'                  # [win]
 
 requirements:
   build:

--- a/recipes/r-ergm.multi/meta.yaml
+++ b/recipes/r-ergm.multi/meta.yaml
@@ -1,0 +1,103 @@
+{% set version = '0.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ergm.multi
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ergm.multi_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ergm.multi/ergm.multi_{{ version }}.tar.gz
+  sha256: 13e27ba59b087f09cfb3dc6fccaa360e4ae0159f13e7a20d2c3306b5fe74fb5a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-matrix
+    - r-rdpack >=2.4
+    - r-ergm >=4.5.0
+    - r-glue >=1.6.2
+    - r-network >=1.18.0
+    - r-purrr >=0.3.5
+    - r-rlang >=1.0.6
+    - r-rle >=0.9.2
+    - r-statnet.common >=4.9.0
+    - r-tibble >=3.1.8
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-matrix
+    - r-rdpack >=2.4
+    - r-ergm >=4.5.0
+    - r-glue >=1.6.2
+    - r-network >=1.18.0
+    - r-purrr >=0.3.5
+    - r-rlang >=1.0.6
+    - r-rle >=0.9.2
+    - r-statnet.common >=4.9.0
+    - r-tibble >=3.1.8
+
+test:
+  commands:
+    - $R -e "library('ergm.multi')"           # [not win]
+    - "\"%R%\" -e \"library('ergm.multi')\""  # [win]
+
+about:
+  home: https://statnet.org
+  license: GPL-3
+  summary: A set of extensions for the 'ergm' package to fit multilayer/multiplex/multirelational
+    networks and samples of multiple networks. 'ergm.multi' is a part of the Statnet
+    suite of packages for network analysis. See Krivitsky, Koehly, and Marcum (2020)
+    <doi:10.1007/s11336-020-09720-7> and Krivitsky, Coletti, and Hens (2022) <doi:10.48550/arXiv.2202.03685>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ergm.multi
+# Version: 0.2.0
+# Date: 2023-05-29
+# Title: Fit, Simulate and Diagnose Exponential-Family Models for Multiple or Multilayer Networks
+# Authors@R: c(person(c("Pavel", "N."), "Krivitsky", role=c("aut","cre"), email="pavel@statnet.org", comment=c(ORCID="0000-0002-9101-3362")), person(c("Mark", "S."), "Handcock", role=c("ctb"), email="handcock@stat.ucla.edu"), person(c("David", "R."), "Hunter", role=c("ctb"), email="dhunter@stat.psu.edu"), person("Chad", "Klumb", role=c("ctb"), email="cklumb@gmail.com"), person("Pietro", "Coletti", role=c("ctb"), email="pietro.coletti@uhasselt.be"), person("Joyce", "Cheng", role=c("ctb"), email="joyce.cheng@student.unsw.edu.au"))
+# Depends: R (>= 3.5.0), ergm (>= 4.5.0), network (>= 1.18.0)
+# Imports: statnet.common (>= 4.9.0), rlang (>= 1.0.6), purrr (>= 0.3.5), tibble (>= 3.1.8), glue (>= 1.6.2), rle (>= 0.9.2), Rdpack (>= 2.4), Matrix, methods, parallel
+# LinkingTo: ergm
+# Suggests: rmarkdown (>= 2.18), knitr (>= 1.41), dplyr (>= 1.0.10), testthat (>= 3.1.6), ggplot2, ggrepel, generics
+# RdMacros: Rdpack
+# BugReports: https://github.com/statnet/ergm.multi/issues
+# Description: A set of extensions for the 'ergm' package to fit multilayer/multiplex/multirelational networks and samples of multiple networks. 'ergm.multi' is a part of the Statnet suite of packages for network analysis. See Krivitsky, Koehly, and Marcum (2020) <doi:10.1007/s11336-020-09720-7> and Krivitsky, Coletti, and Hens (2022) <doi:10.48550/arXiv.2202.03685>.
+# License: GPL-3 + file LICENSE
+# URL: https://statnet.org
+# VignetteBuilder: rmarkdown, knitr
+# RoxygenNote: 7.2.3
+# Config/testthat/parallel: true
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# NeedsCompilation: yes
+# Packaged: 2023-05-29 06:39:09 UTC; pavel
+# Author: Pavel N. Krivitsky [aut, cre] (<https://orcid.org/0000-0002-9101-3362>), Mark S. Handcock [ctb], David R. Hunter [ctb], Chad Klumb [ctb], Pietro Coletti [ctb], Joyce Cheng [ctb]
+# Maintainer: Pavel N. Krivitsky <pavel@statnet.org>
+# Repository: CRAN
+# Date/Publication: 2023-05-30 07:10:05 UTC

--- a/recipes/r-ergm.multi/meta.yaml
+++ b/recipes/r-ergm.multi/meta.yaml
@@ -21,14 +21,14 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ posix }}filesystem        # [win]
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('m2w64_c') }}  # [win]
+    - {{ posix }}filesystem      # [win]
     - {{ posix }}make
-    - {{ posix }}sed               # [win]
-    - {{ posix }}coreutils         # [win]
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}sed             # [win]
+    - {{ posix }}coreutils       # [win]
+    - {{ posix }}zip             # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
   host:
     - r-base
     - r-matrix
@@ -43,7 +43,7 @@ requirements:
     - r-tibble >=3.1.8
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
+    - {{ native }}gcc-libs       # [win]
     - r-matrix
     - r-rdpack >=2.4
     - r-ergm >=4.5.0
@@ -62,14 +62,15 @@ test:
 
 about:
   home: https://statnet.org
-  license: GPL-3
+  dev_url: https://github.com/statnet/ergm.multi
+  license: GPL-3.0-only
   summary: A set of extensions for the 'ergm' package to fit multilayer/multiplex/multirelational
     networks and samples of multiple networks. 'ergm.multi' is a part of the Statnet
     suite of packages for network analysis. See Krivitsky, Koehly, and Marcum (2020)
     <doi:10.1007/s11336-020-09720-7> and Krivitsky, Coletti, and Hens (2022) <doi:10.48550/arXiv.2202.03685>.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
     - LICENSE
 
 extra:


### PR DESCRIPTION
Adds [CRAN package `ergm.multi`](https://cran.r-project.org/package=ergm.multi) as `r-ergm.multi`. Recipe generated with `conda_r_skeleton_helper`, with license conformed to SPDX and development URL added. 

Need as new dependency in https://github.com/conda-forge/r-tergm-feedstock/pull/14.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
