### PR TITLE
Add dbt-postgres

### DIFF
--- a/recipes/dbt-postgres/meta.yaml
+++ b/recipes/dbt-postgres/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 876f6670bacd74972f999ccd5d7b8ee8cf8c65cbc32ebf2dda68a8f727387ed0
 
 build:
-  skip: true  # [py<38]
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
@@ -20,9 +20,10 @@ requirements:
     - hatchling
     - pip
   run:
+    # Note: psycopg2-binary is noarch, and works also for linux, so instead of adding
+    # an os-dependent requirement, we instead use psycopg2-binary for simplicity.
     - python >=3.8.0
-    - psycopg2 >=2.9,<3.0  # [linux]
-    - psycopg2-binary >=2.9,<3.0  # [not linux]
+    - psycopg2-binary >=2.9,<3.0
     - dbt-adapters >=0.1.0a1,<2.0
     - dbt-core >=1.8.0a1
     - dbt-common >=0.1.0a1,<2.0

--- a/recipes/dbt-postgres/meta.yaml
+++ b/recipes/dbt-postgres/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "dbt-postgres" %}
+{% set version = "1.8.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/dbt_postgres-{{ version }}.tar.gz
+  sha256: 876f6670bacd74972f999ccd5d7b8ee8cf8c65cbc32ebf2dda68a8f727387ed0
+
+build:
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8.0
+    - hatchling
+    - pip
+  run:
+    - python >=3.8.0
+    - psycopg2 >=2.9,<3.0  # [linux]
+    - psycopg2-binary >=2.9,<3.0  # [not linux]
+    - dbt-adapters >=0.1.0a1,<2.0
+    - dbt-core >=1.8.0a1
+    - dbt-common >=0.1.0a1,<2.0
+    - agate >=1.0,<2.0
+
+test:
+  imports:
+    - dbt_postgres
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: The set of adapter protocols and base functionality that supports integration with dbt-core
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - maresb

--- a/recipes/dbt-postgres/meta.yaml
+++ b/recipes/dbt-postgres/meta.yaml
@@ -38,7 +38,8 @@ test:
     - pip
 
 about:
-  summary: The set of adapter protocols and base functionality that supports integration with dbt-core
+  home: https://github.com/dbt-labs/dbt-postgres
+  summary: The dbt-postgres package contains all of the code enabling dbt to work with a Postgres database.
   license: Apache-2.0
   license_file: LICENSE
 

--- a/recipes/dbt-postgres/meta.yaml
+++ b/recipes/dbt-postgres/meta.yaml
@@ -46,3 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - maresb
+    - rxm7706

--- a/recipes/dbt-postgres/meta.yaml
+++ b/recipes/dbt-postgres/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
 test:
   imports:
-    - dbt_postgres
+    - dbt.adapters.postgres
   commands:
     - pip check
   requires:

--- a/recipes/dbt-postgres/meta.yaml
+++ b/recipes/dbt-postgres/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:


### PR DESCRIPTION
The dbt-postgres package has been split off upstream, so we need a new feedstock.

Since this is already an output of dbt-feedstock, I have taken the following steps:
1. Set the build number to 1 because build 0 of dbt-postgres already exists.
2. Prepared a PR to add this future feedstock for the allowed outputters in https://github.com/conda-forge/feedstock-outputs/pull/71
3. Prepared a PR to make dbt-feedstock a single-output feedstock with just dbt-core in https://github.com/conda-forge/dbt-feedstock/pull/112
4. [Asked for clarification](https://matrix.to/#/!SOyumkgPRWoXfQYIFH:matrix.org/$171552674516416NXnut:matrix.org?via=matrix.org&via=gitter.im&via=cadair.com) in the Matrix chat about whether I also need to create a new dbt-core feedstock


<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
