### PR TITLE
add lintrunner-adapters 0.11.0

### DIFF
--- a/recipes/lintrunner-adapters/meta.yaml
+++ b/recipes/lintrunner-adapters/meta.yaml
@@ -11,7 +11,10 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    - |-
+      {{ PYTHON }} -c "import os, pathlib; sp = pathlib.Path(os.environ['SP_DIR']); [(sp / f).unlink() for f in ['LICENSE']]"
   entry_points:
     - lintrunner_adapters = lintrunner_adapters.__main__:cli
 

--- a/recipes/lintrunner-adapters/meta.yaml
+++ b/recipes/lintrunner-adapters/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "0.11.0" %}
+
+package:
+  name: lintrunner-adapters
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/l/lintrunner-adapters/lintrunner_adapters-{{ version }}.tar.gz
+  sha256: 18bef20e795133995314db26bbc5e9290ad18adf5d7150d935fe8cb879200c08
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - lintrunner_adapters = lintrunner_adapters.__main__:cli
+
+requirements:
+  host:
+    - pip
+    - poetry-core
+    - python >=3.7
+  run:
+    - click >=8.1.3,<9.0.0
+    - python >=3.7.0
+
+test:
+  imports:
+    - lintrunner_adapters
+  commands:
+    - pip check
+    - lintrunner_adapters --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/justinchuby/lintrunner-adapters
+  summary: Adapters and tools for lintrunner
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
  - [x] remove duplicate clobberific `LICENSE` from `site-packages`. buh `poetry`
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
