### PR TITLE
Adds `r-clarify`

### DIFF
--- a/recipes/r-clarify/bld.bat
+++ b/recipes/r-clarify/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-clarify/build.sh
+++ b/recipes/r-clarify/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-clarify/meta.yaml
+++ b/recipes/r-clarify/meta.yaml
@@ -49,8 +49,9 @@ test:
     - "\"%R%\" -e \"library('clarify')\""  # [win]
 
 about:
-  home: https://github.com/iqss/clarify, https://iqss.github.io/clarify/
-  license: GPL-3
+  home: https://iqss.github.io/clarify/
+  dev_url: https://github.com/iqss/clarify
+  license: GPL-3.0-or-later
   summary: Performs simulation-based inference as an alternative to the delta method for obtaining
     valid confidence intervals and p-values for regression post-estimation quantities,
     such as average marginal effects and predictions at representative values. This
@@ -61,7 +62,7 @@ about:
     'Zelig'; see the vignette "Translating Zelig to clarify" for replicating this functionality.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-clarify/meta.yaml
+++ b/recipes/r-clarify/meta.yaml
@@ -1,0 +1,91 @@
+{% set version = '0.1.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-clarify
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/clarify_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/clarify/clarify_{{ version }}.tar.gz
+  sha256: a5f481d795bd109bac0a7576ffb668aeb439a8da804e5b125cd696bdb8baba26
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-chk >=0.8.1
+    - r-ggplot2
+    - r-insight >=0.19.0
+    - r-marginaleffects >=0.9.0
+    - r-mvnfast
+    - r-pbapply
+    - r-rlang
+  run:
+    - r-base
+    - r-chk >=0.8.1
+    - r-ggplot2
+    - r-insight >=0.19.0
+    - r-marginaleffects >=0.9.0
+    - r-mvnfast
+    - r-pbapply
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('clarify')"           # [not win]
+    - "\"%R%\" -e \"library('clarify')\""  # [win]
+
+about:
+  home: https://github.com/iqss/clarify, https://iqss.github.io/clarify/
+  license: GPL-3
+  summary: Performs simulation-based inference as an alternative to the delta method for obtaining
+    valid confidence intervals and p-values for regression post-estimation quantities,
+    such as average marginal effects and predictions at representative values. This
+    framework for simulation-based inference is especially useful when the resulting
+    quantity is not normally distributed and the delta method approximation fails. The
+    methodology is described in King, Tomz, and Wittenberg (2000) <doi:10.2307/2669316>.
+    'clarify' is meant to replace some of the functionality of the archived package
+    'Zelig'; see the vignette "Translating Zelig to clarify" for replicating this functionality.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: clarify
+# Type: Package
+# Title: Simulation-Based Inference for Regression Models
+# Version: 0.1.3
+# Authors@R: c( person("Noah", "Greifer", role = c("aut", "cre"), email = "ngreifer@iq.harvard.edu", comment = c(ORCID="0000-0003-3067-7154")), person("Steven", "Worthington", role = c("aut"), email = "sworthington@iq.harvard.edu", comment = c(ORCID="0000-0001-9550-5797")), person("Stefano", "Iacus", role = c("aut"), email = "siacus@iq.harvard.edu", comment = c(ORCID="0000-0002-4884-0047")), person("Gary", "King", role = c("aut"), email = "king@harvard.edu", comment = c(ORCID="0000-0002-5327-7631")) )
+# Description: Performs simulation-based inference as an alternative to the delta method for obtaining valid confidence intervals and p-values for regression post-estimation quantities, such as average marginal effects and predictions at representative values. This framework for simulation-based inference is especially useful when the resulting quantity is not normally distributed and the delta method approximation fails. The methodology is described in King, Tomz, and Wittenberg (2000) <doi:10.2307/2669316>. 'clarify' is meant to replace some of the functionality of the archived package 'Zelig'; see the vignette "Translating Zelig to clarify" for replicating this functionality.
+# License: GPL (>= 3)
+# Encoding: UTF-8
+# Depends: R (>= 3.5.0)
+# Imports: ggplot2, pbapply, chk (>= 0.8.1), rlang, insight (>= 0.19.0), marginaleffects (>= 0.9.0), mvnfast
+# Suggests: testthat (>= 3.0.0), MatchIt (>= 4.0.0), parallel, knitr, rmarkdown, Amelia, MASS, betareg, survey, estimatr, fixest, logistf, geepack, rms, robustbase, robust, AER, ivreg, mgcv, sandwich
+# Config/testthat/edition: 3
+# RoxygenNote: 7.2.3
+# URL: https://github.com/iqss/clarify, https://iqss.github.io/clarify/
+# BugReports: https://github.com/iqss/clarify/issues
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2023-05-03 20:30:29 UTC; NoahGreifer
+# Author: Noah Greifer [aut, cre] (<https://orcid.org/0000-0003-3067-7154>), Steven Worthington [aut] (<https://orcid.org/0000-0001-9550-5797>), Stefano Iacus [aut] (<https://orcid.org/0000-0002-4884-0047>), Gary King [aut] (<https://orcid.org/0000-0002-5327-7631>)
+# Maintainer: Noah Greifer <ngreifer@iq.harvard.edu>
+# Repository: CRAN
+# Date/Publication: 2023-05-04 06:50:06 UTC


### PR DESCRIPTION
Adds [CRAN package `clarify`](https://cran.r-project.org/package=clarify) as `r-clarify`. Recipe generated with `conda_r_skeleton_helper`, with URLs split and adjusted for SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
