### PR TITLE
add `r-semantic.assets`

### DIFF
--- a/recipes/r-semantic.assets/LICENSE-Fomantic-UI.md
+++ b/recipes/r-semantic.assets/LICENSE-Fomantic-UI.md
@@ -1,0 +1,7 @@
+# The MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/r-semantic.assets/bld.bat
+++ b/recipes/r-semantic.assets/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-semantic.assets/build.sh
+++ b/recipes/r-semantic.assets/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-semantic.assets/meta.yaml
+++ b/recipes/r-semantic.assets/meta.yaml
@@ -42,7 +42,8 @@ about:
   summary: Style sheets and JavaScript assets for 'shiny.semantic' package.
   license_family: LGPL
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3
+    - LICENSE-Fomantic-UI.md
 
 extra:
   recipe-maintainers:

--- a/recipes/r-semantic.assets/meta.yaml
+++ b/recipes/r-semantic.assets/meta.yaml
@@ -22,8 +22,8 @@ build:
 
 requirements:
   build:
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}zip             # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
   host:
     - r-base
     - r-htmlwidgets
@@ -38,7 +38,7 @@ test:
 
 about:
   home: https://github.com/Appsilon/semantic.assets
-  license: LGPL-3
+  license: LGPL-3.0-only
   summary: Style sheets and JavaScript assets for 'shiny.semantic' package.
   license_family: LGPL
   license_file:

--- a/recipes/r-semantic.assets/meta.yaml
+++ b/recipes/r-semantic.assets/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = '1.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-semantic.assets
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/semantic.assets_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/semantic.assets/semantic.assets_{{ version }}.tar.gz
+  sha256: 47d715e0c8d01ca04e3832cf8551fcf3c27ed02bc88df801a30df197977e1300
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-htmlwidgets
+  run:
+    - r-base
+    - r-htmlwidgets
+
+test:
+  commands:
+    - $R -e "library('semantic.assets')"           # [not win]
+    - "\"%R%\" -e \"library('semantic.assets')\""  # [win]
+
+about:
+  home: https://github.com/Appsilon/semantic.assets
+  license: LGPL-3
+  summary: Style sheets and JavaScript assets for 'shiny.semantic' package.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: semantic.assets
+# Type: Package
+# Title: Assets for 'shiny.semantic'
+# Version: 1.1.0
+# Authors@R: c( person("Jakub", "Nowicki", role = c("aut", "cre"), email = "opensource+kuba@appsilon.com") )
+# Description: Style sheets and JavaScript assets for 'shiny.semantic' package.
+# URL: https://github.com/Appsilon/semantic.assets
+# BugReports: https://github.com/Appsilon/semantic.assets/issues
+# License: LGPL-3
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: htmlwidgets
+# Suggests: shiny, shiny.semantic
+# NeedsCompilation: no
+# Packaged: 2024-01-08 11:37:57 UTC; kuba
+# Author: Jakub Nowicki [aut, cre]
+# Maintainer: Jakub Nowicki <opensource+kuba@appsilon.com>
+# Repository: CRAN
+# Date/Publication: 2024-01-08 16:20:02 UTC


### PR DESCRIPTION
Adds [CRAN package `semantic.assets`](https://cran.r-project.org/package=semantic.assets) as `r-semantic.assets`. Recipe generated with `conda_r_skeleton_helper` with license conformed to SPDX and Fomantic-UI license bundled.

Needed as new dependency of `r-shiny.semantic` (see https://github.com/conda-forge/r-shiny.semantic-feedstock/pull/11).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] ~~Package does not vendor other packages.~~ Package includes license for vendored frontend assets (Fomantic-UI).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
