### PR TITLE
Adding cad-to-dagmc

### DIFF
--- a/recipes/cad_to_dagmc/LICENSE
+++ b/recipes/cad_to_dagmc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Fusion Energy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -35,6 +35,14 @@ requirements:
 test:
   imports:
     - cad_to_dagmc
+  requires:
+    - pip
+    - pytest
+    - openmc
+    - openmc_data_downloader
+  commands:
+    - pip check
+    - pytest tests/test_cad_to_dagmc/
 
 about:
   home: https://github.com/fusion-energy/cad_to_dagmc

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -1,0 +1,94 @@
+# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
+# If your package is python based, we recommend using Grayskull to generate it instead:
+# https://github.com/conda-incubator/grayskull
+
+# Jinja variables help maintain the recipe as you'll update the version only here.
+# Using the name variable with the URL in line 16 is convenient
+# when copying and pasting from another recipe, but not really needed.
+{% set name = "cad_to_dagmc" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  # If getting the source from GitHub, remove the line above,
+  # uncomment the line below, and modify as needed. Use releases if available:
+  # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
+  # and otherwise fall back to archive:
+  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
+  sha256: 15c5cc7ec474cb705a5fdccd71c90cfe6204cd14bec5c0bd6cf14ef8a954732a
+  # sha256 is the preferred checksum -- you can get it for a file with:
+  #  `openssl sha256 <file name>`.
+  # You may need the openssl package, available on conda-forge:
+  #  `conda install openssl -c conda-forge``
+
+build:
+  # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
+  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
+  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
+  # noarch: python
+  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
+  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
+  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
+  # More info about selectors can be found in the conda-build docs: 
+  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors
+  script: {{ PYTHON }} -m pip install -vv .
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8,<=3.10
+    - pip
+  run:
+    - python >=3.8,<=3.10
+    - cadquery
+    - occt
+    - moab
+    - numpy
+    - trimesh
+    - networkx
+
+test:
+  # Some packages might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - cad_to_dagmc
+  # For python packages, it is useful to run pip check. However, sometimes the
+  # metadata used by pip is out of date. Thus this section is optional if it is
+  # failing.
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pytest tests
+
+about:
+  home: https://github.com/fusion-energy/cad_to_dagmc
+  summary: 'Convert CAD geometry, Cadquery objects and vertices to DAGMC h5m files'
+  description: |
+    Convert CAD geometry (STP or Brep files), Cadquery assemblies and vertices
+    to DAGMC h5m files.
+  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
+  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
+  # See https://spdx.org/licenses/
+  license: MIT
+  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". 
+  # Optional
+  license_family: MIT
+  # It is required to include a license file in the package,
+  # (even if the license doesn't require it) using the license_file entry.
+  # Please also note that some projects have multiple license files which all need to be added using a valid yaml list.
+  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
+  license_file: LICENSE
+  # The doc_url and dev_url are optional.
+  doc_url: https://github.com/fusion-energy/cad_to_dagmc/blob/main/README.md
+  dev_url: https://github.com/fusion-energy/cad_to_dagmc
+
+extra:
+  recipe-maintainers:
+    # GitHub IDs for maintainers of the recipe.
+    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
+    - shimwell

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -1,10 +1,4 @@
-# Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
-# If your package is python based, we recommend using Grayskull to generate it instead:
-# https://github.com/conda-incubator/grayskull
 
-# Jinja variables help maintain the recipe as you'll update the version only here.
-# Using the name variable with the URL in line 16 is convenient
-# when copying and pasting from another recipe, but not really needed.
 {% set name = "cad_to_dagmc" %}
 {% set version = "0.3.1" %}
 
@@ -14,29 +8,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  # If getting the source from GitHub, remove the line above,
-  # uncomment the line below, and modify as needed. Use releases if available:
-  # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz
-  # and otherwise fall back to archive:
-  # url: https://github.com/simplejson/simplejson/archive/v{{ version }}.tar.gz
   sha256: 15c5cc7ec474cb705a5fdccd71c90cfe6204cd14bec5c0bd6cf14ef8a954732a
-  # sha256 is the preferred checksum -- you can get it for a file with:
-  #  `openssl sha256 <file name>`.
-  # You may need the openssl package, available on conda-forge:
-  #  `conda install openssl -c conda-forge``
 
 build:
-  # Uncomment the following line if the package is pure Python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#noarch-python for more details.
   # noarch: python
-  # If the installation is complex, or different between Unix and Windows, use separate bld.bat and build.sh files instead of this key.
-  # By default, the package will be built for the Python versions supported by conda-forge and for all major OSs.
-  # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
-  # More info about selectors can be found in the conda-build docs: 
-  # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors
-  script: {{ PYTHON }} -m pip install -vv .
+  script: python -m pip install --no-deps --ignore-installed .
   number: 0
+  skip: true  # [win]
 
 requirements:
   host:
@@ -44,26 +22,19 @@ requirements:
     - pip
   run:
     - python >=3.8,<=3.10
-    - cadquery
-    - occt
-    - moab
+    - cadquery >=2.2.0
+    - occt >=7.7.0
+    - moab * {{ mpi_prefix }}_tempest_*
     - numpy
     - trimesh
     - networkx
+    - gmsh
+    - python-gmsh
+
 
 test:
-  # Some packages might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - cad_to_dagmc
-  # For python packages, it is useful to run pip check. However, sometimes the
-  # metadata used by pip is out of date. Thus this section is optional if it is
-  # failing.
-  requires:
-    - pip
-    - pytest
-  commands:
-    - pytest tests
 
 about:
   home: https://github.com/fusion-energy/cad_to_dagmc
@@ -71,24 +42,12 @@ about:
   description: |
     Convert CAD geometry (STP or Brep files), Cadquery assemblies and vertices
     to DAGMC h5m files.
-  # Remember to specify the license variants for BSD, Apache, GPL, and LGPL.
-  # Use the SPDX identifier, e.g: GPL-2.0-only instead of GNU General Public License version 2.0
-  # See https://spdx.org/licenses/
   license: MIT
-  # The license_family, i.e. "BSD" if license is "BSD-3-Clause". 
-  # Optional
   license_family: MIT
-  # It is required to include a license file in the package,
-  # (even if the license doesn't require it) using the license_file entry.
-  # Please also note that some projects have multiple license files which all need to be added using a valid yaml list.
-  # See https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#license-file
   license_file: LICENSE
-  # The doc_url and dev_url are optional.
   doc_url: https://github.com/fusion-energy/cad_to_dagmc/blob/main/README.md
   dev_url: https://github.com/fusion-energy/cad_to_dagmc
 
 extra:
   recipe-maintainers:
-    # GitHub IDs for maintainers of the recipe.
-    # Always check with the people listed below if they are OK becoming maintainers of the recipe. (There will be spam!)
     - shimwell

--- a/recipes/cad_to_dagmc/yum_requirements.txt
+++ b/recipes/cad_to_dagmc/yum_requirements.txt
@@ -1,0 +1,4 @@
+mesa-libGLU-devel
+mesa-libGLU
+mesa-libgl
+libglu1-mesa


### PR DESCRIPTION
This PR is an attempt to add cad-to-dagmc package to conda forge. This package makes use of existing conda-forge packages (gmsh, cadquery) to make dagmc files (which is another conda forge package).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
