### PR TITLE
adds r-ordinalnet

### DIFF
--- a/recipes/r-ordinalnet/bld.bat
+++ b/recipes/r-ordinalnet/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ordinalnet/build.sh
+++ b/recipes/r-ordinalnet/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ordinalnet/meta.yaml
+++ b/recipes/r-ordinalnet/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
+  noarch: generic
   number: 0
   rpaths:
     - lib/R/lib/

--- a/recipes/r-ordinalnet/meta.yaml
+++ b/recipes/r-ordinalnet/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '2.12' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ordinalnet
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ordinalNet_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ordinalNet/ordinalNet_{{ version }}.tar.gz
+  sha256: 71f36530ccc1b651adf80d1e672acdee4ea38b0b04940bf47c0b1248c3ed4f46
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('ordinalNet')"           # [not win]
+    - "\"%R%\" -e \"library('ordinalNet')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=ordinalNet
+  license: MIT
+  summary: Fits ordinal regression models with elastic net penalty. Supported model families
+    include cumulative probability, stopping ratio, continuation ratio, and adjacent
+    category. These families are a subset of vector glm's which belong to a model class
+    we call the elementwise link multinomial-ordinal (ELMO) class. Each family in this
+    class links a vector of covariates to a vector of class probabilities. Each of these
+    families has a parallel form, which is appropriate for ordinal response data, as
+    well as a nonparallel form that is appropriate for an unordered categorical response,
+    or as a more flexible model for ordinal data. The parallel model has a single set
+    of coefficients, whereas the nonparallel model has a set of coefficients for each
+    response category except the baseline category. It is also possible to fit a model
+    with both parallel and nonparallel terms, which we call the semi-parallel model.
+    The semi-parallel model has the flexibility of the nonparallel model, but the elastic
+    net penalty shrinks it toward the parallel model. For details, refer to Wurm, Hanlon,
+    and Rathouz (2021) <doi:10.18637/jss.v099.i06>.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ordinalNet
+# Type: Package
+# Title: Penalized Ordinal Regression
+# Version: 2.12
+# Authors@R: c( person("Michael", "Wurm", email = "wurm@uwalumni.com", role = c("aut", "cre")), person("Paul", "Rathouz", email = "rathouz@biostat.wisc.edu", role = "aut"), person("Bret", "Hanlon", email = "hanlon@stat.wisc.edu", role = "aut"))
+# Description: Fits ordinal regression models with elastic net penalty. Supported model families include cumulative probability, stopping ratio, continuation ratio, and adjacent category. These families are a subset of vector glm's which belong to a model class we call the elementwise link multinomial-ordinal (ELMO) class. Each family in this class links a vector of covariates to a vector of class probabilities. Each of these families has a parallel form, which is appropriate for ordinal response data, as well as a nonparallel form that is appropriate for an unordered categorical response, or as a more flexible model for ordinal data. The parallel model has a single set of coefficients, whereas the nonparallel model has a set of coefficients for each response category except the baseline category. It is also possible to fit a model with both parallel and nonparallel terms, which we call the semi-parallel model. The semi-parallel model has the flexibility of the nonparallel model, but the elastic net penalty shrinks it toward the parallel model. For details, refer to Wurm, Hanlon, and Rathouz (2021) <doi:10.18637/jss.v099.i06>.
+# License: MIT + file LICENSE
+# Imports: stats, graphics
+# Suggests: testthat (>= 1.0.2), MASS (>= 7.3-45), glmnet (>= 2.0-5), penalized (>= 0.9-50), VGAM (>= 1.0-3), rms (>= 5.1-0)
+# RoxygenNote: 7.1.1
+# NeedsCompilation: yes
+# Packaged: 2022-03-22 02:50:08 UTC; mike
+# Author: Michael Wurm [aut, cre], Paul Rathouz [aut], Bret Hanlon [aut]
+# Maintainer: Michael Wurm <wurm@uwalumni.com>
+# Repository: CRAN
+# Date/Publication: 2022-03-22 08:10:02 UTC


### PR DESCRIPTION
Adds [CRAN package `ordinalNet`](https://cran.r-project.org/package=ordinalNet) as `r-ordinalnet`. Recipe generated with `conda_r_skeleton_helper`. Needed as new dependency in https://github.com/conda-forge/r-ordpens-feedstock/pull/5.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
