### PR TITLE
Add `inspect_artifacts` to scripts

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -73,6 +73,11 @@ conda index ${FEEDSTOCK_ROOT}/build_artifacts
 echo "Building all recipes"
 python ${CI_SUPPORT}/build_all.py
 
+( startgroup "Inspecting artifacts" ) 2> /dev/null
+# inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+( endgroup "Inspecting artifacts" ) 2> /dev/null
+
 ( startgroup "Final checks" ) 2> /dev/null
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -54,7 +54,7 @@ source run_conda_forge_build_setup
 set -e
 
 # make sure there is a package directory so that artifact publishing works
-mkdir -p "${MINIFORGE_ROOT}/conda-bld/osx-64/"
+mkdir -p "${MINIFORGE_ROOT}/conda-bld/osx-64/" "${MINIFORGE_ROOT}/conda-bld/noarch/"
 
 # Find the recipes from main in this PR and remove them.
 echo ""

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -70,3 +70,8 @@ echo ""
 # We just want to build all of the recipes.
 echo "Building all recipes"
 python .ci_support/build_all.py
+
+( startgroup "Inspecting artifacts" ) 2> /dev/null
+# inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+command -v inspect_artifacts >/dev/null 2>&1 && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+( endgroup "Inspecting artifacts" ) 2> /dev/null

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -50,6 +50,7 @@ cd ..
 
 :: make sure there is a package directory so that artifact publishing works
 if not exist "%CONDA_BLD_PATH%\win-64\" mkdir "%CONDA_BLD_PATH%\win-64\"
+if not exist "%CONDA_BLD_PATH%\noarch\" mkdir "%CONDA_BLD_PATH%\noarch\"
 
 echo Index %CONDA_BLD_PATH%
 conda.exe index "%CONDA_BLD_PATH%"
@@ -62,8 +63,10 @@ python .ci_support\build_all.py --arch 64
 if errorlevel 1 exit 1
 
 call :start_group "Inspecting artifacts"
+
 :: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
 WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+
 call :end_group
 
 exit

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -61,6 +61,11 @@ echo Building all recipes
 python .ci_support\build_all.py --arch 64
 if errorlevel 1 exit 1
 
+call :start_group "Inspecting artifacts"
+:: inspect_artifacts was only added in conda-forge-ci-setup 4.6.0
+WHERE inspect_artifacts >nul 2>nul && inspect_artifacts || echo "inspect_artifacts needs conda-forge-ci-setup >=4.6.0"
+call :end_group
+
 exit
 
 :: Logging subroutines


### PR DESCRIPTION
Ports the same code added in https://github.com/conda-forge/conda-smithy/pull/1947. 

For an example, watch for "Inspecting artifacts" at the bottom in any recent feedstock PR; e.g. [this one](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=954079&view=logs&j=d0d954b5-f111-5dc4-4d76-03b6c9d0cf7e&t=6d4b912b-175d-51da-0fd9-4d30fe1eb4e7&l=2969)