### PR TITLE
Adding pyhdbpp, python extractor for tango-hdb++ databases

### DIFF
--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   entry_points:
     - hdbpp-reader = pyhdbpp.reader:read
-    - hdb2csv = pyhdbpp.tools.hdb2csv:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
@@ -24,6 +23,8 @@ requirements:
   run:
     - python >=3.7
     - pyyaml
+    - pymysql
+    - psycopg2
 
 test:
   imports:

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyhdbpp" %}
-{% set version = "1.5.6" %}
+{% set version = "1.5.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyhdbpp-{{ version }}.tar.gz
-  sha256: 0cef461afb40ad7c4a8cbf5d34fc6ad7db8cdbcec0108674d0d362a2a72826b7
+  sha256: 906ca14864c667961da2e47aa87484c9a95d78d73f15f784ece7cebad642c204
 
 build:
   entry_points:

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyhdbpp" %}
-{% set version = "1.5.11" %}
+{% set version = "1.5.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyhdbpp-{{ version }}.tar.gz
-  sha256: 906ca14864c667961da2e47aa87484c9a95d78d73f15f784ece7cebad642c204
+  sha256: 4f484e5b38c326c97effddf06677ea64b92577b521453b706eed3092775e7c9f
 
 build:
   entry_points:

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyhdbpp-{{ version }}.tar.gz
-  sha256: 41b6a82cfdc64aa9770aa1c3e4d05edd767537012a4a6765c633b01fbe1f3b02
+  sha256: 0cef461afb40ad7c4a8cbf5d34fc6ad7db8cdbcec0108674d0d362a2a72826b7
 
 build:
   entry_points:

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pyhdbpp" %}
+{% set version = "1.1.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyhdbpp-{{ version }}.tar.gz
+  sha256: 41b6a82cfdc64aa9770aa1c3e4d05edd767537012a4a6765c633b01fbe1f3b02
+
+build:
+  entry_points:
+    - hdbpp-reader = pyhdbpp.reader:read
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.7
+    - pip
+  run:
+    - python >=3.7
+    - pyyaml
+
+test:
+  imports:
+    - pyhdbpp
+  commands:
+    - pip check
+    - hdbpp-reader --help
+  requires:
+    - pip
+
+about:
+  home: https://gitlab.com/tango-controls/hdbpp/libhdbpp-python
+  summary: hdb++ python3 API
+  license: LGPL-3.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - sergirubio

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   entry_points:
     - hdbpp-reader = pyhdbpp.reader:read
+    - hdb2csv = pyhdbpp.tools.hdb2csv:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyhdbpp" %}
-{% set version = "1.1.5" %}
+{% set version = "1.5.6" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -38,7 +38,7 @@ test:
 about:
   home: https://gitlab.com/tango-controls/hdbpp/libhdbpp-python
   summary: hdb++ python3 API
-  license: LGPL-3.0
+  license: LGPL-3.0-or-later
   license_file: LICENSE
 
 extra:

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -12,6 +12,7 @@ source:
 build:
   entry_points:
     - hdbpp-reader = pyhdbpp.reader:main
+    - hdb2csv = pyhdbpp.tools.hdb2csv:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0

--- a/recipes/pyhdbpp/meta.yaml
+++ b/recipes/pyhdbpp/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   entry_points:
-    - hdbpp-reader = pyhdbpp.reader:read
+    - hdbpp-reader = pyhdbpp.reader:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0


### PR DESCRIPTION

pyhdbpp is a python module for extracting data from Tango Control System archiving databases (HDB++), it actually supports mysql/mariadb and timescaledb. It is used by some other packages already available in conda-forge (taurus).

@conda-forge/help-python

