### PR TITLE
Add r-runonce from CRAN using conda_r_skeleton_helper

### DIFF
--- a/recipes/r-runonce/bld.bat
+++ b/recipes/r-runonce/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-runonce/build.sh
+++ b/recipes/r-runonce/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-runonce/meta.yaml
+++ b/recipes/r-runonce/meta.yaml
@@ -1,0 +1,75 @@
+{% set version = '0.2.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-runonce
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/runonce_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/runonce/runonce_{{ version }}.tar.gz
+  sha256: d686d9735af28b987cb8858620c5194454155dae23ebc3da376bb04613ff9512
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-bigassertr
+    - r-urltools
+  run:
+    - r-base
+    - r-bigassertr
+    - r-urltools
+
+test:
+  commands:
+    - $R -e "library('runonce')"           # [not win]
+    - "\"%R%\" -e \"library('runonce')\""  # [win]
+
+about:
+  home: https://github.com/privefl/runonce
+  license: GPL-3-only
+  summary: Package 'runonce' helps automating the saving of long-running code to help running
+    the same code multiple times. If you run some long-running code once, it saves the
+    result in a file on disk. Then, if the result already exists, i.e. if the code has
+    already been run and its output has already been saved, it just reads the result
+    from the stored file instead of running the code again.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - pettyalex
+
+# Package: runonce
+# Title: Run Once and Save Result
+# Version: 0.2.3
+# Authors@R: person("Florian", "Prive", role = c("aut", "cre"), email = "florian.prive.21@gmail.com")
+# Description: Package 'runonce' helps automating the saving of long-running code to help running the same code multiple times. If you run some long-running code once, it saves the result in a file on disk. Then, if the result already exists, i.e. if the code has already been run and its output has already been saved, it just reads the result from the stored file instead of running the code again.
+# License: GPL-3
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# Imports: bigassertr, urltools
+# Suggests: testthat (>= 2.1.0), covr
+# URL: https://github.com/privefl/runonce
+# BugReports: https://github.com/privefl/runonce/issues
+# NeedsCompilation: no
+# Packaged: 2021-10-02 08:22:15 UTC; au639593
+# Author: Florian Prive [aut, cre]
+# Maintainer: Florian Prive <florian.prive.21@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-10-02 08:30:02 UTC

--- a/recipes/r-runonce/meta.yaml
+++ b/recipes/r-runonce/meta.yaml
@@ -40,7 +40,7 @@ test:
 
 about:
   home: https://github.com/privefl/runonce
-  license: GPL-3-only
+  license: GPL-3.0-only
   summary: Package 'runonce' helps automating the saving of long-running code to help running
     the same code multiple times. If you run some long-running code once, it saves the
     result in a file on disk. Then, if the result already exists, i.e. if the code has


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io
-->

I'm hoping to add [r-runonce](https://cran.r-project.org/web/packages/runonce/index.html) from CRAN. It depends on several packages not in conda-forge yet, including this one.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
