### PR TITLE
adds PyPI package `cloupy`

### DIFF
--- a/recipes/cloupy/meta.yaml
+++ b/recipes/cloupy/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.8
     - pip
   run:
-    - python
+    - python >=3.8
     - pandas >=1.3.3,<=1.3.5
     - matplotlib-base >=3.4.3,<=3.5.1
     - requests >=2.26.0,<=2.27.1

--- a/recipes/cloupy/meta.yaml
+++ b/recipes/cloupy/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "cloupy" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cloupy-{{ version }}.tar.gz
+  sha256: e6281daddaeb05a62b001b12d823101a9b985508858d357705a7537cf7942021
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - pandas >=1.3.3,<=1.3.5
+    - matplotlib-base >=3.4.3,<=3.5.1
+    - requests >=2.26.0,<=2.27.1
+    - beautifulsoup4 >=4.9.3,<=4.10.0
+    - numpy >=1.21.4,<=1.22.1
+    - pyshp ==2.1.3
+    - pyproj >=3.2.1,<=3.3.0
+    - scipy >=1.7.2,<=1.7.3
+    - pillow >=8.4.0,<=9.0.0
+    - cycler ==0.11.0
+
+test:
+  imports:
+    - cloupy
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/pdGruby/cloupy
+  summary: The package allows to download, process and visualize climatological data from reliable sources
+  license: MIT
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - mfansler


### PR DESCRIPTION
Adds [the PyPI package `cloupy`](https://pypi.org/project/cloupy/) as `cloupy`. Recipe generated with `grayskull` with lower bound added to `python` specifications (matched to upstream).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
