### PR TITLE
Add Python package veerer

### DIFF
--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -12,6 +12,9 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  # SageMath is not available on Windows. We could build veerer but it cannot
+  # even be imported then without sagelib.
+  skip: True  # [win]
 
 requirements:
   build:

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -30,10 +30,13 @@ requirements:
 test:
   imports:
     - veerer
-  commands:
-    - pip check
-  requires:
-    - pip
+  # pip check fails due to
+  # https://github.com/conda-forge/sagelib-feedstock/issues/169. The
+  # dependencies of veerer are all satisfied.
+  # commands:
+  #   - pip check
+  # requires:
+  #   - pip
 
 about:
   home: https://github.com/flatsurf/veerer

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "veerer" %}
-{% set version = "0.1.2" %}
+{% set version = "0.2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/veerer-{{ version }}.tar.gz
-  sha256: b306569197d564eddab0495f369c6e0621d1ed21f43771076db36bfefb58fc08
+  sha256: e64b6559a8409d0c9616f1ca5e9e290e9223fdfcec13653b13502988d2461be9
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -22,6 +22,7 @@ requirements:
     - pip
   run:
     - python
+    - sagelib
 
 test:
   imports:
@@ -33,7 +34,7 @@ test:
 
 about:
   home: https://github.com/flatsurf/veerer
-  summary: A Python module to manipulate Veering triangulations and their associated flat structures
+  summary: Veerer is a package for SageMath to deal with veering triangulations of surfaces and their associated flat structures.
   license: GPL-2.0-or-later
   license_file: COPYING
 

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   host:
     - python
     - cython
+    - {{ compiler('c') }}
     - pip
   run:
     - python

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/veerer-{{ version }}.tar.gz
-  sha256: 70dbb901bd897d31c0305875dd039cd96d5dd90bfd5e360f250874d40a90b369
+  sha256: b306569197d564eddab0495f369c6e0621d1ed21f43771076db36bfefb58fc08
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "veerer" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/veerer-{{ version }}.tar.gz
+  sha256: 7bc29950fc4fc3b7ecfe1f636c40e6bb52aaad3c3b6b99997d9c044eb3277998
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - cython
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - veerer
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/flatsurf/veerer
+  summary: A Python module to manipulate Veering triangulations and their associated flat structures
+  license: GPL-2.0-or-later
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - saraedum

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -14,10 +14,11 @@ build:
   number: 0
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python
     - cython
-    - {{ compiler('c') }}
     - pip
   run:
     - python

--- a/recipes/veerer/meta.yaml
+++ b/recipes/veerer/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "veerer" %}
-{% set version = "0.1.1" %}
+{% set version = "0.1.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/veerer-{{ version }}.tar.gz
-  sha256: 7bc29950fc4fc3b7ecfe1f636c40e6bb52aaad3c3b6b99997d9c044eb3277998
+  sha256: 70dbb901bd897d31c0305875dd039cd96d5dd90bfd5e360f250874d40a90b369
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
This recipe was originally created with `grayskull`, however some modifications were made.

* I removed `noarch: python`. veerer is a Python package that uses Cython. So it relies on compiled code and is therefore not a noarch package.
* Also, `pip check` fails. This is a problem in the sagelib dependency which currently also installs `sagemath_standard`. `veerer` does not need `sagemath-standard` (and its dependencies) so this is not a problem in veerer but in the conda-forge package sagelib.