### PR TITLE
adds `r-wfe`

### DIFF
--- a/recipes/r-wfe/bld.bat
+++ b/recipes/r-wfe/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-wfe/build.sh
+++ b/recipes/r-wfe/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-wfe/meta.yaml
+++ b/recipes/r-wfe/meta.yaml
@@ -18,28 +18,34 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'
+    - '*/Rblas.dll'
+    - '*/Rlapack.dll'
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ posix }}filesystem        # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+    - {{ compiler('c') }}        # [not win]
+    - {{ compiler('m2w64_c') }}  # [win]
+    - {{ posix }}filesystem      # [win]
     - {{ posix }}make
-    - {{ posix }}sed               # [win]
-    - {{ posix }}coreutils         # [win]
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}sed             # [win]
+    - {{ posix }}coreutils       # [win]
+    - {{ posix }}zip             # [win]
   host:
     - r-base
+    - r-arm
     - r-mass
     - r-matrix
-    - r-arm
+    - libblas
+    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
+    - r-arm
     - r-mass
     - r-matrix
-    - r-arm
 
 test:
   commands:
@@ -48,7 +54,8 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=wfe
-  license: GPL-2.0-only
+  dev_url: https://github.com/insongkim/wfe
+  license: GPL-2.0-or-later
   summary: Provides a computationally efficient way of fitting weighted linear fixed effects
     estimators for causal inference with various weighting schemes. Weighted linear
     fixed effects estimators can be used to estimate the average treatment effects under
@@ -59,7 +66,8 @@ about:
     Data?", available at <https://imai.fas.harvard.edu/research/FEmatch.html>.
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-wfe/meta.yaml
+++ b/recipes/r-wfe/meta.yaml
@@ -1,0 +1,86 @@
+{% set version = '1.9.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-wfe
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/wfe_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/wfe/wfe_{{ version }}.tar.gz
+  sha256: 3a1ed72086a01622ea5290e361a546b08463493569cee679c33c50da3e3c8f51
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-mass
+    - r-matrix
+    - r-arm
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-mass
+    - r-matrix
+    - r-arm
+
+test:
+  commands:
+    - $R -e "library('wfe')"           # [not win]
+    - "\"%R%\" -e \"library('wfe')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=wfe
+  license: GPL-2.0-only
+  summary: Provides a computationally efficient way of fitting weighted linear fixed effects
+    estimators for causal inference with various weighting schemes. Weighted linear
+    fixed effects estimators can be used to estimate the average treatment effects under
+    different identification strategies. This includes stratified randomized experiments,
+    matching and stratification for observational studies, first differencing, and difference-in-differences.
+    The package implements methods described in Imai and Kim (2017) "When should We
+    Use Linear Fixed Effects Regression Models for Causal Inference with Longitudinal
+    Data?", available at <https://imai.fas.harvard.edu/research/FEmatch.html>.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: wfe
+# Type: Package
+# Title: Weighted Linear Fixed Effects Regression Models for Causal Inference
+# Version: 1.9.1
+# Date: 2019-04-17
+# Authors@R: c( person("In Song", "Kim", email = "insong@mit.edu", role = c("aut", "cre")), person("Kosuke", "Imai", email = "imai@Harvard.edu", role = c("aut")) )
+# Description: Provides a computationally efficient way of fitting weighted linear fixed effects estimators for causal inference with various weighting schemes. Weighted linear fixed effects estimators can be used to estimate the average treatment effects under different identification strategies. This includes stratified randomized experiments, matching and stratification for observational studies, first differencing, and difference-in-differences. The package implements methods described in Imai and Kim (2017) "When should We Use Linear Fixed Effects Regression Models for Causal Inference with Longitudinal Data?", available at <https://imai.fas.harvard.edu/research/FEmatch.html>.
+# License: GPL (>= 2)
+# Imports: utils, arm, Matrix, MASS, methods
+# Depends: R (>= 3.2.0)
+# Encoding: UTF-8
+# LazyData: true
+# BugReports: https://github.com/insongkim/wfe/issues
+# NeedsCompilation: yes
+# Packaged: 2019-04-17 21:25:40 UTC; insong
+# Author: In Song Kim [aut, cre], Kosuke Imai [aut]
+# Maintainer: In Song Kim <insong@mit.edu>
+# Repository: CRAN
+# Date/Publication: 2019-04-17 21:50:03 UTC

--- a/recipes/r-wfe/meta.yaml
+++ b/recipes/r-wfe/meta.yaml
@@ -20,8 +20,6 @@ build:
     - lib/
   missing_dso_whitelist:
     - '*/R.dll'
-    - '*/Rblas.dll'
-    - '*/Rlapack.dll'
 
 requirements:
   build:
@@ -38,8 +36,6 @@ requirements:
     - r-arm
     - r-mass
     - r-matrix
-    - libblas
-    - liblapack
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]


### PR DESCRIPTION
Adds [CRAN package `wfe`](https://cran.r-project.org/package=wfe) as `r-wfe`. Recipe generated with `conda_r_skeleton_helper` with adjustments for DSO whitelist, BLAS/LAPACK libs, dev URL, and corrected SPDX license.

Closes #24568 

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
