### PR TITLE
Add AutoROM package

### DIFF
--- a/recipes/autorom-accept-rom-license/LICENSE.txt
+++ b/recipes/autorom-accept-rom-license/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Farama Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/autorom-accept-rom-license/meta.yaml
+++ b/recipes/autorom-accept-rom-license/meta.yaml
@@ -1,0 +1,37 @@
+{% set name = "AutoROM-accept-rom-license" %}
+{% set version = "0.6.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - autorom
+  run:
+    - python >=3.6
+    - autorom
+
+test:
+  imports:
+    - AutoROM
+  commands:
+    - python -c "import ale_py.roms as roms; print(roms.__all__)"  # print ROMs the ALE can find
+    - python -c "from ale_py.roms import Pong; import sys; sys.exit(not Pong.exists())"  # test that it can be imported
+  requires:
+    - ale-py
+
+about:
+  home: https://github.com/Farama-Foundation/AutoROM
+  summary: Automated installation of Atari ROMs for Gymnasium/ALE-Py
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - ChristofKaufmann

--- a/recipes/autorom-accept-rom-license/post-link.bat
+++ b/recipes/autorom-accept-rom-license/post-link.bat
@@ -1,0 +1,7 @@
+set do_download=import pathlib;^
+import AutoROM;^
+download_dir = pathlib.Path(AutoROM.__file__).parent / 'roms';^
+download_dir.mkdir(exist_ok=True, parents=True);^
+AutoROM.main(True, None, download_dir, False)
+
+python -c "%do_download%"

--- a/recipes/autorom-accept-rom-license/post-link.sh
+++ b/recipes/autorom-accept-rom-license/post-link.sh
@@ -1,0 +1,8 @@
+python << EndOfLine
+import pathlib
+import AutoROM
+
+download_dir = pathlib.Path(AutoROM.__file__).parent / "roms"
+download_dir.mkdir(exist_ok=True, parents=True)
+AutoROM.main(True, None, download_dir, False)
+EndOfLine

--- a/recipes/autorom/meta.yaml
+++ b/recipes/autorom/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "AutoROM" %}
+{% set version = "0.6.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6eff1f1b96a9d519577437f71d96a8d3b896238eca3433a8e69c5c92f6de3231
+
+build:
+  noarch: python
+  entry_points:
+    - AutoROM=AutoROM:cli
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - farama-notifications
+    - setuptools
+    - wheel
+    - pip
+  run:
+    - python >=3.6
+    - click
+    - requests
+
+test:
+  imports:
+    - {{ name }}
+  commands:
+    - pip check
+    - AutoROM --help
+    - mkdir -p roms && pushd roms
+    - AutoROM --accept-license --install-dir .
+    - python -c "import ale_py.roms as roms; print(roms.__all__)"
+    # workaround for windows until https://github.com/conda-forge/ale-py-feedstock/issues/10 is resolved
+    - ale-import-roms ./  # [not win]
+    - python -c "import sys; sys.argv.append('.'); from ale_py.scripts.import_roms import main; main()"  # [win]
+    - python -c "from ale_py.roms import Pong; import sys; sys.exit(not Pong.exists())"
+    - popd && rm -r roms
+  requires:
+    - pip
+    - ale-py
+
+about:
+  home: https://github.com/Farama-Foundation/AutoROM
+  summary: Automated installation of Atari ROMs for Gymnasium/ALE-Py
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - ChristofKaufmann


### PR DESCRIPTION
<!--
`@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
  → partially, see my question below.
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

~@conda-forge/help-python: One question I could not figure out is how the license field should be handled for pure meta packages, that do not contain source code. So I like to add `AutoROM` to conda-forge. In addition I made a meta package `AutoROM-accept-rom-license` that has `AutoROM` as dependency and a post-link script to install the Atari ROMs, as if the user executed `AutoROM --accept-rom-license` afterwards. This mimics the behaviour of the corresponding [pip package](https://pypi.org/project/AutoROM/#description) with the extra: `autorom[accept-rom-license]`. I did not include any source code license information in the meta package `AutoROM-accept-rom-license`. In the real package `AutoROM` I added the information as usual.~

Sorry for the noise. I realized that the post-link script is also source code and needs a license. I copied the license from the source code to the recipe directory and added it in `meta.yaml`.