### PR TITLE
BUG: Add missing channel pinnings

### DIFF
--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -1,28 +1,28 @@
 c_stdlib_version:
-  - 2.17
+- 2.17
 c_stdlib:
-  - sysroot
+- sysroot
 cdt_name:
-  - cos7
+- cos7
 c_compiler:
-  - gcc
+- gcc
 cxx_compiler:
-  - gxx
+- gxx
 fortran_compiler:
-  - gfortran
+- gfortran
 go_compiler:
-  - go-nocgo
+- go-nocgo
 cgo_compiler:
-  - go-cgo
+- go-cgo
 target_platform:
-  - linux-64
+- linux-64
 channel_sources:
-  - conda-forge
+- conda-forge
 docker_image:
-  - quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler:
-  - None
+- None
 cuda_compiler_version:
-  - None
+- None
 cuda_compiler_version_min:
-  - None
+- None

--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -1,26 +1,28 @@
 c_stdlib_version:
-- 2.17
+  - 2.17
+c_stdlib:
+  - sysroot
 cdt_name:
-- cos7
+  - cos7
 c_compiler:
-- gcc
+  - gcc
 cxx_compiler:
-- gxx
+  - gxx
 fortran_compiler:
-- gfortran
+  - gfortran
 go_compiler:
-- go-nocgo
+  - go-nocgo
 cgo_compiler:
-- go-cgo
+  - go-cgo
 target_platform:
-- linux-64
+  - linux-64
 channel_sources:
-- conda-forge
+  - conda-forge
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+  - quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler:
-- None
+  - None
 cuda_compiler_version:
-- None
+  - None
 cuda_compiler_version_min:
-- None
+  - None

--- a/.ci_support/linux64_cuda118.yaml
+++ b/.ci_support/linux64_cuda118.yaml
@@ -1,34 +1,34 @@
 c_compiler:
-  - gcc
+- gcc
 cxx_compiler:
-  - gxx
+- gxx
 fortran_compiler:
-  - gfortran
+- gfortran
 go_compiler:
-  - go-nocgo
+- go-nocgo
 cgo_compiler:
-  - go-cgo
+- go-cgo
 c_compiler_version:
-  - 11
+- 11
 cxx_compiler_version:
-  - 11
+- 11
 fortran_compiler_version:
-  - 11
+- 11
 c_stdlib:
-  - sysroot
+- sysroot
 c_stdlib_version:
-  - 2.17
+- 2.17
 cdt_name:
-  - cos7
+- cos7
 target_platform:
-  - linux-64
+- linux-64
 channel_sources:
-  - conda-forge
+- conda-forge
 docker_image:
-  - quay.io/condaforge/linux-anvil-cuda:11.8
+- quay.io/condaforge/linux-anvil-cuda:11.8
 cuda_compiler:
-  - nvcc
+- nvcc
 cuda_compiler_version:
-  - 11.8
+- 11.8
 cuda_compiler_version_min:
-  - 11.8
+- 11.8

--- a/.ci_support/linux64_cuda118.yaml
+++ b/.ci_support/linux64_cuda118.yaml
@@ -1,32 +1,34 @@
 c_compiler:
-- gcc
+  - gcc
 cxx_compiler:
-- gxx
+  - gxx
 fortran_compiler:
-- gfortran
+  - gfortran
 go_compiler:
-- go-nocgo
+  - go-nocgo
 cgo_compiler:
-- go-cgo
+  - go-cgo
 c_compiler_version:
-- 11
+  - 11
 cxx_compiler_version:
-- 11
+  - 11
 fortran_compiler_version:
-- 11
+  - 11
+c_stdlib:
+  - sysroot
 c_stdlib_version:
-- 2.17
+  - 2.17
 cdt_name:
-- cos7
+  - cos7
 target_platform:
-- linux-64
+  - linux-64
 channel_sources:
-- conda-forge
+  - conda-forge
 docker_image:
-- quay.io/condaforge/linux-anvil-cuda:11.8
+  - quay.io/condaforge/linux-anvil-cuda:11.8
 cuda_compiler:
-- nvcc
+  - nvcc
 cuda_compiler_version:
-- 11.8
+  - 11.8
 cuda_compiler_version_min:
-- 11.8
+  - 11.8

--- a/.ci_support/linux64_cuda120.yaml
+++ b/.ci_support/linux64_cuda120.yaml
@@ -1,34 +1,34 @@
 c_compiler:
-  - gcc
+- gcc
 cxx_compiler:
-  - gxx
+- gxx
 fortran_compiler:
-  - gfortran
+- gfortran
 go_compiler:
-  - go-nocgo
+- go-nocgo
 cgo_compiler:
-  - go-cgo
+- go-cgo
 c_compiler_version:
-  - 12
+- 12
 cxx_compiler_version:
-  - 12
+- 12
 fortran_compiler_version:
-  - 12
+- 12
 c_stdlib:
-  - sysroot
+- sysroot
 c_stdlib_version:
-  - 2.17
+- 2.17
 cdt_name:
-  - cos7
+- cos7
 target_platform:
-  - linux-64
+- linux-64
 channel_sources:
-  - conda-forge
+- conda-forge
 docker_image:
-  - quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler:
-  - cuda-nvcc
+- cuda-nvcc
 cuda_compiler_version:
-  - 12.0
+- 12.0
 cuda_compiler_version_min:
-  - 11.8
+- 11.8

--- a/.ci_support/linux64_cuda120.yaml
+++ b/.ci_support/linux64_cuda120.yaml
@@ -1,32 +1,34 @@
 c_compiler:
-- gcc
+  - gcc
 cxx_compiler:
-- gxx
+  - gxx
 fortran_compiler:
-- gfortran
+  - gfortran
 go_compiler:
-- go-nocgo
+  - go-nocgo
 cgo_compiler:
-- go-cgo
+  - go-cgo
 c_compiler_version:
-- 12
+  - 12
 cxx_compiler_version:
-- 12
+  - 12
 fortran_compiler_version:
-- 12
+  - 12
+c_stdlib:
+  - sysroot
 c_stdlib_version:
-- 2.17
+  - 2.17
 cdt_name:
-- cos7
+  - cos7
 target_platform:
-- linux-64
+  - linux-64
 channel_sources:
-- conda-forge
+  - conda-forge
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+  - quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler:
-- cuda-nvcc
+  - cuda-nvcc
 cuda_compiler_version:
-- 12.0
+  - 12.0
 cuda_compiler_version_min:
-- 11.8
+  - 11.8

--- a/.ci_support/osx64.yaml
+++ b/.ci_support/osx64.yaml
@@ -2,6 +2,8 @@ c_compiler:
   - clang
 cxx_compiler:
   - clangxx
+c_stdlib:
+  - macosx_deployment_target
 fortran_compiler:
   - gfortran
 go_compiler:

--- a/.ci_support/win64.yaml
+++ b/.ci_support/win64.yaml
@@ -1,5 +1,7 @@
 go_compiler:
   - go-nocgo
+c_stdlib:
+  - vs
 cgo_compiler:
   - go-cgo
 channel_sources:


### PR DESCRIPTION
I believe that in order for the new stdlib template to work on staged recipes, `c_stdlib` also needs to be defined in the pinnings because I was trying to build locally and I got the following error:
```
    Encountered problems while solving:
      - nothing provides requested c_linux-64 2.17.*
    
    Could not solve for environment specs
    The following package could not be installed
    └─ c_linux-64 2.17.*  does not exist (perhaps a typo or a missing channel).

```
until I added the pinnings in this PR.

```
(base) bash-5.1$ conda list "conda*"                                                                                                                          
# packages in environment at /home/DCHING/miniforge3:                                                                                                         
#                                                                                                                                                             
# Name                    Version                   Build  Channel                                                                                            
conda                     24.3.0          py311h38be061_0    conda-forge
conda-build               24.3.0          py311h38be061_1    conda-forge
conda-forge-pinning       2024.05.02.11.25.06      hd8ed1ab_0    conda-forge
conda-index               0.4.0              pyhd8ed1ab_0    conda-forge
conda-libmamba-solver     24.1.0             pyhd8ed1ab_0    conda-forge
conda-package-handling    2.2.0              pyh38be061_0    conda-forge
conda-package-streaming   0.9.0              pyhd8ed1ab_0    conda-forge
conda-smithy              3.35.0             pyhd8ed1ab_0    conda-forge
```

https://github.com/conda-forge/staged-recipes/pull/26206
https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5499