### PR TITLE
adds `r-common`

### DIFF
--- a/recipes/r-common/bld.bat
+++ b/recipes/r-common/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-common/build.sh
+++ b/recipes/r-common/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-common/meta.yaml
+++ b/recipes/r-common/meta.yaml
@@ -1,0 +1,73 @@
+{% set version = '1.0.5' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-common
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/common_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/common/common_{{ version }}.tar.gz
+  sha256: 8fc7025c15b5f26d0509e7c9f444030ea717318a0d7d913b8777fe7af3bab21b
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-this.path
+  run:
+    - r-base
+    - r-this.path
+
+test:
+  commands:
+    - $R -e "library('common')"           # [not win]
+    - "\"%R%\" -e \"library('common')\""  # [win]
+
+about:
+  home: https://common.r-sassy.org
+  license: CC0
+  summary: Contains functions for solving commonly encountered problems while programming in
+    R. This package is intended to provide a lightweight supplement to Base R, and will
+    be useful for almost any R user.
+  license_family: CC
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: common
+# Type: Package
+# Title: Solutions for Common Problems in Base R
+# Version: 1.0.5
+# Authors@R: c( person(given = "David", family = "Bosak", role = c("aut", "cre"), email = "dbosak01@gmail.com"), person(given = "Andrew", family = "Simmons", role = c("aut"), email = "akwsimmo@gmail.com"), person(given = "Duong", family = "Tran", role = c("ctb"), email = "trand000@aol.com") )
+# Maintainer: David Bosak <dbosak01@gmail.com>
+# Description: Contains functions for solving commonly encountered problems while programming in R. This package is intended to provide a lightweight supplement to Base R, and will be useful for almost any R user.
+# License: CC0
+# Encoding: UTF-8
+# URL: https://common.r-sassy.org
+# BugReports: https://github.com/dbosak01/common/issues
+# Depends: R (>= 3.6.0)
+# Suggests: knitr, rmarkdown, testthat (>= 3.0.0), glue
+# Enhances: base
+# Imports: this.path, utils
+# Config/testthat/edition: 3
+# RoxygenNote: 7.2.0
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2022-09-27 23:36:25 UTC; dbosa
+# Author: David Bosak [aut, cre], Andrew Simmons [aut], Duong Tran [ctb]
+# Repository: CRAN
+# Date/Publication: 2022-09-29 08:10:12 UTC

--- a/recipes/r-common/meta.yaml
+++ b/recipes/r-common/meta.yaml
@@ -38,7 +38,8 @@ test:
 
 about:
   home: https://common.r-sassy.org
-  license: CC0
+  dev_url: https://github.com/dbosak01/common/
+  license: CC0-1.0
   summary: Contains functions for solving commonly encountered problems while programming in
     R. This package is intended to provide a lightweight supplement to Base R, and will
     be useful for almost any R user.


### PR DESCRIPTION
Adds [CRAN package `common`](https://cran.r-project.org/package=common) as `r-common`. Recipe generated with `conda_r_skeleton_helper`, with license adjusted to SPDX and development URL added.

Need as [new dependency of `r-logr`](https://github.com/conda-forge/r-logr-feedstock/pull/8).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
