### PR TITLE
Add r-box.linters

### DIFF
--- a/recipes/r-box.linters/bld.bat
+++ b/recipes/r-box.linters/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-box.linters/build.sh
+++ b/recipes/r-box.linters/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-box.linters/meta.yaml
+++ b/recipes/r-box.linters/meta.yaml
@@ -53,7 +53,7 @@ test:
 about:
   home: https://appsilon.github.io/box.linters/
   dev_url: https://github.com/Appsilon/box.linters
-  license: LGPL-3
+  license: LGPL-3.0-only
   summary: Static code analysis of 'box' modules. The package enhances code quality by providing
     linters that check for common issues, enforce best practices, and ensure consistent
     coding standards.

--- a/recipes/r-box.linters/meta.yaml
+++ b/recipes/r-box.linters/meta.yaml
@@ -51,14 +51,15 @@ test:
     - "\"%R%\" -e \"library('box.linters')\""  # [win]
 
 about:
-  home: https://appsilon.github.io/box.linters/, https://github.com/Appsilon/box.linters
+  home: https://appsilon.github.io/box.linters/
+  dev_url: https://github.com/Appsilon/box.linters
   license: LGPL-3
   summary: Static code analysis of 'box' modules. The package enhances code quality by providing
     linters that check for common issues, enforce best practices, and ensure consistent
     coding standards.
   license_family: LGPL
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-box.linters/meta.yaml
+++ b/recipes/r-box.linters/meta.yaml
@@ -1,0 +1,87 @@
+{% set version = '0.9.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-box.linters
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/box.linters_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/box.linters/box.linters_{{ version }}.tar.gz
+  sha256: f66fc4190f14766aef65e67342620836348d39bb87207bae42e5be04fefc0cec
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-cli
+    - r-fs
+    - r-glue
+    - r-lintr >=3.0.0
+    - r-rlang
+    - r-stringr
+    - r-xml2
+    - r-xmlparsedata
+  run:
+    - r-base
+    - r-cli
+    - r-fs
+    - r-glue
+    - r-lintr >=3.0.0
+    - r-rlang
+    - r-stringr
+    - r-xml2
+    - r-xmlparsedata
+
+test:
+  commands:
+    - $R -e "library('box.linters')"           # [not win]
+    - "\"%R%\" -e \"library('box.linters')\""  # [win]
+
+about:
+  home: https://appsilon.github.io/box.linters/, https://github.com/Appsilon/box.linters
+  license: LGPL-3
+  summary: Static code analysis of 'box' modules. The package enhances code quality by providing
+    linters that check for common issues, enforce best practices, and ensure consistent
+    coding standards.
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: box.linters
+# Title: Linters for 'box' Modules
+# Version: 0.9.1
+# Authors@R: c( person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"), person("Jakub", "Nowicki", role = "aut", email = "kuba@appsilon.com"), person("Appsilon Sp. z o.o.", role = "cph", email = "opensource@appsilon.com") )
+# Description: Static code analysis of 'box' modules. The package enhances code quality by providing linters that check for common issues, enforce best practices, and ensure consistent coding standards.
+# URL: https://appsilon.github.io/box.linters/, https://github.com/Appsilon/box.linters
+# License: LGPL-3
+# Encoding: UTF-8
+# RoxygenNote: 7.3.1
+# Depends: R (>= 2.10)
+# Imports: cli, fs, glue, lintr (>= 3.0.0), rlang, stringr, xml2, xmlparsedata
+# Suggests: box, covr, dplyr, knitr, rcmdcheck, rmarkdown, R6, rex, rhino, shiny, spelling, testthat (>= 3.0.0), withr,
+# Config/testthat/edition: 3
+# Config/testthat/parallel: true
+# Language: en-US
+# NeedsCompilation: no
+# Packaged: 2024-06-03 08:16:54 UTC; kuba
+# Author: Ricardo Rodrigo Basa [aut, cre], Jakub Nowicki [aut], Appsilon Sp. z o.o. [cph]
+# Maintainer: Ricardo Rodrigo Basa <opensource+rodrigo@appsilon.com>
+# Repository: CRAN
+# Date/Publication: 2024-06-04 09:50:39 UTC


### PR DESCRIPTION
Adds [CRAN package `box.linters`](https://cran.r-project.org/package=box.linters) as `r-box.linters`. Recipe generated with `conda_r_skeleton_helper`.

Needed by https://github.com/conda-forge/r-rhino-feedstock/pull/6.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
