### PR TITLE
Address conda-build deprecations

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -1,7 +1,9 @@
-import conda_build.conda_interface
-import networkx as nx
+import conda.base.context
+import conda.core.index
+import conda.resolve
 import conda_build.api
 import conda_index.api
+import networkx as nx
 from compute_build_graph import construct_graph
 import argparse
 import os
@@ -120,7 +122,7 @@ def build_all(recipes_dir, arch):
 
 
 def get_config(arch, channel_urls):
-    exclusive_config_files = [os.path.join(conda_build.conda_interface.root_dir,
+    exclusive_config_files = [os.path.join(conda.base.context.root_prefix,
                                            'conda_build_config.yaml')]
     script_dir = os.path.dirname(os.path.realpath(__file__))
     # since variant builds override recipe/conda_build_config.yaml, see
@@ -144,8 +146,8 @@ def build_folders(recipes_dir, folders, arch, channel_urls):
     index_path = os.path.join(sys.exec_prefix, 'conda-bld')
     os.makedirs(index_path, exist_ok=True)
     conda_index.api.update_index(index_path)
-    index = conda_build.conda_interface.get_index(channel_urls=channel_urls)
-    conda_resolve = conda_build.conda_interface.Resolve(index)
+    index = conda.core.index.get_index(channel_urls=channel_urls)
+    conda_resolve = conda.resolve.Resolve(index)
 
     config = get_config(arch, channel_urls)
     platform = get_host_platform()


### PR DESCRIPTION
`conda_build.conda_interface` is being deprecated.

`conda_build.conda_interface.get_index` (which is `conda.exports.get_index`) is using the `conda.models.dist.Dist` -> `conda.models.records.PackageRecord` mapping. `Dist` class is legacy code that's being phased out, so avoid it.

refs:
- https://github.com/conda/conda-build/pull/5152
- https://github.com/conda/conda-build/pull/5222
