### PR TITLE
CI: Tweak automated label management

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -61,6 +61,29 @@
                       //
                       https://github.com/conda-forge/staged-recipes/issues/18023#issuecomment-1080451231
                       console.log(`Somebody mentioned ${slug}.`);
+                      if (label == "staged-recipes") {
+                        github.rest.issues.createComment({
+                          issue_number: context.issue.number,
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          body: 'To help direct your pull request to the best reviewers, ' +
+                                'please mention a topic-specifc team if your recipe matches any of the following: ' +
+                                'conda-forge/help-c-cpp, ' +
+                                'conda-forge/help-cdts, ' +
+                                'conda-forge/help-go, ' +
+                                'conda-forge/help-java, ' +
+                                'conda-forge/help-julia, ' +
+                                'conda-forge/help-nodejs, ' +
+                                'conda-forge/help-perl, ' +
+                                'conda-forge/help-python, ' +
+                                'conda-forge/help-python-c, ' +
+                                'conda-forge/help-r, ' +
+                                'or '
+                                'conda-forge/help-ruby' +
+                                '. '
+                                'Thanks!'
+                        });
+                      }
                   }
               }
               return found_label;

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -4,9 +4,9 @@
     issue_comment:
       types: [created]
     issues:
-      types: [unlabeled]
+      types: [unlabeled, labeled]
     pull_request_target:
-      types: [unlabeled]
+      types: [unlabeled, labeled]
 
   permissions:
     issues: write # for adding label to an issue
@@ -79,23 +79,14 @@
                   name: ['Awaiting author contribution']
               })
 
-    check-remove-review-requested-label:
-      name: 'Check that review-requested label was removed by a team member'
+    add-await-when-review-removed:
+      name: 'Add awaiting-author when review-requested removed'
       if: >
         github.event.action == 'unlabeled'
         && github.event.label.name == 'review-requested'
       runs-on: ubuntu-latest
       steps:
-        - name: check-team-membership
-          id: check_team_review
-          uses: actions/github-script@v6
-          with:
-            script: |
-              console.log(`Label was removed by ${context.payload.sender.login}`);
-              return true;
         - name: add-labels
-          if: >
-            (steps.check_team_review.outputs.result == 'true')
           uses: actions/github-script@v6
           with:
             script: |
@@ -105,16 +96,21 @@
                   repo: context.repo.repo,
                   labels: ['Awaiting author contribution']
               });
-        - name: readd-review-label
-          if: >
-            (steps.check_team_review.outputs.result == 'false')
+
+    remove-review-when-await-added:
+      name: 'Removed review-requested when awaiting-author added'
+      if: >
+        github.event.action == 'labeled'
+        && github.event.label.name == 'Awaiting author contribution'
+      runs-on: ubuntu-latest
+      steps:
+        - name: remove-labels
           uses: actions/github-script@v6
           with:
             script: |
-              github.rest.issues.addLabels({
+              github.rest.issues.removeLabel({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  labels: ['review-requested']
-              });
-              console.log('Non-members of staged recipes cannot remove this label.')
+                  name: ['review-requested']
+              })

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -19,7 +19,6 @@
       if: >
         github.event.issue
         && github.event.issue.pull_request
-        && !contains(github.event.issue.labels.*.name, 'review-requested')
       runs-on: ubuntu-latest
       steps:
         - name: check-teams


### PR DESCRIPTION
This PR tweaks the automated label manager based on my observations of reviewers and authors interacting with the labeling system.

My main observations are

1. reviewers prefer to **add** the "Awaiting author contribution" label instead of removing the "review-requested" label. This leads to conflicting labels, so the bot will now automatically remove the "review-requested" label when the other is added.

2. authors like to ask the bot to ping "the team", but this just pings the staged-recipes team and locks out further automated language labeling. When authors later ping a help-* team, the language label is not applied. From now on, the bot will apply language labels any time a team is mentioned regardless of whether a review is currently requested.

I have also removed the dead code related to checking team membership, since it doesn't seem like we will ever implemented that feature due to the special permissions needed for the bot.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not recieve prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
--