### PR TITLE
fix: google-cloud-cpp-core and conda-smithy

### DIFF
--- a/recipes/google-cloud-cpp-core/bld.bat
+++ b/recipes/google-cloud-cpp-core/bld.bat
@@ -1,0 +1,74 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
+set BUILD_PREFIX="%BUILD_PREFIX:\=/%"
+set SRC_DIR="%SRC_DIR:\=/%"
+
+:: Compile the common libraries. These are shared by other feedstocks
+:: and by the subpackages in this feedstock.
+cmake -G "Ninja" ^
+    -S . -B .build/common ^
+    -DGOOGLE_CLOUD_CPP_ENABLE=__common__ ^
+    -DBUILD_TESTING=OFF ^
+    -DBUILD_SHARED_LIBS=OFF ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake" ^
+    -DCMAKE_INSTALL_LIBDIR=lib ^
+    -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF ^
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .build/common --config Release
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --install .build/common --prefix stage
+if %ERRORLEVEL% neq 0 exit 1
+
+set STAGE="%cd:\=/%"
+
+:: These subpackages are the most commonly used features of google-cloud-cpp.
+:: We want to compile them in the core feedstock.
+FOR %%G IN (oauth2 bigtable storage spanner) DO (
+    cmake -G "Ninja" ^
+        -S . -B .build/%%G ^
+        -DGOOGLE_CLOUD_CPP_ENABLE=%%G ^
+        -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON ^
+        -DCMAKE_PREFIX_PATH="%STAGE%/stage" ^
+        -DBUILD_TESTING=OFF ^
+        -DBUILD_SHARED_LIBS=OFF ^
+        -DCMAKE_BUILD_TYPE=Release ^
+        -DCMAKE_CXX_STANDARD=17 ^
+        -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+        -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake" ^
+        -DCMAKE_INSTALL_LIBDIR=lib ^
+        -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF ^
+        -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+    if %ERRORLEVEL% neq 0 exit 1
+
+    cmake --build .build/%%G --config Release
+    if %ERRORLEVEL% neq 0 exit 1
+)
+
+:: `pubsub` must to be compiled with `iam` and policytroubleshooter with `iam`
+cmake -G "Ninja" ^
+    -S . -B .build/pubsub ^
+    -DGOOGLE_CLOUD_CPP_ENABLE=pubsub,iam,policytroubleshooter ^
+    -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON ^
+    -DCMAKE_PREFIX_PATH="%STAGE%/stage" ^
+    -DBUILD_TESTING=OFF ^
+    -DBUILD_SHARED_LIBS=OFF ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake" ^
+    -DCMAKE_INSTALL_LIBDIR=lib ^
+    -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF ^
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .build/pubsub --config Release
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/google-cloud-cpp-core/build.sh
+++ b/recipes/google-cloud-cpp-core/build.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export OPENSSL_ROOT_DIR=$PREFIX
+
+if [[ "${target_platform}" == osx-* ]]; then
+  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ'): Building __common__ features..."
+cmake ${CMAKE_ARGS} \
+    -GNinja -S . -B .build/common \
+    -DGOOGLE_CLOUD_CPP_ENABLE=__common__ \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DOPENSSL_ROOT_DIR=$PREFIX \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc \
+    -DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=$BUILD_PREFIX/bin/grpc_cpp_plugin \
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+
+cmake --build .build/common
+cmake --install .build/common --prefix .build/stage
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ'): DONE - Building __common__ features"
+
+for feature in oauth2 bigtable spanner storage; do
+  echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ'): Building ${feature}"
+  cmake ${CMAKE_ARGS} \
+      -GNinja -S . -B .build/${feature} \
+      -DGOOGLE_CLOUD_CPP_ENABLE=${feature} \
+      -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON \
+      -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH};${PWD}/.build/stage" \
+      -DBUILD_TESTING=OFF \
+      -DBUILD_SHARED_LIBS=ON \
+      -DOPENSSL_ROOT_DIR=$PREFIX \
+      -DCMAKE_BUILD_TYPE=release \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc \
+      -DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=$BUILD_PREFIX/bin/grpc_cpp_plugin \
+      -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+  cmake --build .build/${feature}
+  echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ'): DONE - Building ${feature}"
+done
+
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ'): Building pubsub"
+cmake ${CMAKE_ARGS} \
+    -GNinja -S . -B .build/pubsub \
+    -DGOOGLE_CLOUD_CPP_ENABLE=pubsub,iam,policytroubleshooter \
+    -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON \
+    -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH};${PWD}/.build/stage" \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DOPENSSL_ROOT_DIR=$PREFIX \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc \
+    -DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=$BUILD_PREFIX/bin/grpc_cpp_plugin \
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+cmake --build .build/pubsub
+echo "$(date -u '+%Y-%m-%dT%H:%M:%SZ'): DONE - Building pubsub"

--- a/recipes/google-cloud-cpp-core/conda_build_config.yaml
+++ b/recipes/google-cloud-cpp-core/conda_build_config.yaml
@@ -1,0 +1,4 @@
+# The default at [1] is 10.9 and abseil does not compile with that
+# [1]: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+MACOSX_DEPLOYMENT_TARGET:   # [osx and x86_64]
+  - 10.13                   # [osx and x86_64]

--- a/recipes/google-cloud-cpp-core/install-libgoogle-cloud.bat
+++ b/recipes/google-cloud-cpp-core/install-libgoogle-cloud.bat
@@ -1,0 +1,53 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
+set BUILD_PREFIX="%BUILD_PREFIX:\=/%"
+set SRC_DIR="%SRC_DIR:\=/%"
+
+:: Once DLLs are working, we should install the non-devel packages using
+::     cmake --install .build/%FEATURE% --component google_cloud_cpp_runtime
+:: and the devel packages using
+::     cmake --install .build/%FEATURE% --component google_cloud_cpp_development
+
+if [%PKG_NAME%] == [libgoogle-cloud] (
+  REM TODO: fix when DLL support comes along
+) else if [%PKG_NAME%] == [libgoogle-cloud-devel] (
+  REM cmake --install .build/common --component google_cloud_cpp_development
+  cmake --install .build/common
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-bigtable] (
+  REM TODO: fix when DLL support comes along
+) else if [%PKG_NAME%] == [libgoogle-cloud-bigtable-devel] (
+  cmake --install .build/bigtable
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-oauth2] (
+  REM TODO: fix when DLL support comes along
+) else if [%PKG_NAME%] == [libgoogle-cloud-oauth2-devel] (
+  cmake --install .build/oauth2
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-spanner] (
+  REM TODO: fix when DLL support comes along
+) else if [%PKG_NAME%] == [libgoogle-cloud-spanner-devel] (
+  cmake --install .build/spanner
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-storage] (
+  REM TODO: fix when DLL support comes along
+) else if [%PKG_NAME%] == [libgoogle-cloud-storage-devel] (
+  cmake --install .build/storage
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-pubsub] (
+  REM TODO: fix when DLL support comes along
+) else if [%PKG_NAME%] == [libgoogle-cloud-pubsub-devel] (
+  cmake --install .build/pubsub
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-iam] (
+  REM Nothing to do, installed by pubsub
+) else if [%PKG_NAME%] == [libgoogle-cloud-iam-devel] (
+  REM Nothing to do, installed by pubsub
+) else if [%PKG_NAME%] == [libgoogle-cloud-policytroubleshooter] (
+  REM Nothing to do, installed by pubsub
+) else if [%PKG_NAME%] == [libgoogle-cloud-policytroubleshooter-devel] (
+  REM Nothing to do, installed by pubsub
+)

--- a/recipes/google-cloud-cpp-core/install-libgoogle-cloud.sh
+++ b/recipes/google-cloud-cpp-core/install-libgoogle-cloud.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+case "${PKG_NAME}" in
+  libgoogle-cloud-devel)
+    cmake --install .build/common --component google_cloud_cpp_development
+    ;;
+  libgoogle-cloud)
+    cmake --install .build/common --component google_cloud_cpp_runtime
+    ;;
+  libgoogle-cloud-iam-devel)
+    # Do nothing, this is installed by `libgoogle-cloud-pubsub-devel`.
+    ;;
+  libgoogle-cloud-iam)
+    # Do nothing, this is installed by `libgoogle-cloud-pubsub`.
+    ;;
+  libgoogle-cloud-policytroubleshooter-devel)
+    # Do nothing, this is installed by `libgoogle-cloud-pubsub-devel`.
+    ;;
+  libgoogle-cloud-policytroubleshooter)
+    # Do nothing, this is installed by `libgoogle-cloud-pubsub`.
+    ;;
+  libgoogle-cloud-*-devel)
+    feature=${PKG_NAME/#libgoogle-cloud-/}
+    feature=${feature/%-devel/}
+    cmake --install .build/${feature} --component google_cloud_cpp_development
+    ;;
+  libgoogle-cloud-*)
+    feature=${PKG_NAME/#libgoogle-cloud-/}
+    cmake --install .build/${feature} --component google_cloud_cpp_runtime
+    ;;
+esac

--- a/recipes/google-cloud-cpp-core/meta.yaml
+++ b/recipes/google-cloud-cpp-core/meta.yaml
@@ -1,0 +1,388 @@
+{% set version = "2.17.0" %}
+
+{%- macro test_subpackage(feature) %}
+commands:
+  # presence of shared library (unix)
+  - test -f $PREFIX/lib/libgoogle_cloud_cpp_{{ feature }}.{{ version }}.dylib  # [osx]
+  - test -f $PREFIX/lib/libgoogle_cloud_cpp_{{ feature }}.so.{{ version }}  # [linux]
+  # absence of static library (windows). It belongs only in devel package.
+  - if exist %LIBRARY_LIB%\google_cloud_cpp_{{ feature }}.lib exit 1     # [win]
+
+  # absence of headers (they belong in devel package)
+  - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+  - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+
+  # absence of metadata for CMake & pkgconfig (belongs in devel package)
+  - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_{{ feature }}.pc  # [not win]
+  - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_{{ feature }}/google_cloud_cpp_{{ feature }}-config.cmake  # [not win]
+  - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_{{ feature }}\google_cloud_cpp_{{ feature }}-config.cmake exit 1  # [win]
+{%- endmacro %}
+
+{%- macro standard_subpackage(feature) %}
+script: install-libgoogle-cloud.sh   # [not win]
+script: install-libgoogle-cloud.bat  # [win]
+build:
+  run_exports:
+    # patch versions guaranteed to be ABI-compatible, see
+    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+  run:
+    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+    - libabseil
+    - libprotobuf
+    - libgrpc
+    - libcxx  # [osx]
+test:
+  {{ test_subpackage(feature)|indent(2) }}
+{%- endmacro %}
+
+{%- macro test_devel_subpackage(feature) %}
+commands:
+  - ./run_test_feature.sh   # [not win]
+  - ./run_test_feature.bat  # [win]
+requires:
+  - {{ compiler('cxx') }}
+  - cmake
+  - ninja
+files:
+  - run_test_feature.sh
+  - run_test_feature.bat
+source_files:
+  - google/cloud/{{ feature }}/quickstart/*.cc
+  - google/cloud/{{ feature }}/quickstart/CMakeLists.txt
+{%- endmacro %}
+
+{%- macro standard_devel_subpackage(feature) %}
+script: install-libgoogle-cloud.sh   # [not win]
+script: install-libgoogle-cloud.bat  # [win]
+build:
+  run_exports:
+    # patch versions guaranteed to be ABI-compatible, see
+    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+  run:
+    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, exact=True) }}
+    - libcxx  # [osx]
+test:
+  {{ test_devel_subpackage(feature)|indent(2) }}
+{% endmacro %}
+
+{%- macro child_subpackage(feature, parent) %}
+script: install-libgoogle-cloud.sh   # [not win]
+script: install-libgoogle-cloud.bat  # [win]
+build:
+  run_exports:
+    # patch versions guaranteed to be ABI-compatible, see
+    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - {{ pin_subpackage("libgoogle-cloud-" ~ parent, exact=True) }}
+    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+  run:
+    - {{ pin_subpackage("libgoogle-cloud-" ~ parent, exact=True) }}
+    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+    - libabseil
+    - libprotobuf
+    - libgrpc
+    - libcxx  # [osx]
+test:
+  {{ test_subpackage(feature)|indent(2) }}
+{%- endmacro %}
+
+{%- macro child_devel_subpackage(feature, parent) %}
+script: install-libgoogle-cloud.sh   # [not win]
+script: install-libgoogle-cloud.bat  # [win]
+build:
+  run_exports:
+    # patch versions guaranteed to be ABI-compatible, see
+    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - {{ pin_subpackage("libgoogle-cloud-" ~ parent ~ "-devel", exact=True) }}
+    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+  run:
+    - {{ pin_subpackage("libgoogle-cloud-" ~ parent ~ "-devel", exact=True) }}
+    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, exact=True) }}
+    - libcxx  # [osx]
+test:
+  {{ test_devel_subpackage(feature)|indent(2) }}
+{%- endmacro %}
+
+package:
+  name: google-cloud-cpp-core
+  version: {{ version }}
+
+source:
+  url: https://github.com/googleapis/google-cloud-cpp/archive/v{{ version }}.tar.gz
+  sha256: 8cb87ec2947e691a7f8631877e78453bcfda51b3d3cd4940794a376741888d37
+  patches:
+    # This is an upstream fix to allow sharding google/cloud/oauth2
+    - patches/0001-fix-oauth2-only-enable-via-GOOGLE_CLOUD_CPP_ENABLE-1.patch
+    # This is an upstream fix to break the (unused) dependency because `storage`
+    # and ZLIB::ZLIB
+    - patches/0002-fix-storage-remove-unused-dependencies-12890.patch
+    # This is an upstream fix to use `find_package(CURL)` directly.
+    - patches/0003-cleanup-CMake-3.13-always-has-CURL-libcurl-12938.patch
+
+build:
+  number: 0
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - libgrpc
+    - libprotobuf
+  host:
+    - libabseil
+    - libcrc32c
+    - libcurl
+    - libgrpc
+    - libprotobuf
+    - openssl
+    - nlohmann_json
+    - zlib
+
+outputs:
+  - name: libgoogle-cloud
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+        - libgrpc
+        - libprotobuf
+      host:
+        - libabseil
+        - libcurl
+        - libgrpc
+        - libprotobuf
+        - openssl
+        - nlohmann_json
+        - libcxx  # [osx]
+      run:
+        - libcxx  # [osx]
+      run_constrained:
+        - libgoogle-cloud {{ version }} *_{{ PKG_BUILDNUM }}
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_common.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_common.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_common.lib exit 1  # [win]
+
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_common.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_common/google_cloud_cpp_common-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_common\google_cloud_cpp_common-config.cmake exit 1  # [win]
+
+  - name: libgoogle-cloud-devel
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage("libgoogle-cloud", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+        - libcurl
+        - libgrpc
+        - libprotobuf
+        - openssl
+        - nlohmann_json
+        # cannot load package without zlib because it's specified
+        # as required; if possible, this should be removed upstream
+        - zlib
+      host:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libcurl
+        - libgrpc
+        - libprotobuf
+        - openssl
+        - nlohmann_json
+      run:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libcurl
+        - libgrpc
+        - libprotobuf
+        - openssl
+        - nlohmann_json
+        # cannot load package without zlib because it's specified
+        # as required; if possible, this should be removed upstream
+        - zlib        
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of headers
+        - test -f $PREFIX/include/google/cloud/version.h            # [unix]
+        - if not exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+        # build and example
+        - ./run_test_common.sh   # [unix]
+        - ./run_test_common.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_common.sh
+        - run_test_common.bat
+        - tests/CMakeLists.txt
+        - tests/quickstart.cc
+
+  - name: libgoogle-cloud-oauth2
+    {{ standard_subpackage("oauth2")|indent(4) }}
+  - name: libgoogle-cloud-bigtable
+    {{ standard_subpackage("bigtable")|indent(4) }}
+  - name: libgoogle-cloud-pubsub
+    {{ standard_subpackage("pubsub")|indent(4) }}
+  - name: libgoogle-cloud-spanner
+    {{ standard_subpackage("spanner")|indent(4) }}
+
+  - name: libgoogle-cloud-oauth2-devel
+    {{ standard_devel_subpackage("oauth2")|indent(4) }}
+  - name: libgoogle-cloud-bigtable-devel
+    {{ standard_devel_subpackage("bigtable")|indent(4) }}
+  - name: libgoogle-cloud-pubsub-devel
+    {{ standard_devel_subpackage("pubsub")|indent(4) }}
+  - name: libgoogle-cloud-spanner-devel
+    {{ standard_devel_subpackage("spanner")|indent(4) }}
+
+  - name: libgoogle-cloud-iam
+    {{ child_subpackage("iam", "pubsub")|indent(4) }}
+  - name: libgoogle-cloud-policytroubleshooter
+    {{ child_subpackage("policytroubleshooter", "pubsub")|indent(4) }}
+
+  - name: libgoogle-cloud-iam-devel
+    {{ child_devel_subpackage("iam", "pubsub")|indent(4) }}
+  - name: libgoogle-cloud-policytroubleshooter-devel
+    {{ child_devel_subpackage("policytroubleshooter", "pubsub")|indent(4) }}
+
+  - name: libgoogle-cloud-storage
+    # This cannot use the standard subpackages because it has different direct
+    # dependencies: libcrc32c and libcurl being the most prominent ones.
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-storage", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libcrc32c
+        # This can be removed on the first release (likely v2.18.0) of
+        # google-cloud-cpp containing:
+        #   https://github.com/googleapis/google-cloud-cpp/pull/12890
+        - zlib
+      run:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libcrc32c
+        - libcurl
+        - openssl
+        - libcxx  # [osx]
+    test:
+      {{ test_subpackage("storage")|indent(6) }}
+
+  - name: libgoogle-cloud-storage-devel
+    # This cannot use the standard subpackages because it has different direct
+    # dependencies: libcrc32c and libcurl being the most prominent ones.
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-storage", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - libabseil
+        - libcrc32c
+        - libcurl
+        - openssl
+        - nlohmann_json
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-storage", exact=True) }}
+        - libabseil
+        - libcrc32c
+        - libcurl
+        - openssl
+        - nlohmann_json
+        - libcxx  # [osx]
+    test:
+      {{ test_devel_subpackage("storage")|indent(6) }}
+
+about:
+  home: https://github.com/googleapis/google-cloud-cpp
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Google Cloud Client Library for C++
+
+extra:
+  feedstock-name: google-cloud-cpp-core
+  recipe-maintainers:
+    - coryan
+    - conda-forge/google-cloud-cpp

--- a/recipes/google-cloud-cpp-core/meta.yaml
+++ b/recipes/google-cloud-cpp-core/meta.yaml
@@ -1,143 +1,5 @@
 {% set version = "2.17.0" %}
 
-{%- macro test_subpackage(feature) %}
-commands:
-  # presence of shared library (unix)
-  - test -f $PREFIX/lib/libgoogle_cloud_cpp_{{ feature }}.{{ version }}.dylib  # [osx]
-  - test -f $PREFIX/lib/libgoogle_cloud_cpp_{{ feature }}.so.{{ version }}  # [linux]
-  # absence of static library (windows). It belongs only in devel package.
-  - if exist %LIBRARY_LIB%\google_cloud_cpp_{{ feature }}.lib exit 1     # [win]
-
-  # absence of headers (they belong in devel package)
-  - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
-  - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
-
-  # absence of metadata for CMake & pkgconfig (belongs in devel package)
-  - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_{{ feature }}.pc  # [not win]
-  - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_{{ feature }}/google_cloud_cpp_{{ feature }}-config.cmake  # [not win]
-  - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_{{ feature }}\google_cloud_cpp_{{ feature }}-config.cmake exit 1  # [win]
-{%- endmacro %}
-
-{%- macro standard_subpackage(feature) %}
-script: install-libgoogle-cloud.sh   # [not win]
-script: install-libgoogle-cloud.bat  # [win]
-build:
-  run_exports:
-    # patch versions guaranteed to be ABI-compatible, see
-    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
-    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - cmake
-    - ninja
-  host:
-    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
-  run:
-    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
-    - libabseil
-    - libprotobuf
-    - libgrpc
-    - libcxx  # [osx]
-test:
-  {{ test_subpackage(feature)|indent(2) }}
-{%- endmacro %}
-
-{%- macro test_devel_subpackage(feature) %}
-commands:
-  - ./run_test_feature.sh   # [not win]
-  - ./run_test_feature.bat  # [win]
-requires:
-  - {{ compiler('cxx') }}
-  - cmake
-  - ninja
-files:
-  - run_test_feature.sh
-  - run_test_feature.bat
-source_files:
-  - google/cloud/{{ feature }}/quickstart/*.cc
-  - google/cloud/{{ feature }}/quickstart/CMakeLists.txt
-{%- endmacro %}
-
-{%- macro standard_devel_subpackage(feature) %}
-script: install-libgoogle-cloud.sh   # [not win]
-script: install-libgoogle-cloud.bat  # [win]
-build:
-  run_exports:
-    # patch versions guaranteed to be ABI-compatible, see
-    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
-    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - cmake
-    - ninja
-  host:
-    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
-  run:
-    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
-    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, exact=True) }}
-    - libcxx  # [osx]
-test:
-  {{ test_devel_subpackage(feature)|indent(2) }}
-{% endmacro %}
-
-{%- macro child_subpackage(feature, parent) %}
-script: install-libgoogle-cloud.sh   # [not win]
-script: install-libgoogle-cloud.bat  # [win]
-build:
-  run_exports:
-    # patch versions guaranteed to be ABI-compatible, see
-    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
-    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - cmake
-    - ninja
-  host:
-    - {{ pin_subpackage("libgoogle-cloud-" ~ parent, exact=True) }}
-    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
-  run:
-    - {{ pin_subpackage("libgoogle-cloud-" ~ parent, exact=True) }}
-    - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
-    - libabseil
-    - libprotobuf
-    - libgrpc
-    - libcxx  # [osx]
-test:
-  {{ test_subpackage(feature)|indent(2) }}
-{%- endmacro %}
-
-{%- macro child_devel_subpackage(feature, parent) %}
-script: install-libgoogle-cloud.sh   # [not win]
-script: install-libgoogle-cloud.bat  # [win]
-build:
-  run_exports:
-    # patch versions guaranteed to be ABI-compatible, see
-    # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
-    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, max_pin="x.x") }}
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - cmake
-    - ninja
-  host:
-    - {{ pin_subpackage("libgoogle-cloud-" ~ parent ~ "-devel", exact=True) }}
-    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
-  run:
-    - {{ pin_subpackage("libgoogle-cloud-" ~ parent ~ "-devel", exact=True) }}
-    - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
-    - {{ pin_subpackage("libgoogle-cloud-" ~ feature, exact=True) }}
-    - libcxx  # [osx]
-test:
-  {{ test_devel_subpackage(feature)|indent(2) }}
-{%- endmacro %}
-
 package:
   name: google-cloud-cpp-core
   version: {{ version }}
@@ -279,32 +141,456 @@ outputs:
         - tests/quickstart.cc
 
   - name: libgoogle-cloud-oauth2
-    {{ standard_subpackage("oauth2")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-oauth2", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_oauth2.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_oauth2.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_oauth2.lib exit 1     # [win]
+      
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+      
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_oauth2.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_oauth2/google_cloud_cpp_oauth2-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_oauth2\google_cloud_cpp_oauth2-config.cmake exit 1  # [win]
+
   - name: libgoogle-cloud-bigtable
-    {{ standard_subpackage("bigtable")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-bigtable", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_bigtable.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_bigtable.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_bigtable.lib exit 1     # [win]
+      
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+      
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_bigtable.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_bigtable/google_cloud_cpp_bigtable-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_bigtable\google_cloud_cpp_bigtable-config.cmake exit 1  # [win]
+
   - name: libgoogle-cloud-pubsub
-    {{ standard_subpackage("pubsub")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_pubsub.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_pubsub.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_pubsub.lib exit 1     # [win]
+      
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+      
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_pubsub.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_pubsub/google_cloud_cpp_pubsub-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_pubsub\google_cloud_cpp_pubsub-config.cmake exit 1  # [win]
+
   - name: libgoogle-cloud-spanner
-    {{ standard_subpackage("spanner")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-spanner", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_spanner.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_spanner.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_spanner.lib exit 1     # [win]
+      
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+      
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_spanner.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_spanner/google_cloud_cpp_spanner-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_spanner\google_cloud_cpp_spanner-config.cmake exit 1  # [win]
 
   - name: libgoogle-cloud-oauth2-devel
-    {{ standard_devel_subpackage("oauth2")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-oauth2", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-oauth2", exact=True) }}
+        - libcxx  # [osx]
+    test:
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/oauth2/quickstart/*.cc
+        - google/cloud/oauth2/quickstart/CMakeLists.txt
+
   - name: libgoogle-cloud-bigtable-devel
-    {{ standard_devel_subpackage("bigtable")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-bigtable", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-bigtable", exact=True) }}
+        - libcxx  # [osx]
+    test:
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/bigtable/quickstart/*.cc
+        - google/cloud/bigtable/quickstart/CMakeLists.txt
+
   - name: libgoogle-cloud-pubsub-devel
-    {{ standard_devel_subpackage("pubsub")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", exact=True) }}
+        - libcxx  # [osx]
+    test:
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/pubsub/quickstart/*.cc
+        - google/cloud/pubsub/quickstart/CMakeLists.txt
+
   - name: libgoogle-cloud-spanner-devel
-    {{ standard_devel_subpackage("spanner")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-spanner", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-spanner", exact=True) }}
+        - libcxx  # [osx]
+    test:
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/spanner/quickstart/*.cc
+        - google/cloud/spanner/quickstart/CMakeLists.txt
 
   - name: libgoogle-cloud-iam
-    {{ child_subpackage("iam", "pubsub")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-iam", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_iam.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_iam.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_iam.lib exit 1     # [win]
+
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_iam.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_iam/google_cloud_cpp_iam-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_iam\google_cloud_cpp_iam-config.cmake exit 1  # [win]
+
   - name: libgoogle-cloud-policytroubleshooter
-    {{ child_subpackage("policytroubleshooter", "pubsub")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-policytroubleshooter", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud", exact=True) }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+        - libcxx  # [osx]
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_policytroubleshooter.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_policytroubleshooter.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_policytroubleshooter.lib exit 1     # [win]
+
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_policytroubleshooter.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_policytroubleshooter/google_cloud_cpp_policytroubleshooter-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_policytroubleshooter\google_cloud_cpp_policytroubleshooter-config.cmake exit 1  # [win]
 
   - name: libgoogle-cloud-iam-devel
-    {{ child_devel_subpackage("iam", "pubsub")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-iam", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-iam", exact=True) }}
+        - libcxx  # [osx]
+    test:
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/iam/quickstart/*.cc
+        - google/cloud/iam/quickstart/CMakeLists.txt
+
   - name: libgoogle-cloud-policytroubleshooter-devel
-    {{ child_devel_subpackage("policytroubleshooter", "pubsub")|indent(4) }}
+    script: install-libgoogle-cloud.sh   # [not win]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-policytroubleshooter", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-pubsub-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-devel", exact=True) }}
+        - {{ pin_subpackage("libgoogle-cloud-policytroubleshooter", exact=True) }}
+        - libcxx  # [osx]
+    test:
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/policytroubleshooter/quickstart/*.cc
+        - google/cloud/policytroubleshooter/quickstart/CMakeLists.txt
 
   - name: libgoogle-cloud-storage
     # This cannot use the standard subpackages because it has different direct
@@ -337,7 +623,21 @@ outputs:
         - openssl
         - libcxx  # [osx]
     test:
-      {{ test_subpackage("storage")|indent(6) }}
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_storage.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_storage.so.{{ version }}  # [linux]
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_storage.lib exit 1     # [win]
+
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/version.h  # [not win]
+        - if exist %LIBRARY_INC%\google\cloud\version.h exit 1  # [win]
+
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_storage.pc  # [not win]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_storage/google_cloud_cpp_storage-config.cmake  # [not win]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_storage\google_cloud_cpp_storage-config.cmake exit 1  # [win]
 
   - name: libgoogle-cloud-storage-devel
     # This cannot use the standard subpackages because it has different direct
@@ -372,7 +672,19 @@ outputs:
         - nlohmann_json
         - libcxx  # [osx]
     test:
-      {{ test_devel_subpackage("storage")|indent(6) }}
+      commands:
+        - ./run_test_feature.sh   # [not win]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/storage/quickstart/*.cc
+        - google/cloud/storage/quickstart/CMakeLists.txt
 
 about:
   home: https://github.com/googleapis/google-cloud-cpp

--- a/recipes/google-cloud-cpp-core/patches/0001-fix-oauth2-only-enable-via-GOOGLE_CLOUD_CPP_ENABLE-1.patch
+++ b/recipes/google-cloud-cpp-core/patches/0001-fix-oauth2-only-enable-via-GOOGLE_CLOUD_CPP_ENABLE-1.patch
@@ -1,0 +1,31 @@
+From 7398c77dfda91468b4ed62dec662ff69d61f439c Mon Sep 17 00:00:00 2001
+From: Carlos O'Ryan <coryan@google.com>
+Date: Tue, 17 Oct 2023 09:35:26 -0400
+Subject: [PATCH 1/2] fix(oauth2): only enable via GOOGLE_CLOUD_CPP_ENABLE
+ (#12911)
+
+Enabling `oauth2` if `GOOGLE_CLOUD_CPPP_ENABLE_REST` is set is a bug: it
+introduces a cycle in the dependencies of the library, and makes it
+impossible to compile `oauth2`, `storage`, and `compute` in different
+shards.
+---
+ cmake/GoogleCloudCppFeatures.cmake | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/cmake/GoogleCloudCppFeatures.cmake b/cmake/GoogleCloudCppFeatures.cmake
+index a69cd85a..e86b9d03 100644
+--- a/cmake/GoogleCloudCppFeatures.cmake
++++ b/cmake/GoogleCloudCppFeatures.cmake
+@@ -361,9 +361,6 @@ macro (google_cloud_cpp_enable_cleanup)
+         OR (sql IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+         OR (generator IN_LIST GOOGLE_CLOUD_CPP_ENABLE))
+         set(GOOGLE_CLOUD_CPP_ENABLE_REST ON)
+-        # Backwards compatibility. In the original release of `oauth2` we
+-        # automatically compiled the library if REST was enabled
+-        list(APPEND GOOGLE_CLOUD_CPP_ENABLE oauth2)
+     endif ()
+ 
+     list(REMOVE_DUPLICATES GOOGLE_CLOUD_CPP_ENABLE)
+-- 
+2.42.0.655.g421f12c284-goog
+

--- a/recipes/google-cloud-cpp-core/patches/0002-fix-storage-remove-unused-dependencies-12890.patch
+++ b/recipes/google-cloud-cpp-core/patches/0002-fix-storage-remove-unused-dependencies-12890.patch
@@ -1,0 +1,54 @@
+From 15ecaeab73b3b8495c7bd8a98ce0da250a2079d9 Mon Sep 17 00:00:00 2001
+From: Carlos O'Ryan <coryan@google.com>
+Date: Fri, 13 Oct 2023 06:18:18 -0400
+Subject: [PATCH 2/2] fix(storage): remove unused dependencies (#12890)
+
+We do not directly use `OpenSSL::SSL` or `ZLIB::ZLIB`. Both are used
+indirectly via `CURL::libcurl`. We should not require the package or
+link the libraries.
+---
+ google/cloud/storage/google_cloud_cpp_storage.cmake      | 5 +----
+ google/cloud/storage/google_cloud_cpp_storage_grpc.cmake | 4 +---
+ 2 files changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/google/cloud/storage/google_cloud_cpp_storage.cmake b/google/cloud/storage/google_cloud_cpp_storage.cmake
+index 92d740a4..629860cd 100644
+--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
++++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
+@@ -16,7 +16,6 @@
+ 
+ include(FindCurlWithTargets)
+ find_package(OpenSSL REQUIRED)
+-find_package(ZLIB REQUIRED)
+ 
+ # the client library
+ add_library(
+@@ -259,9 +258,7 @@ target_link_libraries(
+            Crc32c::crc32c
+            CURL::libcurl
+            Threads::Threads
+-           OpenSSL::SSL
+-           OpenSSL::Crypto
+-           ZLIB::ZLIB)
++           OpenSSL::Crypto)
+ if (WIN32)
+     # We use `setsockopt()` directly, which requires the ws2_32 (Winsock2 for
+     # Windows32?) library on Windows.
+diff --git a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+index 5be4813c..8f292fc3 100644
+--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
++++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+@@ -144,9 +144,7 @@ else ()
+                Crc32c::crc32c
+                CURL::libcurl
+                Threads::Threads
+-               OpenSSL::SSL
+-               OpenSSL::Crypto
+-               ZLIB::ZLIB)
++               OpenSSL::Crypto)
+     google_cloud_cpp_add_common_options(google_cloud_cpp_storage_grpc)
+     target_include_directories(
+         google_cloud_cpp_storage_grpc
+-- 
+2.42.0.655.g421f12c284-goog
+

--- a/recipes/google-cloud-cpp-core/patches/0003-cleanup-CMake-3.13-always-has-CURL-libcurl-12938.patch
+++ b/recipes/google-cloud-cpp-core/patches/0003-cleanup-CMake-3.13-always-has-CURL-libcurl-12938.patch
@@ -1,0 +1,188 @@
+From e0c98bb473f3571b86637691395f79fd869c9089 Mon Sep 17 00:00:00 2001
+From: Carlos O'Ryan <coryan@google.com>
+Date: Fri, 20 Oct 2023 13:47:21 -0400
+Subject: [PATCH] cleanup: CMake >= 3.13 always has `CURL::libcurl` (#12938)
+
+Since we now require CMake >= 3.13, we do not need workarounds to define
+`CURL::libcurl`.
+---
+ cmake/FindCurlWithTargets.cmake               | 68 -------------------
+ examples/CMakeLists.txt                       |  2 +-
+ .../google_cloud_cpp_rest_internal.cmake      |  2 +-
+ .../cloud/storage/benchmarks/CMakeLists.txt   |  2 -
+ google/cloud/storage/config-grpc.cmake.in     | 11 ---
+ .../storage/google_cloud_cpp_storage.cmake    |  2 +-
+ google/cloud/storage/tests/CMakeLists.txt     |  1 -
+ 7 files changed, 3 insertions(+), 85 deletions(-)
+ delete mode 100644 cmake/FindCurlWithTargets.cmake
+
+diff --git a/cmake/FindCurlWithTargets.cmake b/cmake/FindCurlWithTargets.cmake
+deleted file mode 100644
+index 77c35b40f1..0000000000
+--- a/cmake/FindCurlWithTargets.cmake
++++ /dev/null
+@@ -1,68 +0,0 @@
+-# ~~~
+-# Copyright 2018 Google Inc.
+-#
+-# Licensed under the Apache License, Version 2.0 (the "License");
+-# you may not use this file except in compliance with the License.
+-# You may obtain a copy of the License at
+-#
+-#     https://www.apache.org/licenses/LICENSE-2.0
+-#
+-# Unless required by applicable law or agreed to in writing, software
+-# distributed under the License is distributed on an "AS IS" BASIS,
+-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-# See the License for the specific language governing permissions and
+-# limitations under the License.
+-# ~~~
+-
+-# gRPC always requires thread support.
+-find_package(Threads REQUIRED)
+-
+-# The `FindCurl` CMake module does not handle static libraries correctly, and
+-# does not produce consistent names for the CURL targets. This file first tries
+-# to load the CURL config files, and only if not found fallsback to the FindCurl
+-# module. In the latter case, it adjusts the targets to work consistently across
+-# CMake versions and to link the right dependencies when compiled statically.
+-
+-find_package(CURL CONFIG QUIET)
+-if (CURL_FOUND)
+-    message(STATUS "CURL found using via CONFIG module")
+-else ()
+-    # As searching for libcurl using CONFIG mode failed, try again using the
+-    # CMake config module. We will need to fix up a few things if the module is
+-    # found this way.
+-    find_package(CURL REQUIRED)
+-    # If the library is static, we need to explicitly link its dependencies. The
+-    # CMake module does not do so. However, we should not do so for shared
+-    # libraries, because the version of OpenSSL (for example) found by
+-    # find_package() may be newer than the version linked against libcurl.
+-    if ("${CURL_LIBRARY}" MATCHES "${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+-        find_package(OpenSSL REQUIRED)
+-        find_package(ZLIB REQUIRED)
+-        set_property(
+-            TARGET CURL::libcurl
+-            APPEND
+-            PROPERTY INTERFACE_LINK_LIBRARIES OpenSSL::SSL OpenSSL::Crypto
+-                     ZLIB::ZLIB)
+-        message(STATUS "CURL linkage will be static")
+-        # On WIN32 and APPLE there are even more libraries needed for static
+-        # linking.
+-        if (WIN32)
+-            set_property(
+-                TARGET CURL::libcurl
+-                APPEND
+-                PROPERTY INTERFACE_LINK_LIBRARIES crypt32 wsock32 ws2_32)
+-            set_property(
+-                TARGET CURL::libcurl
+-                APPEND
+-                PROPERTY INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")
+-        endif ()
+-        if (APPLE)
+-            set_property(
+-                TARGET CURL::libcurl
+-                APPEND
+-                PROPERTY INTERFACE_LINK_LIBRARIES ldap)
+-        endif ()
+-    else ()
+-        message(STATUS "CURL linkage will be non-static")
+-    endif ()
+-endif (CURL_FOUND)
+diff --git a/examples/CMakeLists.txt b/examples/CMakeLists.txt
+index ec8b73953e..ce44aafea4 100644
+--- a/examples/CMakeLists.txt
++++ b/examples/CMakeLists.txt
+@@ -32,7 +32,7 @@ if (bigtable IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND storage IN_LIST
+     google_cloud_cpp_add_common_options(gcs2cbt)
+ endif ()
+ 
+-include(FindCurlWithTargets)
++find_package(CURL REQUIRED)
+ include(FindgRPC)
+ 
+ if (spanner IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND iam IN_LIST
+diff --git a/google/cloud/google_cloud_cpp_rest_internal.cmake b/google/cloud/google_cloud_cpp_rest_internal.cmake
+index e6d7b97109..750df05d50 100644
+--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
++++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
+@@ -15,7 +15,7 @@
+ # ~~~
+ 
+ include(IncludeNlohmannJson)
+-include(FindCurlWithTargets)
++find_package(CURL REQUIRED)
+ find_package(OpenSSL REQUIRED)
+ 
+ # the library
+diff --git a/google/cloud/storage/benchmarks/CMakeLists.txt b/google/cloud/storage/benchmarks/CMakeLists.txt
+index 7f951126d7..064ab041a7 100644
+--- a/google/cloud/storage/benchmarks/CMakeLists.txt
++++ b/google/cloud/storage/benchmarks/CMakeLists.txt
+@@ -69,7 +69,6 @@ foreach (fname ${storage_benchmark_programs})
+                 google-cloud-cpp::storage
+                 google-cloud-cpp::common
+                 absl::strings
+-                CURL::libcurl
+                 Threads::Threads
+                 nlohmann_json)
+     google_cloud_cpp_add_common_options(${target})
+@@ -104,7 +103,6 @@ foreach (fname ${storage_benchmarks_unit_tests})
+                 GTest::gmock_main
+                 GTest::gmock
+                 GTest::gtest
+-                CURL::libcurl
+                 absl::strings
+                 nlohmann_json)
+     google_cloud_cpp_add_common_options(${target})
+diff --git a/google/cloud/storage/config-grpc.cmake.in b/google/cloud/storage/config-grpc.cmake.in
+index 1cdd8a45fe..3fe82f3001 100644
+--- a/google/cloud/storage/config-grpc.cmake.in
++++ b/google/cloud/storage/config-grpc.cmake.in
+@@ -24,17 +24,6 @@ find_dependency(nlohmann_json)
+ find_dependency(OpenSSL)
+ find_dependency(ZLIB)
+ 
+-# Some versions of FindCURL do not define CURL::libcurl, so we define it ourselves.
+-if (NOT TARGET CURL::libcurl)
+-    add_library(CURL::libcurl UNKNOWN IMPORTED)
+-    set_property(TARGET CURL::libcurl
+-                 APPEND
+-                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIR}")
+-    set_property(TARGET CURL::libcurl
+-                 APPEND
+-                 PROPERTY IMPORTED_LOCATION "${CURL_LIBRARY}")
+-endif ()
+-
+ include("${CMAKE_CURRENT_LIST_DIR}/storage-targets.cmake")
+ 
+ # TODO(12698) - remove transition name (experimental-storage-grpc)
+diff --git a/google/cloud/storage/google_cloud_cpp_storage.cmake b/google/cloud/storage/google_cloud_cpp_storage.cmake
+index 629860cdf5..be505487f4 100644
+--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
++++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
+@@ -14,7 +14,7 @@
+ # limitations under the License.
+ # ~~~
+ 
+-include(FindCurlWithTargets)
++find_package(CURL REQUIRED)
+ find_package(OpenSSL REQUIRED)
+ 
+ # the client library
+diff --git a/google/cloud/storage/tests/CMakeLists.txt b/google/cloud/storage/tests/CMakeLists.txt
+index 2a7f74ecfc..ab05ea1e1a 100644
+--- a/google/cloud/storage/tests/CMakeLists.txt
++++ b/google/cloud/storage/tests/CMakeLists.txt
+@@ -102,7 +102,6 @@ foreach (fname IN LISTS storage_client_integration_tests)
+                 GTest::gmock_main
+                 GTest::gmock
+                 GTest::gtest
+-                CURL::libcurl
+                 Threads::Threads
+                 absl::strings
+                 nlohmann_json)
+-- 
+2.42.0.655.g421f12c284-goog
+

--- a/recipes/google-cloud-cpp-core/recipe-scripts-license.txt
+++ b/recipes/google-cloud-cpp-core/recipe-scripts-license.txt
@@ -1,0 +1,27 @@
+BSD-3-Clause license
+Copyright (c) 2015-2022, conda-forge contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/recipes/google-cloud-cpp-core/run_test_common.bat
+++ b/recipes/google-cloud-cpp-core/run_test_common.bat
@@ -1,0 +1,16 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
+
+cmake -GNinja ^
+    -S tests -B .build/quickstart ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake"
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .build/quickstart --config Release
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/google-cloud-cpp-core/run_test_common.sh
+++ b/recipes/google-cloud-cpp-core/run_test_common.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Stop on first error
+set -euo pipefail
+
+if [[ "${target_platform}" == osx-* ]]; then
+  # as in build.sh
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+cmake -GNinja \
+    -S tests -B .build \
+    -DCMAKE_PREFIX_PATH="$PREFIX" \
+    -DCMAKE_MODULE_PATH="$PREFIX/lib/cmake"
+cmake --build .build

--- a/recipes/google-cloud-cpp-core/run_test_feature.bat
+++ b/recipes/google-cloud-cpp-core/run_test_feature.bat
@@ -1,0 +1,19 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
+
+set FEATURE=%PKG_NAME:libgoogle-cloud-=%
+set FEATURE=%FEATURE:-devel=%
+
+cmake -GNinja ^
+    -S "google/cloud/%FEATURE%/quickstart" -B .build/quickstart ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake"
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .build/quickstart --config Release
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/google-cloud-cpp-core/run_test_feature.sh
+++ b/recipes/google-cloud-cpp-core/run_test_feature.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Stop on first error
+set -euo pipefail
+
+if [[ "${target_platform}" == osx-* ]]; then
+  # as in build.sh
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+feature=${PKG_NAME/#libgoogle-cloud-/}
+feature=${feature/%-devel/}
+
+cmake -GNinja \
+    -S "google/cloud/${feature}/quickstart" -B .build \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_PREFIX_PATH="$PREFIX" \
+    -DCMAKE_MODULE_PATH="$PREFIX/lib/cmake"
+cmake --build .build

--- a/recipes/google-cloud-cpp-core/tests/CMakeLists.txt
+++ b/recipes/google-cloud-cpp-core/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10...3.24)
+project(google-cloud-cpp-quickstart CXX)
+
+find_package(OpenSSL REQUIRED)
+find_package(google_cloud_cpp_common REQUIRED)
+
+add_executable(quickstart quickstart.cc)
+target_compile_features(quickstart PRIVATE cxx_std_17)
+target_link_libraries(quickstart google-cloud-cpp::common)

--- a/recipes/google-cloud-cpp-core/tests/quickstart.cc
+++ b/recipes/google-cloud-cpp-core/tests/quickstart.cc
@@ -1,0 +1,7 @@
+#include <google/cloud/version.h>
+#include <iostream>
+
+int main() {
+  std::cout << "Hello: " << google::cloud::version_string() << "\n";
+  return 0;
+}


### PR DESCRIPTION
Manually expand the Jinja macros for `google-cloud-cpp-core`. It seems they do not work with `conda-smithy`.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
