### PR TITLE
set -xeo pipefail on Linux docker script

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -204,7 +204,9 @@ def read_mambabuild(recipes_dir):
             conda_build_tools.append(cfy.get("conda_build_tool", "conda-build"))
         else:
             conda_build_tools.append("conda-build")
-    return all([tool == "mambabuild" for tool in conda_build_tools])
+    if conda_build_tools:
+        return all([tool == "mambabuild" for tool in conda_build_tools])
+    return False
 
 
 def use_mambabuild():

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -6,6 +6,8 @@ source .scripts/logging_utils.sh
 
 ( startgroup "Configure Docker" ) 2> /dev/null
 
+set -xeo pipefail
+
 REPO_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 ARTIFACTS="$REPO_ROOT/build_artifacts"
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"


### PR DESCRIPTION
A fix for #23926. `run_docker_build.sh` was not setting `set -e` and others so the last logging command always made it successful. Seen in https://github.com/conda-forge/staged-recipes/pull/23927 by @synapticarbors. Thanks! 