### PR TITLE
Additional CUDA 11.2 cleanup

### DIFF
--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -16,9 +16,9 @@ channel_sources:
 - conda-forge
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
-cuda_compiler_version:
-- None
 cuda_compiler:
+- None
+cuda_compiler_version:
 - None
 cuda_compiler_version_min:
 - None

--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -22,5 +22,3 @@ cuda_compiler:
 - None
 cuda_compiler_version_min:
 - None
-cudnn:
-- undefined

--- a/.ci_support/linux64_cuda112.yaml
+++ b/.ci_support/linux64_cuda112.yaml
@@ -14,8 +14,6 @@ cxx_compiler_version:
 - 10
 fortran_compiler_version:
 - 10
-cudnn:
-- 8
 cdt_name:
 - cos7
 target_platform:
@@ -30,5 +28,3 @@ cuda_compiler:
 - nvcc
 cuda_compiler_version_min:
 - 11.2
-cudnn:
-- 8

--- a/.ci_support/linux64_cuda112.yaml
+++ b/.ci_support/linux64_cuda112.yaml
@@ -29,6 +29,6 @@ cuda_compiler_version:
 cuda_compiler:
 - nvcc
 cuda_compiler_version_min:
-- 10.2
+- 11.2
 cudnn:
 - 8

--- a/.ci_support/linux64_cuda112.yaml
+++ b/.ci_support/linux64_cuda112.yaml
@@ -22,9 +22,9 @@ channel_sources:
 - conda-forge
 docker_image:
 - quay.io/condaforge/linux-anvil-cuda:11.2
-cuda_compiler_version:
-- 11.2
 cuda_compiler:
 - nvcc
+cuda_compiler_version:
+- 11.2
 cuda_compiler_version_min:
 - 11.2


### PR DESCRIPTION
* Bumps `‎cuda_compiler_version_min` to `11.2`
* Drops `cudnn` variant key


xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/1708
xref: https://github.com/conda-forge/staged-recipes/pull/23436