### PR TITLE
Adds `r-dbitest`

### DIFF
--- a/recipes/r-dbitest/bld.bat
+++ b/recipes/r-dbitest/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dbitest/build.sh
+++ b/recipes/r-dbitest/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dbitest/meta.yaml
+++ b/recipes/r-dbitest/meta.yaml
@@ -1,0 +1,100 @@
+{% set version = '1.7.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-dbitest
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/DBItest_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/DBItest/DBItest_{{ version }}.tar.gz
+  sha256: 30b7026378fedaec7e730fa4e242968dd70642f496457d7bf47d35e5c7ab891c
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dbi >=1.1.3
+    - r-r6
+    - r-blob >=1.2.0
+    - r-callr
+    - r-desc
+    - r-hms >=0.5.0
+    - r-lubridate
+    - r-palmerpenguins
+    - r-rlang >=0.2.0
+    - r-testthat >=2.0.0
+    - r-vctrs
+    - r-withr
+  run:
+    - r-base
+    - r-dbi >=1.1.3
+    - r-r6
+    - r-blob >=1.2.0
+    - r-callr
+    - r-desc
+    - r-hms >=0.5.0
+    - r-lubridate
+    - r-palmerpenguins
+    - r-rlang >=0.2.0
+    - r-testthat >=2.0.0
+    - r-vctrs
+    - r-withr
+
+test:
+  commands:
+    - $R -e "library('DBItest')"           # [not win]
+    - "\"%R%\" -e \"library('DBItest')\""  # [win]
+
+about:
+  home: https://dbitest.r-dbi.org, https://github.com/r-dbi/DBItest
+  license: LGPL-2.1
+  summary: A helper that tests DBI back ends for conformity to the interface.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: DBItest
+# Title: Testing DBI Backends
+# Version: 1.7.3
+# Date: 2022-10-18
+# Authors@R: c(person(given = "Kirill", family = "M\u00fcller", role = c("aut", "cre"), email = "kirill@cynkra.com", comment = c(ORCID = "0000-0002-1416-3412")), person(given = "RStudio", role = "cph"), person(given = "R Consortium", role = "fnd"))
+# Description: A helper that tests DBI back ends for conformity to the interface.
+# License: LGPL (>= 2.1)
+# URL: https://dbitest.r-dbi.org, https://github.com/r-dbi/DBItest
+# BugReports: https://github.com/r-dbi/DBItest/issues
+# Depends: R (>= 3.2.0)
+# Imports: blob (>= 1.2.0), callr, DBI (>= 1.1.3), desc, hms (>= 0.5.0), lubridate, methods, palmerpenguins, R6, rlang (>= 0.2.0), testthat (>= 2.0.0), utils, withr, vctrs
+# Suggests: clipr, dblog (>= 0.0.0.9008), debugme, devtools, knitr, lintr, rmarkdown, RSQLite
+# VignetteBuilder: knitr
+# Additional_repositories: https://r-dbi.r-universe.dev
+# Encoding: UTF-8
+# KeepSource: true
+# RoxygenNote: 7.2.1
+# Collate: 'DBItest.R' 'compat-purrr.R' 'context.R' 'dbi.R' 'dummy.R' 'expectations.R' 'generics.R' 'import-dbi.R' 'import-testthat.R' 'run.R' 's4.R' 'spec-getting-started.R' 'spec-compliance-methods.R' 'spec-driver-constructor.R' 'spec-driver-data-type.R' 'spec-connection-data-type.R' 'spec-result-create-table-with-data-type.R' 'spec-driver-connect.R' 'spec-connection-disconnect.R' 'spec-result-send-query.R' 'spec-result-fetch.R' 'spec-result-roundtrip.R' 'spec-result-clear-result.R' 'spec-result-get-query.R' 'spec-result-send-statement.R' 'spec-result-execute.R' 'spec-sql-quote-string.R' 'spec-sql-quote-literal.R' 'spec-sql-quote-identifier.R' 'spec-sql-unquote-identifier.R' 'spec-sql-read-table.R' 'spec-sql-create-table.R' 'spec-sql-append-table.R' 'spec-sql-write-table.R' 'spec-sql-list-tables.R' 'spec-sql-exists-table.R' 'spec-sql-remove-table.R' 'spec-sql-list-objects.R' 'spec-meta-bind-runner.R' 'spec-meta-bind-tester-extra.R' 'spec-meta-bind.R' 'spec-meta-bind-.R' 'spec-meta-is-valid.R' 'spec-meta-has-completed.R' 'spec-meta-get-statement.R' 'spec-meta-get-row-count.R' 'spec-meta-get-rows-affected.R' 'spec-transaction-begin-commit-rollback.R' 'spec-transaction-with-transaction.R' 'spec-driver-get-info.R' 'spec-connection-get-info.R' 'spec-sql-list-fields.R' 'spec-meta-column-info.R' 'spec-meta-get-info-result.R' 'spec-driver.R' 'spec-connection.R' 'spec-result.R' 'spec-sql.R' 'spec-meta.R' 'spec-transaction.R' 'spec-compliance.R' 'spec-stress-connection.R' 'spec-stress.R' 'spec-all.R' 'spec-.R' 'test-all.R' 'test-getting-started.R' 'test-driver.R' 'test-connection.R' 'test-result.R' 'test-sql.R' 'test-meta.R' 'test-transaction.R' 'test-compliance.R' 'test-stress.R' 'tweaks.R' 'utf8.R' 'utils.R' 'zzz.R'
+# Config/autostyle/scope: line_breaks
+# Config/autostyle/strict: false
+# Config/testthat/edition: 3
+# Config/gha/extra-packages: r-dbi/dblog
+# NeedsCompilation: no
+# Packaged: 2022-10-18 02:48:17 UTC; kirill
+# Author: Kirill Muller [aut, cre] (<https://orcid.org/0000-0002-1416-3412>), RStudio [cph], R Consortium [fnd]
+# Maintainer: Kirill Muller <kirill@cynkra.com>
+# Repository: CRAN
+# Date/Publication: 2022-10-18 07:25:35 UTC

--- a/recipes/r-dbitest/meta.yaml
+++ b/recipes/r-dbitest/meta.yaml
@@ -22,8 +22,8 @@ build:
 
 requirements:
   build:
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}zip             # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
   host:
     - r-base
     - r-dbi >=1.1.3
@@ -59,12 +59,14 @@ test:
     - "\"%R%\" -e \"library('DBItest')\""  # [win]
 
 about:
-  home: https://dbitest.r-dbi.org, https://github.com/r-dbi/DBItest
-  license: LGPL-2.1
+  home: https://dbitest.r-dbi.org
+  dev_url: https://github.com/r-dbi/DBItest
+  license: LGPL-2.1-or-later
   summary: A helper that tests DBI back ends for conformity to the interface.
   license_family: LGPL
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `DBItest`](https://cran.r-project.org/package=DBItest) as `r-dbitest`. Recipe generated with `conda_r_skeleton_helper` with license conformed to SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
