### PR TITLE
Add pykerr 0.1.0

### DIFF
--- a/recipes/pykerr/meta.yaml
+++ b/recipes/pykerr/meta.yaml
@@ -33,9 +33,9 @@ test:
     - pip
 
 about:
-  home: https://github.com/cdcapano/pykerr.git
+  home: https://github.com/cdcapano/pykerr
   summary: QNM frequencies and spheroidal harmonics of Kerr black holes.
-  license: GPL-3.0
+  license: GPL-3.0-or-later
   license_file: LICENSE
 
 extra:

--- a/recipes/pykerr/meta.yaml
+++ b/recipes/pykerr/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "pykerr" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pykerr-{{ version }}.tar.gz
+  sha256: b1c1bfe3f22dd74cb2e08c80ed474aba56b29e3f27b7bdc71db8f7100fd8da3e
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+    - numpy
+    - scipy
+    - h5py
+
+test:
+  imports:
+    - pykerr
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/cdcapano/pykerr.git
+  summary: QNM frequencies and spheroidal harmonics of Kerr black holes.
+  license: GPL-3.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - cdcapano


### PR DESCRIPTION
@conda-forge-admin, please ping @conda-forge/help-python

This adds `pykerr` which is a package used for computing quasi-normal modes and spheroidal harmonics of perturbed black holes. This is used in the gravitational-wave data analysis community.