### PR TITLE
adds `r-fastcpd`

### DIFF
--- a/recipes/r-fastcpd/bld.bat
+++ b/recipes/r-fastcpd/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-fastcpd/build.sh
+++ b/recipes/r-fastcpd/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-fastcpd/meta.yaml
+++ b/recipes/r-fastcpd/meta.yaml
@@ -21,16 +21,18 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - libgomp                      # [linux]
+    - llvm-openmp                  # [osx]
   host:
     - r-base
     - r-desctools
@@ -40,6 +42,7 @@ requirements:
     - r-fastglm
     - r-glmnet
     - r-testthat
+    - libblas
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
@@ -49,7 +52,6 @@ requirements:
     - r-rcpparmadillo
     - r-fastglm
     - r-glmnet
-    - r-testthat
 
 test:
   commands:
@@ -57,8 +59,9 @@ test:
     - "\"%R%\" -e \"library('fastcpd')\""  # [win]
 
 about:
-  home: https://fastcpd.xingchi.li, https://github.com/doccstat/fastcpd
-  license: GPL-3
+  home: https://fastcpd.xingchi.li
+  dev_url: https://github.com/doccstat/fastcpd
+  license: GPL-3.0-or-later
   summary: Implements fast change point detection algorithm based on the paper "Sequential Gradient
     Descent and Quasi-Newton's Method for Change-Point Analysis" by Xianyang Zhang,
     Trisha Dawn <https://proceedings.mlr.press/v206/zhang23b.html>. The algorithm is
@@ -69,8 +72,7 @@ about:
     with custom cost function in case the user wants to use their own cost function.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
-# Type: Package
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-fastcpd/meta.yaml
+++ b/recipes/r-fastcpd/meta.yaml
@@ -1,0 +1,98 @@
+{% set version = '0.9.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-fastcpd
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/fastcpd_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/fastcpd/fastcpd_{{ version }}.tar.gz
+  sha256: 21f64136c28d720d7c6459adfb8f6d7cffa02d78ee28f4af24b0b1004320c844
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-desctools
+    - r-matrix
+    - r-rcpp >=0.11.0
+    - r-rcpparmadillo
+    - r-fastglm
+    - r-glmnet
+    - r-testthat
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-desctools
+    - r-matrix
+    - r-rcpp >=0.11.0
+    - r-rcpparmadillo
+    - r-fastglm
+    - r-glmnet
+    - r-testthat
+
+test:
+  commands:
+    - $R -e "library('fastcpd')"           # [not win]
+    - "\"%R%\" -e \"library('fastcpd')\""  # [win]
+
+about:
+  home: https://fastcpd.xingchi.li, https://github.com/doccstat/fastcpd
+  license: GPL-3
+  summary: Implements fast change point detection algorithm based on the paper "Sequential Gradient
+    Descent and Quasi-Newton's Method for Change-Point Analysis" by Xianyang Zhang,
+    Trisha Dawn <https://proceedings.mlr.press/v206/zhang23b.html>. The algorithm is
+    based on dynamic programming with pruning and sequential gradient descent. It is
+    able to detect change points a magnitude faster than the vanilla Pruned Exact Linear
+    Time(PELT). The package includes examples of linear regression, logistic regression,
+    Poisson regression, penalized linear regression data, and whole lot more examples
+    with custom cost function in case the user wants to use their own cost function.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+# Type: Package
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: fastcpd
+# Title: Fast Change Point Detection via Sequential Gradient Descent
+# Version: 0.9.0
+# Authors@R: c( person("Xingchi", "Li", , "anthony.li@stat.tamu.edu", role = c("aut", "cre", "cph"), comment = c(ORCID = "0009-0006-2493-0853")), person("Xianyang", "Zhang", , "zhangxiany@stat.tamu.edu", role = c("aut", "cph")), person("Trisha", "Dawn", , "trisha@stat.tamu.edu", role = c("aut", "cph")) )
+# Description: Implements fast change point detection algorithm based on the paper "Sequential Gradient Descent and Quasi-Newton's Method for Change-Point Analysis" by Xianyang Zhang, Trisha Dawn <https://proceedings.mlr.press/v206/zhang23b.html>. The algorithm is based on dynamic programming with pruning and sequential gradient descent. It is able to detect change points a magnitude faster than the vanilla Pruned Exact Linear Time(PELT). The package includes examples of linear regression, logistic regression, Poisson regression, penalized linear regression data, and whole lot more examples with custom cost function in case the user wants to use their own cost function.
+# License: GPL (>= 3)
+# URL: https://fastcpd.xingchi.li, https://github.com/doccstat/fastcpd
+# BugReports: https://github.com/doccstat/fastcpd/issues
+# Imports: DescTools, fastglm, glmnet, Matrix, methods, Rcpp (>= 0.11.0), stats, utils
+# Suggests: abind, forecast, ggplot2, knitr, mockthat, mvtnorm, rmarkdown, testthat (>= 3.0.0), xml2
+# LinkingTo: Rcpp, RcppArmadillo, testthat
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# NeedsCompilation: yes
+# Packaged: 2023-10-18 22:16:15 UTC; doccstat
+# Author: Xingchi Li [aut, cre, cph] (<https://orcid.org/0009-0006-2493-0853>), Xianyang Zhang [aut, cph], Trisha Dawn [aut, cph]
+# Maintainer: Xingchi Li <anthony.li@stat.tamu.edu>
+# Repository: CRAN
+# Date/Publication: 2023-10-19 07:00:13 UTC


### PR DESCRIPTION
Adds [CRAN package `fastcpd`](https://cran.r-project.org/package=fastcpd) as `r-fastcpd`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- x ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
