### PR TITLE
add selenium-manager 4.11.2

### DIFF
--- a/recipes/selenium-manager/bld.bat
+++ b/recipes/selenium-manager/bld.bat
@@ -1,0 +1,23 @@
+:: NOTE: mostly derived from
+:: https://github.com/conda-forge/py-spy-feedstock/blob/master/recipe/bld.bat
+
+cd rust
+
+:: build
+cargo install --locked --root "%PREFIX%" --path . || goto :error
+
+:: move to scripts
+md %SCRIPTS% || echo "%SCRIPTS% already exists"
+move %PREFIX%\bin\selenium-manager.exe %SCRIPTS%
+
+cargo-bundle-licenses --format yaml --output %SRC_DIR%\THIRDPARTY.yml
+
+:: remove extra build files
+del /F /Q "%PREFIX%\.crates2.json"
+del /F /Q "%PREFIX%\.crates.toml"
+
+goto :EOF
+
+:error
+echo Failed with error #%errorlevel%.
+exit /b %errorlevel%

--- a/recipes/selenium-manager/build.sh
+++ b/recipes/selenium-manager/build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# NOTE: mostly derived from
+# https://github.com/conda-forge/py-spy-feedstock/blob/master/recipe/build.sh
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+export RUST_BACKTRACE=1
+
+if [ $(uname) = Darwin ] ; then
+  export RUSTFLAGS="-C link-args=-Wl,-rpath,${PREFIX}/lib"
+else
+  export RUSTFLAGS="-C link-arg=-Wl,-rpath-link,${PREFIX}/lib -L${PREFIX}/lib"
+fi
+
+cd rust
+# build statically linked binary with Rust
+cargo install --locked --root "$PREFIX" --path .
+
+# install cargo-license and dump licenses
+cargo-bundle-licenses --format yaml --output $SRC_DIR/THIRDPARTY.yml
+
+# remove extra build files
+rm -f "${PREFIX}/.crates2.json"
+rm -f "${PREFIX}/.crates.toml"

--- a/recipes/selenium-manager/meta.yaml
+++ b/recipes/selenium-manager/meta.yaml
@@ -13,6 +13,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
 

--- a/recipes/selenium-manager/meta.yaml
+++ b/recipes/selenium-manager/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "4.11.0" %}
+
+package:
+  name: selenium-manager
+  version: {{ version }}
+
+source:
+  url: https://github.com/SeleniumHQ/selenium/archive/refs/tags/selenium-{{ version }}.tar.gz
+  sha256: f7d75ead14b4bb5da2df47b68394e90be5cb310e8c4c39fb81cfce68afc3acbe
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+test:
+  commands:
+    - selenium-manager --version
+    - selenium-manager --help
+
+about:
+  home: https://github.com/SeleniumHQ/selenium
+  license: Apache-2.0
+  license_file:
+    - THIRDPARTY.yml
+    - LICENSE
+    - NOTICE
+  summary: |-
+    Selenium Manager is a standalone tool that automatically manages the browser
+    infrastructure required by Selenium (i.e., browsers and drivers).
+
+extra:
+  recipe-maintainers:
+    - conda-forge/selenium
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


References:

- derived from https://github.com/conda-forge/selenium-feedstock/issues/63

Notes:

- the versioning regime is unclear, as this reports `1.0.0-M4`, and selenium hasn't _yet_ started tagging point patch releases for rust...
  -  as (at present) we're only worried about the python bindings, we could use a similar approach as there to pull the matching version