### PR TITLE
Add pyjuliacall and pyjuliapkg via grayskull

### DIFF
--- a/recipes/pyjuliacall/meta.yaml
+++ b/recipes/pyjuliacall/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "pyjuliacall" %}
+{% set version = "0.9.15" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/juliacall-{{ version }}.tar.gz
+  sha256: 08163ae1290dda155cdabdccc4035a4cf0c8e361522a5b3f8e6532401b4f29cc
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.7
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python >=3.7
+    - juliapkg >=0.1.8,<0.2.dev0
+
+test:
+  imports:
+    - pyjuliacall
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: http://github.com/JuliaPy/PythonCall.jl
+  summary: Julia and Python in seamless harmony
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mkitti

--- a/recipes/pyjuliapkg/meta.yaml
+++ b/recipes/pyjuliapkg/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "pyjuliapkg" %}
+{% set version = "0.1.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/juliapkg-{{ version }}.tar.gz
+  sha256: 70507318d51ac8663e856f56048764e49f5a0c4c90d81a3712d039a316369505
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - semantic_version >=2.9,<3.dev0
+
+test:
+  imports:
+    - pyjuliapkg
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Julia version manager and package manager
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mkitti


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

@conda-forge/help-python @conda-forge/help-julia

This pull request packages [julicall](https://pypi.org/project/juliacall/) from and [juliapkg] from pypi as pyjuliacall and pyjuliapkg respectively. pyjuliapkg is a dependency of pyjuliacall.

There also exists a [R package called JuliaCall on CRAN](https://cran.r-project.org/web/packages/JuliaCall/index.html).

The "py" prefix is added to disambiguate these packages from the R package with a similar name and potential Julia packages following the deconfliction protocol of
https://github.com/conda-forge/conda-forge.github.io/issues/18#issue-132717022 . Also note that the upstream source repository of juliapkg is called pyjuliapkg.

This pull request is meant so supersede https://github.com/conda-forge/staged-recipes/pull/20379 and https://github.com/conda-forge/staged-recipes/pull/20380 which are both now stale. The main difference between this pull request and those ones is that the added "py" prefix.

The upstream source repositories are as follows.
* https://github.com/JuliaPy/PythonCall.jl
* https://github.com/JuliaPy/pyjuliapkg

These recipes were generated by grayskull and modified to add the `py` prefix.
