### PR TITLE
Adds `r-bien`

### DIFF
--- a/recipes/r-bien/bld.bat
+++ b/recipes/r-bien/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-bien/build.sh
+++ b/recipes/r-bien/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-bien/meta.yaml
+++ b/recipes/r-bien/meta.yaml
@@ -1,0 +1,88 @@
+{% set version = '1.2.6' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-bien
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/BIEN_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/BIEN/BIEN_{{ version }}.tar.gz
+  sha256: fa7a25d89f26c10686fb4ab4d0aa704beb50dc44b173ff56abe4ab3e5991f99f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dbi
+    - r-rpostgresql
+    - r-ape
+    - r-doparallel
+    - r-fasterize
+    - r-foreach
+    - r-raster
+    - r-sf
+    - r-terra
+  run:
+    - r-base
+    - r-dbi
+    - r-rpostgresql
+    - r-ape
+    - r-doparallel
+    - r-fasterize
+    - r-foreach
+    - r-raster
+    - r-sf
+    - r-terra
+
+test:
+  commands:
+    - $R -e "library('BIEN')"           # [not win]
+    - "\"%R%\" -e \"library('BIEN')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=BIEN
+  license: MIT
+  summary: Provides Tools for Accessing the Botanical Information and Ecology Network Database.  The
+    BIEN database contains cleaned and standardized botanical data including occurrence,
+    trait, plot and taxonomic data (See <https://bien.nceas.ucsb.edu/bien/> for more
+    Information).  This package provides functions that query the BIEN database by constructing
+    and executing optimized SQL queries.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: BIEN
+# Title: Tools for Accessing the Botanical Information and Ecology Network Database
+# Version: 1.2.6
+# Authors@R: person("Brian", "Maitner", email = "bmaitner@gmail.com", role = c("aut", "cre"))
+# Description: Provides Tools for Accessing the Botanical Information and Ecology Network Database.  The BIEN database contains cleaned and standardized botanical data including occurrence, trait, plot and taxonomic data (See <https://bien.nceas.ucsb.edu/bien/> for more Information).  This package provides functions that query the BIEN database by constructing and executing optimized SQL queries.
+# Depends: R (>= 3.2.1), RPostgreSQL
+# License: MIT + file LICENSE
+# Imports: DBI, ape, sf, fasterize, raster, terra, doParallel, parallel, foreach
+# Suggests: knitr, rmarkdown, testthat, maps
+# VignetteBuilder: knitr
+# RoxygenNote: 7.2.2
+# NeedsCompilation: no
+# Packaged: 2023-01-06 03:04:57 UTC; Brian Maitner
+# Author: Brian Maitner [aut, cre]
+# Maintainer: Brian Maitner <bmaitner@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-01-06 07:50:10 UTC


### PR DESCRIPTION
Adds [CRAN package `BIEN`](https://cran.r-project.org/package=BIEN) as `r-bien`. Recipe generated with `conda_r_skeleton_helper`.

Needed for https://github.com/conda-forge/r-rangemodelmetadata-feedstock/pull/4.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
