### PR TITLE
Add `c_stdlib_version` to Linux variants

### DIFF
--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -1,3 +1,5 @@
+c_stdlib_version:
+- 2.17
 cdt_name:
 - cos7
 c_compiler:

--- a/.ci_support/linux64_cuda112.yaml
+++ b/.ci_support/linux64_cuda112.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - 10
 fortran_compiler_version:
 - 10
+c_stdlib_version:
+- 2.17
 cdt_name:
 - cos7
 target_platform:

--- a/.ci_support/linux64_cuda118.yaml
+++ b/.ci_support/linux64_cuda118.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - 11
 fortran_compiler_version:
 - 11
+c_stdlib_version:
+- 2.17
 cdt_name:
 - cos7
 target_platform:

--- a/.ci_support/linux64_cuda120.yaml
+++ b/.ci_support/linux64_cuda120.yaml
@@ -14,6 +14,8 @@ cxx_compiler_version:
 - 12
 fortran_compiler_version:
 - 12
+c_stdlib_version:
+- 2.17
 cdt_name:
 - cos7
 target_platform:


### PR DESCRIPTION
Make sure `c_stdlib_version` is specified in Linux variants. Also set this next to `cdt_name` to make it easier to update them together