### PR TITLE
Adds `r-pcadapt` and dep `r-mmapcharr`

### DIFF
--- a/recipes/r-mmapcharr/bld.bat
+++ b/recipes/r-mmapcharr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mmapcharr/build.sh
+++ b/recipes/r-mmapcharr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mmapcharr/meta.yaml
+++ b/recipes/r-mmapcharr/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-mmapcharr/meta.yaml
+++ b/recipes/r-mmapcharr/meta.yaml
@@ -21,16 +21,16 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-rcpp
@@ -48,12 +48,12 @@ test:
 
 about:
   home: https://github.com/privefl/mmapcharr
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Uses memory-mapping to enable the random access of elements of a text file of characters
     separated by characters as if it were a simple R(cpp) matrix.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-mmapcharr/meta.yaml
+++ b/recipes/r-mmapcharr/meta.yaml
@@ -1,0 +1,85 @@
+{% set version = '0.3.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mmapcharr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/mmapcharr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/mmapcharr/mmapcharr_{{ version }}.tar.gz
+  sha256: 19143a055dd6488045dc0cad1091444c7ed71aadd420f63b6b8c7ee39559b89c
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp
+    - r-rmio
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-rmio
+
+test:
+  commands:
+    - $R -e "library('mmapcharr')"           # [not win]
+    - "\"%R%\" -e \"library('mmapcharr')\""  # [win]
+
+about:
+  home: https://github.com/privefl/mmapcharr
+  license: GPL-3
+  summary: Uses memory-mapping to enable the random access of elements of a text file of characters
+    separated by characters as if it were a simple R(cpp) matrix.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: mmapcharr
+# Title: Memory-Map Character Files
+# Version: 0.3.0
+# Date: 2019-02-26
+# Authors@R: person("Florian", "Prive", email = "florian.prive.21@gmail.com", role = c("aut", "cre"))
+# Description: Uses memory-mapping to enable the random access of elements of a text file of characters separated by characters as if it were a simple R(cpp) matrix.
+# Encoding: UTF-8
+# License: GPL-3
+# LazyData: TRUE
+# ByteCompile: TRUE
+# Depends: R (>= 3.3.0)
+# Imports: methods, Rcpp
+# LinkingTo: Rcpp, rmio
+# Suggests: covr, testthat
+# RoxygenNote: 6.1.0.9000
+# URL: https://github.com/privefl/mmapcharr
+# BugReports: https://github.com/privefl/mmapcharr/issues
+# Collate: 'RcppExports.R' 'extract.R' 'file-dim.R' 'mmapchar.R' 'mmapcharr-package.r' 'utils.R'
+# NeedsCompilation: yes
+# Packaged: 2019-02-26 09:09:38 UTC; privef
+# Author: Florian Prive [aut, cre]
+# Maintainer: Florian Prive <florian.prive.21@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2019-02-26 12:20:02 UTC

--- a/recipes/r-pcadapt/bld.bat
+++ b/recipes/r-pcadapt/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-pcadapt/build.sh
+++ b/recipes/r-pcadapt/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-pcadapt/meta.yaml
+++ b/recipes/r-pcadapt/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
 
 requirements:
   build:

--- a/recipes/r-pcadapt/meta.yaml
+++ b/recipes/r-pcadapt/meta.yaml
@@ -21,16 +21,16 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-rspectra
@@ -60,14 +60,15 @@ test:
 
 about:
   home: https://github.com/bcm-uga/pcadapt
-  license: GPL-2.0-only
+  license: GPL-2.0-or-later
   summary: "Methods to detect genetic markers involved in biological adaptation. 'pcadapt' provides
     statistical tools for outlier detection based on Principal Component Analysis. Implements
     the method described in (Luu, 2016) <DOI:10.1111/1755-0998.12592> and later revised
     in (Priv\xE9, 2020) <DOI:10.1093/molbev/msaa053>."
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-pcadapt/meta.yaml
+++ b/recipes/r-pcadapt/meta.yaml
@@ -1,0 +1,97 @@
+{% set version = '4.3.5' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-pcadapt
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/pcadapt_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/pcadapt/pcadapt_{{ version }}.tar.gz
+  sha256: 3b61b18daafe091c13f13b49a39a9985f956e5710089d0f3a321f6887737d080
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rspectra
+    - r-rcpp >=0.12.8
+    - r-bigutilsr >=0.3
+    - r-data.table
+    - r-ggplot2
+    - r-magrittr
+    - r-mmapcharr >=0.3
+    - r-rmio
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rspectra
+    - r-rcpp >=0.12.8
+    - r-bigutilsr >=0.3
+    - r-data.table
+    - r-ggplot2
+    - r-magrittr
+    - r-mmapcharr >=0.3
+    - r-rmio
+
+test:
+  commands:
+    - $R -e "library('pcadapt')"           # [not win]
+    - "\"%R%\" -e \"library('pcadapt')\""  # [win]
+
+about:
+  home: https://github.com/bcm-uga/pcadapt
+  license: GPL-2.0-only
+  summary: "Methods to detect genetic markers involved in biological adaptation. 'pcadapt' provides
+    statistical tools for outlier detection based on Principal Component Analysis. Implements
+    the method described in (Luu, 2016) <DOI:10.1111/1755-0998.12592> and later revised
+    in (Priv\xE9, 2020) <DOI:10.1093/molbev/msaa053>."
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: pcadapt
+# Type: Package
+# Title: Fast Principal Component Analysis for Outlier Detection
+# Version: 4.3.5
+# Date: 2023-08-29
+# Authors@R: c( person("Keurcien", "Luu", role = "aut"), person("Michael", "Blum", role = "aut"), person("Florian", "Prive", role = c("aut", "cre"), email = "florian.prive.21@gmail.com"), person("Eric", "Bazin", role = "ctb"), person("Nicolas", "Duforet-Frebourg", role = "ctb"))
+# Description: Methods to detect genetic markers involved in biological adaptation. 'pcadapt' provides statistical tools for outlier detection based on Principal Component Analysis. Implements the method described in (Luu, 2016) <DOI:10.1111/1755-0998.12592> and later revised in (Prive, 2020) <DOI:10.1093/molbev/msaa053>.
+# License: GPL (>= 2)
+# Imports: bigutilsr (>= 0.3), data.table, ggplot2, magrittr, mmapcharr (>= 0.3), Rcpp (>= 0.12.8), RSpectra
+# LinkingTo: mmapcharr, Rcpp, rmio
+# Suggests: plotly, shiny, spelling, testthat, vcfR
+# RoxygenNote: 7.2.3
+# Encoding: UTF-8
+# Language: en-US
+# URL: https://github.com/bcm-uga/pcadapt
+# BugReports: https://github.com/bcm-uga/pcadapt/issues
+# NeedsCompilation: yes
+# Packaged: 2023-08-29 13:43:33 UTC; au639593
+# Author: Keurcien Luu [aut], Michael Blum [aut], Florian Prive [aut, cre], Eric Bazin [ctb], Nicolas Duforet-Frebourg [ctb]
+# Maintainer: Florian Prive <florian.prive.21@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-08-29 14:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `pcadapt`](https://cran.r-project.org/package=pcadapt) as `r-pcadapt` and (dependency) [CRAN package `mmapcharr`](https://cran.r-project.org/package=mmapcharr) as `r-mmapcharr`. Recipes generated with `conda_r_skeleton_helper` with licenses conformed to SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
