### PR TITLE
Add graspologic package

### DIFF
--- a/recipes/graspologic/LICENSE.txt
+++ b/recipes/graspologic/LICENSE.txt
@@ -1,0 +1,21 @@
+Copyright (c) Pixelgen Technologies.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/graspologic/meta.yaml
+++ b/recipes/graspologic/meta.yaml
@@ -51,6 +51,7 @@ about:
   home: https://github.com/microsoft/graspologic
   summary: A set of python modules for graph statistics
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
 
 extra:

--- a/recipes/graspologic/meta.yaml
+++ b/recipes/graspologic/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "graspologic" %}
+{% set version = "3.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/graspologic-{{ version }}.tar.gz
+  sha256: 08fe052694a027995b3222d01d8cb64e1bf242e7915a5016268927c64f6229fc
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.8,<3.12
+    - setuptools >=24.2.0
+    - pip
+  run:
+    - python >=3.8,<3.12
+    - anytree >=2.8.0
+    - beartype >=0.10.0
+    - gensim >=4.0.0,!=4.2.0
+    - graspologic-native >=1.1.1
+    - hyppo >=0.3.2
+    - joblib >=0.17.0
+    - matplotlib-base >=3.0.0,!=3.3.*,!=3.6.1
+    - networkx >=2.1
+    - numpy >=1.8.1
+    - pot >=0.7.0
+    - seaborn >=0.11.0
+    - scikit-learn >=0.22.0
+    - scipy >=1.9.0
+    - statsmodels >=0.13.2
+    - typing-extensions >=4.4.0
+    - umap-learn >=0.4.6
+
+test:
+  imports:
+    - graspologic
+    - graspologic.partition.leiden
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/microsoft/graspologic
+  summary: A set of python modules for graph statistics
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - johandahlberg
+    - fbdtemme
+    - bdpedigo
+    - ambarrio


### PR DESCRIPTION
This adds a conda recipe for the python package `graspologic` (https://github.com/microsoft/graspologic).

This follows up on adding the rust companion library in https://github.com/conda-forge/staged-recipes/pull/25270

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
