### PR TITLE
Add Unity Test for conda-forge

### DIFF
--- a/recipes/unity-test/CMakeLists.txt
+++ b/recipes/unity-test/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.12)
+project(cmake_build_test)
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+find_package(unity REQUIRED)
+add_executable(${PROJECT_NAME} test.c)
+target_link_libraries(${PROJECT_NAME} unity::framework)

--- a/recipes/unity-test/bld.bat
+++ b/recipes/unity-test/bld.bat
@@ -11,7 +11,7 @@ cmake ../ -G "Ninja" ^
 
 if errorlevel 1 exit 1
 
-cmake --build . --target INSTALL --config Release --parallel %NUMBER_OF_PRECESSOR%
+cmake --build . --target install --config Release --parallel %NUMBER_OF_PRECESSOR%
 if errorlevel 1 exit 1
 
 popd

--- a/recipes/unity-test/bld.bat
+++ b/recipes/unity-test/bld.bat
@@ -1,0 +1,17 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+mkdir "%SRC_DIR%"\build
+pushd "%SRC_DIR%"\build
+
+cmake ../ -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_BUILD_TYPE:STRING=Release
+
+if errorlevel 1 exit 1
+
+cmake --build . --target INSTALL --config Release --parallel %NUMBER_OF_PRECESSOR%
+if errorlevel 1 exit 1
+
+popd

--- a/recipes/unity-test/build.sh
+++ b/recipes/unity-test/build.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+mkdir -p $PREFIX/include
+mkdir build
+cd build
+
+cmake "${SRC_DIR}" -G "Ninja" \
+    -DCMAKE_INSTALL_PREFIX:PATH="$PREFIX" \
+    -DCMAKE_PREFIX_PATH:PATH="$PREFIX" \
+    -DCMAKE_BUILD_TYPE:STRING=Release
+
+cmake --build . --target install --config Release --parallel ${CPU_COUNT}

--- a/recipes/unity-test/meta.yaml
+++ b/recipes/unity-test/meta.yaml
@@ -34,8 +34,8 @@ test:
 
 about:
   home: https://github.com/ThrowTheSwitch/Unity
-  summary: 'Simple Unit Testing for C '
-  description: |
+  summary: Simple Unit Testing for C
+  description:
     Welcome to the Unity Test Project, one of the main projects of ThrowTheSwitch.org. Unity Test is a unit testing framework built for C, with a focus on working with embedded toolchains.
     This project is made to test code targetting microcontrollers big and small. The core project is a single C file and a pair of headers, allowing it to be added to your existing build setup without too much headache. You may use any compiler you wish, and may use most existing build systems including Make, CMake, etc. If you'd like to leave the hard work to us, you might be interested in Ceedling, a build tool also by ThrowTheSwitch.org.
   license: MIT

--- a/recipes/unity-test/meta.yaml
+++ b/recipes/unity-test/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "unity-test" %}
+{% set version = "2.5.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/ThrowTheSwitch/Unity/archive/v{{ version }}.tar.gz
+  fn: Unity-{{ version }}.tar.gz
+  sha256: 3786de6c8f389be3894feae4f7d8680a02e70ed4dbcce36109c8f8646da2671a
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - cmake >=3.12
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - ninja
+  host:
+  run:
+
+test:
+  files:
+    - test.c
+    - CMakeLists.txt
+  requires:
+    - cmake >=3.12
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - ninja
+
+about:
+  home: https://github.com/ThrowTheSwitch/Unity
+  summary: 'Simple Unit Testing for C '
+  description: |
+    Welcome to the Unity Test Project, one of the main projects of ThrowTheSwitch.org. Unity Test is a unit testing framework built for C, with a focus on working with embedded toolchains.
+    This project is made to test code targetting microcontrollers big and small. The core project is a single C file and a pair of headers, allowing it to be added to your existing build setup without too much headache. You may use any compiler you wish, and may use most existing build systems including Make, CMake, etc. If you'd like to leave the hard work to us, you might be interested in Ceedling, a build tool also by ThrowTheSwitch.org.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  doc_url: https://github.com/ThrowTheSwitch/Unity/tree/master/docs
+  dev_url: https://github.com/ThrowTheSwitch/Unity/
+
+extra:
+  recipe-maintainers:
+    - argltuc

--- a/recipes/unity-test/run_test.bat
+++ b/recipes/unity-test/run_test.bat
@@ -1,0 +1,13 @@
+mkdir build
+pushd build
+
+cmake ../ -G "Ninja"
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+cmake_build_test.exe
+if errorlevel 1 exit 1
+
+popd

--- a/recipes/unity-test/run_test.sh
+++ b/recipes/unity-test/run_test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Stop on first error
+set -ex
+
+# Try compiling example using CMake
+mkdir build && cd build
+cmake ../ -G "Ninja"
+cmake --build . --config Release
+./cmake_build_test

--- a/recipes/unity-test/test.c
+++ b/recipes/unity-test/test.c
@@ -1,0 +1,21 @@
+#include <stdlib.h>
+#include <unity.h>
+
+
+void setUp (){
+};
+void tearDown(){
+};
+void test_unity(){
+    int i = 2;
+    int a = 2;
+
+    TEST_ASSERT_EQUAL(a,i);
+}
+void main () {
+    UNITY_BEGIN();
+
+    RUN_TEST(test_unity);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
This PR provide a recipe to build C unit test library `Unity Test`.
This library is a static only lib. But since it is a library for testing binaries, it is not inteded to be a run dependency for other packages.

@conda-forge/help-c-cpp, read for review
