### PR TITLE
adds `r-rayvertex`

### DIFF
--- a/recipes/r-rayvertex/bld.bat
+++ b/recipes/r-rayvertex/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rayvertex/build.sh
+++ b/recipes/r-rayvertex/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rayvertex/meta.yaml
+++ b/recipes/r-rayvertex/meta.yaml
@@ -21,16 +21,16 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-rcpp >=1.0.6
@@ -55,8 +55,9 @@ test:
     - "\"%R%\" -e \"library('rayvertex')\""  # [win]
 
 about:
-  home: https://www.rayvertex.com, https://github.com/tylermorganwall/rayvertex
-  license: GPL-3
+  home: https://www.rayvertex.com
+  dev_url: https://github.com/tylermorganwall/rayvertex
+  license: GPL-3.0-or-later
   summary: Rasterize images using a 3D software renderer. 3D scenes are created either by importing
     external files, building scenes out of the included objects, or by constructing
     meshes manually. Supports point and directional lights, anti-aliased lines, shadow

--- a/recipes/r-rayvertex/meta.yaml
+++ b/recipes/r-rayvertex/meta.yaml
@@ -66,7 +66,8 @@ about:
     ambient occlusion.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
+    - inst/COPYRIGHTS
 
 extra:
   recipe-maintainers:

--- a/recipes/r-rayvertex/meta.yaml
+++ b/recipes/r-rayvertex/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'
 
 requirements:
   build:
@@ -33,20 +35,21 @@ requirements:
     - {{ posix }}zip               # [win]
   host:
     - r-base
-    - r-rcpp >=1.0.6
-    - r-rcppthread
     - r-digest
     - r-png
     - r-rayimage >=0.10.0
+    - r-rcpp >=1.0.6
+    - r-rcppthread
     - r-spacefillr
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
-    - r-rcpp >=1.0.6
-    - r-rcppthread
+    - {{ native }}gcc-libs           # [win]
+    - {{ native }}libwinpthread-git  # [win]
     - r-digest
     - r-png
     - r-rayimage >=0.10.0
+    - r-rcpp >=1.0.6
+    - r-rcppthread
     - r-spacefillr
 
 test:

--- a/recipes/r-rayvertex/meta.yaml
+++ b/recipes/r-rayvertex/meta.yaml
@@ -1,0 +1,97 @@
+{% set version = '0.10.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rayvertex
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rayvertex_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rayvertex/rayvertex_{{ version }}.tar.gz
+  sha256: e629276b4c0237d71c8bdae532a99665808b8d08133e8e2a2dafcd3d623513aa
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp >=1.0.6
+    - r-rcppthread
+    - r-digest
+    - r-png
+    - r-rayimage >=0.10.0
+    - r-spacefillr
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp >=1.0.6
+    - r-rcppthread
+    - r-digest
+    - r-png
+    - r-rayimage >=0.10.0
+    - r-spacefillr
+
+test:
+  commands:
+    - $R -e "library('rayvertex')"           # [not win]
+    - "\"%R%\" -e \"library('rayvertex')\""  # [win]
+
+about:
+  home: https://www.rayvertex.com, https://github.com/tylermorganwall/rayvertex
+  license: GPL-3
+  summary: Rasterize images using a 3D software renderer. 3D scenes are created either by importing
+    external files, building scenes out of the included objects, or by constructing
+    meshes manually. Supports point and directional lights, anti-aliased lines, shadow
+    mapping, transparent objects, translucent objects, multiple materials types, reflection,
+    refraction, environment maps, multicore rendering, bloom, tone-mapping, and screen-space
+    ambient occlusion.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rayvertex
+# Type: Package
+# Title: 3D Software Rasterizer
+# Version: 0.10.3
+# Date: 2023-12-09
+# Authors@R: c(person("Tyler", "Morgan-Wall", email = "tylermw@gmail.com", role = c("aut", "cph", "cre"), comment = c(ORCID = "0000-0002-3131-3814")), person("Syoyo", "Fujita", role=c("ctb", "cph")), person("Vilya", "Harvey", role = c("ctb", "cph")), person("G-Truc Creation", role = c("ctb", "cph")), person("Sean", "Barrett", role = c("ctb", "cph")))
+# Maintainer: Tyler Morgan-Wall <tylermw@gmail.com>
+# Description: Rasterize images using a 3D software renderer. 3D scenes are created either by importing external files, building scenes out of the included objects, or by constructing meshes manually. Supports point and directional lights, anti-aliased lines, shadow mapping, transparent objects, translucent objects, multiple materials types, reflection, refraction, environment maps, multicore rendering, bloom, tone-mapping, and screen-space ambient occlusion.
+# License: GPL (>= 3)
+# Copyright: file inst/COPYRIGHTS
+# Depends: R (>= 4.1)
+# Imports: Rcpp (>= 1.0.6), grDevices, rayimage (>= 0.10.0), png, digest
+# Suggests: Rvcg, magick, raster
+# LinkingTo: Rcpp, spacefillr, RcppThread, rayimage
+# RoxygenNote: 7.2.3
+# URL: https://www.rayvertex.com, https://github.com/tylermorganwall/rayvertex
+# BugReports: https://github.com/tylermorganwall/rayvertex/issues
+# Encoding: UTF-8
+# SystemRequirements: C++17
+# NeedsCompilation: yes
+# Packaged: 2023-12-10 03:37:06 UTC; tyler
+# Author: Tyler Morgan-Wall [aut, cph, cre] (<https://orcid.org/0000-0002-3131-3814>), Syoyo Fujita [ctb, cph], Vilya Harvey [ctb, cph], G-Truc Creation [ctb, cph], Sean Barrett [ctb, cph]
+# Repository: CRAN
+# Date/Publication: 2023-12-10 06:00:02 UTC


### PR DESCRIPTION
Adds [CRAN package `rayvertex`](https://cran.r-project.org/package=rayvertex) as `r-rayvertex`. Recipe generated with `conda_r_skeleton_helper` with license conformed to SPDX and URLs split.

Needed for https://github.com/conda-forge/r-rayrender-feedstock/pull/10.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
