### PR TITLE
Add metis-python

### DIFF
--- a/recipes/metis-python/LICENSE.txt
+++ b/recipes/metis-python/LICENSE.txt
@@ -1,0 +1,22 @@
+Copyright (c) 2012 Ken Watford
+
+Permission is hereby granted, free of charge, to any person 
+obtaining a copy of this software and associated documentation 
+files (the "Software"), to deal in the Software without 
+restriction, including without limitation the rights to use, 
+copy, modify, merge, publish, distribute, sublicense, and/or 
+sell copies of the Software, and to permit persons to whom the 
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be 
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, 
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES 
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR 
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF 
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+tl;dr - MIT license.

--- a/recipes/metis-python/meta.yaml
+++ b/recipes/metis-python/meta.yaml
@@ -22,8 +22,6 @@ requirements:
     - python >=3.7
 
 test:
-  imports:
-    - metis
   commands:
     - pip check
   requires:

--- a/recipes/metis-python/meta.yaml
+++ b/recipes/metis-python/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "metis-python" %}
+{% set version = "0.2a5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/metis-{{ version }}.tar.gz
+  sha256: c98f4aa129141554bea8d9e62daea5fea8351439f723e8e27fe593c2b7c53903
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+
+test:
+  imports:
+    - metis
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/kw/metis-python
+  summary: METIS wrapper using ctypes
+  license: MIT
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - Chrismarsh

--- a/recipes/metis-python/meta.yaml
+++ b/recipes/metis-python/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/metis-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/metis/metis-{{ version }}.tar.gz
   sha256: c98f4aa129141554bea8d9e62daea5fea8351439f723e8e27fe593c2b7c53903
 
 build:

--- a/recipes/metis-python/meta.yaml
+++ b/recipes/metis-python/meta.yaml
@@ -33,7 +33,7 @@ about:
   home: https://github.com/kw/metis-python
   summary: METIS wrapper using ctypes
   license: MIT
-  license_file: PLEASE_ADD_LICENSE_FILE
+  license_file: LICENSE.txt
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This adds the `metis-python` package, available in PyPi, to conda.
https://github.com/kw/metis-python

These are python bindings for the `metis` code. Although `metis-python` is a no longer maintained package, some projects use these bindings. Thus, having them available is important. 

@conda-forge-admin, please ping conda-forge/help-python


Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
