### PR TITLE
Adds `r-openalexr`

### DIFF
--- a/recipes/r-openalexr/bld.bat
+++ b/recipes/r-openalexr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-openalexr/build.sh
+++ b/recipes/r-openalexr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-openalexr/meta.yaml
+++ b/recipes/r-openalexr/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = '1.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-openalexr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/openalexR_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/openalexR/openalexR_{{ version }}.tar.gz
+  sha256: 1369e5c4954ab7434298454729bfac96bd9efdfd33ec9152651d81a3bb1f2306
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-httr
+    - r-jsonlite
+    - r-progress
+    - r-tibble
+  run:
+    - r-base
+    - r-httr
+    - r-jsonlite
+    - r-progress
+    - r-tibble
+
+test:
+  commands:
+    - $R -e "library('openalexR')"           # [not win]
+    - "\"%R%\" -e \"library('openalexR')\""  # [win]
+
+about:
+  home: https://github.com/ropensci/openalexR, https://docs.ropensci.org/openalexR/
+  license: MIT
+  summary: A set of tools to extract bibliographic content from 'OpenAlex' database using API
+    <https://docs.openalex.org>.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+# Type: Package
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: openalexR
+# Title: Getting Bibliographic Records from 'OpenAlex' Database Using 'DSL' API
+# Version: 1.2.0
+# Authors@R: c( person(given = "Massimo", family = "Aria", role = c("aut", "cre", "cph"), email = "aria@unina.it", comment = c(ORCID = "0000-0002-8517-9411")), person(given = "Corrado", family = "Cuccurullo", role = c("ctb"), email = "cuccurullocorrado@gmail.com", comment = c(ORCID = "0000-0002-7401-8575")), person(given = "Trang", family = "Le", role = "aut", email = "grixor@gmail.com", comment = c(ORCID = "0000-0003-3737-6565")), person(given = "June", family = "Choe", role = c("ctb"), email = "jchoe001@gmail.com", comment = c(ORCID = "0000-0002-0701-921X")) )
+# Description: A set of tools to extract bibliographic content from 'OpenAlex' database using API <https://docs.openalex.org>.
+# License: MIT + file LICENSE
+# URL: https://github.com/ropensci/openalexR, https://docs.ropensci.org/openalexR/
+# BugReports: https://github.com/ropensci/openalexR/issues
+# Imports: httr, jsonlite, progress, tibble
+# Suggests: testthat (>= 3.0.0), dplyr, knitr, rmarkdown, tidyr, purrr, ggplot2, covr
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.2.3
+# Config/testthat/edition: 3
+# Depends: R (>= 2.10)
+# NeedsCompilation: no
+# Packaged: 2023-08-08 09:45:17 UTC; massimoaria
+# Author: Massimo Aria [aut, cre, cph] (<https://orcid.org/0000-0002-8517-9411>), Corrado Cuccurullo [ctb] (<https://orcid.org/0000-0002-7401-8575>), Trang Le [aut] (<https://orcid.org/0000-0003-3737-6565>), June Choe [ctb] (<https://orcid.org/0000-0002-0701-921X>)
+# Maintainer: Massimo Aria <aria@unina.it>
+# Repository: CRAN
+# Date/Publication: 2023-08-08 12:50:02 UTC

--- a/recipes/r-openalexr/meta.yaml
+++ b/recipes/r-openalexr/meta.yaml
@@ -43,7 +43,8 @@ test:
     - "\"%R%\" -e \"library('openalexR')\""  # [win]
 
 about:
-  home: https://github.com/ropensci/openalexR, https://docs.ropensci.org/openalexR/
+  home: https://github.com/ropensci/openalexR
+  doc_url: https://docs.ropensci.org/openalexR/
   license: MIT
   summary: A set of tools to extract bibliographic content from 'OpenAlex' database using API
     <https://docs.openalex.org>.
@@ -51,7 +52,6 @@ about:
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
     - LICENSE
-# Type: Package
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `openalexR`](https://cran.r-project.org/package=openalexR) as `r-openalexr`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
