### PR TITLE
Add recipe for pilotpy

### DIFF
--- a/recipes/pilotpy/meta.yaml
+++ b/recipes/pilotpy/meta.yaml
@@ -1,0 +1,68 @@
+package:
+  name: pilotpy
+  version: "2.0.6"
+
+source:
+  url: https://github.com/CostaLab/PILOT/archive/refs/tags/v2.0.6.tar.gz
+  sha256: 7f63b4a4ecdf42c3c02f92d35cc5403352c1151b6debdc572b1fdd90844f2af4
+
+build:
+  number: 0
+  script: python -m pip install . -vv
+  - {{ stdlib("c") }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - python =3.11.5
+    - pip
+  host:
+    - python =3.11.5
+    - pip
+  run:
+    - python =3.11.5
+    - r-base
+    - cycler >=0.11.0,<0.12.0
+    - joypy >=0.2.6,<0.3.0
+    - leidenalg >=0.10.1,<0.11.0
+    - numpy >=1.24.4,<1.25.0
+    - matplotlib >=3.8.0,<3.9.0
+    - pandas >=2.0.3,<2.1.0
+    - plotly >=5.22.0,<5.23.0
+    - plotnine >=0.12.3,<0.13.0
+    - pot >=0.9.1,<0.10.0
+    - pydiffmap >=0.2.0.1,<0.3.0
+    - scanpy >=1.9.5,<1.10.0
+    - scikit-learn >=1.3.0,<1.4.0
+    - scikit-network >=0.31.0,<0.32.0
+    - scipy >=1.11.2,<1.12.0
+    - seaborn >=0.12.2,<0.13.0
+    - shap >=0.42.1,<0.43.0
+    - statsmodels >=0.14.0,<0.15.0
+    - elpigraph-python >=0.3.1,<0.4.0
+    - adjusttext >=0.8,<0.9
+    - gprofiler-official >=1.0.0,<1.1.0
+    - rpy2==3.5.11 
+
+test:
+  requires:
+    - pytest
+  imports:
+    - pilotpy
+  commands:
+    - pytest
+
+about:
+  home: https://github.com/CostaLab/PILOT
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: "PILOT: A Python package for patient-level distances from single cell genomics and pathomics data"
+  description: |
+    PILOT is a Python library for Detection of PatIent-Level distances from single cell genomics and pathomics data with Optimal Transport.
+  doc_url: https://pilot.readthedocs.io/en/latest/
+  dev_url: https://github.com/CostaLab/PILOT
+
+extra:
+  recipe-maintainers:
+    - MehdiJoodaki


### PR DESCRIPTION
This pull request adds a conda recipe for the pilotpy package, version 2.0.6.

Details
Package Name: pilotpy
Version: 2.0.6
Source URL: [PILOT v2.0.6](https://github.com/CostaLab/PILOT/archive/refs/tags/v2.0.6.tar.gz)
License: MIT
Summary: PILOT is a Python package for patient-level distances from single cell genomics and pathomics data.
Testing
Tested with pytest