### PR TITLE
Add `r-latexpdf`

### DIFF
--- a/recipes/r-latexpdf/bld.bat
+++ b/recipes/r-latexpdf/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-latexpdf/build.sh
+++ b/recipes/r-latexpdf/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-latexpdf/meta.yaml
+++ b/recipes/r-latexpdf/meta.yaml
@@ -34,8 +34,8 @@ test:
     - r-tinytex
     - perl
   commands:
-    - $R -e "library('latexpdf')"                                                                 # [not win]
-    - $R -e "tinytex::install_tinytex(extra_packages='colortbl');latexpdf::as.pdf(head(Theoph))"  # [not win]
+    - $R -e "library('latexpdf')"  # [not win]
+    - $R -e "tinytex::install_tinytex(extra_packages=c('colortbl','multirow'));latexpdf::as.pdf(head(Theoph))"  # [linux]
     - "\"%R%\" -e \"library('latexpdf')\""  # [win]
 
 about:

--- a/recipes/r-latexpdf/meta.yaml
+++ b/recipes/r-latexpdf/meta.yaml
@@ -30,13 +30,17 @@ requirements:
     - r-base
 
 test:
+  requires:
+    - r-tinytex
+    - perl
   commands:
-    - $R -e "library('latexpdf')"           # [not win]
-    - "\"%R%\" -e \"library('latexpdf')\""  # [win]
+    - $R -e "library('latexpdf')"                                        # [not win]
+    - $R -e "tinytex::install_tinytex();latexpdf::as.pdf(head(Theoph))"  # [not win]
+    - "\"%R%\" -e \"library('latexpdf')\""                               # [win]
 
 about:
   home: https://CRAN.R-project.org/package=latexpdf
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Converts table-like objects to stand-alone PDF or PNG. Can be used to embed tables
     and arbitrary content in PDF or Word documents. Provides a low-level R interface
     for creating 'LaTeX' code, e.g. command() and a high-level interface for creating

--- a/recipes/r-latexpdf/meta.yaml
+++ b/recipes/r-latexpdf/meta.yaml
@@ -35,7 +35,7 @@ test:
     - perl
   commands:
     - $R -e "library('latexpdf')"  # [not win]
-    - $R -e "tinytex::install_tinytex(extra_packages=c('colortbl','multirow'));latexpdf::as.pdf(head(Theoph))"  # [linux]
+    - $R -e "tinytex::install_tinytex(extra_packages=c('colortbl','multirow'),force=TRUE);latexpdf::as.pdf(head(Theoph))"  # [linux]
     - "\"%R%\" -e \"library('latexpdf')\""  # [win]
 
 about:

--- a/recipes/r-latexpdf/meta.yaml
+++ b/recipes/r-latexpdf/meta.yaml
@@ -34,9 +34,9 @@ test:
     - r-tinytex
     - perl
   commands:
-    - $R -e "library('latexpdf')"                                        # [not win]
-    - $R -e "tinytex::install_tinytex();latexpdf::as.pdf(head(Theoph))"  # [not win]
-    - "\"%R%\" -e \"library('latexpdf')\""                               # [win]
+    - $R -e "library('latexpdf')"                                                                 # [not win]
+    - $R -e "tinytex::install_tinytex(extra_packages='colortbl');latexpdf::as.pdf(head(Theoph))"  # [not win]
+    - "\"%R%\" -e \"library('latexpdf')\""  # [win]
 
 about:
   home: https://CRAN.R-project.org/package=latexpdf

--- a/recipes/r-latexpdf/meta.yaml
+++ b/recipes/r-latexpdf/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = '0.1.7' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-latexpdf
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/latexpdf_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/latexpdf/latexpdf_{{ version }}.tar.gz
+  sha256: d43d491b4dedab20ccee9b392707031d79a3c863f031698a9d23bc2953fe1058
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('latexpdf')"           # [not win]
+    - "\"%R%\" -e \"library('latexpdf')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=latexpdf
+  license: GPL-3
+  summary: Converts table-like objects to stand-alone PDF or PNG. Can be used to embed tables
+    and arbitrary content in PDF or Word documents. Provides a low-level R interface
+    for creating 'LaTeX' code, e.g. command() and a high-level interface for creating
+    PDF documents, e.g. as.pdf.data.frame(). Extensive customization is available via
+    mid-level functions, e.g. as.tabular(). See also 'package?latexpdf'. Support for
+    PNG is experimental; see 'as.png.data.frame'. Adapted from 'metrumrg' <https://r-forge.r-project.org/R/?group_id=1215>.
+    Requires a compatible installation of 'pdflatex', e.g. <https://miktex.org/>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: latexpdf
+# Type: Package
+# Title: Convert Tables to PDF or PNG
+# Version: 0.1.7
+# Author: Tim Bergsma
+# Maintainer: Tim Bergsma <bergsmat@gmail.com>
+# Description: Converts table-like objects to stand-alone PDF or PNG. Can be used to embed tables and arbitrary content in PDF or Word documents. Provides a low-level R interface for creating 'LaTeX' code, e.g. command() and a high-level interface for creating PDF documents, e.g. as.pdf.data.frame(). Extensive customization is available via mid-level functions, e.g. as.tabular(). See also 'package?latexpdf'. Support for PNG is experimental; see 'as.png.data.frame'. Adapted from 'metrumrg' <https://r-forge.r-project.org/R/?group_id=1215>. Requires a compatible installation of 'pdflatex', e.g. <https://miktex.org/>.
+# License: GPL-3
+# Encoding: UTF-8
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2021-08-17 18:02:01 UTC; tim.bergsma
+# Repository: CRAN
+# Date/Publication: 2021-08-17 18:40:02 UTC


### PR DESCRIPTION
Adds [CRAN package `latexpdf`](https://cran.r-project.org/package=latexpdf) as `r-latexpdf`. Recipe generated with `conda_r_skeleton_helper` with license adjusted to SPDX and functionality test added.

As with CRAN and Anaconda versions of this package, this will not install a LaTeX installation for the user. However, the functional test here should demonstrate how `r-tinytex` can be used to get a minimal functional installation.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
