### PR TITLE
Correctly set the MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/.ci_support/osx64.yaml
+++ b/.ci_support/osx64.yaml
@@ -1,3 +1,5 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
 c_compiler:
   - clang
 cxx_compiler:

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,2 +1,0 @@
-c_stdlib_version:  # [osx]
-  - 11.0                   # [osx]


### PR DESCRIPTION
We need to set `MACOSX_DEPLOYMENT_TARGET` so that `conda-forge-ci-setup` set the correct value if the recipe doesn't set anything. This value is parsed before the global pinning is taken into account.

This also removes the top-level `conda_build_config.yaml` which should never been placed there.