### PR TITLE
adds `r-spam64`

### DIFF
--- a/recipes/r-spam64/bld.bat
+++ b/recipes/r-spam64/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-spam64/build.sh
+++ b/recipes/r-spam64/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-spam64/meta.yaml
+++ b/recipes/r-spam64/meta.yaml
@@ -42,11 +42,17 @@ requirements:
   run:
     - r-base
     - {{ native }}gcc-libs             # [win]
+  run_constrained:
+    - r-spam =={{ version|replace("-", "_") }}
 
 test:
+  requires:
+    - r-spam
   commands:
-    - $R -e "library('spam64')"           # [not win]
-    - "\"%R%\" -e \"library('spam64')\""  # [win]
+    - $R -e "library('spam64')"                           # [not win]
+    - $R -e "library('spam');library('spam64')"           # [not win]
+    - "\"%R%\" -e \"library('spam64')\""                  # [win]
+    - "\"%R%\" -e \"library('spam');library('spam64')\""  # [win]
 
 about:
   home: https://git.math.uzh.ch/reinhard.furrer/spam
@@ -57,8 +63,8 @@ about:
     is provided in Gerber, Moesinger and Furrer (2017) <doi:10.1016/j.cageo.2016.11.015>.
   license_family: LGPL
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause
     - LICENSE
 
 extra:

--- a/recipes/r-spam64/meta.yaml
+++ b/recipes/r-spam64/meta.yaml
@@ -18,24 +18,30 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
+    - '*/Rblas.dll'       # [win]
+    - '*/Rlapack.dll'     # [win]
 
 requirements:
   build:
+    - cross-r-base {{ r_base }}        # [build_platform != target_platform]
     - {{ compiler('c') }}              # [not win]
     - {{ compiler('m2w64_c') }}        # [win]
     - {{ compiler('fortran') }}        # [not win]
     - {{ compiler('m2w64_fortran') }}  # [win]
-    - {{ posix }}filesystem        # [win]
+    - {{ posix }}filesystem            # [win]
     - {{ posix }}make
-    - {{ posix }}sed               # [win]
-    - {{ posix }}coreutils         # [win]
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}sed                   # [win]
+    - {{ posix }}coreutils             # [win]
+    - {{ posix }}zip                   # [win]
   host:
+    - libblas
+    - liblapack
     - r-base
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
+    - {{ native }}gcc-libs             # [win]
 
 test:
   commands:
@@ -44,7 +50,7 @@ test:
 
 about:
   home: https://git.math.uzh.ch/reinhard.furrer/spam
-  license: LGPL-2 | BSD_3_clause
+  license: LGPL-2.0-only OR BSD_3_Clause
   summary: Provides the Fortran code of the R package 'spam' with 64-bit integers. Loading this
     package together with the R package spam enables the sparse matrix class spam to
     handle huge sparse matrices with more than 2^31-1 non-zero elements. Documentation

--- a/recipes/r-spam64/meta.yaml
+++ b/recipes/r-spam64/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '2.10-0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-spam64
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/spam64_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/spam64/spam64_{{ version }}.tar.gz
+  sha256: 969a003edd72a048b08e8f22ca173f3a80560b3a777470562111ac2ec297674d
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('fortran') }}        # [not win]
+    - {{ compiler('m2w64_fortran') }}  # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+
+test:
+  commands:
+    - $R -e "library('spam64')"           # [not win]
+    - "\"%R%\" -e \"library('spam64')\""  # [win]
+
+about:
+  home: https://git.math.uzh.ch/reinhard.furrer/spam
+  license: LGPL-2 | BSD_3_clause
+  summary: Provides the Fortran code of the R package 'spam' with 64-bit integers. Loading this
+    package together with the R package spam enables the sparse matrix class spam to
+    handle huge sparse matrices with more than 2^31-1 non-zero elements. Documentation
+    is provided in Gerber, Moesinger and Furrer (2017) <doi:10.1016/j.cageo.2016.11.015>.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: spam64
+# Type: Package
+# Title: 64-Bit Extension of the SPArse Matrix R Package 'spam'
+# Version: 2.10-0
+# Date: 2023-10-17
+# Authors@R: c(person("Reinhard", "Furrer", role = c("aut", "cre"), email = "reinhard.furrer@math.uzh.ch", comment = c(ORCID = "0000-0002-6319-2332")), person("Florian", "Gerber", role = c("aut"), email = "florian.gerber@math.uzh.ch", comment = c(ORCID = "0000-0001-8545-5263")), person("Roman", "Flury", role = c("aut"), email = "roman.flury@math.uzh.ch", comment = c(ORCID = "0000-0002-0349-8698")), person("Daniel", "Gerber", role = "ctb", email = "daniel_gerber_2222@hotmail.com"), person("Kaspar", "Moesinger", role = "ctb", email = "kaspar.moesinger@gmail.com"), person("Youcef", "Saad", role = "ctb", comment = "SPARSEKIT http://www-users.cs.umn.edu/~saad/software/SPARSKIT/"), person(c("Esmond", "G."), "Ng", role = "ctb", comment = "Fortran Cholesky routines"), person(c("Barry", "W."), "Peyton", role = "ctb", comment = "Fortran Cholesky routines"), person(c("Joseph", "W.H."), "Liu", role = "ctb", comment = "Fortran Cholesky routines"), person(c("Alan", "D."), "George", role = "ctb", comment = "Fortran Cholesky routines"), person(c("Lehoucq", "B."), "Rich", role = "ctb", comment = "ARPACK"), person(c("Maschhoff"), "Kristi", role = "ctb", comment = "ARPACK"), person(c("Sorensen", "C."), "Danny", role = "ctb", comment = "ARPACK"), person(c("Yang"), "Chao", role = "ctb", comment = "ARPACK"))
+# Description: Provides the Fortran code of the R package 'spam' with 64-bit integers. Loading this package together with the R package spam enables the sparse matrix class spam to handle huge sparse matrices with more than 2^31-1 non-zero elements. Documentation is provided in Gerber, Moesinger and Furrer (2017) <doi:10.1016/j.cageo.2016.11.015>.
+# Suggests: spam (== 2.10-0)
+# License: LGPL-2 | BSD_3_clause + file LICENSE
+# URL: https://git.math.uzh.ch/reinhard.furrer/spam
+# NeedsCompilation: yes
+# Packaged: 2023-10-17 18:28:47 UTC; furrer
+# Author: Reinhard Furrer [aut, cre] (<https://orcid.org/0000-0002-6319-2332>), Florian Gerber [aut] (<https://orcid.org/0000-0001-8545-5263>), Roman Flury [aut] (<https://orcid.org/0000-0002-0349-8698>), Daniel Gerber [ctb], Kaspar Moesinger [ctb], Youcef Saad [ctb] (SPARSEKIT http://www-users.cs.umn.edu/~saad/software/SPARSKIT/), Esmond G. Ng [ctb] (Fortran Cholesky routines), Barry W. Peyton [ctb] (Fortran Cholesky routines), Joseph W.H. Liu [ctb] (Fortran Cholesky routines), Alan D. George [ctb] (Fortran Cholesky routines), Lehoucq B. Rich [ctb] (ARPACK), Maschhoff Kristi [ctb] (ARPACK), Sorensen C. Danny [ctb] (ARPACK), Yang Chao [ctb] (ARPACK)
+# Maintainer: Reinhard Furrer <reinhard.furrer@math.uzh.ch>
+# Repository: CRAN
+# Date/Publication: 2023-10-17 20:10:02 UTC

--- a/recipes/r-spam64/meta.yaml
+++ b/recipes/r-spam64/meta.yaml
@@ -56,7 +56,7 @@ test:
 
 about:
   home: https://git.math.uzh.ch/reinhard.furrer/spam
-  license: LGPL-2.0-only OR BSD_3_Clause
+  license: LGPL-2.0-only OR BSD-3-Clause
   summary: Provides the Fortran code of the R package 'spam' with 64-bit integers. Loading this
     package together with the R package spam enables the sparse matrix class spam to
     handle huge sparse matrices with more than 2^31-1 non-zero elements. Documentation


### PR DESCRIPTION
Adds [CRAN package `spam64`](https://cran.r-project.org/package=spam64) as `r-spam64`. Recipe generated with `conda_r_skeleton_helper` with dependencies added and license conformed to SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
