### PR TITLE
adds `r-paran`

### DIFF
--- a/recipes/r-paran/bld.bat
+++ b/recipes/r-paran/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-paran/build.sh
+++ b/recipes/r-paran/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-paran/meta.yaml
+++ b/recipes/r-paran/meta.yaml
@@ -37,7 +37,8 @@ test:
     - "\"%R%\" -e \"library('paran')\""  # [win]
 
 about:
-  home: http://alexisdinno.com/Software/files/PA_for_PCA_vs_FA.pdf
+  home: https://cran.r-project.org/package=paran
+  doc_url: http://alexisdinno.com/Software/files/PA_for_PCA_vs_FA.pdf
   license: GPL-2.0-only
   summary: An implementation of Horn's technique for numerically and graphically evaluating the
     components or factors retained in a principle components analysis (PCA) or common
@@ -50,7 +51,7 @@ about:
     to reduce the likelihood of over-retention.
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
 
 extra:
   recipe-maintainers:

--- a/recipes/r-paran/meta.yaml
+++ b/recipes/r-paran/meta.yaml
@@ -1,0 +1,74 @@
+{% set version = '1.5.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-paran
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/paran_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/paran/paran_{{ version }}.tar.gz
+  sha256: 7a089af1db4fb7ca13b588a106ce12725ce6ca6480289c5d7beeba5e07523435
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-mass
+  run:
+    - r-base
+    - r-mass
+
+test:
+  commands:
+    - $R -e "library('paran')"           # [not win]
+    - "\"%R%\" -e \"library('paran')\""  # [win]
+
+about:
+  home: http://alexisdinno.com/Software/files/PA_for_PCA_vs_FA.pdf
+  license: GPL-2.0-only
+  summary: An implementation of Horn's technique for numerically and graphically evaluating the
+    components or factors retained in a principle components analysis (PCA) or common
+    factor analysis (FA). Horn's method contrasts eigenvalues produced through a PCA
+    or FA on a number of random data sets of uncorrelated variables with the same number
+    of variables and observations as the experimental or observational data set to produce
+    eigenvalues for components or factors that are adjusted for the sample error-induced
+    inflation. Components with adjusted eigenvalues greater than one are retained. paran
+    may also be used to conduct parallel analysis following Glorfeld's (1995) suggestions
+    to reduce the likelihood of over-retention.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: paran
+# Version: 1.5.2
+# Date: 2018-10-14
+# Title: Horn's Test of Principal Components/Factors
+# Author: Alexis Dinno <alexis.dinno@pdx.edu>
+# Maintainer: Alexis Dinno <alexis.dinno@pdx.edu>
+# Depends: R (>= 1.8.0), MASS
+# Description: An implementation of Horn's technique for numerically and graphically evaluating the components or factors retained in a principle components analysis (PCA) or common factor analysis (FA). Horn's method contrasts eigenvalues produced through a PCA or FA on a number of random data sets of uncorrelated variables with the same number of variables and observations as the experimental or observational data set to produce eigenvalues for components or factors that are adjusted for the sample error-induced inflation. Components with adjusted eigenvalues greater than one are retained. paran may also be used to conduct parallel analysis following Glorfeld's (1995) suggestions to reduce the likelihood of over-retention.
+# URL: http://alexisdinno.com/Software/files/PA_for_PCA_vs_FA.pdf
+# License: GPL-2
+# LazyLoad: true
+# Encoding: UTF-8
+# NeedsCompilation: no
+# Packaged: 2018-10-14 21:29:35 UTC; Alexis
+# Repository: CRAN
+# Date/Publication: 2018-10-14 23:30:03 UTC


### PR DESCRIPTION
Adds [CRAN package `paran`](https://cran.r-project.org/package=paran) as `r-paran`. Recipe generated with `conda_r_skeleton_helper`.

Needed for https://github.com/conda-forge/r-umx-feedstock/pull/12.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
