### PR TITLE
add go-vendor-licenses 1.1.2

### DIFF
--- a/recipes/go-vendor-licenses/build.sh
+++ b/recipes/go-vendor-licenses/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eux
+
+module="github.com/tq-systems/go-vendor-licenses"
+
+export GOPATH="$( pwd )"
+export GOROOT="${BUILD_PREFIX}/go"
+export GO_EXTLINK_ENABLED=1
+export GO111MODULE=on
+
+pushd "src/${module}"
+    go get -v "./cmd/${PKG_NAME}"
+    go build \
+        -buildmode=pie \
+        -o "${PREFIX}/bin/${PKG_NAME}" \
+        "./cmd/${PKG_NAME}" \
+        || exit 1
+    go-licenses save "./cmd/${PKG_NAME}" \
+        --save_path "${SRC_DIR}/license-files" \
+        --ignore=github.com/xi2/xz \
+        || exit 1
+popd
+
+# Make GOPATH directories writeable so conda-build can clean everything up.
+find "$( go env GOPATH )" -type d -exec chmod +w {} \;

--- a/recipes/go-vendor-licenses/conda_build_config.yaml
+++ b/recipes/go-vendor-licenses/conda_build_config.yaml
@@ -1,0 +1,2 @@
+go_compiler_version:
+  - "1.20"

--- a/recipes/go-vendor-licenses/meta.yaml
+++ b/recipes/go-vendor-licenses/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "1.1.2" %}
+{% set gomodule = "github.com/tq-systems/go-vendor-licenses" %}
+
+package:
+  name: go-vendor-licenses
+  version: {{ version }}
+
+source:
+  folder: src/{{ gomodule }}
+  url: https://{{ gomodule }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 24bdbaf911273ace1004f02e0a2b58748eec2401ed3161570d6e5f59069b6dff
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('go-cgo') }}
+    - posix  # [win]
+    - go-licenses
+  host: []
+  run: []
+
+test:
+  requires:
+    - m2-grep  # [win]
+  commands:
+    - go-vendor-licenses --help
+
+about:
+  home: https://github.com/tq-systems/go-vendor-licenses
+  license: MIT
+  license_family: MIT
+  license_file:
+    - src/{{ gomodule }}/LICENSE
+    - license-files/
+  summary: Provides license information
+  dev_url: https://{{ gomodule }}
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
