### PR TITLE
Adding auto-dotenv recipe

### DIFF
--- a/recipes/auto-dotenv/.env
+++ b/recipes/auto-dotenv/.env
@@ -1,0 +1,1 @@
+export HELLO=WORLD

--- a/recipes/auto-dotenv/LICENSE
+++ b/recipes/auto-dotenv/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Apoorv Khandelwal (@apoorvkh)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/auto-dotenv/build.sh
+++ b/recipes/auto-dotenv/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+for CHANGE in "activate" "deactivate"
+do
+    mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+    cp "${RECIPE_DIR}/scripts/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}.sh"
+done

--- a/recipes/auto-dotenv/meta.yaml
+++ b/recipes/auto-dotenv/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.0
 
 build:
+  skip: true  # [win]
   number: 0
 
 test:

--- a/recipes/auto-dotenv/meta.yaml
+++ b/recipes/auto-dotenv/meta.yaml
@@ -1,0 +1,16 @@
+package:
+  name: auto-dotenv
+  version: 1.0
+
+build:
+  number: 0
+
+about:
+  summary: 'Automatically load environment variables from .env when activating a conda environment.'
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - apoorvkh

--- a/recipes/auto-dotenv/meta.yaml
+++ b/recipes/auto-dotenv/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0
 
 build:
-  skip: true  # [win]
+  noarch: generic
   number: 0
 
 test:

--- a/recipes/auto-dotenv/meta.yaml
+++ b/recipes/auto-dotenv/meta.yaml
@@ -5,7 +5,14 @@ package:
 build:
   number: 0
 
+test:
+  files:
+    - .env
+  commands:
+    - test "$HELLO" == "WORLD"
+
 about:
+  home: https://github.com/conda-forge/auto-dotenv-feedstock
   summary: 'Automatically load environment variables from .env when activating a conda environment.'
   license: MIT
   license_family: MIT

--- a/recipes/auto-dotenv/scripts/activate.sh
+++ b/recipes/auto-dotenv/scripts/activate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+if [ -e "./.env" ]; then
+
+    if [ ! -v "DOTENV_STACK" ]; then
+        # Parse .env file
+        dotenv_keys=$(sed -e '/^$/d' -e '/^#/d' -e 's/^export //' -e 's/=.*//' .env)
+
+        # Split string by spaces
+        if [ -n "$ZSH_VERSION" ]; then
+            dotenv_keys=$(echo $dotenv_keys | tr '\n' ' ')
+            dotenv_keys=(${(s/ /)dotenv_keys})
+        fi
+
+        # Preserve environment variables
+        DOTENV_STACK=()
+
+        for key in $dotenv_keys; do
+            if [ -n "$ZSH_VERSION" ]; then
+                DOTENV_STACK+="$key=${(P)key}";
+            else
+                DOTENV_STACK+=("$key=${!key}")
+            fi
+        done
+
+        unset dotenv_keys
+    fi
+
+    # Load new environment variables
+    source ./.env
+
+fi

--- a/recipes/auto-dotenv/scripts/deactivate.sh
+++ b/recipes/auto-dotenv/scripts/deactivate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Reset env variables to pre-activation values
+for env_var in ${DOTENV_STACK[@]}; do
+    eval $env_var;
+done
+
+# Cleanup
+unset env_var
+unset DOTENV_STACK


### PR DESCRIPTION
This is a super lightweight recipe that automatically loads environment variables from `.env` after `conda activate` is called. The previous variables are restored when the environment is deactivated.

### Motivation

Some projects need users to set certain environment variables (commonly stored in a `.env` file). This is a convenience package that guarantees the environment variables will be loaded when the environment is activated. This also saves the user one command (i.e. running `source .env` themselves) every session.

Normally, conda [supports](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#setting-environment-variables) including `variables:` entries in `environment.yml`. But micromamba doesn't actually implement this (https://github.com/mamba-org/mamba/issues/1026). And perhaps `.env` is more conventional. This package provides a workaround.

### Other details

This is currently implemented for Linux and supports bash/zsh shells. We can consider adding scripts for csh/fish later. The script is currently pretty straightforward and I have tested it manually (e.g. by creating a `.env` file, loading and unloading environments, etc). There is no source or URL for these scripts.

Hope that sounds good. Thanks!

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not recieve prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
