### PR TITLE
add binwalk 2.3.4

### DIFF
--- a/recipes/binwalk/0000-setup-py-version.diff
+++ b/recipes/binwalk/0000-setup-py-version.diff
@@ -1,0 +1,43 @@
+diff --git a/setup.py b/setup.py
+index 1c6a555..ca990d1 100755
+--- a/setup.py
++++ b/setup.py
+@@ -12,7 +12,7 @@ except ImportError:
+ from distutils.dir_util import remove_tree
+ 
+ MODULE_NAME = "binwalk"
+-MODULE_VERSION = "2.3.3"
++MODULE_VERSION = os.environ.get("PKG_VERSION")  # conda-forge
+ SCRIPT_NAME = MODULE_NAME
+ MODULE_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+ 
+@@ -23,17 +23,6 @@ try:
+ except ImportError:
+     DEVNULL = open(os.devnull, 'wb')
+ 
+-# If this version of binwalk was checked out from the git repository,
+-# include the git commit hash as part of the version number reported
+-# by binwalk.
+-try:
+-    label = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], stderr=DEVNULL).decode('utf-8')
+-    MODULE_VERSION = "%s+%s" % (MODULE_VERSION, label.strip())
+-except KeyboardInterrupt as e:
+-    raise e
+-except Exception:
+-    pass
+-
+ # Python2/3 compliance
+ try:
+     raw_input
+@@ -340,11 +329,6 @@ setup(
+     package_dir={"": "src"},
+     packages=[MODULE_NAME],
+     package_data={MODULE_NAME: install_data_files},
+-    scripts=[
+-        os.path.join(
+-            "src",
+-            "scripts",
+-            SCRIPT_NAME)],
+     cmdclass={
+         'clean': CleanCommand,
+         'uninstall': UninstallCommand,

--- a/recipes/binwalk/0001-extractor-is-zero.diff
+++ b/recipes/binwalk/0001-extractor-is-zero.diff
@@ -1,0 +1,43 @@
+diff --git a/binwalk-2.3.4/src/binwalk/modules/extractor.py b/binwalk-2.3.4/src/binwalk/modules/extractor.py
+index 4e4660a..9c50097 100644
+--- a/src/binwalk/modules/extractor.py
++++ b/src/binwalk/modules/extractor.py
+@@ -963,10 +963,10 @@ class Extractor(Module):
+         # If a run-as user is not the current user, we'll need to switch privileges to that user account
+         if self.runas_uid != os.getuid():
+             binwalk.core.common.debug("Switching privileges to %s (%d:%d)" % (self.runas_user, self.runas_uid, self.runas_gid))
+-            
++
+             # Fork a child process
+             child_pid = os.fork()
+-            if child_pid is 0:
++            if child_pid == 0:
+                 # Switch to the run-as user privileges, if one has been set
+                 if self.runas_uid is not None and self.runas_gid is not None:
+                     os.setgid(self.runas_uid)
+@@ -974,14 +974,14 @@ class Extractor(Module):
+         else:
+             # child_pid of None indicates that no os.fork() occured
+             child_pid = None
+-            
++
+         # If we're the child, or there was no os.fork(), execute the command
+         if child_pid in [0, None]:
+             binwalk.core.common.debug("subprocess.call(%s, stdout=%s, stderr=%s)" % (command, str(tmp), str(tmp)))
+             rval = subprocess.call(shlex.split(command), stdout=tmp, stderr=tmp)
+ 
+         # A true child process should exit with the subprocess exit value
+-        if child_pid is 0:
++        if child_pid == 0:
+             sys.exit(rval)
+         # If no os.fork() happened, just return the subprocess exit value
+         elif child_pid is None:
+@@ -993,7 +993,7 @@ class Extractor(Module):
+     def symlink_sanitizer(self, file_list, extraction_directory):
+         # User can disable this if desired
+         if self.do_not_sanitize_symlinks is True:
+-            return 
++            return
+ 
+         # Allows either a single file path, or a list of file paths to be passed in for sanitization.
+         if type(file_list) is not list:

--- a/recipes/binwalk/meta.yaml
+++ b/recipes/binwalk/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "2.3.4" %}
+
+package:
+  name: binwalk
+  version: {{ version }}
+
+source:
+  # pypi version is... very old
+  url: https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 60416bfec2390cec76742ce942737df3e6585c933c2467932f59c21e002ba7a9
+  patches:
+    - 0000-setup-py-version.diff
+    - 0001-extractor-is-zero.diff
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  entry_points:
+    - binwalk = binwalk.__main__:main
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+
+test:
+  source_files:
+    - testing/tests
+  requires:
+    - m2-grep  # [win]
+    - nose
+    - pip
+    - pytest-cov
+  imports:
+    - binwalk
+  commands:
+    - pip check
+    - binwalk --help
+    - binwalk --help | grep -iE "Binwalk v{{ version.replace('.', '\.') }}"
+    - cd testing/tests && pytest -vv --cov=binwalk --cov=branch --cov-report=term-missing:skip-covered -k "not firmware_zip" --cov-fail-under=57
+
+about:
+  home: https://github.com/ReFirmLabs/binwalk
+  summary: Firmware analysis tool
+  license: MIT
+  license_file:
+    - LICENSE
+    - NOTICE.md
+  doc_url: https://github.com/ReFirmLabs/binwalk/wiki
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
  - > the pypi sdist is out-of-date
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

References:
- optional dependency for https://github.com/conda-forge/diffoscope-feedstock/pull/147
  - chosen because
    -  useful 
    - _seemingly_ simple python-only 

Notes:
- this will not **work on windows**, but is `noarch: python`
  - osx is just a bonus :slot_machine: 