### PR TITLE
add _numpy_rc

### DIFF
--- a/recipes/_numpy_rc/conda_build_config.yaml
+++ b/recipes/_numpy_rc/conda_build_config.yaml
@@ -1,0 +1,2 @@
+channel_targets:
+  - conda-forge numpy_rc

--- a/recipes/_numpy_rc/meta.yaml
+++ b/recipes/_numpy_rc/meta.yaml
@@ -1,0 +1,24 @@
+{% set version = "1" %}
+
+package:
+  name: _numpy_rc
+  version: {{ version }}
+
+build:
+  number: 0
+  noarch: generic
+
+test:
+  commands:
+  - echo "Keep conda-smithy happy."
+
+about:
+  home: https://github.com/conda-forge/_numpy_rc-feedstock
+  summary: 'Dummy package to force selection of numpy_rc channel when channel_priority is set to strict'
+  description: 'See https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/280'
+  license: Unlicense
+
+extra:
+  recipe-maintainers:
+    - h-vetinari
+    - conda-forge/numpy


### PR DESCRIPTION
Modeled after #24067, to solve the same kind of problem as for the python 3.12 rc migration in the context of https://github.com/conda-forge/conda-forge.github.io/issues/1997 / https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5790