### PR TITLE
adding cad-to-dagmc

### DIFF
--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -12,14 +12,16 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  noarch: python
+  skip: True  # [win]
+  skip: True  # [py<310]
+  skip: True  # [py>=312]
 
 requirements:
   host:
-    - python >=3.10
+    - python
     - pip
   run:
-    - python >=3.10
+    - python
     - moab >=5.3.0
     - gmsh
     - python-gmsh

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  skip: True  # [win]
   noarch: python
 
 requirements:

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -12,16 +12,16 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  skip: true  # [win]
+  skip: True  # [win]
   skip: True  # [py<310]
   skip: True  # [py>=312]
 
 requirements:
   host:
-    - python >=3.10,<3.12
+    - python
     - pip
   run:
-    - python >=3.10,<3.12
+    - python
     - moab >=5.3.0
     - gmsh
     - python-gmsh

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -12,16 +12,14 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  skip: True  # [win]
-  skip: True  # [py<310]
-  skip: True  # [py>=312]
+  noarch: python
 
 requirements:
   host:
-    - python
+    - python >=3.10
     - pip
   run:
-    - python
+    - python >=3.10
     - moab >=5.3.0
     - gmsh
     - python-gmsh

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.10
     - pip
   run:
-    - python
+    - python >=3.10
     - moab >=5.3.0
     - gmsh
     - python-gmsh

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -44,7 +44,7 @@ about:
   home: https://github.com/fusion-energy/cad_to_dagmc
   summary: 'Converts CAD geometry to a DAGMC h5m file'
   description: |
-    Convert CAD geometry (STP files) or Cadquery assemblies to DAGMC h5m files
+    Convert CAD geometry (STP files) or CadQuery assemblies to DAGMC h5m files
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -12,9 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
-  skip: True  # [win]
-  skip: True  # [py<310]
-  skip: True  # [py>=312]
+  noarch: python
 
 requirements:
   host:

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "cad_to_dagmc" %}
+{% set version = "0.6.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: b6b7f34dec0d54a19a9476a2c5c157ef23eb3d6796af86dee6798cdc2420fda9
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: true  # [win]
+  skip: True  # [py<310]
+  skip: True  # [py>=312]
+
+requirements:
+  host:
+    - python >=3.10,<3.12
+    - pip
+  run:
+    - python >=3.10,<3.12
+    - moab >=5.3.0
+    - gmsh
+    - python-gmsh
+    - cadquery >=2.4.0
+    - ocp >=7.7.2
+    - trimesh
+    - networkx
+
+test:
+  imports:
+    - cad_to_dagmc
+  requires:
+    - pip
+    - pytest
+  source_files:
+    - tests
+  commands:
+    - pip check
+    - pytest tests
+
+about:
+  home: https://github.com/fusion-energy/cad_to_dagmc
+  summary: 'Converts CAD geometry to a DAGMC h5m file'
+  description: |
+    Convert CAD geometry (STP files) or Cadquery assemblies to DAGMC h5m files
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - shimwell

--- a/recipes/cad_to_dagmc/meta.yaml
+++ b/recipes/cad_to_dagmc/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: True  # [win]
   noarch: python
 
 requirements:

--- a/recipes/cad_to_dagmc/yum_requirements.txt
+++ b/recipes/cad_to_dagmc/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGLU-devel


### PR DESCRIPTION
This PR adds a recipe for cad-to-dagmc. This makes use of an existing conda forge packages (moab, ocp and cadquery) to make files for another conda forge package (dagmc).

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
