### PR TITLE
Adds r-bibliometrix and dependencies

### DIFF
--- a/recipes/r-bibliometrix/bld.bat
+++ b/recipes/r-bibliometrix/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-bibliometrix/build.sh
+++ b/recipes/r-bibliometrix/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-bibliometrix/meta.yaml
+++ b/recipes/r-bibliometrix/meta.yaml
@@ -1,0 +1,120 @@
+{% set version = '4.1.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-bibliometrix
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/bibliometrix_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/bibliometrix/bibliometrix_{{ version }}.tar.gz
+  sha256: fe08ecf0826906ebe4ff1a96c3435c4a171016ed95cdd06a1efe0275c536defc
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dt
+    - r-factominer
+    - r-matrix
+    - r-snowballc
+    - r-bibliometrixdata
+    - r-dimensionsr
+    - r-dplyr
+    - r-forcats
+    - r-ggplot2
+    - r-ggrepel
+    - r-igraph
+    - r-openxlsx
+    - r-plotly
+    - r-pubmedr
+    - r-readr
+    - r-readxl
+    - r-rscopus
+    - r-shiny
+    - r-stringdist
+    - r-stringi
+    - r-tidyr
+    - r-tidytext
+  run:
+    - r-base
+    - r-dt
+    - r-factominer
+    - r-matrix
+    - r-snowballc
+    - r-bibliometrixdata
+    - r-dimensionsr
+    - r-dplyr
+    - r-forcats
+    - r-ggplot2
+    - r-ggrepel
+    - r-igraph
+    - r-openxlsx
+    - r-plotly
+    - r-pubmedr
+    - r-readr
+    - r-readxl
+    - r-rscopus
+    - r-shiny
+    - r-stringdist
+    - r-stringi
+    - r-tidyr
+    - r-tidytext
+
+test:
+  commands:
+    - $R -e "library('bibliometrix')"           # [not win]
+    - "\"%R%\" -e \"library('bibliometrix')\""  # [win]
+
+about:
+  home: https://www.bibliometrix.org, https://github.com/massimoaria/bibliometrix, https://www.k-synth.com
+  license: GPL-3
+  summary: Tool for quantitative research in scientometrics and bibliometrics. It provides various
+    routines for importing bibliographic data from 'SCOPUS', 'Clarivate Analytics Web
+    of Science' (<https://www.webofknowledge.com/>), 'Digital Science Dimensions' (<https://www.dimensions.ai/>),
+    'Cochrane Library' (<https://www.cochranelibrary.com/>),  'Lens' (<https://lens.org>),
+    and 'PubMed' (<https://pubmed.ncbi.nlm.nih.gov/>) databases, performing bibliometric
+    analysis and building networks for co-citation, coupling, scientific collaboration
+    and co-word analysis.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: bibliometrix
+# Type: Package
+# Title: Comprehensive Science Mapping Analysis
+# Version: 4.1.3
+# Authors@R: c( person(given = "Massimo", family = "Aria", role = c("cre", "aut", "cph"), email = "aria@unina.it", comment = c(ORCID = "0000-0002-8517-9411")), person(given = "Corrado", family = "Cuccurullo", role = "aut", email = "cuccurullocorrado@gmail.com", comment = c(ORCID = "0000-0002-7401-8575")))
+# Description: Tool for quantitative research in scientometrics and bibliometrics. It provides various routines for importing bibliographic data from 'SCOPUS', 'Clarivate Analytics Web of Science' (<https://www.webofknowledge.com/>), 'Digital Science Dimensions' (<https://www.dimensions.ai/>), 'Cochrane Library' (<https://www.cochranelibrary.com/>),  'Lens' (<https://lens.org>), and 'PubMed' (<https://pubmed.ncbi.nlm.nih.gov/>) databases, performing bibliometric analysis and building networks for co-citation, coupling, scientific collaboration and co-word analysis.
+# License: GPL-3
+# URL: https://www.bibliometrix.org, https://github.com/massimoaria/bibliometrix, https://www.k-synth.com
+# BugReports: https://github.com/massimoaria/bibliometrix/issues
+# LazyData: true
+# Encoding: UTF-8
+# Depends: R (>= 3.3.0)
+# Imports: stats, grDevices, bibliometrixData, dimensionsR, dplyr, DT, FactoMineR, forcats, ggplot2, ggrepel, igraph, Matrix, plotly, openxlsx, pubmedR, readr, readxl, rscopus, shiny, SnowballC, stringdist, stringi, tidyr, tidytext
+# Suggests: knitr, rmarkdown, openalexR, testthat (>= 3.0.0), shinycssloaders, visNetwork, wordcloud2
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Config/testthat/edition: 3
+# Packaged: 2023-06-15 19:34:27 UTC; massimoaria
+# Author: Massimo Aria [cre, aut, cph] (<https://orcid.org/0000-0002-8517-9411>), Corrado Cuccurullo [aut] (<https://orcid.org/0000-0002-7401-8575>)
+# Maintainer: Massimo Aria <aria@unina.it>
+# Repository: CRAN
+# Date/Publication: 2023-06-15 20:10:02 UTC

--- a/recipes/r-bibliometrix/meta.yaml
+++ b/recipes/r-bibliometrix/meta.yaml
@@ -79,8 +79,9 @@ test:
     - "\"%R%\" -e \"library('bibliometrix')\""  # [win]
 
 about:
-  home: https://www.bibliometrix.org, https://github.com/massimoaria/bibliometrix, https://www.k-synth.com
-  license: GPL-3
+  home: https://www.bibliometrix.org
+  dev_url: https://github.com/massimoaria/bibliometrix
+  license: GPL-3.0-only
   summary: Tool for quantitative research in scientometrics and bibliometrics. It provides various
     routines for importing bibliographic data from 'SCOPUS', 'Clarivate Analytics Web
     of Science' (<https://www.webofknowledge.com/>), 'Digital Science Dimensions' (<https://www.dimensions.ai/>),

--- a/recipes/r-bibliometrixdata/bld.bat
+++ b/recipes/r-bibliometrixdata/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-bibliometrixdata/build.sh
+++ b/recipes/r-bibliometrixdata/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-bibliometrixdata/meta.yaml
+++ b/recipes/r-bibliometrixdata/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = '0.3.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-bibliometrixdata
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/bibliometrixData_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/bibliometrixData/bibliometrixData_{{ version }}.tar.gz
+  sha256: 74a6cda7ff51ed01c85ae5df7d75f3f982f1d17d4dc2fde94bbc241ad32b6f36
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('bibliometrixData')"           # [not win]
+    - "\"%R%\" -e \"library('bibliometrixData')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=bibliometrixData
+  license: MIT
+  summary: It contains some example datasets used in 'bibliometrix'. The data are bibliographic
+    datasets exported from the 'SCOPUS' (<https://scopus.com>) and 'Clarivate Analytics
+    Web of Science' (<https://www.webofscience.com/>) databases. They can be used to
+    test the different features of the package 'bibliometrix' (<https://bibliometrix.org>).
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: bibliometrixData
+# Title: Bibliometrix Example Datasets
+# Version: 0.3.0
+# Authors@R: person(given = "Massimo", family = "Aria", role = c("aut", "cre"), email = "massimo.aria@gmail.com", comment = c(ORCID = "0000-0002-8517-9411"))
+# Description: It contains some example datasets used in 'bibliometrix'. The data are bibliographic datasets exported from the 'SCOPUS' (<https://scopus.com>) and 'Clarivate Analytics Web of Science' (<https://www.webofscience.com/>) databases. They can be used to test the different features of the package 'bibliometrix' (<https://bibliometrix.org>).
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# Depends: R (>= 3.3.0)
+# Suggests: bibliometrix
+# LazyData: false
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2022-04-20 10:23:41 UTC; massimoaria
+# Author: Massimo Aria [aut, cre] (<https://orcid.org/0000-0002-8517-9411>)
+# Maintainer: Massimo Aria <massimo.aria@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-04-20 12:42:39 UTC

--- a/recipes/r-dimensionsr/bld.bat
+++ b/recipes/r-dimensionsr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dimensionsr/build.sh
+++ b/recipes/r-dimensionsr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dimensionsr/meta.yaml
+++ b/recipes/r-dimensionsr/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = '0.0.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-dimensionsr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/dimensionsR_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/dimensionsR/dimensionsR_{{ version }}.tar.gz
+  sha256: 8e28a6b0c76cd9bc26851e158b582540971b01c8a86cb606ace45f85ad2f2cae
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-httr
+    - r-jsonlite
+  run:
+    - r-base
+    - r-httr
+    - r-jsonlite
+
+test:
+  commands:
+    - $R -e "library('dimensionsR')"           # [not win]
+    - "\"%R%\" -e \"library('dimensionsR')\""  # [win]
+
+about:
+  home: https://github.com/massimoaria/dimensionsR
+  license: GPL-3
+  summary: A set of tools to extract bibliographic content from 'Digital Science Dimensions'
+    using 'DSL' API <https://www.dimensions.ai/dimensions-apis/>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: dimensionsR
+# Title: Gathering Bibliographic Records from 'Digital Science Dimensions' Using 'DSL' API
+# Version: 0.0.3
+# Authors@R: person(given = "Massimo", family = "Aria", role = c("aut", "cre"), email = "massimo.aria@gmail.com", comment = c(ORCID = "0000-0002-8517-9411"))
+# Description: A set of tools to extract bibliographic content from 'Digital Science Dimensions' using 'DSL' API <https://www.dimensions.ai/dimensions-apis/>.
+# License: GPL-3
+# URL: https://github.com/massimoaria/dimensionsR
+# BugReports: https://github.com/massimoaria/dimensionsR/issues
+# Encoding: UTF-8
+# Imports: httr, jsonlite
+# Suggests: bibliometrix, knitr, rmarkdown
+# RoxygenNote: 7.1.1
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2022-02-07 13:31:09 UTC; massimoaria
+# Author: Massimo Aria [aut, cre] (<https://orcid.org/0000-0002-8517-9411>)
+# Maintainer: Massimo Aria <massimo.aria@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-02-07 13:50:02 UTC

--- a/recipes/r-dimensionsr/meta.yaml
+++ b/recipes/r-dimensionsr/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/massimoaria/dimensionsR
-  license: GPL-3
+  license: GPL-3.0-only
   summary: A set of tools to extract bibliographic content from 'Digital Science Dimensions'
     using 'DSL' API <https://www.dimensions.ai/dimensions-apis/>.
   license_family: GPL3

--- a/recipes/r-pubmedr/bld.bat
+++ b/recipes/r-pubmedr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-pubmedr/build.sh
+++ b/recipes/r-pubmedr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-pubmedr/meta.yaml
+++ b/recipes/r-pubmedr/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/massimoaria/pubmedR
-  license: GPL-3
+  license: GPL-3.0-only
   summary: A set of tools to extract bibliographic content from 'PubMed' database using 'NCBI'
     REST API <https://www.ncbi.nlm.nih.gov/home/develop/api/>.
   license_family: GPL3

--- a/recipes/r-pubmedr/meta.yaml
+++ b/recipes/r-pubmedr/meta.yaml
@@ -1,0 +1,73 @@
+{% set version = '0.0.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-pubmedr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/pubmedR_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/pubmedR/pubmedR_{{ version }}.tar.gz
+  sha256: 8d751e5e88480710a3f2687edb9cfdb66646e3c8a0fffcdfded92b1c49ca6b94
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-xml
+    - r-rentrez
+  run:
+    - r-base
+    - r-xml
+    - r-rentrez
+
+test:
+  commands:
+    - $R -e "library('pubmedR')"           # [not win]
+    - "\"%R%\" -e \"library('pubmedR')\""  # [win]
+
+about:
+  home: https://github.com/massimoaria/pubmedR
+  license: GPL-3
+  summary: A set of tools to extract bibliographic content from 'PubMed' database using 'NCBI'
+    REST API <https://www.ncbi.nlm.nih.gov/home/develop/api/>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: pubmedR
+# Title: Gathering Metadata About Publications, Grants, Clinical Trials from 'PubMed' Database
+# Version: 0.0.3
+# Authors@R: person(given = "Massimo", family = "Aria", role = c("aut", "cre"), email = "massimo.aria@gmail.com", comment = c(ORCID = "0000-0002-8517-9411"))
+# Description: A set of tools to extract bibliographic content from 'PubMed' database using 'NCBI' REST API <https://www.ncbi.nlm.nih.gov/home/develop/api/>.
+# License: GPL-3
+# URL: https://github.com/massimoaria/pubmedR
+# BugReports: https://github.com/massimoaria/pubmedR/issues
+# Encoding: UTF-8
+# LazyData: true
+# Imports: rentrez, XML
+# Suggests: bibliometrix, knitr, rmarkdown
+# RoxygenNote: 7.1.0
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2020-07-09 10:40:28 UTC; massimoaria
+# Author: Massimo Aria [aut, cre] (<https://orcid.org/0000-0002-8517-9411>)
+# Maintainer: Massimo Aria <massimo.aria@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2020-07-09 11:00:02 UTC

--- a/recipes/r-rscopus/bld.bat
+++ b/recipes/r-rscopus/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rscopus/build.sh
+++ b/recipes/r-rscopus/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rscopus/meta.yaml
+++ b/recipes/r-rscopus/meta.yaml
@@ -1,0 +1,84 @@
+{% set version = '0.6.6' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rscopus
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rscopus_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rscopus/rscopus_{{ version }}.tar.gz
+  sha256: fcb2a733091f75b4b926cd60e807373422545cb814f8fd235a260d21c1ce864e
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dplyr
+    - r-glue
+    - r-httr
+    - r-jsonlite
+    - r-plyr
+    - r-tidyr
+  run:
+    - r-base
+    - r-dplyr
+    - r-glue
+    - r-httr
+    - r-jsonlite
+    - r-plyr
+    - r-tidyr
+
+test:
+  commands:
+    - $R -e "library('rscopus')"           # [not win]
+    - "\"%R%\" -e \"library('rscopus')\""  # [win]
+
+about:
+  home: https://dev.elsevier.com/sc_apis.html, https://github.com/muschellij2/rscopus
+  license: GPL-2.0-or-later
+  summary: Uses Elsevier 'Scopus' API <https://dev.elsevier.com/sc_apis.html> to download information
+    about authors and their citations.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rscopus
+# Type: Package
+# Title: Scopus Database 'API' Interface
+# Version: 0.6.6
+# Date: 2019-09-17
+# Authors@R: person(given = "John", family = "Muschelli", role = c("aut", "cre"), email = "muschellij2@gmail.com")
+# Maintainer: John Muschelli <muschellij2@gmail.com>
+# Description: Uses Elsevier 'Scopus' API <https://dev.elsevier.com/sc_apis.html> to download information about authors and their citations.
+# License: GPL-2
+# Depends: R (>= 3.0.0)
+# Imports: httr, jsonlite, utils, stats, plyr, tidyr, dplyr, tools, glue
+# LazyData: TRUE
+# Suggests: xml2, rvest, graphics, testthat, jpeg, knitr, rmarkdown, purrr
+# URL: https://dev.elsevier.com/sc_apis.html, https://github.com/muschellij2/rscopus
+# BugReports: https://github.com/muschellij2/rscopus/issues
+# RoxygenNote: 6.1.1
+# Encoding: UTF-8
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2019-09-17 19:00:22 UTC; johnmuschelli
+# Author: John Muschelli [aut, cre]
+# Repository: CRAN
+# Date/Publication: 2019-09-17 20:20:02 UTC

--- a/recipes/r-rscopus/meta.yaml
+++ b/recipes/r-rscopus/meta.yaml
@@ -47,8 +47,9 @@ test:
     - "\"%R%\" -e \"library('rscopus')\""  # [win]
 
 about:
-  home: https://dev.elsevier.com/sc_apis.html, https://github.com/muschellij2/rscopus
-  license: GPL-2.0-or-later
+  home: https://dev.elsevier.com/sc_apis.html
+  dev_url: https://github.com/muschellij2/rscopus
+  license: GPL-2.0-only
   summary: Uses Elsevier 'Scopus' API <https://dev.elsevier.com/sc_apis.html> to download information
     about authors and their citations.
   license_family: GPL2


### PR DESCRIPTION
Adds [CRAN package `bibliometrix`](https://cran.r-project.org/package=bibliometrix) as `r-bibliometrix`. Recipe generated with `conda_r_skeleton_helper`.

Additionally adds dependencies `r-bibliometrixdata`, `r-dimensionsr`, `r-pubmedr`, and `r-rscopus`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
