### PR TITLE
adds `r-chatgpt`

### DIFF
--- a/recipes/r-chatgpt/bld.bat
+++ b/recipes/r-chatgpt/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-chatgpt/build.sh
+++ b/recipes/r-chatgpt/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-chatgpt/meta.yaml
+++ b/recipes/r-chatgpt/meta.yaml
@@ -48,13 +48,13 @@ test:
 
 about:
   home: https://github.com/jcrodriguez1989/chatgpt
-  license: GPL-3
+  license: GPL-3.0-or-later
   summary: '''OpenAI''s ''ChatGPT'' <https://chat.openai.com/> coding assistant for ''RStudio''.
     A set of functions and ''RStudio'' addins that aim to help the R developer in tedious
     coding tasks.'
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-chatgpt/meta.yaml
+++ b/recipes/r-chatgpt/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = '0.2.3' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-chatgpt
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/chatgpt_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/chatgpt/chatgpt_{{ version }}.tar.gz
+  sha256: ce99d582b104d93571a4a41f2e99496f9a22d302b6b07b96a580f452e3cfe1a8
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-clipr
+    - r-httr
+    - r-jsonlite
+    - r-miniui
+    - r-rstudioapi
+    - r-shiny
+  run:
+    - r-base
+    - r-clipr
+    - r-httr
+    - r-jsonlite
+    - r-miniui
+    - r-rstudioapi
+    - r-shiny
+
+test:
+  commands:
+    - $R -e "library('chatgpt')"           # [not win]
+    - "\"%R%\" -e \"library('chatgpt')\""  # [win]
+
+about:
+  home: https://github.com/jcrodriguez1989/chatgpt
+  license: GPL-3
+  summary: '''OpenAI''s ''ChatGPT'' <https://chat.openai.com/> coding assistant for ''RStudio''.
+    A set of functions and ''RStudio'' addins that aim to help the R developer in tedious
+    coding tasks.'
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: chatgpt
+# Type: Package
+# Title: Interface to 'ChatGPT' from R
+# Version: 0.2.3
+# Authors@R: c( person( given = "Juan Cruz", family = "Rodriguez", role = c("aut", "cre"), email = "jcrodriguez@unc.edu.ar" ) )
+# Maintainer: Juan Cruz Rodriguez <jcrodriguez@unc.edu.ar>
+# Description: 'OpenAI's 'ChatGPT' <https://chat.openai.com/> coding assistant for 'RStudio'. A set of functions and 'RStudio' addins that aim to help the R developer in tedious coding tasks.
+# License: GPL (>= 3)
+# URL: https://github.com/jcrodriguez1989/chatgpt
+# BugReports: https://github.com/jcrodriguez1989/chatgpt/issues
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: clipr, httr, jsonlite, miniUI, rstudioapi, shiny, utils
+# NeedsCompilation: no
+# Packaged: 2023-05-05 15:07:13 UTC; jcrodriguez
+# Author: Juan Cruz Rodriguez [aut, cre]
+# Repository: CRAN
+# Date/Publication: 2023-05-05 23:00:06 UTC


### PR DESCRIPTION
Adds [CRAN package `chatgpt`](https://cran.r-project.org/package=chatgpt) as `r-chatgpt`. Recipe generated with `conda_r_skeleton_helper` with license adjust for SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
