### PR TITLE
adds `r-usemodels`

### DIFF
--- a/recipes/r-usemodels/bld.bat
+++ b/recipes/r-usemodels/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-usemodels/build.sh
+++ b/recipes/r-usemodels/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-usemodels/meta.yaml
+++ b/recipes/r-usemodels/meta.yaml
@@ -1,0 +1,87 @@
+{% set version = '0.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-usemodels
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/usemodels_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/usemodels/usemodels_{{ version }}.tar.gz
+  sha256: 510ff71bbe7209bc5723c3e0ef090ef8617d3ca853c3db9818452edbc82687b5
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-cli
+    - r-clipr
+    - r-dplyr
+    - r-purrr
+    - r-recipes >=0.1.15
+    - r-rlang
+    - r-tidyr
+    - r-tune >=0.1.2
+  run:
+    - r-base
+    - r-cli
+    - r-clipr
+    - r-dplyr
+    - r-purrr
+    - r-recipes >=0.1.15
+    - r-rlang
+    - r-tidyr
+    - r-tune >=0.1.2
+
+test:
+  commands:
+    - $R -e "library('usemodels')"           # [not win]
+    - "\"%R%\" -e \"library('usemodels')\""  # [win]
+
+about:
+  home: https://usemodels.tidymodels.org/, https://github.com/tidymodels/usemodels
+  license: MIT
+  summary: Code snippets to fit models using the tidymodels framework can be easily created for
+    a given data set.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: usemodels
+# Title: Boilerplate Code for 'Tidymodels' Analyses
+# Version: 0.2.0
+# Authors@R: c( person("Max", "Kuhn", , "max@rstudio.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2402-136X")), person("RStudio", role = "cph") )
+# Description: Code snippets to fit models using the tidymodels framework can be easily created for a given data set.
+# License: MIT + file LICENSE
+# URL: https://usemodels.tidymodels.org/, https://github.com/tidymodels/usemodels
+# BugReports: https://github.com/tidymodels/usemodels/issues
+# Imports: cli, clipr, dplyr, purrr, recipes (>= 0.1.15), rlang, tidyr, tune (>= 0.1.2)
+# Suggests: covr, modeldata, spelling, testthat
+# Config/Needs/website: tidyverse/tidytemplate
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# Language: en-US
+# RoxygenNote: 7.1.2
+# NeedsCompilation: no
+# Packaged: 2022-02-18 20:14:14 UTC; max
+# Author: Max Kuhn [aut, cre] (<https://orcid.org/0000-0003-2402-136X>), RStudio [cph]
+# Maintainer: Max Kuhn <max@rstudio.com>
+# Repository: CRAN
+# Date/Publication: 2022-02-18 22:10:02 UTC

--- a/recipes/r-usemodels/meta.yaml
+++ b/recipes/r-usemodels/meta.yaml
@@ -51,7 +51,8 @@ test:
     - "\"%R%\" -e \"library('usemodels')\""  # [win]
 
 about:
-  home: https://usemodels.tidymodels.org/, https://github.com/tidymodels/usemodels
+  home: https://usemodels.tidymodels.org/
+  dev_url: https://github.com/tidymodels/usemodels
   license: MIT
   summary: Code snippets to fit models using the tidymodels framework can be easily created for
     a given data set.


### PR DESCRIPTION
Adds [CRAN package `usemodels`](https://cran.r-project.org/package=usemodels) as `r-usemodels`. Recipe generated with `conda_r_skeleton_helper` with URLs split.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
