### PR TITLE
add `r-interleave`

### DIFF
--- a/recipes/r-interleave/bld.bat
+++ b/recipes/r-interleave/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-interleave/build.sh
+++ b/recipes/r-interleave/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-interleave/meta.yaml
+++ b/recipes/r-interleave/meta.yaml
@@ -1,0 +1,84 @@
+{% set version = '0.1.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-interleave
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/interleave_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/interleave/interleave_{{ version }}.tar.gz
+  sha256: fa67491d03ca81898afc5df75fc50ef067bee79906b8c7617c8a0c1da61e6a25
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp
+    - r-geometries >=0.2.4
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-geometries >=0.2.4
+
+test:
+  commands:
+    - $R -e "library('interleave')"           # [not win]
+    - "\"%R%\" -e \"library('interleave')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=interleave
+  license: MIT
+  summary: Converts matrices and lists of matrices into a single vector by interleaving their
+    values. That is, each element of the result vector is filled from the input matrices
+    one row at a time. This is the same as transposing a matrix, then removing the dimension
+    attribute, but is designed to operate on matrices in nested list structures.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: interleave
+# Type: Package
+# Title: Converts Tabular Data to Interleaved Vectors
+# Version: 0.1.2
+# Date: 2024-01-18
+# Authors@R: c( person("David", "Cooley", email = "david.cooley.au@gmail.com", role = c("aut", "cre")), person("Mapbox", role = "cph", comment = "author of header library earcut.hpp") )
+# Description: Converts matrices and lists of matrices into a single vector by interleaving their values. That is, each element of the result vector is filled from the input matrices one row at a time. This is the same as transposing a matrix, then removing the dimension attribute, but is designed to operate on matrices in nested list structures.
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Depends: R (>= 3.0.2)
+# LinkingTo: geometries (>= 0.2.4), Rcpp
+# Imports: Rcpp
+# Suggests: covr, sfheaders, tinytest
+# NeedsCompilation: yes
+# Packaged: 2024-01-17 23:38:07 UTC; dave
+# Author: David Cooley [aut, cre], Mapbox [cph] (author of header library earcut.hpp)
+# Maintainer: David Cooley <david.cooley.au@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2024-01-17 23:50:02 UTC

--- a/recipes/r-interleave/meta.yaml
+++ b/recipes/r-interleave/meta.yaml
@@ -21,16 +21,16 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-rcpp
@@ -55,7 +55,7 @@ about:
     attribute, but is designed to operate on matrices in nested list structures.
   license_family: MIT
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
     - LICENSE
 
 extra:

--- a/recipes/r-interleave/meta.yaml
+++ b/recipes/r-interleave/meta.yaml
@@ -18,6 +18,8 @@ build:
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'  # [win]
 
 requirements:
   build:


### PR DESCRIPTION
Adds [CRAN package `interleave`](https://cran.r-project.org/package=interleave) as `r-interleave`. Recipe generated with `conda_r_skeleton_helper`.

Needed as [new dependency of `r-spatialwidget`](https://github.com/conda-forge/r-spatialwidget-feedstock/pull/7).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
