### PR TITLE
feat: add `google-cloud-cpp-bigquery` feedstock

### DIFF
--- a/recipes/google-cloud-cpp-bigquery/bld.bat
+++ b/recipes/google-cloud-cpp-bigquery/bld.bat
@@ -5,7 +5,7 @@ setlocal EnableDelayedExpansion
 set LIBRARY_PREFIX=%LIBRARY_PREFIX:\=/%
 
 cmake -G "Ninja" ^
-    -S . -B .b ^
+    -S . -B build ^
     -DGOOGLE_CLOUD_CPP_ENABLE=bigquery ^
     -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON ^
     -DBUILD_TESTING=OFF ^
@@ -19,5 +19,5 @@ cmake -G "Ninja" ^
     -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
 if %ERRORLEVEL% neq 0 exit 1
 
-cmake --build .b --config Release
+cmake --build build --config Release
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/google-cloud-cpp-bigquery/bld.bat
+++ b/recipes/google-cloud-cpp-bigquery/bld.bat
@@ -1,0 +1,23 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX=%LIBRARY_PREFIX:\=/%
+
+cmake -G "Ninja" ^
+    -S . -B .b ^
+    -DGOOGLE_CLOUD_CPP_ENABLE=bigquery ^
+    -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON ^
+    -DBUILD_TESTING=OFF ^
+    -DBUILD_SHARED_LIBS=OFF ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
+    -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake" ^
+    -DCMAKE_INSTALL_LIBDIR=lib ^
+    -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF ^
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .b --config Release
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/google-cloud-cpp-bigquery/build.sh
+++ b/recipes/google-cloud-cpp-bigquery/build.sh
@@ -10,7 +10,7 @@ if [[ "${target_platform}" == osx-* ]]; then
 fi
 
 cmake ${CMAKE_ARGS} \
-    -GNinja -S . -B .build/bigquery \
+    -GNinja -S . -B build \
     -DGOOGLE_CLOUD_CPP_ENABLE=bigquery \
     -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON \
     -DBUILD_TESTING=OFF \
@@ -23,4 +23,4 @@ cmake ${CMAKE_ARGS} \
     -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc \
     -DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=$BUILD_PREFIX/bin/grpc_cpp_plugin \
     -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
-cmake --build .build/bigquery
+cmake --build build

--- a/recipes/google-cloud-cpp-bigquery/build.sh
+++ b/recipes/google-cloud-cpp-bigquery/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export OPENSSL_ROOT_DIR=$PREFIX
+
+if [[ "${target_platform}" == osx-* ]]; then
+  # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+cmake ${CMAKE_ARGS} \
+    -GNinja -S . -B .build/bigquery \
+    -DGOOGLE_CLOUD_CPP_ENABLE=bigquery \
+    -DGOOGLE_CLOUD_CPP_USE_INSTALLED_COMMON=ON \
+    -DBUILD_TESTING=OFF \
+    -DBUILD_SHARED_LIBS=ON \
+    -DOPENSSL_ROOT_DIR=$PREFIX \
+    -DCMAKE_BUILD_TYPE=release \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DProtobuf_PROTOC_EXECUTABLE=$BUILD_PREFIX/bin/protoc \
+    -DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=$BUILD_PREFIX/bin/grpc_cpp_plugin \
+    -DGOOGLE_CLOUD_CPP_ENABLE_WERROR=OFF
+cmake --build .build/bigquery

--- a/recipes/google-cloud-cpp-bigquery/conda_build_config.yaml
+++ b/recipes/google-cloud-cpp-bigquery/conda_build_config.yaml
@@ -1,0 +1,4 @@
+# The default at [1] is 10.9 and abseil does not compile with that
+# [1]: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.13  # [osx and x86_64]

--- a/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.bat
+++ b/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.bat
@@ -1,0 +1,22 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
+set BUILD_PREFIX="%BUILD_PREFIX:\=/%"
+set SRC_DIR="%SRC_DIR:\=/%"
+
+:: Once DLLs are working, we should install the non-devel packages using
+::     cmake --install .b --component google_cloud_cpp_runtime
+:: and the devel packages using
+::     cmake --install .b --component google_cloud_cpp_development
+
+if [%PKG_NAME%] == [libgoogle-cloud-bigquery-devel] (
+  cmake --install .b
+  if %ERRORLEVEL% neq 0 exit 1
+) else if [%PKG_NAME%] == [libgoogle-cloud-bigquery] (
+  @REM TODO: fix when DLL support comes along
+) else (
+  @ECHO Unknown package name %PKG_NAME%
+  exit 1
+)

--- a/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.bat
+++ b/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.bat
@@ -12,7 +12,7 @@ set SRC_DIR="%SRC_DIR:\=/%"
 ::     cmake --install .b --component google_cloud_cpp_development
 
 if [%PKG_NAME%] == [libgoogle-cloud-bigquery-devel] (
-  cmake --install .b
+  cmake --install build
   if %ERRORLEVEL% neq 0 exit 1
 ) else if [%PKG_NAME%] == [libgoogle-cloud-bigquery] (
   @REM TODO: fix when DLL support comes along

--- a/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.sh
+++ b/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+case "${PKG_NAME}" in
+  libgoogle-cloud-*-devel)
+    feature=${PKG_NAME/#libgoogle-cloud-/}
+    feature=${feature/%-devel/}
+    cmake --install .build/${feature} --component google_cloud_cpp_development
+    ;;
+  libgoogle-cloud-*)
+    feature=${PKG_NAME/#libgoogle-cloud-/}
+    cmake --install .build/${feature} --component google_cloud_cpp_runtime
+    ;;
+  *)
+    echo Unknown package name "${PKG_NAME}"
+    exit 1
+    ;;
+esac

--- a/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.sh
+++ b/recipes/google-cloud-cpp-bigquery/install-libgoogle-cloud.sh
@@ -3,14 +3,11 @@
 set -euo pipefail
 
 case "${PKG_NAME}" in
-  libgoogle-cloud-*-devel)
-    feature=${PKG_NAME/#libgoogle-cloud-/}
-    feature=${feature/%-devel/}
-    cmake --install .build/${feature} --component google_cloud_cpp_development
+  libgoogle-cloud-bigquery-devel)
+    cmake --install build --component google_cloud_cpp_development
     ;;
-  libgoogle-cloud-*)
-    feature=${PKG_NAME/#libgoogle-cloud-/}
-    cmake --install .build/${feature} --component google_cloud_cpp_runtime
+  libgoogle-cloud-bigquery)
+    cmake --install build --component google_cloud_cpp_runtime
     ;;
   *)
     echo Unknown package name "${PKG_NAME}"

--- a/recipes/google-cloud-cpp-bigquery/meta.yaml
+++ b/recipes/google-cloud-cpp-bigquery/meta.yaml
@@ -36,9 +36,6 @@ outputs:
   - name: libgoogle-cloud-bigquery
     script: install-libgoogle-cloud.sh   # [unix]
     script: install-libgoogle-cloud.bat  # [win]
-    build:
-      run_exports:
-        - libgoogle-cloud =={{ version }}
     requirements:
       build:
         - {{ compiler('c') }}

--- a/recipes/google-cloud-cpp-bigquery/meta.yaml
+++ b/recipes/google-cloud-cpp-bigquery/meta.yaml
@@ -21,9 +21,9 @@ requirements:
     - ninja
     - libgrpc
     - libprotobuf
-    - libgoogle-cloud-devel =={{ version }}
     - zlib # Needed by gRPC
   host:
+    - libgoogle-cloud-devel =={{ version }}
     - libabseil
     - libcurl
     - libgrpc
@@ -111,7 +111,7 @@ about:
   summary: Google Cloud Client Library for C++
 
 extra:
-  feedstock-name: google-cloud-cpp-core
+  feedstock-name: google-cloud-cpp-bigquery
   recipe-maintainers:
     - coryan
     - conda-forge/google-cloud-cpp

--- a/recipes/google-cloud-cpp-bigquery/meta.yaml
+++ b/recipes/google-cloud-cpp-bigquery/meta.yaml
@@ -1,0 +1,117 @@
+{% set version = "2.17.0" %}
+
+package:
+  name: google-cloud-cpp-bigquery
+  version: {{ version }}
+
+source:
+  url: https://github.com/googleapis/google-cloud-cpp/archive/v{{ version }}.tar.gz
+  sha256: 8cb87ec2947e691a7f8631877e78453bcfda51b3d3cd4940794a376741888d37
+  patches:
+    # This is an upstream fix to allow sharding google/cloud/oauth2
+    - patches/0001-Backport-12911-from-upstream.patch
+
+build:
+  number: 0
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - libgrpc
+    - libprotobuf
+    - libgoogle-cloud-devel =={{ version }}
+    - zlib # Needed by gRPC
+  host:
+    - libabseil
+    - libcurl
+    - libgrpc
+    - libprotobuf
+    - openssl
+    - nlohmann_json
+    - zlib # Needed by gRPC
+
+outputs:
+  - name: libgoogle-cloud-bigquery
+    script: install-libgoogle-cloud.sh   # [unix]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        - libgoogle-cloud =={{ version }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - libgoogle-cloud-devel =={{ version }}
+        - libabseil
+        - libprotobuf
+        - libgrpc
+    test:
+      commands:
+        # presence of shared library (unix)
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_bigquery.{{ version }}.dylib  # [osx]
+        - test -f $PREFIX/lib/libgoogle_cloud_cpp_bigquery.so.{{ version }}  # [linux]
+
+        # absence of static library (windows). It belongs only in devel package.
+        - if exist %LIBRARY_LIB%\google_cloud_cpp_bigquery.lib exit 1  # [win]
+
+        # absence of headers (they belong in devel package)
+        - test ! -f $PREFIX/include/google/cloud/bigquery/storage/v1/bigquery_read_client.h  # [unix]
+        - if exist %LIBRARY_INC%\google\cloud\bigquery\storage\v1\bigquery_read_client.h exit 1  # [win]
+
+        # absence of metadata for CMake & pkgconfig (belongs in devel package)
+        - test ! -f $PREFIX/lib/pkgconfig/google_cloud_cpp_bigquery.pc  # [unix]
+        - test ! -f $PREFIX/lib/cmake/google_cloud_cpp_common/google_cloud_cpp_bigquery-config.cmake  # [unix]
+        - if exist %LIBRARY_LIB%\cmake\google_cloud_cpp_common\google_cloud_cpp_bigquery-config.cmake exit 1  # [win]
+
+  - name: libgoogle-cloud-bigquery-devel
+    script: install-libgoogle-cloud.sh   # [unix]
+    script: install-libgoogle-cloud.bat  # [win]
+    build:
+      run_exports:
+        # patch versions guaranteed to be ABI-compatible, see
+        # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/adr/2023-05-03-patch-releases-are-ABI-compatible.md
+        - {{ pin_subpackage("libgoogle-cloud-bigquery", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+      host:
+        - libgoogle-cloud-devel =={{ version }}
+      run:
+        - {{ pin_subpackage("libgoogle-cloud-bigquery", exact=True) }}
+    test:
+      commands:
+        # build an example
+        - ./run_test_feature.sh   # [unix]
+        - ./run_test_feature.bat  # [win]
+      requires:
+        - {{ compiler('cxx') }}
+        - cmake
+        - ninja
+        - libgoogle-cloud-devel =={{ version }}
+      files:
+        - run_test_feature.sh
+        - run_test_feature.bat
+      source_files:
+        - google/cloud/bigquery/quickstart/*.cc
+        - google/cloud/bigquery/quickstart/CMakeLists.txt
+
+about:
+  home: https://github.com/googleapis/google-cloud-cpp
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Google Cloud Client Library for C++
+
+extra:
+  feedstock-name: google-cloud-cpp-core
+  recipe-maintainers:
+    - coryan
+    - conda-forge/google-cloud-cpp

--- a/recipes/google-cloud-cpp-bigquery/patches/0001-Backport-12911-from-upstream.patch
+++ b/recipes/google-cloud-cpp-bigquery/patches/0001-Backport-12911-from-upstream.patch
@@ -1,0 +1,23 @@
+From 379266c74e0a3fce4e48b4788ad32508b02ec626 Mon Sep 17 00:00:00 2001
+From: Carlos O'Ryan <coryan@google.com>
+Date: Wed, 20 Dec 2023 16:57:10 +0000
+Subject: [PATCH] Backport #12911 from upstream
+
+---
+ cmake/GoogleCloudCppFeatures.cmake | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/cmake/GoogleCloudCppFeatures.cmake b/cmake/GoogleCloudCppFeatures.cmake
+index a69cd85a..e86b9d03 100644
+--- a/cmake/GoogleCloudCppFeatures.cmake
++++ b/cmake/GoogleCloudCppFeatures.cmake
+@@ -361,9 +361,6 @@ macro (google_cloud_cpp_enable_cleanup)
+         OR (sql IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+         OR (generator IN_LIST GOOGLE_CLOUD_CPP_ENABLE))
+         set(GOOGLE_CLOUD_CPP_ENABLE_REST ON)
+-        # Backwards compatibility. In the original release of `oauth2` we
+-        # automatically compiled the library if REST was enabled
+-        list(APPEND GOOGLE_CLOUD_CPP_ENABLE oauth2)
+     endif ()
+ 
+     list(REMOVE_DUPLICATES GOOGLE_CLOUD_CPP_ENABLE)

--- a/recipes/google-cloud-cpp-bigquery/run_test_feature.bat
+++ b/recipes/google-cloud-cpp-bigquery/run_test_feature.bat
@@ -1,0 +1,19 @@
+@echo on
+setlocal EnableDelayedExpansion
+
+:: CMake does not like paths with \ characters
+set LIBRARY_PREFIX="%LIBRARY_PREFIX:\=/%"
+
+set FEATURE=%PKG_NAME:libgoogle-cloud-=%
+set FEATURE=%FEATURE:-devel=%
+
+cmake -GNinja ^
+    -S "google/cloud/%FEATURE%/quickstart" -B .build ^
+    -DCMAKE_CXX_STANDARD=17 ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DCMAKE_PREFIX_PATH="%LIBRARY_PREFIX%" ^
+    -DCMAKE_MODULE_PATH="%LIBRARY_PREFIX%/lib/cmake"
+if %ERRORLEVEL% neq 0 exit 1
+
+cmake --build .build --config Release
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/google-cloud-cpp-bigquery/run_test_feature.sh
+++ b/recipes/google-cloud-cpp-bigquery/run_test_feature.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Stop on first error
+set -euo pipefail
+
+if [[ "${target_platform}" == osx-* ]]; then
+  # as in build.sh
+  CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+feature=${PKG_NAME/#libgoogle-cloud-/}
+feature=${feature/%-devel/}
+
+cmake -GNinja \
+    -S "google/cloud/${feature}/quickstart" -B .build \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DCMAKE_PREFIX_PATH="$PREFIX" \
+    -DCMAKE_MODULE_PATH="$PREFIX/lib/cmake"
+cmake --build .build


### PR DESCRIPTION
More sharding for `google-cloud-cpp`. This adds some headroom for growth upstream.

See https://github.com/conda-forge/google-cloud-cpp-feedstock/issues/141 for more details.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
