### PR TITLE
require pygithub 2.1.1 and use timezone aware 'now'

### DIFF
--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -41,10 +41,10 @@ mamba install --yes --quiet \
   "conda-smithy>=3.7.1,<4.0.0a0" \
   conda-forge-pinning \
   "conda-build>=3.16" \
-  "gitpython>=3.0.8" \
+  "gitpython>=3.0.8,<3.1.20"" \
   requests \
   ruamel.yaml \
-  "gitpython<3.1.20"
+  "pygithub>=2.1.1"
 
 conda info
 mamba info

--- a/.github/workflows/scripts/create_feedstocks.py
+++ b/.github/workflows/scripts/create_feedstocks.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 from conda_build.metadata import MetaData
 from conda_smithy.utils import get_feedstock_name_from_meta
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from github import Github, GithubException
 import os.path
 import shutil
@@ -139,7 +139,7 @@ def print_rate_limiting_info(gh, user):
 
     # Compute time until GitHub API Rate Limit reset
     gh_api_reset_time = gh.get_rate_limit().core.reset
-    gh_api_reset_time -= datetime.utcnow()
+    gh_api_reset_time -= datetime.now(timezone.utc)
 
     print("")
     print("GitHub API Rate Limit Info:")
@@ -161,7 +161,7 @@ def sleep_until_reset(gh):
     if gh_api_remaining == 0:
         # Compute time until GitHub API Rate Limit reset
         gh_api_reset_time = gh.get_rate_limit().core.reset
-        gh_api_reset_time -= datetime.utcnow()
+        gh_api_reset_time -= datetime.now(timezone.utc)
 
         mins_to_sleep = int(gh_api_reset_time.total_seconds() / 60)
         mins_to_sleep += 2


### PR DESCRIPTION
[Fixes errors in scheduled runs](https://github.com/conda-forge/admin-requests/actions/runs/6852041734/job/18629657409#step:6:687).

PyGithub 2.1.0 "fixed" their datetimes by making them UTC aware. But our code was using UTC naive timestamps, so now we have to make them match.

While PyGithub 2.1 has been out for a bit, this only started failing 3 days ago with the introduction of a new conda-smithy that no longer pins pygithub <2, but instead requires >=2,<3. 