### PR TITLE
Fix review label workflow wrongly applying r label on ruby and rust PRs

### DIFF
--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -38,12 +38,13 @@
                 '@conda-forge/help-python',
                 '@conda-forge/help-python-c',
                 '@conda-forge/help-r',
-                '@conda-forge/help-ruby'
+                '@conda-forge/help-ruby',
+                '@conda-forge/help-rust'
               ];
               let found_label = false;
               for (const team of teams) {
                   let text = context.payload.comment.body;
-                  const regex = new RegExp(team + '[^\-]|' + team + '$');
+                  const regex = new RegExp(team + '[^\w-]|' + team + '$');
                   let result = regex.test(text);
                   if (result) {
                       const slug = team.replace("@conda-forge/", "");


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Previously the workflow would apply the `r` label to all PRs where `conda-forge/help-ruby` or `conda-forge/help-rust` were mentioned. The changed regex fixes this by not allowing alphanumeric characters directly after the name of the team.

Additionally this adds support for the `conda-forge/help-rust` team, which was added to the help message, but not to the code in commit 9464db9cb5af7f8c027b76a39d7872c833a13c19.
