### PR TITLE
Fix failure in `create_feedstocks` [skip lint]

### DIFF
--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -15,14 +15,14 @@ export CPU_COUNT=2
 
 export PYTHONUNBUFFERED=1
 
-# Install Mambaforge.
+# Install Miniforge3.
 echo ""
-echo "Installing a fresh version of Mambaforge."
-curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh > ~/Mambaforge.sh
-bash ~/Mambaforge.sh -b -p ~/Mambaforge
-touch ~/Mambaforge/conda-meta/pinned
+echo "Installing a fresh version of Miniforge3."
+curl -L https://github.com/conda-forge/miniforge/releases/download/latest/Miniforge3-$(uname)-$(uname -m).sh > ~/Miniforge3.sh
+bash ~/Miniforge3.sh -b -p ~/Miniforge3
+touch ~/Miniforge3/conda-meta/pinned
 (
-    source ~/Mambaforge/bin/activate base
+    source ~/Miniforge3/bin/activate base
 
     # Configure conda.
     echo ""
@@ -31,10 +31,9 @@ touch ~/Mambaforge/conda-meta/pinned
     conda config --set auto_update_conda false
     conda config --set add_pip_as_python_dependency false
 
-    unset conda
     mamba update -n base --yes --quiet conda mamba
 )
-source ~/Mambaforge/bin/activate root
+source ~/Miniforge3/bin/activate
 
 mamba install --yes --quiet \
   conda-forge-ci-setup=3.* \

--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -32,11 +32,11 @@ touch ~/Miniforge3/conda-meta/pinned
     conda config --set add_pip_as_python_dependency false
     conda config --set solver libmamba
 
-    mamba update -n base --yes --quiet conda mamba conda-libmamba-solver
+    conda update -n base --yes --quiet conda mamba conda-libmamba-solver
 )
 source ~/Miniforge3/bin/activate
 
-mamba install --yes --quiet \
+conda install --yes --quiet \
   conda-forge-ci-setup=3.* \
   "conda-smithy>=3.7.1,<4.0.0a0" \
   conda-forge-pinning \

--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -30,6 +30,7 @@ touch ~/Miniforge3/conda-meta/pinned
     conda config --set show_channel_urls true
     conda config --set auto_update_conda false
     conda config --set add_pip_as_python_dependency false
+    conda config --set solver libmamba
 
     mamba update -n base --yes --quiet conda mamba
 )

--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -32,7 +32,7 @@ touch ~/Miniforge3/conda-meta/pinned
     conda config --set add_pip_as_python_dependency false
     conda config --set solver libmamba
 
-    mamba update -n base --yes --quiet conda mamba
+    mamba update -n base --yes --quiet conda mamba conda-libmamba-solver
 )
 source ~/Miniforge3/bin/activate
 


### PR DESCRIPTION
Recently [`create_feedstocks` started failing]( https://github.com/conda-forge/admin-requests/actions/runs/7094372697 ). It looks `mamba` is running into a new perplexing bug

```
mamba install --yes --quiet 'conda-forge-ci-setup=3.*' 'conda-smithy>=3.7.1,<4.0.0a0' conda-forge-pinning 'conda-build>=3.16' 'gitpython>=3.0.8,<3.1.20' requests ruamel.yaml 'pygithub>=2.1.1'
Currently, only install, create, list, search, run, info, clean, remove, update, repoquery, activate and deactivate are supported through mamba.
```

To fix it, this just moves to `conda` + `libmamba` as is already being done elsewhere in `staged-recipes` and in `conda-forge`

Hopefully this clears up that error