### PR TITLE
adds wot

### DIFF
--- a/recipes/wot/meta.yaml
+++ b/recipes/wot/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "wot" %}
+{% set version = "1.0.8.post2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/wot-{{ version }}.tar.gz
+  sha256: 89f2a4440c9516d66bc453f4f50ed81d5c33f1223f0f927f9e35a2c9e875bfb9
+
+build:
+  entry_points:
+    - wot=wot.__main__:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.0
+    - setuptools-scm
+    - cython
+    - pip
+  run:
+    - python >=3.0
+    - numpy
+    - pandas
+    - h5py
+    - anndata
+    - scikit-learn
+    - scipy
+    - matplotlib-base
+    - pot
+
+test:
+  imports:
+    - wot
+  commands:
+    - pip check
+    - wot --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/broadinstitute/wot
+  summary: Optimal transport for time-course single cell data
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mfansler


### PR DESCRIPTION
Adds [PyPI package `wot`](https://pypi.org/project/wot/) as `wot`. Recipe generated with `grayskull`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
