### PR TITLE
add hdxms-datasets

### DIFF
--- a/recipes/hdxms-datasets/meta.yaml
+++ b/recipes/hdxms-datasets/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "hdxms-datasets" %}
+{% set version = "0.1.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/hdxms_datasets-{{ version }}.tar.gz
+  sha256: 515a840e83b094e83af35afc173a0efacf6aa64e3539e1cb1e8642b61b8d8705
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python >=3.9
+    - pandas
+    - pyyaml
+    - requests
+    - packaging
+
+test:
+  imports:
+    - hdxms_datasets
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Download and parse curated HDX-MS datasets
+  dev_url: https://github.com/Jhsmit/hdxms-datasets/
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Jhsmit


### PR DESCRIPTION
Adds hdxms-datasets via grayskull pypi

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
