### PR TITLE
add pyodide-lock 0.1.0a3

### DIFF
--- a/recipes/pyodide-lock/meta.yaml
+++ b/recipes/pyodide-lock/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.1.0a1" %}
+
+package:
+  name: pyodide-lock
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/pyodide-lock/pyodide_lock-{{ version }}.tar.gz
+  sha256: b16b7d8584b437009a93dae957251ab8eb5ec004391447da752d81356b22a0da
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python >=3.10
+    - pydantic
+
+test:
+  source_files:
+    - tests
+  imports:
+    - pyodide_lock
+  commands:
+    - pip check
+    - pytest -vv --cov=pyodide_lock --cov-branch --cov-report=term-missing:skip-covered --no-cov-on-fail --cov-fail-under=81
+  requires:
+    - pip
+    - pytest-cov
+
+about:
+  summary: Tooling to manage the `pyodide-lock.json` file
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl

--- a/recipes/pyodide-lock/meta.yaml
+++ b/recipes/pyodide-lock/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0a1" %}
+{% set version = "0.1.0a3" %}
 
 package:
   name: pyodide-lock
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/p/pyodide-lock/pyodide_lock-{{ version }}.tar.gz
-  sha256: b16b7d8584b437009a93dae957251ab8eb5ec004391447da752d81356b22a0da
+  sha256: 58820b96ff0fad312e55a0bdcf41c504990168f638898bd7ea84bfe1a759801b
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipes/pyodide-lock/meta.yaml
+++ b/recipes/pyodide-lock/meta.yaml
@@ -36,6 +36,7 @@ test:
     - pytest-cov
 
 about:
+  home: https://github.com/pyodide/pyodide-lock
   summary: Tooling to manage the `pyodide-lock.json` file
   license: BSD-3-Clause
   license_file: LICENSE


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

References:
- blocks https://github.com/conda-forge/pyodide-build-feedstock/pull/6

Notes:
- upstream does not yet have a non-`a`/`b` release