### PR TITLE
Add `r-rxode2` and dependencies

### DIFF
--- a/recipes/r-rxode2/bld.bat
+++ b/recipes/r-rxode2/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rxode2/build.sh
+++ b/recipes/r-rxode2/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rxode2/meta.yaml
+++ b/recipes/r-rxode2/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-rxode2/meta.yaml
+++ b/recipes/r-rxode2/meta.yaml
@@ -20,6 +20,8 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'           # [win]
+    - '*/Rblas.dll'       # [win]
+    - '*/Rlapack.dll'     # [win]
 
 requirements:
   build:

--- a/recipes/r-rxode2/meta.yaml
+++ b/recipes/r-rxode2/meta.yaml
@@ -38,6 +38,8 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils             # [win]
     - {{ posix }}zip                   # [win]
+    - libgomp                          # [linux]
+    - llvm-openmp                      # [osx]
   host:
     - r-base
     - r-bh
@@ -60,6 +62,8 @@ requirements:
     - r-rxode2parse >=2.0.12
     - r-rxode2random >=2.0.9
     - r-sys
+    - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-rxode2/meta.yaml
+++ b/recipes/r-rxode2/meta.yaml
@@ -21,23 +21,23 @@ build:
 
 requirements:
   build:
+    - cross-r-base {{ r_base }}        # [build_platform != target_platform]
     - {{ compiler('c') }}              # [not win]
     - {{ compiler('m2w64_c') }}        # [win]
     - {{ compiler('cxx') }}            # [not win]
     - {{ compiler('m2w64_cxx') }}      # [win]
     - {{ compiler('fortran') }}        # [not win]
     - {{ compiler('m2w64_fortran') }}  # [win]
-    - {{ posix }}filesystem        # [win]
-    - {{ posix }}sed               # [win]
-    - {{ posix }}grep              # [win]
+    - {{ posix }}filesystem            # [win]
+    - {{ posix }}sed                   # [win]
+    - {{ posix }}grep                  # [win]
     - {{ posix }}autoconf
-    - {{ posix }}automake          # [not win]
-    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}automake              # [not win]
+    - {{ posix }}automake-wrapper      # [win]
     - {{ posix }}pkg-config
     - {{ posix }}make
-    - {{ posix }}coreutils         # [win]
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}coreutils             # [win]
+    - {{ posix }}zip                   # [win]
   host:
     - r-base
     - r-bh
@@ -90,8 +90,9 @@ test:
     - "\"%R%\" -e \"library('rxode2')\""  # [win]
 
 about:
-  home: https://nlmixr2.github.io/rxode2/, https://github.com/nlmixr2/rxode2/
-  license: GPL-3
+  home: https://nlmixr2.github.io/rxode2/
+  dev_url: https://github.com/nlmixr2/rxode2/
+  license: GPL-3.0-or-later
   summary: 'Facilities for running simulations from ordinary differential equation (''ODE'')
     models, such as pharmacometrics and other compartmental models.  A compilation manager
     translates the ODE model into C, compiles it, and dynamically loads the object code

--- a/recipes/r-rxode2/meta.yaml
+++ b/recipes/r-rxode2/meta.yaml
@@ -1,0 +1,136 @@
+{% set version = '2.0.14' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rxode2
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rxode2_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rxode2/rxode2_{{ version }}.tar.gz
+  sha256: 0057cd815711835edbe7e43d070e6026040a52c4c14c5d884ab64e3c7f71679c
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('fortran') }}        # [not win]
+    - {{ compiler('m2w64_fortran') }}  # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-bh
+    - r-precisesums >=0.3
+    - r-rcpp >=0.12.3
+    - r-rcpparmadillo >=0.9.300.2.0
+    - r-backports
+    - r-checkmate
+    - r-cli >=2.0.0
+    - r-data.table >=1.12.4
+    - r-ggplot2 >=3.4.0
+    - r-inline
+    - r-lotri >=0.4.0
+    - r-magrittr
+    - r-memoise
+    - r-qs
+    - r-rex
+    - r-rxode2et >=2.0.9
+    - r-rxode2ll >=2.0.9
+    - r-rxode2parse >=2.0.12
+    - r-rxode2random >=2.0.9
+    - r-sys
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-bh
+    - r-precisesums >=0.3
+    - r-rcpp >=0.12.3
+    - r-rcpparmadillo >=0.9.300.2.0
+    - r-backports
+    - r-checkmate
+    - r-cli >=2.0.0
+    - r-data.table >=1.12.4
+    - r-ggplot2 >=3.4.0
+    - r-inline
+    - r-lotri >=0.4.0
+    - r-magrittr
+    - r-memoise
+    - r-qs
+    - r-rex
+    - r-rxode2et >=2.0.9
+    - r-rxode2ll >=2.0.9
+    - r-rxode2parse >=2.0.12
+    - r-rxode2random >=2.0.9
+    - r-sys
+
+test:
+  commands:
+    - $R -e "library('rxode2')"           # [not win]
+    - "\"%R%\" -e \"library('rxode2')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/rxode2/, https://github.com/nlmixr2/rxode2/
+  license: GPL-3
+  summary: 'Facilities for running simulations from ordinary differential equation (''ODE'')
+    models, such as pharmacometrics and other compartmental models.  A compilation manager
+    translates the ODE model into C, compiles it, and dynamically loads the object code
+    into R for improved computational efficiency.  An event table object facilitates
+    the specification of complex dosing regimens (optional) and sampling schedules.  NB:
+    The use of this package requires both C and Fortran compilers, for details on their
+    use with R please see Section 6.3, Appendix A, and Appendix D in the "R Administration
+    and Installation" manual. Also the code is mostly released under GPL.  The ''VODE''
+    and ''LSODA'' are in the public domain.  The information is available in the inst/COPYRIGHTS.'
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rxode2
+# Version: 2.0.14
+# Title: Facilities for Simulating from ODE-Based Models
+# Authors@R: c( person("Matthew L.","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")), person("Melissa", "Hallow", role = "aut", email = "hallowkm@uga.edu"), person("Wenping", "Wang", role = c("aut"), email = "wwang8198@gmail.com"), person("Zufar", "Mulyukov", role="ctb", email="zufar.mulyukov@novartis.com"), person("Alan", "Hindmarsh",role="ctb"), person("Arun", "Srinivasan", role="ctb", email="arunkumar.sriniv@gmail.com"), person("Awad H.", "Al-Mohy",role="ctb"), person("Cleve", "Moler", role="ctb"), person("Drew", "Schmidt", role="ctb"), person("Ernst", "Hairer", role="ctb"), person("Gerhard", "Wanner", role="ctb"), person("Gilbert", "Stewart", role="ctb"), person("Hadley", "Wickham", role="ctb"), person("Jack", "Dongarra", role="ctb"), person("Jim", "Bunch", role="ctb"), person("Linda", "Petzold", role="ctb"), person("Martin", "Maechler", role="ctb"), person("Matt", "Dowle", role="ctb", email="mattjdowle@gmail.com"), person("Matteo", "Fasiolo", email = "matteo.fasiolo@gmail.com", role = "ctb"), person("Nicholas J.", "Higham",role="ctb"), person("Roger B.", "Sidje", role="ctb"), person("Simon", "Frost", role="ctb"), person("Yu", "Feng", role="ctb"), person("Bill", "Denney", email="wdenney@humanpredictions.com", role="ctb", comment=c(ORCID="0000-0002-5759-428X")) )
+# Maintainer: Matthew L. Fidler <matthew.fidler@gmail.com>
+# Depends: R (>= 4.0.0)
+# Suggests: Matrix, DT, covr, crayon, curl, digest, dplyr (>= 0.8.0), ggrepel, gridExtra, htmltools, knitr, learnr, microbenchmark, nlme, remotes, rlang, rmarkdown, scales, shiny, stringi, symengine, testthat, tidyr, usethis, vdiffr (>= 1.0), withr, xgxr, pillar, tibble, units (>= 0.6-0), rsconnect, devtools, patchwork, nlmixr2data, lifecycle
+# Imports: PreciseSums (>= 0.3), Rcpp (>= 0.12.3), backports, cli (>= 2.0.0), checkmate, ggplot2 (>= 3.4.0), inline, lotri (>= 0.4.0), magrittr, memoise, methods, rex, sys, tools, utils, rxode2ll(>= 2.0.9), rxode2et (>= 2.0.9), rxode2parse (>= 2.0.12), rxode2random (>= 2.0.9), data.table (>= 1.12.4), qs
+# Description: Facilities for running simulations from ordinary differential equation ('ODE') models, such as pharmacometrics and other compartmental models.  A compilation manager translates the ODE model into C, compiles it, and dynamically loads the object code into R for improved computational efficiency.  An event table object facilitates the specification of complex dosing regimens (optional) and sampling schedules.  NB: The use of this package requires both C and Fortran compilers, for details on their use with R please see Section 6.3, Appendix A, and Appendix D in the "R Administration and Installation" manual. Also the code is mostly released under GPL.  The 'VODE' and 'LSODA' are in the public domain.  The information is available in the inst/COPYRIGHTS.
+# BugReports: https://github.com/nlmixr2/rxode2/issues/
+# NeedsCompilation: yes
+# VignetteBuilder: knitr
+# License: GPL (>= 3)
+# URL: https://nlmixr2.github.io/rxode2/, https://github.com/nlmixr2/rxode2/
+# RoxygenNote: 7.2.3
+# Biarch: true
+# LinkingTo: rxode2parse (>= 2.0.12), rxode2random, PreciseSums (>= 0.3), Rcpp, RcppArmadillo (>= 0.9.300.2.0), BH
+# Encoding: UTF-8
+# LazyData: true
+# Language: en-US
+# Config/testthat/edition: 3
+# Packaged: 2023-10-06 23:05:56 UTC; matt
+# Author: Matthew L. Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Melissa Hallow [aut], Wenping Wang [aut], Zufar Mulyukov [ctb], Alan Hindmarsh [ctb], Arun Srinivasan [ctb], Awad H. Al-Mohy [ctb], Cleve Moler [ctb], Drew Schmidt [ctb], Ernst Hairer [ctb], Gerhard Wanner [ctb], Gilbert Stewart [ctb], Hadley Wickham [ctb], Jack Dongarra [ctb], Jim Bunch [ctb], Linda Petzold [ctb], Martin Maechler [ctb], Matt Dowle [ctb], Matteo Fasiolo [ctb], Nicholas J. Higham [ctb], Roger B. Sidje [ctb], Simon Frost [ctb], Yu Feng [ctb], Bill Denney [ctb] (<https://orcid.org/0000-0002-5759-428X>)
+# Repository: CRAN
+# Date/Publication: 2023-10-07 05:00:02 UTC

--- a/recipes/r-rxode2et/bld.bat
+++ b/recipes/r-rxode2et/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rxode2et/build.sh
+++ b/recipes/r-rxode2et/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rxode2et/meta.yaml
+++ b/recipes/r-rxode2et/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-rxode2et/meta.yaml
+++ b/recipes/r-rxode2et/meta.yaml
@@ -1,0 +1,102 @@
+{% set version = '2.0.10' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rxode2et
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rxode2et_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rxode2et/rxode2et_{{ version }}.tar.gz
+  sha256: 22458b463139a9fa91ba63105de58d155ac5dd3c985ca35eb2ec8314faa1f2d3
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp
+    - r-checkmate
+    - r-cli
+    - r-crayon
+    - r-lotri
+    - r-magrittr
+    - r-rxode2parse >2.0.13
+    - r-rxode2random
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-checkmate
+    - r-cli
+    - r-crayon
+    - r-lotri
+    - r-magrittr
+    - r-rxode2parse >2.0.13
+    - r-rxode2random
+
+test:
+  commands:
+    - $R -e "library('rxode2et')"           # [not win]
+    - "\"%R%\" -e \"library('rxode2et')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/rxode2et/, https://github.com/nlmixr2/rxode2et/
+  license: GPL-3
+  summary: Provides the event table and support functions needed for 'rxode2' (Wang, Hallow and  James
+    (2016) <doi:10.1002/psp4.12052>) and 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>).
+    This split will reduce computational burden of recompiling 'rxode2'.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rxode2et
+# Title: Event Table Functions for 'rxode2'
+# Version: 2.0.10
+# Authors@R: c( person("Matthew L.", "Fidler", , "matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCIDf = "0000-0001-8538-6691")), person("Wenping", "Wang", , "wwang8198@gmail.com", role = "ctb"), person("Fuji", "Goro", email="gfuji@cpan.org", role="ctb"), person("Morwenn", "", role="ctb"), person("Igor", "Kushnir", email="igorkuo@gmail.com", role="ctb") )
+# Description: Provides the event table and support functions needed for 'rxode2' (Wang, Hallow and  James (2016) <doi:10.1002/psp4.12052>) and 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>). This split will reduce computational burden of recompiling 'rxode2'.
+# License: GPL (>= 3)
+# URL: https://nlmixr2.github.io/rxode2et/, https://github.com/nlmixr2/rxode2et/
+# BugReports: https://github.com/nlmixr2/rxode2et/issues/
+# Depends: R (>= 4.0.0)
+# Imports: stats, utils, methods, Rcpp, checkmate, rxode2random, rxode2parse (> 2.0.13), cli, crayon, magrittr, lotri
+# Suggests: testthat (>= 3.0.0), units, tibble, data.table, dplyr, pillar, nlmixr2data, qs
+# LinkingTo: rxode2random, rxode2parse, Rcpp
+# Biarch: true
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# Language: en-US
+# NeedsCompilation: yes
+# RoxygenNote: 7.2.1
+# Packaged: 2023-03-17 19:48:52 UTC; matt
+# Author: Matthew L. Fidler [aut, cre] (0000-0001-8538-6691), Wenping Wang [ctb], Fuji Goro [ctb], Morwenn [ctb], Igor Kushnir [ctb]
+# Maintainer: Matthew L. Fidler <matthew.fidler@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-03-17 23:00:02 UTC

--- a/recipes/r-rxode2et/meta.yaml
+++ b/recipes/r-rxode2et/meta.yaml
@@ -21,10 +21,11 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
@@ -35,7 +36,6 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-rcpp
@@ -64,8 +64,9 @@ test:
     - "\"%R%\" -e \"library('rxode2et')\""  # [win]
 
 about:
-  home: https://nlmixr2.github.io/rxode2et/, https://github.com/nlmixr2/rxode2et/
-  license: GPL-3
+  home: https://nlmixr2.github.io/rxode2et/
+  dev_url: https://github.com/nlmixr2/rxode2et/
+  license: GPL-3.0-or-later
   summary: Provides the event table and support functions needed for 'rxode2' (Wang, Hallow and  James
     (2016) <doi:10.1002/psp4.12052>) and 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>).
     This split will reduce computational burden of recompiling 'rxode2'.

--- a/recipes/r-rxode2ll/bld.bat
+++ b/recipes/r-rxode2ll/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rxode2ll/build.sh
+++ b/recipes/r-rxode2ll/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rxode2ll/meta.yaml
+++ b/recipes/r-rxode2ll/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:
@@ -41,16 +43,16 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
-    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
+    - tbb
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
+    - {{ native }}gcc-libs           # [win]
+    - {{ native }}libwinpthread-git  # [win]
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
-    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
 

--- a/recipes/r-rxode2ll/meta.yaml
+++ b/recipes/r-rxode2ll/meta.yaml
@@ -21,10 +21,11 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
@@ -35,7 +36,6 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-bh >=1.78.0.0
@@ -60,8 +60,9 @@ test:
     - "\"%R%\" -e \"library('rxode2ll')\""  # [win]
 
 about:
-  home: https://nlmixr2.github.io/rxode2ll/, https://github.com/nlmixr2/rxode2ll/
-  license: GPL-3
+  home: https://nlmixr2.github.io/rxode2ll/
+  dev_url: https://github.com/nlmixr2/rxode2ll/
+  license: GPL-3.0-or-later
   summary: Provides the log-likelihoods with gradients from 'stan' (Carpenter et al (2015), <arXiv:1509.07164>)
     needed for generalized log-likelihood estimation in 'nlmixr2' (Fidler et al (2019)
     <doi:10.1002/psp4.12445>). This is split of to reduce computational burden of recompiling

--- a/recipes/r-rxode2ll/meta.yaml
+++ b/recipes/r-rxode2ll/meta.yaml
@@ -20,6 +20,7 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'           # [win]
+    - '*/tbb.dll'         # [win]
 
 requirements:
   build:
@@ -46,7 +47,6 @@ requirements:
     - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
-    - tbb
   run:
     - r-base
     - {{ native }}gcc-libs           # [win]

--- a/recipes/r-rxode2ll/meta.yaml
+++ b/recipes/r-rxode2ll/meta.yaml
@@ -1,0 +1,100 @@
+{% set version = '2.0.11' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rxode2ll
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rxode2ll_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rxode2ll/rxode2ll_{{ version }}.tar.gz
+  sha256: 43e74c5fa82b27045b8dfe11c7391d5e03a933425b59c7bd6c2abc63f4a2453a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-bh >=1.78.0.0
+    - r-rcpp >=1.0.8
+    - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
+    - r-stanheaders >=2.21.0.7
+    - r-checkmate
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-bh >=1.78.0.0
+    - r-rcpp >=1.0.8
+    - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
+    - r-stanheaders >=2.21.0.7
+    - r-checkmate
+
+test:
+  commands:
+    - $R -e "library('rxode2ll')"           # [not win]
+    - "\"%R%\" -e \"library('rxode2ll')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/rxode2ll/, https://github.com/nlmixr2/rxode2ll/
+  license: GPL-3
+  summary: Provides the log-likelihoods with gradients from 'stan' (Carpenter et al (2015), <arXiv:1509.07164>)
+    needed for generalized log-likelihood estimation in 'nlmixr2' (Fidler et al (2019)
+    <doi:10.1002/psp4.12445>). This is split of to reduce computational burden of recompiling
+    'rxode2' (Wang, Hallow and James (2016) <doi:10.1002/psp4.12052>) which runs the
+    'nlmixr2' models during estimation.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rxode2ll
+# Version: 2.0.11
+# Title: Log-Likelihood Functions for 'rxode2'
+# Authors@R: c( person("Matthew L.","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")))
+# Maintainer: Matthew L. Fidler <matthew.fidler@gmail.com>
+# Depends: R (>= 4.0.0)
+# Suggests: covr, testthat (>= 3.0.0)
+# Imports: Rcpp (>= 1.0.8), checkmate, RcppParallel
+# Description: Provides the log-likelihoods with gradients from 'stan' (Carpenter et al (2015), <arXiv:1509.07164>) needed for generalized log-likelihood estimation in 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>). This is split of to reduce computational burden of recompiling 'rxode2' (Wang, Hallow and James (2016) <doi:10.1002/psp4.12052>) which runs the 'nlmixr2' models during estimation.
+# BugReports: https://github.com/nlmixr2/rxode2ll/issues/
+# NeedsCompilation: yes
+# License: GPL (>= 3)
+# URL: https://nlmixr2.github.io/rxode2ll/, https://github.com/nlmixr2/rxode2ll/
+# RoxygenNote: 7.2.3
+# Biarch: true
+# LinkingTo: Rcpp (>= 1.0.8), RcppEigen (>= 0.3.3.9.2), StanHeaders (>= 2.21.0.7), BH (>= 1.78.0.0), RcppParallel
+# Encoding: UTF-8
+# Language: en-US
+# Config/testthat/edition: 3
+# Packaged: 2023-03-17 17:09:38 UTC; matt
+# Author: Matthew L. Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>)
+# Repository: CRAN
+# Date/Publication: 2023-03-17 23:40:02 UTC

--- a/recipes/r-rxode2ll/meta.yaml
+++ b/recipes/r-rxode2ll/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - tbb
@@ -53,6 +54,7 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
 

--- a/recipes/r-rxode2parse/bld.bat
+++ b/recipes/r-rxode2parse/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rxode2parse/build.sh
+++ b/recipes/r-rxode2parse/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rxode2parse/meta.yaml
+++ b/recipes/r-rxode2parse/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - r-crayon
@@ -56,6 +57,7 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - r-crayon

--- a/recipes/r-rxode2parse/meta.yaml
+++ b/recipes/r-rxode2parse/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - r-crayon
@@ -60,6 +61,7 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
+    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - r-crayon

--- a/recipes/r-rxode2parse/meta.yaml
+++ b/recipes/r-rxode2parse/meta.yaml
@@ -20,6 +20,7 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'           # [win]
+    - '*/tbb.dll'         # [win]
 
 requirements:
   build:
@@ -53,7 +54,6 @@ requirements:
     - r-knitr
     - r-qs
     - r-rex
-    - tbb
   run:
     - r-base
     - {{ native }}gcc-libs           # [win]

--- a/recipes/r-rxode2parse/meta.yaml
+++ b/recipes/r-rxode2parse/meta.yaml
@@ -21,10 +21,11 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
@@ -35,7 +36,6 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-bh >=1.78.0.0
@@ -72,8 +72,9 @@ test:
     - "\"%R%\" -e \"library('rxode2parse')\""  # [win]
 
 about:
-  home: https://nlmixr2.github.io/rxode2parse/, https://github.com/nlmixr2/rxode2parse/
-  license: GPL-3
+  home: https://nlmixr2.github.io/rxode2parse/
+  dev_url: https://github.com/nlmixr2/rxode2parse/
+  license: GPL-3.0-or-later
   summary: Provides the parsing needed for 'rxode2' (Wang, Hallow and James (2016) <doi:10.1002/psp4.12052>).
     It also provides the 'stan' based advan linear compartment model solutions with
     gradients (Carpenter et al (2015), <arXiv:1509.07164>) needed in 'nlmixr2' (Fidler

--- a/recipes/r-rxode2parse/meta.yaml
+++ b/recipes/r-rxode2parse/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:
@@ -41,7 +43,6 @@ requirements:
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
-    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - r-crayon
@@ -51,13 +52,14 @@ requirements:
     - r-knitr
     - r-qs
     - r-rex
+    - tbb
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
+    - {{ native }}gcc-libs           # [win]
+    - {{ native }}libwinpthread-git  # [win]
     - r-bh >=1.78.0.0
     - r-rcpp >=1.0.8
     - r-rcppeigen >=0.3.3.9.2
-    - r-rcppparallel
     - r-stanheaders >=2.21.0.7
     - r-checkmate
     - r-crayon

--- a/recipes/r-rxode2parse/meta.yaml
+++ b/recipes/r-rxode2parse/meta.yaml
@@ -1,0 +1,112 @@
+{% set version = '2.0.16' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rxode2parse
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rxode2parse_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rxode2parse/rxode2parse_{{ version }}.tar.gz
+  sha256: 722f8a6c3080a9afe1ca30bcd0865fd43b67572537572410b4ecccb8377c1078
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-bh >=1.78.0.0
+    - r-rcpp >=1.0.8
+    - r-rcppeigen >=0.3.3.9.2
+    - r-stanheaders >=2.21.0.7
+    - r-checkmate
+    - r-crayon
+    - r-data.table >=1.12.4
+    - r-digest
+    - r-dparser
+    - r-knitr
+    - r-qs
+    - r-rex
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-bh >=1.78.0.0
+    - r-rcpp >=1.0.8
+    - r-rcppeigen >=0.3.3.9.2
+    - r-stanheaders >=2.21.0.7
+    - r-checkmate
+    - r-crayon
+    - r-data.table >=1.12.4
+    - r-digest
+    - r-dparser
+    - r-knitr
+    - r-qs
+    - r-rex
+
+test:
+  commands:
+    - $R -e "library('rxode2parse')"           # [not win]
+    - "\"%R%\" -e \"library('rxode2parse')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/rxode2parse/, https://github.com/nlmixr2/rxode2parse/
+  license: GPL-3
+  summary: Provides the parsing needed for 'rxode2' (Wang, Hallow and James (2016) <doi:10.1002/psp4.12052>).
+    It also provides the 'stan' based advan linear compartment model solutions with
+    gradients (Carpenter et al (2015), <arXiv:1509.07164>) needed in 'nlmixr2' (Fidler
+    et al (2019) <doi:10.1002/psp4.12445>). This split will reduce computational burden
+    of recompiling 'rxode2'.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rxode2parse
+# Title: Parsing and Code Generation Functions for 'rxode2'
+# Version: 2.0.16
+# Authors@R: c( person("Matthew L.", "Fidler", , "matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")), person("Wenping", "Wang", , "wwang8198@gmail.com", role = "aut"), person("Richard", "Upton", role = "ctb"), person("Gabriel", "Staples", role="ctb"), person("Goro", "Fuji",  role="ctb", email="gfuji@cpan.org"), person("Morwenn","", role="ctb"), person("Igor", "Kushnir", role="ctb"), person("Kevin", "Ushey", role="ctb"), person("David", "Cooley", role="ctb"))
+# Maintainer: Matthew L. Fidler <matthew.fidler@gmail.com>
+# Description: Provides the parsing needed for 'rxode2' (Wang, Hallow and James (2016) <doi:10.1002/psp4.12052>). It also provides the 'stan' based advan linear compartment model solutions with gradients (Carpenter et al (2015), <arXiv:1509.07164>) needed in 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>). This split will reduce computational burden of recompiling 'rxode2'.
+# License: GPL (>= 3)
+# URL: https://nlmixr2.github.io/rxode2parse/, https://github.com/nlmixr2/rxode2parse/
+# BugReports: https://github.com/nlmixr2/rxode2parse/issues/
+# Depends: R (>= 4.0.0)
+# Imports: checkmate, crayon, dparser, knitr, methods, qs, Rcpp (>= 1.0.8), utils, digest, rex, data.table (>= 1.12.4)
+# Suggests: testthat (>= 3.0.0), dplyr, nlmixr2data, devtools
+# LinkingTo: BH (>= 1.78.0.0), dparser (>= 1.3.1-10), Rcpp (>= 1.0.8), RcppEigen (>= 0.3.3.9.2), StanHeaders (>= 2.21.0.7)
+# Biarch: true
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# Language: en-US
+# NeedsCompilation: yes
+# RoxygenNote: 7.2.3
+# Packaged: 2023-03-28 13:16:54 UTC; matt
+# Author: Matthew L. Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Wenping Wang [aut], Richard Upton [ctb], Gabriel Staples [ctb], Goro Fuji [ctb], Morwenn [ctb], Igor Kushnir [ctb], Kevin Ushey [ctb], David Cooley [ctb]
+# Repository: CRAN
+# Date/Publication: 2023-03-28 15:10:05 UTC

--- a/recipes/r-rxode2random/bld.bat
+++ b/recipes/r-rxode2random/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rxode2random/build.sh
+++ b/recipes/r-rxode2random/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rxode2random/meta.yaml
+++ b/recipes/r-rxode2random/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-rxode2random/meta.yaml
+++ b/recipes/r-rxode2random/meta.yaml
@@ -20,6 +20,8 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'           # [win]
+    - '*/Rblas.dll'       # [win]
+    - '*/Rlapack.dll'     # [win]
 
 requirements:
   build:

--- a/recipes/r-rxode2random/meta.yaml
+++ b/recipes/r-rxode2random/meta.yaml
@@ -36,6 +36,8 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
+    - libgomp                      # [linux]
+    - llvm-openmp                  # [osx]
   host:
     - r-base
     - r-bh
@@ -45,6 +47,7 @@ requirements:
     - r-lotri
     - r-rxode2parse >2.0.13
     - r-sitmo
+    - libblas
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-rxode2random/meta.yaml
+++ b/recipes/r-rxode2random/meta.yaml
@@ -1,0 +1,100 @@
+{% set version = '2.0.11' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rxode2random
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rxode2random_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rxode2random/rxode2random_{{ version }}.tar.gz
+  sha256: 37ce9a2ec829f6ac8b60e3d499e8bc8f140929bca8a3dcfaa06b779b24396967
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-bh
+    - r-rcpp
+    - r-rcpparmadillo
+    - r-checkmate
+    - r-lotri
+    - r-rxode2parse >2.0.13
+    - r-sitmo
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-bh
+    - r-rcpp
+    - r-rcpparmadillo
+    - r-checkmate
+    - r-lotri
+    - r-rxode2parse >2.0.13
+    - r-sitmo
+
+test:
+  commands:
+    - $R -e "library('rxode2random')"           # [not win]
+    - "\"%R%\" -e \"library('rxode2random')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/rxode2random/, https://github.com/nlmixr2/rxode2random/
+  license: GPL-3
+  summary: Provides the random number generation (in parallel) needed for 'rxode2' (Wang, Hallow
+    and  James (2016) <doi:10.1002/psp4.12052>) and 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>).
+    This split will reduce computational burden of recompiling 'rxode2'.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rxode2random
+# Title: Random Number Generation Functions for 'rxode2'
+# Version: 2.0.11
+# Authors@R: c( person("Matthew L.", "Fidler", , "matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")), person("Wenping", "Wang", , "wwang8198@gmail.com", role = "ctb"), person("Bill", "Denney", email="wdenney@humanpredictions.com", role="ctb", comment=c(ORCID="0000-0002-5759-428X")) )
+# Description: Provides the random number generation (in parallel) needed for 'rxode2' (Wang, Hallow and  James (2016) <doi:10.1002/psp4.12052>) and 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>). This split will reduce computational burden of recompiling 'rxode2'.
+# License: GPL (>= 3)
+# URL: https://nlmixr2.github.io/rxode2random/, https://github.com/nlmixr2/rxode2random/
+# BugReports: https://github.com/nlmixr2/rxode2random/issues/
+# Depends: R (>= 4.0.0)
+# Imports: stats, Rcpp, checkmate, lotri, rxode2parse (> 2.0.13)
+# Suggests: testthat (>= 3.0.0)
+# LinkingTo: sitmo, rxode2parse (>= 2.0.12), Rcpp, RcppArmadillo, BH
+# Biarch: true
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# Language: en-US
+# NeedsCompilation: yes
+# RoxygenNote: 7.2.3
+# Packaged: 2023-03-18 13:47:19 UTC; matt
+# Author: Matthew L. Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Wenping Wang [ctb], Bill Denney [ctb] (<https://orcid.org/0000-0002-5759-428X>)
+# Maintainer: Matthew L. Fidler <matthew.fidler@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-03-28 08:30:02 UTC

--- a/recipes/r-rxode2random/meta.yaml
+++ b/recipes/r-rxode2random/meta.yaml
@@ -48,6 +48,7 @@ requirements:
     - r-rxode2parse >2.0.13
     - r-sitmo
     - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-rxode2random/meta.yaml
+++ b/recipes/r-rxode2random/meta.yaml
@@ -21,10 +21,11 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
@@ -35,7 +36,6 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-bh
@@ -62,8 +62,9 @@ test:
     - "\"%R%\" -e \"library('rxode2random')\""  # [win]
 
 about:
-  home: https://nlmixr2.github.io/rxode2random/, https://github.com/nlmixr2/rxode2random/
-  license: GPL-3
+  home: https://nlmixr2.github.io/rxode2random/
+  dev_url: https://github.com/nlmixr2/rxode2random/
+  license: GPL-3.0-or-later
   summary: Provides the random number generation (in parallel) needed for 'rxode2' (Wang, Hallow
     and  James (2016) <doi:10.1002/psp4.12052>) and 'nlmixr2' (Fidler et al (2019) <doi:10.1002/psp4.12445>).
     This split will reduce computational burden of recompiling 'rxode2'.


### PR DESCRIPTION
Adds [CRAN package `rxode2`](https://cran.r-project.org/package=rxode2) as `r-rxode2`, as well its obligate dependencies (`r-rxode2et`, `r-rxode2ll`, `r-rxode2parse`, `r-rxode2random`). All recipes generated with `conda_r_skeleton_helper` with licenses adjusted to SPDX and URLs split.

Closes #23103

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
