### PR TITLE
bump conda-forge-ci-setup version & conda-build lower bound

### DIFF
--- a/.ci_support/requirements.txt
+++ b/.ci_support/requirements.txt
@@ -1,8 +1,8 @@
 conda>=23.7.3
 conda-libmamba-solver>=23.7.0
-conda-build>=3.16,!=3.28.3
+conda-build>=24.3
 conda-index>=0.3.0
-conda-forge-ci-setup=3.*
+conda-forge-ci-setup=4.*
 conda-forge-pinning
 frozendict
 networkx=2.4

--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -38,10 +38,10 @@ touch ~/Miniforge3/conda-meta/pinned
 source ~/Miniforge3/bin/activate
 
 conda install --yes --quiet \
-  conda-forge-ci-setup=3.* \
+  conda-forge-ci-setup=4.* \
   "conda-smithy>=3.7.1,<4.0.0a0" \
   conda-forge-pinning \
-  "conda-build>=3.16,!=3.28.3" \
+  "conda-build>=24.3" \
   "gitpython>=3.0.8,<3.1.20" \
   requests \
   ruamel.yaml \

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -31,7 +31,7 @@ CONDARC
 source "${MINIFORGE_ROOT}/etc/profile.d/conda.sh"
 conda activate base
 
-echo -e "\n\nInstalling conda-forge-ci-setup=3, conda-build."
+echo -e "\n\nInstalling conda-forge-ci-setup, conda-build."
 conda install --quiet --file .ci_support/requirements.txt
 
 echo -e "\n\nSetting up the condarc and mangling the compiler."


### PR DESCRIPTION
Discussed in core call today; the conda-build used here is constrained by the old ci-setup; update to what the rest of our infra is using as well.

First time I'm doing an upgrade of staged-recipes, please let me know if I missed something.