### PR TITLE
Use `conda-index`'s `update_index`

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -1,6 +1,7 @@
 import conda_build.conda_interface
 import networkx as nx
 import conda_build.api
+import conda_index.api
 from compute_build_graph import construct_graph
 import argparse
 import os
@@ -142,7 +143,7 @@ def build_folders(recipes_dir, folders, arch, channel_urls):
 
     index_path = os.path.join(sys.exec_prefix, 'conda-bld')
     os.makedirs(index_path, exist_ok=True)
-    conda_build.api.update_index(index_path)
+    conda_index.api.update_index(index_path)
     index = conda_build.conda_interface.get_index(channel_urls=channel_urls)
     conda_resolve = conda_build.conda_interface.Resolve(index)
 

--- a/.ci_support/requirements.txt
+++ b/.ci_support/requirements.txt
@@ -1,6 +1,7 @@
 conda>=23.7.3
 conda-libmamba-solver>=23.7.0
 conda-build>=3.16,!=3.28.3
+conda-index>=0.3.0
 conda-forge-ci-setup=3.*
 conda-forge-pinning
 networkx=2.4


### PR DESCRIPTION
Fixes https://github.com/conda-forge/staged-recipes/issues/25028

Update `build_all.py` to address a `conda-build` deprecation warning by moving to `conda-index` instead.