### PR TITLE
adds `marimo`

### DIFF
--- a/recipes/marimo/bld.bat
+++ b/recipes/marimo/bld.bat
@@ -1,0 +1,7 @@
+@echo on
+
+bash %RECIPE_DIR%/build_win.sh
+IF %ERRORLEVEL% NEQ 0 exit 1
+
+"%PYTHON%" -m pip install . -vv --no-deps --no-build-isolation
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/marimo/build.sh
+++ b/recipes/marimo/build.sh
@@ -2,7 +2,7 @@
 
 ## remove copilot
 rm -rf marimo/_lsp
-sed -i '/_lsp/d' MANIFEST.in marimo.egg-info/SOURCES.txt
+sed -i.bak -e '/_lsp/d' MANIFEST.in marimo.egg-info/SOURCES.txt
 
 ## build
 ${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/marimo/build.sh
+++ b/recipes/marimo/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## remove copilot
+rm -rf marimo/_lsp
+sed -i '/_lsp/d' MANIFEST.in marimo.egg-info/SOURCES.txt
+
+## build
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/marimo/build_win.sh
+++ b/recipes/marimo/build_win.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+## remove copilot
+rm -rf marimo/_lsp
+sed -i '/_lsp/d' MANIFEST.in marimo.egg-info/SOURCES.txt

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "marimo" %}
-{% set version = "0.1.66" %}
+{% set version = "0.1.67" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/marimo-{{ version }}.tar.gz
-  sha256: 3f10cc9fd7b66376066d213cfb7902eef6c62e2ec7a0400e7e5063f76ec84d96
+  sha256: ca6bce8f40b1332cc09bf1c735cbc33bf446ac051a4c35c2ce634b5813184342
 
 build:
   entry_points:
     - marimo = marimo._cli.cli:main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 3f10cc9fd7b66376066d213cfb7902eef6c62e2ec7a0400e7e5063f76ec84d96
 
 build:
-  noarch: generic
   entry_points:
     - marimo = marimo._cli.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -18,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - setuptools
     - pip
   run:
-    - python >=3.8
+    - python
     - click >=8.0,<9
     - importlib-resources >=5.10.2  # [py<39]
     - jedi >=0.18.0

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   skip: true  # [py<38]
+  noarch: python
   entry_points:
     - marimo = marimo._cli.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -44,6 +45,8 @@ test:
     - pip
 
 about:
+  home: https://marimo.io
+  dev_url: https://github.com/marimo-team/marimo
   summary: A library for making reactive notebooks and apps
   license: Apache-2.0
   license_file: LICENSE

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: 3f10cc9fd7b66376066d213cfb7902eef6c62e2ec7a0400e7e5063f76ec84d96
 
 build:
-  skip: true  # [py<38]
   noarch: python
   entry_points:
     - marimo = marimo._cli.cli:main

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "marimo" %}
-{% set version = "0.1.67" %}
+{% set version = "0.1.68" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/marimo-{{ version }}.tar.gz
-  sha256: ca6bce8f40b1332cc09bf1c735cbc33bf446ac051a4c35c2ce634b5813184342
+  sha256: 316334b4e9edfafd72b8e4e91abeeb010e9762eb0c4a2eba7ab84b153119a76c
 
 build:
   entry_points:
@@ -46,7 +46,10 @@ about:
   dev_url: https://github.com/marimo-team/marimo
   summary: A library for making reactive notebooks and apps
   license: Apache-2.0
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - third_party.txt
+    - third_party_licenses.txt
 
 extra:
   recipe-maintainers:

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "marimo" %}
+{% set version = "0.1.66" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/marimo-{{ version }}.tar.gz
+  sha256: 3f10cc9fd7b66376066d213cfb7902eef6c62e2ec7a0400e7e5063f76ec84d96
+
+build:
+  skip: true  # [py<38]
+  entry_points:
+    - marimo = marimo._cli.cli:main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - setuptools
+    - pip
+  run:
+    - python >=3.8
+    - click >=8.0,<9
+    - importlib-resources >=5.10.2  # [py<39]
+    - jedi >=0.18.0
+    - markdown >=3.4,<4
+    - pymdown-extensions >=9.0,<11
+    - pygments >=2.13,<3
+    - tomlkit >=0.12.0
+    - tornado >=6.1,<7
+    - typing-extensions >=4.4.0  # [py<310]
+    - black
+
+test:
+  imports:
+    - marimo
+  commands:
+    - pip check
+    - marimo --help
+  requires:
+    - pip
+
+about:
+  summary: A library for making reactive notebooks and apps
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mfansler

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -50,4 +50,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - akshayka
     - mfansler

--- a/recipes/marimo/meta.yaml
+++ b/recipes/marimo/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3f10cc9fd7b66376066d213cfb7902eef6c62e2ec7a0400e7e5063f76ec84d96
 
 build:
-  noarch: python
+  noarch: generic
   entry_points:
     - marimo = marimo._cli.cli:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation


### PR DESCRIPTION
Adds [PyPI package `marimo`](https://pypi.org/project/marimo/) as `marimo`. Recipe generate with `grayskull` with URLs manually added. Redistributed binaries are removed during build. All vendored code is isolated (will not clobber) and has all corresponding licensing information packaged.

Resolves https://github.com/marimo-team/marimo/issues/477.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
