### PR TITLE
add `r-nlmixr2` and supporting dependencies

### DIFF
--- a/recipes/r-nlmixr2/bld.bat
+++ b/recipes/r-nlmixr2/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-nlmixr2/build.sh
+++ b/recipes/r-nlmixr2/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nlmixr2/meta.yaml
+++ b/recipes/r-nlmixr2/meta.yaml
@@ -1,0 +1,89 @@
+{% set version = '2.0.9' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-nlmixr2
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/nlmixr2_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/nlmixr2/nlmixr2_{{ version }}.tar.gz
+  sha256: 07bb04fb17f3065380a07d8f100ceb2997d1ddfdecef06cf9bb84e390aa8cbd5
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-cli
+    - r-crayon
+    - r-lotri
+    - r-magrittr
+    - r-nlmixr2data
+    - r-nlmixr2est >=2.1.1
+    - r-nlmixr2extra
+    - r-nlmixr2plot
+    - r-rxode2 >=2.0.10
+  run:
+    - r-base
+    - r-cli
+    - r-crayon
+    - r-lotri
+    - r-magrittr
+    - r-nlmixr2data
+    - r-nlmixr2est >=2.1.1
+    - r-nlmixr2extra
+    - r-nlmixr2plot
+    - r-rxode2 >=2.0.10
+
+test:
+  commands:
+    - $R -e "library('nlmixr2')"           # [not win]
+    - "\"%R%\" -e \"library('nlmixr2')\""  # [win]
+
+about:
+  home: https://nlmixr2.org/, https://github.com/nlmixr2/nlmixr2/
+  license: GPL-3
+  summary: Fit and compare nonlinear mixed-effects models in differential equations with flexible
+    dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist,
+    Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation
+    solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and
+    James 2015 <doi:10.1002/psp4.12052>).
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: nlmixr2
+# Title: Nonlinear Mixed Effects Models in Population PK/PD
+# Version: 2.0.9
+# Authors@R: c(person("Matthew","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")), person("Yuan", "Xiong", role = "ctb", email = "yuan.xiong@gmail.com"), person("Rik", "Schoemaker", role = "ctb", email = "rik.schoemaker@occams.com", comment=c(ORCID="0000-0002-7538-3005")), person("Justin", "Wilkins", role = "ctb", email = "justin.wilkins@occams.com", comment=c(ORCID="0000-0002-7099-9396")), person("Wenping", "Wang", role = "ctb", email = "wwang8198@gmail.com"), person("Mirjam","Trame", role = "ctb", email="mirjam.trame@gmail.com"), person("Huijuan", "Xu", role="ctb", email="huijuan.xu.pmx@gmail.com"), person("John", "Harrold", role="ctb", email="john.m.harrold@gmail.com"), person("Bill", "Denney", email="wdenney@humanpredictions.com", role="ctb", comment=c(ORCID="0000-0002-5759-428X")), person("Theodoros", "Papathanasiou",  role="ctb"), person("Teun","Post", role = "ctb", email = "t.post@lapp.nl"), person("Richard", "Hooijmaijers", email = "richardhooijmaijers@gmail.com", role = "ctb"))
+# Description: Fit and compare nonlinear mixed-effects models in differential equations with flexible dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist, Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and James 2015 <doi:10.1002/psp4.12052>).
+# License: GPL (>= 3)
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: nlmixr2est (>= 2.1.1), nlmixr2extra, rxode2 (>= 2.0.10), lotri, nlmixr2plot, magrittr, crayon, cli
+# Depends: nlmixr2data
+# Suggests: rmarkdown, knitr, devtools, ggplot2, testthat, n1qn1, withr
+# BugReports: https://github.com/nlmixr2/nlmixr2/issues/
+# URL: https://nlmixr2.org/, https://github.com/nlmixr2/nlmixr2/
+# NeedsCompilation: no
+# Packaged: 2023-02-21 01:04:35 UTC; matt
+# Author: Matthew Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Yuan Xiong [ctb], Rik Schoemaker [ctb] (<https://orcid.org/0000-0002-7538-3005>), Justin Wilkins [ctb] (<https://orcid.org/0000-0002-7099-9396>), Wenping Wang [ctb], Mirjam Trame [ctb], Huijuan Xu [ctb], John Harrold [ctb], Bill Denney [ctb] (<https://orcid.org/0000-0002-5759-428X>), Theodoros Papathanasiou [ctb], Teun Post [ctb], Richard Hooijmaijers [ctb]
+# Maintainer: Matthew Fidler <matthew.fidler@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-02-21 04:00:02 UTC

--- a/recipes/r-nlmixr2/meta.yaml
+++ b/recipes/r-nlmixr2/meta.yaml
@@ -53,8 +53,9 @@ test:
     - "\"%R%\" -e \"library('nlmixr2')\""  # [win]
 
 about:
-  home: https://nlmixr2.org/, https://github.com/nlmixr2/nlmixr2/
-  license: GPL-3
+  home: https://nlmixr2.org/
+  dev_url: https://github.com/nlmixr2/nlmixr2/
+  license: GPL-3.0-or-later
   summary: Fit and compare nonlinear mixed-effects models in differential equations with flexible
     dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist,
     Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation
@@ -62,7 +63,7 @@ about:
     James 2015 <doi:10.1002/psp4.12052>).
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-nlmixr2data/bld.bat
+++ b/recipes/r-nlmixr2data/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-nlmixr2data/build.sh
+++ b/recipes/r-nlmixr2data/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nlmixr2data/meta.yaml
+++ b/recipes/r-nlmixr2data/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '2.0.8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-nlmixr2data
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/nlmixr2data_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/nlmixr2data/nlmixr2data_{{ version }}.tar.gz
+  sha256: bbcf1fe237cc9a9ec44a061710f40e697a5f763b7c542cc67dea19d53809eeeb
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('nlmixr2data')"           # [not win]
+    - "\"%R%\" -e \"library('nlmixr2data')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/nlmixr2data/
+  dev_url: https://github.com/nlmixr2/nlmixr2data/
+  license: GPL-3.0-or-later
+  summary: Datasets for 'nlmixr2' and 'rxode2'. 'nlmixr2' is used for fitting and comparing nonlinear
+    mixed-effects models in differential equations with flexible dosing information
+    commonly seen in pharmacokinetics and pharmacodynamics (Almquist, Leander, and Jirstrand
+    2015 <doi:10.1007/s10928-015-9409-1>). Differential equation solving is by compiled
+    C code provided in the 'rxode2' package (Wang, Hallow, and James 2015 <doi:10.1002/psp4.12052>).
+  license_family: GPL3
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: nlmixr2data
+# Title: Nonlinear Mixed Effects Models in Population PK/PD, Data
+# Version: 2.0.8
+# Authors@R: c(person("Matthew","Fidler", role = c("aut", "cre"), email = "matthew.fidler@gmail.com", comment=c(ORCID="0000-0001-8538-6691")), person("Rik", "Schoemaker", role = "ctb", email = "rik.schoemaker@occams.com", comment=c(ORCID="0000-0002-7538-3005")), person("Thierry", "Wendling", role = "ctb"), person("Ted","Grasella", role="ctb"), person("C", "Weil", role="ctb"), person("Yaning", "Wang", role="ctb"), person("R", "O'Reilly", role="ctb"), person("David", "D'Argenio", role="ctb"), person("", "Rodriguez-Vera", role="ctb"), person("D", "Gaver", role="ctb"), person("Yuan", "Xiong", role="ctb"), person("Wenping", "Wang", role = "aut", email = "wwang8198@gmail.com") )
+# Description: Datasets for 'nlmixr2' and 'rxode2'. 'nlmixr2' is used for fitting and comparing nonlinear mixed-effects models in differential equations with flexible dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist, Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and James 2015 <doi:10.1002/psp4.12052>).
+# License: GPL (>= 3)
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Depends: R (>= 2.10)
+# LazyData: true
+# BugReports: https://github.com/nlmixr2/nlmixr2data/issues/
+# URL: https://nlmixr2.github.io/nlmixr2data/, https://github.com/nlmixr2/nlmixr2data/
+# NeedsCompilation: no
+# Packaged: 2023-08-30 22:55:52 UTC; matt
+# Author: Matthew Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Rik Schoemaker [ctb] (<https://orcid.org/0000-0002-7538-3005>), Thierry Wendling [ctb], Ted Grasella [ctb], C Weil [ctb], Yaning Wang [ctb], R O'Reilly [ctb], David D'Argenio [ctb], Rodriguez-Vera [ctb], D Gaver [ctb], Yuan Xiong [ctb], Wenping Wang [aut]
+# Maintainer: Matthew Fidler <matthew.fidler@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-08-30 23:30:02 UTC

--- a/recipes/r-nlmixr2est/bld.bat
+++ b/recipes/r-nlmixr2est/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-nlmixr2est/build.sh
+++ b/recipes/r-nlmixr2est/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nlmixr2est/meta.yaml
+++ b/recipes/r-nlmixr2est/meta.yaml
@@ -70,7 +70,6 @@ requirements:
     - r-base
     - {{ native }}gcc-libs           # [win]
     - {{ native }}libwinpthread-git  # [win]
-    - r-bh
     - r-matrix
     - r-rcpp
     - r-rcpparmadillo >=0.11.2.3.1

--- a/recipes/r-nlmixr2est/meta.yaml
+++ b/recipes/r-nlmixr2est/meta.yaml
@@ -1,0 +1,131 @@
+{% set version = '2.1.8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-nlmixr2est
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/nlmixr2est_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/nlmixr2est/nlmixr2est_{{ version }}.tar.gz
+  sha256: bd2c2e6c7922bc86837e28859e8c967bbb72abf90d2ffd98b735c9e883aab4d3
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
+
+requirements:
+  build:
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+  host:
+    - r-base
+    - r-bh
+    - r-matrix
+    - r-rcpp
+    - r-rcpparmadillo >=0.11.2.3.1
+    - r-backports
+    - r-checkmate
+    - r-cli
+    - r-knitr
+    - r-lbfgsb3c
+    - r-lotri
+    - r-magrittr
+    - r-minqa
+    - r-n1qn1 >=6.0.1_10
+    - r-nlme
+    - r-nlmixr2data
+    - r-rex
+    - r-rxode2 >=2.0.12
+    - r-rxode2parse >=2.0.11
+    - r-rxode2random >=2.0.9
+    - r-symengine
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-bh
+    - r-matrix
+    - r-rcpp
+    - r-rcpparmadillo >=0.11.2.3.1
+    - r-backports
+    - r-checkmate
+    - r-cli
+    - r-knitr
+    - r-lbfgsb3c
+    - r-lotri
+    - r-magrittr
+    - r-minqa
+    - r-n1qn1 >=6.0.1_10
+    - r-nlme
+    - r-nlmixr2data
+    - r-rex
+    - r-rxode2 >=2.0.12
+    - r-rxode2parse >=2.0.11
+    - r-rxode2random >=2.0.9
+    - r-symengine
+
+test:
+  commands:
+    - $R -e "library('nlmixr2est')"           # [not win]
+    - "\"%R%\" -e \"library('nlmixr2est')\""  # [win]
+
+about:
+  home: https://github.com/nlmixr2/nlmixr2est
+  dev_url: https://nlmixr2.github.io/nlmixr2est/
+  license: GPL-3.0-or-later
+  summary: Fit and compare nonlinear mixed-effects models in differential equations with flexible
+    dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist,
+    Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation
+    solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and
+    James 2015 <doi:10.1002/psp4.12052>).
+  license_family: GPL3
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: nlmixr2est
+# Title: Nonlinear Mixed Effects Models in Population PK/PD, Estimation Routines
+# Version: 2.1.8
+# Authors@R: c( person("Matthew", "Fidler", , "matt.fidler@novartis.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")), person("Yuan", "Xiong", , "yuan.xiong@gmail.com", role = "aut"), person("Rik", "Schoemaker", , "rik.schoemaker@occams.com", role = "aut", comment = c(ORCID = "0000-0002-7538-3005")), person("Justin", "Wilkins", , "justin.wilkins@occams.com", role = "aut", comment = c(ORCID = "0000-0002-7099-9396")), person("Wenping", "Wang", , "wwang8198@gmail.com", role = "aut"), person("Robert", "Leary", role = "ctb"), person("Mason", "McComb", , "mason.c.mccomb@gmail.com", role = "ctb", comment = c(ORCID = "0000-0001-9871-8616")), person("Vipul", "Mann", , "vm2583@columbia.edu", role = "aut"), person("Mirjam", "Trame", , "mirjam.trame@gmail.com", role = "ctb"), person("Mahmoud", "Abdelwahab", , "mah.tareq87@gmail.com", role = "ctb"), person("Teun", "Post", , "t.post@lapp.nl", role = "ctb"), person("Richard", "Hooijmaijers", , "richardhooijmaijers@gmail.com", role = "aut"), person("Hadley", "Wickham", role = "ctb"), person("Dirk", "Eddelbuettel", , "edd@debian.org", role = "cph"), person("Johannes", "Pfeifer", role = "ctb"), person("Robert B.", "Schnabel", role = "ctb"), person("Elizabeth", "Eskow", role = "ctb"), person("Emmanuelle", "Comets", , "emmanuelle.comets@inserm.fr", role = "ctb"), person("Audrey", "Lavenu", role = "ctb"), person("Marc", "Lavielle", role = "ctb"), person("David", "Ardia", role = "cph"), person("Katharine", "Mullen", role = "cph"), person("Ben", "Goodrich", role = "ctb") )
+# Maintainer: Matthew Fidler <matt.fidler@novartis.com>
+# Description: Fit and compare nonlinear mixed-effects models in differential equations with flexible dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist, Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and James 2015 <doi:10.1002/psp4.12052>).
+# License: GPL (>= 3)
+# URL: https://github.com/nlmixr2/nlmixr2est, https://nlmixr2.github.io/nlmixr2est/
+# Depends: nlmixr2data, R (>= 4.0)
+# Imports: backports, checkmate, cli, graphics, knitr, lbfgsb3c, lotri, magrittr, Matrix, methods, minqa, n1qn1 (>= 6.0.1-10), nlme, Rcpp, rex, rxode2 (>= 2.0.12), stats, symengine, utils
+# Suggests: broom.mixed, crayon, data.table, devtools, digest, dplyr (>= 1.1.0), generics, nloptr, qs, sys, testthat, tibble, withr, xgxr, sfsmisc, rxode2parse (>= 2.0.11), rxode2random (>= 2.0.9)
+# LinkingTo: BH, lbfgsb3c, Rcpp, RcppArmadillo (>= 0.11.2.3.1), rxode2 (>= 2.0.12), rxode2parse (>= 2.0.11), rxode2random (>= 2.0.9)
+# Biarch: true
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# Language: en-US
+# NeedsCompilation: yes
+# RoxygenNote: 7.2.3
+# LazyData: true
+# Packaged: 2023-10-08 03:07:25 UTC; matt
+# Author: Matthew Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Yuan Xiong [aut], Rik Schoemaker [aut] (<https://orcid.org/0000-0002-7538-3005>), Justin Wilkins [aut] (<https://orcid.org/0000-0002-7099-9396>), Wenping Wang [aut], Robert Leary [ctb], Mason McComb [ctb] (<https://orcid.org/0000-0001-9871-8616>), Vipul Mann [aut], Mirjam Trame [ctb], Mahmoud Abdelwahab [ctb], Teun Post [ctb], Richard Hooijmaijers [aut], Hadley Wickham [ctb], Dirk Eddelbuettel [cph], Johannes Pfeifer [ctb], Robert B. Schnabel [ctb], Elizabeth Eskow [ctb], Emmanuelle Comets [ctb], Audrey Lavenu [ctb], Marc Lavielle [ctb], David Ardia [cph], Katharine Mullen [cph], Ben Goodrich [ctb]
+# Repository: CRAN
+# Date/Publication: 2023-10-08 04:40:03 UTC

--- a/recipes/r-nlmixr2est/meta.yaml
+++ b/recipes/r-nlmixr2est/meta.yaml
@@ -20,6 +20,8 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'           # [win]
+    - '*/Rblas.dll'       # [win]
+    - '*/Rlapack.dll'     # [win]
 
 requirements:
   build:
@@ -38,6 +40,8 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
+    - libgomp                      # [linux]
+    - llvm-openmp                  # [osx]
   host:
     - r-base
     - r-bh
@@ -60,6 +64,8 @@ requirements:
     - r-rxode2parse >=2.0.11
     - r-rxode2random >=2.0.9
     - r-symengine
+    - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-nlmixr2est/meta.yaml
+++ b/recipes/r-nlmixr2est/meta.yaml
@@ -68,7 +68,8 @@ requirements:
     - liblapack
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
+    - {{ native }}gcc-libs           # [win]
+    - {{ native }}libwinpthread-git  # [win]
     - r-bh
     - r-matrix
     - r-rcpp

--- a/recipes/r-nlmixr2extra/bld.bat
+++ b/recipes/r-nlmixr2extra/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-nlmixr2extra/build.sh
+++ b/recipes/r-nlmixr2extra/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nlmixr2extra/meta.yaml
+++ b/recipes/r-nlmixr2extra/meta.yaml
@@ -62,7 +62,8 @@ requirements:
     - liblapack
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
+    - {{ native }}gcc-libs           # [win]
+    - {{ native }}libwinpthread-git  # [win]
     - r-rcpp
     - r-rcpparmadillo
     - r-checkmate

--- a/recipes/r-nlmixr2extra/meta.yaml
+++ b/recipes/r-nlmixr2extra/meta.yaml
@@ -1,0 +1,121 @@
+{% set version = '2.0.8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-nlmixr2extra
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/nlmixr2extra_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/nlmixr2extra/nlmixr2extra_{{ version }}.tar.gz
+  sha256: cd05d39c3877d32910d4b81aadb8908f86a936f593403558228f1a09399eabeb
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'           # [win]
+
+requirements:
+  build:
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+  host:
+    - r-base
+    - r-rcpp
+    - r-rcpparmadillo
+    - r-checkmate
+    - r-cli >=3.4.0
+    - r-crayon
+    - r-data.table
+    - r-digest
+    - r-ggplot2
+    - r-ggtext
+    - r-lotri
+    - r-nlme
+    - r-nlmixr2est >=2.1.1
+    - r-rxode2 >=2.0.10
+    - r-symengine
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-rcpparmadillo
+    - r-checkmate
+    - r-cli >=3.4.0
+    - r-crayon
+    - r-data.table
+    - r-digest
+    - r-ggplot2
+    - r-ggtext
+    - r-lotri
+    - r-nlme
+    - r-nlmixr2est >=2.1.1
+    - r-rxode2 >=2.0.10
+    - r-symengine
+
+test:
+  commands:
+    - $R -e "library('nlmixr2extra')"           # [not win]
+    - "\"%R%\" -e \"library('nlmixr2extra')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/nlmixr2extra/
+  dev_url: https://github.com/nlmixr2/nlmixr2extra/
+  license: GPL-3.0-or-later
+  summary: Fit and compare nonlinear mixed-effects models in differential equations with flexible
+    dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist,
+    Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation
+    solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and
+    James 2015 <doi:10.1002/psp4.12052>). This package is for support functions like
+    preconditioned fits <doi:10.1208/s12248-016-9866-5>, boostrap and stepwise covariate
+    selection.
+  license_family: GPL3
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: nlmixr2extra
+# Title: Nonlinear Mixed Effects Models in Population PK/PD, Extra Support Functions
+# Version: 2.0.8
+# Authors@R: c( person("Matthew", "Fidler", email="matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")), person("Vipul", "Mann",email="vm2583@columbia.edu", role = "aut"), person("Vishal", "Sarsani", email="vsarsani@umass.edu", comment=c(ORCID = "0000-0002-9272-3438"), role="aut"), person("Christian", "Bartels", email="christian.bartels@novartis.com", role="ctb") )
+# Maintainer: Matthew Fidler <matthew.fidler@gmail.com>
+# Description: Fit and compare nonlinear mixed-effects models in differential equations with flexible dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist, Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and James 2015 <doi:10.1002/psp4.12052>). This package is for support functions like preconditioned fits <doi:10.1208/s12248-016-9866-5>, boostrap and stepwise covariate selection.
+# Depends: R (>= 4.0)
+# License: GPL (>= 3)
+# URL: https://nlmixr2.github.io/nlmixr2extra/, https://github.com/nlmixr2/nlmixr2extra/
+# BugReports: https://github.com/nlmixr2/nlmixr2extra/issues/
+# Imports: checkmate, cli (>= 3.4.0), crayon, data.table, digest, ggplot2, ggtext, lotri, nlme, nlmixr2est (>= 2.1.1), Rcpp, rxode2 (>= 2.0.10), stats, symengine, utils
+# Suggests: brms, nlmixr2data, testthat (>= 3.0.0), withr, dplyr, devtools
+# LinkingTo: Rcpp, RcppArmadillo
+# Biarch: true
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# NeedsCompilation: yes
+# RoxygenNote: 7.2.1
+# LazyData: true
+# Packaged: 2022-10-22 15:12:13 UTC; matt
+# Author: Matthew Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Vipul Mann [aut], Vishal Sarsani [aut] (<https://orcid.org/0000-0002-9272-3438>), Christian Bartels [ctb]
+# Repository: CRAN
+# Date/Publication: 2022-10-22 22:32:34 UTC

--- a/recipes/r-nlmixr2extra/meta.yaml
+++ b/recipes/r-nlmixr2extra/meta.yaml
@@ -20,6 +20,8 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'           # [win]
+    - '*/Rblas.dll'       # [win]
+    - '*/Rlapack.dll'     # [win]
 
 requirements:
   build:
@@ -38,6 +40,8 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
+    - libgomp                      # [linux]
+    - llvm-openmp                  # [osx]
   host:
     - r-base
     - r-rcpp
@@ -54,6 +58,8 @@ requirements:
     - r-nlmixr2est >=2.1.1
     - r-rxode2 >=2.0.10
     - r-symengine
+    - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]

--- a/recipes/r-nlmixr2plot/bld.bat
+++ b/recipes/r-nlmixr2plot/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-nlmixr2plot/build.sh
+++ b/recipes/r-nlmixr2plot/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nlmixr2plot/meta.yaml
+++ b/recipes/r-nlmixr2plot/meta.yaml
@@ -1,0 +1,85 @@
+{% set version = '2.0.7' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-nlmixr2plot
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/nlmixr2plot_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/nlmixr2plot/nlmixr2plot_{{ version }}.tar.gz
+  sha256: aada8a21e697ad598c180183ed5f1b047181e946bcae46f11c8f5fd9fa4deb2e
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-ggplot2
+    - r-nlmixr2est
+    - r-nlmixr2extra
+    - r-rxode2
+    - r-vpc
+    - r-xgxr
+  run:
+    - r-base
+    - r-ggplot2
+    - r-nlmixr2est
+    - r-nlmixr2extra
+    - r-rxode2
+    - r-vpc
+    - r-xgxr
+
+test:
+  commands:
+    - $R -e "library('nlmixr2plot')"           # [not win]
+    - "\"%R%\" -e \"library('nlmixr2plot')\""  # [win]
+
+about:
+  home: https://nlmixr2.github.io/nlmixr2plot/
+  dev_url: https://github.com/nlmixr2/nlmixr2plot
+  license: GPL-3.0-or-later
+  summary: Fit and compare nonlinear mixed-effects models in differential equations with flexible
+    dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist,
+    Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation
+    solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and
+    James 2015 <doi:10.1002/psp4.12052>). This package is for 'ggplot2' plotting methods
+    for 'nlmixr2' objects.
+  license_family: GPL3
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: nlmixr2plot
+# Title: Nonlinear Mixed Effects Models in Population PK/PD, Plot Functions
+# Version: 2.0.7
+# Authors@R: c( person("Matthew", "Fidler", email="matthew.fidler@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-8538-6691")), person("Bill", "Denney", email="wdenney@humanpredictions.com", role = "ctb", comment = c(ORCID = "0000-0002-5759-428X")), person("Wenping", "Wang", email="wwang8198@gmail.com", role = "aut"), person("Vipul", "Mann", email="vm2583@columbia.edu", role = "aut") )
+# Description: Fit and compare nonlinear mixed-effects models in differential equations with flexible dosing information commonly seen in pharmacokinetics and pharmacodynamics (Almquist, Leander, and Jirstrand 2015 <doi:10.1007/s10928-015-9409-1>). Differential equation solving is by compiled C code provided in the 'rxode2' package (Wang, Hallow, and James 2015 <doi:10.1002/psp4.12052>). This package is for 'ggplot2' plotting methods for 'nlmixr2' objects.
+# License: GPL (>= 3)
+# URL: https://github.com/nlmixr2/nlmixr2plot
+# BugReports: https://github.com/nlmixr2/nlmixr2plot/issues/
+# Imports: ggplot2, nlmixr2est, nlmixr2extra, rxode2, utils, vpc, xgxr
+# Suggests: testthat (>= 3.0.0), dplyr, withr, nlmixr2data
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# RoxygenNote: 7.2.1
+# NeedsCompilation: no
+# Packaged: 2022-10-20 01:52:54 UTC; matt
+# Author: Matthew Fidler [aut, cre] (<https://orcid.org/0000-0001-8538-6691>), Bill Denney [ctb] (<https://orcid.org/0000-0002-5759-428X>), Wenping Wang [aut], Vipul Mann [aut]
+# Maintainer: Matthew Fidler <matthew.fidler@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-10-20 03:12:36 UTC

--- a/recipes/r-xgxr/bld.bat
+++ b/recipes/r-xgxr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-xgxr/build.sh
+++ b/recipes/r-xgxr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-xgxr/meta.yaml
+++ b/recipes/r-xgxr/meta.yaml
@@ -1,0 +1,115 @@
+{% set version = '1.1.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-xgxr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/xgxr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/xgxr/xgxr_{{ version }}.tar.gz
+  sha256: fba919415726ed5ff80db1e7b207aaf633789a2e760f7adda2149fa5be81b656
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-deriv
+    - r-desctools
+    - r-hmisc
+    - r-rcurl
+    - r-assertthat
+    - r-binom
+    - r-dplyr
+    - r-ggplot2
+    - r-glue
+    - r-gtable
+    - r-labeling
+    - r-magrittr
+    - r-minpack.lm
+    - r-pander
+    - r-png
+    - r-readr
+    - r-scales
+    - r-stringr
+    - r-tibble
+  run:
+    - r-base
+    - r-deriv
+    - r-desctools
+    - r-hmisc
+    - r-rcurl
+    - r-assertthat
+    - r-binom
+    - r-dplyr
+    - r-ggplot2
+    - r-glue
+    - r-gtable
+    - r-labeling
+    - r-magrittr
+    - r-minpack.lm
+    - r-pander
+    - r-png
+    - r-readr
+    - r-scales
+    - r-stringr
+    - r-tibble
+
+test:
+  commands:
+    - $R -e "library('xgxr')"           # [not win]
+    - "\"%R%\" -e \"library('xgxr')\""  # [win]
+
+about:
+  home: https://opensource.nibr.com/xgx/
+  dev_url: https://github.com/Novartis/xgxr
+  license: MIT
+  summary: Supports a structured approach for exploring PKPD data <https://opensource.nibr.com/xgx/>.
+    It also contains helper functions for enabling the modeler to follow best R practices
+    (by appending the program name, figure name location, and draft status to each plot).
+    In addition, it enables the modeler to follow best graphical practices (by providing
+    a theme that reduces chart ink, and by providing time-scale, log-scale, and reverse-log-transform-scale
+    functions for more readable axes). Finally, it provides some data checking and summarizing
+    functions for rapidly exploring pharmacokinetics and pharmacodynamics (PKPD) datasets.
+  license_family: MIT
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: xgxr
+# Title: Exploratory Graphics for Pharmacometrics
+# Version: 1.1.2
+# Authors@R: c(person(given = "Andrew", family = "Stein", role = c("aut", "cre"), email = "andy.stein@gmail.com"), person(given = "Alison", family = "Margolskee", role = "aut", email = "alison.margolskee@gmail.com"), person(given = "Fariba", family = "Khanshan", role = "aut", email = "faribashan@gmail.com"), person(given = "Konstantin", family = "Krismer", role = "aut", email = "krismer@mit.edu", comment = c(ORCID = "0000-0001-8994-3416")), person(given = "Matthew", family = "Fidler", role = "ctb", email = "matthew.fidler@gmail.com", comment = c(ORCID = "0000-0001-8538-6691")), person("Novartis Pharma AG", role = c("cph","fnd")))
+# Description: Supports a structured approach for exploring PKPD data <https://opensource.nibr.com/xgx/>. It also contains helper functions for enabling the modeler to follow best R practices (by appending the program name, figure name location, and draft status to each plot). In addition, it enables the modeler to follow best graphical practices (by providing a theme that reduces chart ink, and by providing time-scale, log-scale, and reverse-log-transform-scale functions for more readable axes). Finally, it provides some data checking and summarizing functions for rapidly exploring pharmacokinetics and pharmacodynamics (PKPD) datasets.
+# License: MIT + file LICENSE
+# URL: https://opensource.nibr.com/xgx/
+# BugReports: https://github.com/Novartis/xgxr/issues
+# Depends: R (>= 3.5.0)
+# Imports: assertthat, binom, Deriv, DescTools, dplyr, ggplot2, glue, graphics, grDevices, gtable, Hmisc, labeling, magrittr, minpack.lm, pander, png, RCurl, readr, scales, stats, stringr, tibble, utils
+# Suggests: caTools, gridExtra, knitr, pkgdown, rmarkdown, testthat, tidyr
+# VignetteBuilder: knitr
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.1.2
+# NeedsCompilation: no
+# Packaged: 2023-03-22 12:37:10 UTC; steinanf
+# Author: Andrew Stein [aut, cre], Alison Margolskee [aut], Fariba Khanshan [aut], Konstantin Krismer [aut] (<https://orcid.org/0000-0001-8994-3416>), Matthew Fidler [ctb] (<https://orcid.org/0000-0001-8538-6691>), Novartis Pharma AG [cph, fnd]
+# Maintainer: Andrew Stein <andy.stein@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-03-22 14:20:02 UTC


### PR DESCRIPTION
Adds [CRAN package `nlmixr2`](https://cran.r-project.org/package=nlmixr2) as `r-nlmixr2`, as well as supporting dependencies `r-nlmixr2data`, `r-nlmixr2est`, `r-nlmixr2extra`, `r-nlmixr2plot`, and `r-xgxr`. Recipes generated with `conda_r_skeleton_helper` with licenses conformed to SPDX and URLs split.

Resolves #23137

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
