### PR TITLE
Add CUDA 11.8

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -90,3 +90,47 @@ jobs:
     displayName: Run docker build for CUDA 11.2
   - publish: build_artifacts/linux-64/
     artifact: conda_pkgs_linux_64_cuda112
+
+- job: linux_64_cuda_118
+  dependsOn: linux_64
+  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
+  pool:
+    vmImage: ubuntu-latest
+  timeoutInMinutes: 360
+  steps:
+  - script: |
+      sudo mkdir -p /opt/empty_dir
+      for d in \
+          /opt/ghc \
+          /opt/hostedtoolcache \
+          /usr/lib/jvm \
+          /usr/local/.ghcup \
+          /usr/local/android \
+          /usr/local/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift \
+          ; do
+          sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+      done
+    displayName: Manage disk space
+
+  - script: |
+      # sudo pip install --upgrade pip
+      sudo pip install setuptools shyaml
+    displayName: Install dependencies
+
+  - script: |
+      set -e
+
+      # make sure there is a package directory so that artifact publishing works
+      mkdir -p build_artifacts/linux-64/
+
+      export CI=azure
+      export CONFIG=linux64_cuda118
+      export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-cuda:11.8
+      export AZURE=True
+      .scripts/run_docker_build.sh
+
+    displayName: Run docker build for CUDA 11.8
+  - publish: build_artifacts/linux-64/
+    artifact: conda_pkgs_linux_64_cuda118

--- a/.ci_support/linux64_cuda118.yaml
+++ b/.ci_support/linux64_cuda118.yaml
@@ -1,0 +1,30 @@
+c_compiler:
+- gcc
+cxx_compiler:
+- gxx
+fortran_compiler:
+- gfortran
+go_compiler:
+- go-nocgo
+cgo_compiler:
+- go-cgo
+c_compiler_version:
+- 11
+cxx_compiler_version:
+- 11
+fortran_compiler_version:
+- 11
+cdt_name:
+- cos7
+target_platform:
+- linux-64
+channel_sources:
+- conda-forge
+docker_image:
+- quay.io/condaforge/linux-anvil-cuda:11.8
+cuda_compiler:
+- nvcc
+cuda_compiler_version:
+- 11.8
+cuda_compiler_version_min:
+- 11.2


### PR DESCRIPTION
Now that CUDA 11.8 is included in the global pinnings. Add it to staged-recipes to ensure it is tested as well.

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5340