### PR TITLE
Add r-mimic-demo

### DIFF
--- a/recipes/r-mimic-demo/bld.bat
+++ b/recipes/r-mimic-demo/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mimic-demo/build.sh
+++ b/recipes/r-mimic-demo/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mimic-demo/meta.yaml
+++ b/recipes/r-mimic-demo/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = '0.2.8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mimic-demo
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - https://github.com/eth-mds/mimic-demo/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 73cc9e0dfbb1fd893288c317dc90d43c55696b3ae8ef3a2845eeea7bef23470a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rlang
+  run:
+    - r-base
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('mimic.demo')"           # [not win]
+    - "\"%R%\" -e \"library('mimic.demo')\""  # [win]
+
+about:
+  home: https://github.com/eth-mds/mimic-demo
+  license: Open Database License v1.0 
+  summary: As an Enhances dependency to the CRAN R package ricu, this data package
+  provides the MIMIC-III demo data set. Due to CRAN size restrictions, this cannot be
+  served from CRAN but rather can be installed from a GitHub-hosted drat repository.
+
+extra:
+  recipe-maintainers:
+    - mlondschien
+    - conda-forge/r

--- a/recipes/r-mimic-demo/meta.yaml
+++ b/recipes/r-mimic-demo/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '0.2.8' %}
+{% set version = '1.0.1' %}
 {% set posix = 'm2-' if win else '' %}
 {% set native = 'm2w64-' if win else '' %}
 
@@ -9,7 +9,7 @@ package:
 source:
   url:
     - https://github.com/eth-mds/mimic-demo/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 73cc9e0dfbb1fd893288c317dc90d43c55696b3ae8ef3a2845eeea7bef23470a
+  sha256: 0491c29e3bffacb36e7a87f7896652cd0bc033c6411993a765a6223e5c4fc516
 
 build:
   merge_build_host: True  # [win]
@@ -37,11 +37,12 @@ test:
 
 about:
   home: https://github.com/eth-mds/mimic-demo
-  license: Open Database License v1.0 
-  summary: As an Enhances dependency to the CRAN R package ricu, this data package
-  provides the MIMIC-III demo data set. Due to CRAN size restrictions, this cannot be
-  served from CRAN but rather can be installed from a GitHub-hosted drat repository.
-
+  license: ODbL v1.0
+  license_file: LICENSE.md
+  summary: |
+    As an Enhances dependency to the CRAN R package ricu, this data package
+    provides the MIMIC-III demo data set. Due to CRAN size restrictions, this cannot be
+    served from CRAN but rather can be installed from a GitHub-hosted drat repository.
 extra:
   recipe-maintainers:
     - mlondschien

--- a/recipes/r-mimic-demo/meta.yaml
+++ b/recipes/r-mimic-demo/meta.yaml
@@ -3,7 +3,7 @@
 {% set native = 'm2w64-' if win else '' %}
 
 package:
-  name: r-mimic-demo
+  name: r-mimic.demo
   version: {{ version|replace("-", "_") }}
 
 source:

--- a/recipes/r-mimic-demo/meta.yaml
+++ b/recipes/r-mimic-demo/meta.yaml
@@ -36,7 +36,8 @@ test:
     - "\"%R%\" -e \"library('mimic.demo')\""  # [win]
 
 about:
-  home: https://github.com/eth-mds/mimic-demo
+  home: https://physionet.org/content/mimiciii-demo/1.4/
+  dev_url: https://github.com/eth-mds/mimic-demo
   license: ODbL-1.0
   license_file: LICENSE.md
   summary: |

--- a/recipes/r-mimic-demo/meta.yaml
+++ b/recipes/r-mimic-demo/meta.yaml
@@ -37,7 +37,7 @@ test:
 
 about:
   home: https://github.com/eth-mds/mimic-demo
-  license: ODbL v1.0
+  license: ODbL-1.0
   license_file: LICENSE.md
   summary: |
     As an Enhances dependency to the CRAN R package ricu, this data package

--- a/recipes/r-mimic-demo/meta.yaml
+++ b/recipes/r-mimic-demo/meta.yaml
@@ -41,9 +41,17 @@ about:
   license: ODbL-1.0
   license_file: LICENSE.md
   summary: |
-    As an Enhances dependency to the CRAN R package ricu, this data package
-    provides the MIMIC-III demo data set. Due to CRAN size restrictions, this cannot be
-    served from CRAN but rather can be installed from a GitHub-hosted drat repository.
+    MIMIC-III (Medical Information Mart for Intensive Care III) is a
+    large, freely-available database comprising deidentified health-related
+    data associated with over 40,000 patients who stayed in critical care
+    units of the Beth Israel Deaconess Medical Center between 2001 and 2012.
+    The database includes information such as demographics, vital sign
+    measurements made at the bedside (~1 data point per hour), laboratory test
+    results, procedures, medications, caregiver notes, imaging reports, and
+    mortality (both in and out of hospital). An open-access subset of
+    MIMIC-III, comprising 100 randomly selected patients from the subset of
+    patients who eventually die, is distributed under the Open Database
+    License (ODbL) v1.0 and is provided as R package for convenience.
 extra:
   recipe-maintainers:
     - mlondschien


### PR DESCRIPTION
I'd like to add this dataset package (as well as `eicu-demo`) to conda-forge. This is not on CRAN, and cannot be added, due to size restrictions. The tarball is around 10MB. What is the correct way to add this? @conda-forge/r 

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
