### PR TITLE
Add proxy-tools pure python package

### DIFF
--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -21,10 +21,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:

--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "proxy-tools" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/proxy_tools-{{ version }}.tar.gz
+    sha256: ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010
+    folder: proxy_tools
+  - url: https://github.com/jtushman/proxy_tools/blob/db43f1e35d4f90a65c5a4d56d9e9af88212ec6e6/LICENSE.txt
+    sha256: ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010
+    folder: proxy_tools_license
+
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install --no-deps ./proxy_tools -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - proxy_tools
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: http://github.com/jtushman/proxy_tools
+  summary: Proxy Implementation
+  license: BSD-2-Clause
+  license_file: proxy_tools_license/LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -8,16 +8,15 @@ package:
 source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/proxy_tools-{{ version }}.tar.gz
     sha256: ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010
-    folder: proxy_tools
+
   # The license is not shipped with the PyPI source archive  
-  - url: https://github.com/jtushman/proxy_tools/blob/db43f1e35d4f90a65c5a4d56d9e9af88212ec6e6/LICENSE.txt
-    sha256: 30ca00db4c66cb8bbf70d6dc4d9b07fe7743f8a31d526f8cf784c28082849b16
-    folder: proxy_tools_license
+  - url: https://raw.githubusercontent.com/jtushman/proxy_tools/db43f1e35d4f90a65c5a4d56d9e9af88212ec6e6/LICENSE.txt
+    sha256: a428fb8a2e762af3eb0a6edbbb88e9b42ccfee80fd9b423958bcacf9b9abbfe4
 
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install --no-deps ./proxy_tools -vv
+  script: {{ PYTHON }} -m pip install --no-deps . -vv
   number: 0
 
 requirements:

--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -11,7 +11,7 @@ source:
     folder: proxy_tools
   # The license is not shipped with the PyPI source archive  
   - url: https://github.com/jtushman/proxy_tools/blob/db43f1e35d4f90a65c5a4d56d9e9af88212ec6e6/LICENSE.txt
-    sha256: c0a00dbeeb96785bd86f0b7e3b2915733c932b27c358976d15dd26f0dcc3941c
+    sha256: 30ca00db4c66cb8bbf70d6dc4d9b07fe7743f8a31d526f8cf784c28082849b16
     folder: proxy_tools_license
 
 

--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -11,7 +11,7 @@ source:
     folder: proxy_tools
   # The license is not shipped with the PyPI source archive  
   - url: https://github.com/jtushman/proxy_tools/blob/db43f1e35d4f90a65c5a4d56d9e9af88212ec6e6/LICENSE.txt
-    sha256: ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010
+    sha256: c0a00dbeeb96785bd86f0b7e3b2915733c932b27c358976d15dd26f0dcc3941c
     folder: proxy_tools_license
 
 

--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -38,7 +38,7 @@ about:
   home: http://github.com/jtushman/proxy_tools
   summary: Proxy Implementation
   license: BSD-2-Clause
-  license_file: proxy_tools_license/LICENSE.txt
+  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:

--- a/recipes/proxy-tools/meta.yaml
+++ b/recipes/proxy-tools/meta.yaml
@@ -9,6 +9,7 @@ source:
   - url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/proxy_tools-{{ version }}.tar.gz
     sha256: ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010
     folder: proxy_tools
+  # The license is not shipped with the PyPI source archive  
   - url: https://github.com/jtushman/proxy_tools/blob/db43f1e35d4f90a65c5a4d56d9e9af88212ec6e6/LICENSE.txt
     sha256: ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010
     folder: proxy_tools_license


### PR DESCRIPTION
Add pure-python package proxy-tools (https://pypi.org/project/proxy_tools/, https://github.com/jtushman/proxy_tools). The package did not have a release for a long time, but it is packaged as it is a dependency of the package https://github.com/r0x0r/pywebview that I would like to package.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
