### PR TITLE
Add recipe for pyobjc-framework-security

### DIFF
--- a/recipes/pyobjc-framework-security/meta.yaml
+++ b/recipes/pyobjc-framework-security/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pyobjc-framework-security" %}
+{% set version = "9.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyobjc-framework-Security-{{ version }}.tar.gz
+  sha256: 8d4f7a22db2fe666c7bff4a5825b49d2345e9a8d96ea085f1a614ad9a559b4e5
+
+build:
+  skip: true  # [not osx]
+  script: {{ PYTHON }} -m pip install --no-deps . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.7
+    - setuptools
+    - wheel
+    - pip
+  run:
+    - python >=3.7
+    - pyobjc-core >=9.2
+    - pyobjc-framework-cocoa >=9.2
+
+test:
+  imports:
+    - pyobjc_framework_security
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/ronaldoussoren/pyobjc
+  summary: Wrappers for the framework Security on macOS
+  license: MIT
+  license_file: License.txt
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/pyobjc-framework-security/meta.yaml
+++ b/recipes/pyobjc-framework-security/meta.yaml
@@ -45,6 +45,8 @@ test:
 
 about:
   home: https://github.com/ronaldoussoren/pyobjc
+  dev_url: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-Security
+  doc_url: https://pyobjc.readthedocs.io/en/latest/
   summary: Wrappers for the framework Security on macOS
   license: MIT
   license_file: License.txt

--- a/recipes/pyobjc-framework-security/meta.yaml
+++ b/recipes/pyobjc-framework-security/meta.yaml
@@ -37,7 +37,7 @@ requirements:
 
 test:
   imports:
-    - pyobjc_framework_security
+    - Security
   commands:
     - pip check
   requires:

--- a/recipes/pyobjc-framework-security/meta.yaml
+++ b/recipes/pyobjc-framework-security/meta.yaml
@@ -16,12 +16,12 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - setuptools
     - wheel
     - pip
   run:
-    - python >=3.7
+    - python
     - pyobjc-core >=9.2
     - pyobjc-framework-cocoa >=9.2
 

--- a/recipes/pyobjc-framework-security/meta.yaml
+++ b/recipes/pyobjc-framework-security/meta.yaml
@@ -10,20 +10,30 @@ source:
   sha256: 8d4f7a22db2fe666c7bff4a5825b49d2345e9a8d96ea085f1a614ad9a559b4e5
 
 build:
-  skip: true  # [not osx]
-  script: {{ PYTHON }} -m pip install --no-deps . -vv
+  script:
+    # force pyobjc to use conda-forge's chosen SDK
+    - export CFLAGS="${CFLAGS} -isysroot ${SDKROOT:-$CONDA_BUILD_SYSROOT}"
+    # force ignoring invalid compiler flag (-Wl,-export-dynamic)
+    - export CFLAGS="${CFLAGS} -Wno-unused-command-line-argument"  # [py == 37 or py == 38]
+    - {{ PYTHON }} -m pip install --no-deps . -vv
+  skip: true  # [not osx or py2k or python_impl == 'pypy' or (arm64 and py < 39)]
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
   host:
     - python
-    - setuptools
-    - wheel
     - pip
+    - setuptools
+    - libffi
   run:
     - python
-    - pyobjc-core >=9.2
-    - pyobjc-framework-cocoa >=9.2
+    - pyobjc-core {{ version }}
+    - pyobjc-framework-cocoa {{ version }}
+    - libffi
 
 test:
   imports:


### PR DESCRIPTION
This PR adds a recipe for the pyobjc-framework-security (PyPI package: https://pypi.org/project/pyobjc-framework-Security/, source code: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-Security).

As this package is part of a single repo that is used to generate several python package, for this reason I followed the structure of other packages already present on conda-forge like:
* https://github.com/conda-forge/pyobjc-framework-cocoa-feedstock/blob/main/recipe/meta.yaml
* https://github.com/conda-forge/pyobjc-framework-fsevents-feedstock/blob/main/recipe/meta.yaml


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
