### PR TITLE
MAINT: Bump to macos-12 runners

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -6,7 +6,7 @@ jobs:
 - job: osx
   condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
-    vmImage: macOS-11
+    vmImage: macOS-12
   strategy:
     matrix:
       osx_64:


### PR DESCRIPTION
Comes from https://github.com/conda-forge/conda-forge.github.io/issues/2067.

`macos-11` is deprecated, so let's move to `macos-12`.