### PR TITLE
Add grayskull-generated jax-dataclasses recipe 

### DIFF
--- a/recipes/jax-dataclasses/meta.yaml
+++ b/recipes/jax-dataclasses/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "jax-dataclasses" %}
+{% set version = "1.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/jax_dataclasses-{{ version }}.tar.gz
+  sha256: b2ae33f69b2058fc61be1eca618fbc27516e009698241a140de4da20b9d505ef
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+    - jax
+    - jaxlib
+    - typing-extensions
+
+test:
+  imports:
+    - jax_dataclasses
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: http://github.com/brentyi/jax_dataclasses
+  summary: Dataclasses + JAX
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
[Grayskull](https://github.com/conda/grayskull)-generated recipe for the pure python package [jax-dataclasses](https://github.com/brentyi/jax_dataclasses). PyPi package: https://pypi.org/project/jax-dataclasses/ .

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
