### PR TITLE
Add recipes for zenoh, zenoh-c and zenoh-plugin-webserver

### DIFF
--- a/recipes/zenoh-c/469.patch
+++ b/recipes/zenoh-c/469.patch
@@ -1,0 +1,24 @@
+From dfc18ce94094780bd654dd53eb10df0cd19d9bfe Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Sun, 23 Jun 2024 19:01:28 +0200
+Subject: [PATCH] Fix installation when ZENOHC_CUSTOM_TARGET is not set and
+ CARGO_BUILD_TARGET env variable is set
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c8e4e542..aa577be4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -99,6 +99,9 @@ set(cargo_target_dir_release ${cargo_toml_dir_release}/target)
+ if(NOT(ZENOHC_CUSTOM_TARGET STREQUAL ""))
+ 	set(cargo_target_dir_debug ${cargo_target_dir_debug}/${ZENOHC_CUSTOM_TARGET})
+ 	set(cargo_target_dir_release ${cargo_target_dir_release}/${ZENOHC_CUSTOM_TARGET})
++elseif(NOT("$ENV{CARGO_BUILD_TARGET}" STREQUAL ""))
++	set(cargo_target_dir_debug ${cargo_target_dir_debug}/$ENV{CARGO_BUILD_TARGET})
++	set(cargo_target_dir_release ${cargo_target_dir_release}/$ENV{CARGO_BUILD_TARGET})
+ endif()
+ set(cargo_binary_dir_debug ${cargo_target_dir_debug}/debug)
+ set(cargo_binary_dir_release ${cargo_target_dir_release}/release)

--- a/recipes/zenoh-c/470.patch
+++ b/recipes/zenoh-c/470.patch
@@ -1,0 +1,66 @@
+From c4308e5a40127295251115712e360bc281bee8b2 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Sun, 23 Jun 2024 19:46:44 +0200
+Subject: [PATCH] Ensure that find_package(zenohc) can be called two times
+
+---
+ install/PackageConfig.cmake.in | 40 +++++++++++++++++++---------------
+ 1 file changed, 23 insertions(+), 17 deletions(-)
+
+diff --git a/install/PackageConfig.cmake.in b/install/PackageConfig.cmake.in
+index 13fd98f5d..fe88a38ff 100644
+--- a/install/PackageConfig.cmake.in
++++ b/install/PackageConfig.cmake.in
+@@ -23,29 +23,35 @@ if(_IMPORT_PREFIX STREQUAL "/")
+   set(_IMPORT_PREFIX "")
+ endif()
+ 
+-add_library(__zenohc_static STATIC IMPORTED GLOBAL)
+-add_library(zenohc::static ALIAS __zenohc_static)
+-target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
+-set_target_properties(__zenohc_static PROPERTIES
+-    IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
+-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+-)
++if(NOT TARGET __zenohc_static)
++  add_library(__zenohc_static STATIC IMPORTED GLOBAL)
++  add_library(zenohc::static ALIAS __zenohc_static)
++  target_link_libraries(__zenohc_static INTERFACE @NATIVE_STATIC_LIBS@)
++  set_target_properties(__zenohc_static PROPERTIES
++      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@STATICLIB@"
++      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
++  )
++endif()
+ 
+-add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
+-add_library(zenohc::shared ALIAS __zenohc_shared)
+-set_target_properties(__zenohc_shared PROPERTIES
+-    IMPORTED_NO_SONAME TRUE
+-    INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
+-    IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@DYLIB@"
+-    INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+-)
++if(NOT TARGET __zenohc_shared)
++  add_library(__zenohc_shared SHARED IMPORTED GLOBAL)
++  add_library(zenohc::shared ALIAS __zenohc_shared)
++  set_target_properties(__zenohc_shared PROPERTIES
++      IMPORTED_NO_SONAME TRUE
++      INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
++      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@DYLIB@"
++      INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
++  )
++endif()
+ 
+ if(NOT ("@IMPLIB@" STREQUAL ""))
+     set_property(TARGET __zenohc_shared PROPERTY IMPORTED_IMPLIB "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@IMPLIB@")
+ endif()
+ 
+-if(ZENOHC_LIB_STATIC)
++if(NOT TARGET zenohc::lib)
++  if(ZENOHC_LIB_STATIC)
+     add_library(zenohc::lib ALIAS __zenohc_static)
+-else()
++  else()
+     add_library(zenohc::lib ALIAS __zenohc_shared)
++  endif()
+ endif()

--- a/recipes/zenoh-c/471a.patch
+++ b/recipes/zenoh-c/471a.patch
@@ -1,0 +1,31 @@
+From 108e3daea0c6ab723b308906d2550e0b9f94d89b Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Sun, 23 Jun 2024 20:23:58 +0200
+Subject: [PATCH] Install zenohc.dll in <prefix>/bin on Windows
+
+---
+ install/CMakeLists.txt         | 10 +++++++++-
+ install/PackageConfig.cmake.in |  2 +-
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/install/CMakeLists.txt b/install/CMakeLists.txt
+index 414373edc..8186744e2 100644
+--- a/install/CMakeLists.txt
++++ b/install/CMakeLists.txt
+@@ -23,7 +23,15 @@ function(install_zenohc_lib configurations property_postfix package_name)
+     get_filename_component(STATICLIB ${staticlib_path} NAME)
+ 
+     # Install dynamic, import and static library
+-    install(FILES ${dylib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations})
++
++    # On Windows .dll need to be installed in ${CMAKE_INSTALL_BINDIR}, 
++    # while on Linux and macOS .so and .dylib need to be installed in ${CMAKE_INSTALL_LIBDIR}
++    if(WIN32)
++        set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_BINDIR})
++    else()
++        set(ZENOHC_INSTALL_DYLIBDIR ${CMAKE_INSTALL_LIBDIR})
++    endif()
++    install(FILES ${dylib_path} DESTINATION ${ZENOHC_INSTALL_DYLIBDIR} CONFIGURATIONS ${configurations})
+     if(DEFINED implib_path)
+         install(FILES ${implib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR} CONFIGURATIONS ${configurations})
+     endif()

--- a/recipes/zenoh-c/471b.patch
+++ b/recipes/zenoh-c/471b.patch
@@ -1,0 +1,13 @@
+diff --git a/install/PackageConfig.cmake.in b/install/PackageConfig.cmake.in
+index 13fd98f5d..28a77d968 100644
+--- a/install/PackageConfig.cmake.in
++++ b/install/PackageConfig.cmake.in
+@@ -36,7 +36,7 @@ add_library(zenohc::shared ALIAS __zenohc_shared)
+   set_target_properties(__zenohc_shared PROPERTIES
+       IMPORTED_NO_SONAME TRUE
+       INTERFACE_COMPILE_DEFINITION ZENOHC_DYN_LIB
+-      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@CMAKE_INSTALL_LIBDIR@/@DYLIB@"
++      IMPORTED_LOCATION "${_IMPORT_PREFIX}/@ZENOHC_INSTALL_DYLIBDIR@/@DYLIB@"
+       INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/@CMAKE_INSTALL_INCLUDEDIR@"
+   )
+ 

--- a/recipes/zenoh-c/bld.bat
+++ b/recipes/zenoh-c/bld.bat
@@ -1,0 +1,26 @@
+mkdir build
+cd build
+
+cmake -GNinja %CMAKE_ARGS% ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DBUILD_SHARED_LIBS:BOOL=ON ^
+      -DZENOHC_INSTALL_STATIC_LIBRARY:BOOL=OFF ^
+      -DZENOHC_LIB_STATIC:BOOL=OFF ^
+      -DZENOHC_CARGO_FLAGS:STRING="--locked" ^
+      %SRC_DIR%
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+cmake --build .
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+cmake --install .
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+cargo-bundle-licenses --format yaml --output %SRC_DIR%\THIRDPARTY.yml
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+cmake --build . --target tests --config Release
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+ctest -C Release --output-on-failure -E "(unit_z_api_alignment_test|build_z_build_static)"
+if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipes/zenoh-c/build.sh
+++ b/recipes/zenoh-c/build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# librt is needed for sem_* symbols
+if [[ "${target_platform}" == linux-* ]] ; then
+    export LDFLAGS="-lrt ${LDFLAGS}"
+fi
+
+mkdir build && cd build
+
+cmake -GNinja ${CMAKE_ARGS} \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS:BOOL=ON \
+      -DZENOHC_INSTALL_STATIC_LIBRARY:BOOL=OFF \
+      -DZENOHC_LIB_STATIC:BOOL=OFF \
+      -DZENOHC_CARGO_FLAGS:STRING="--locked" \
+      -DBUILD_TESTING:BOOL=ON \
+      $SRC_DIR
+
+cmake --build .
+cmake --install .
+
+cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml
+
+cmake --build . --target tests --config Release
+ctest -C Release --output-on-failure -E "(unit_z_api_alignment_test|build_z_build_static)"

--- a/recipes/zenoh-c/conda_build_config.yaml
+++ b/recipes/zenoh-c/conda_build_config.yaml
@@ -1,0 +1,3 @@
+rust_compiler_version:
+    - '1.79.0'
+

--- a/recipes/zenoh-c/link_threads_in_tests.patch
+++ b/recipes/zenoh-c/link_threads_in_tests.patch
@@ -1,0 +1,32 @@
+From 04263a44127aff172244b0a3fbbb6e03bfb363a7 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Mon, 24 Jun 2024 14:01:04 +0200
+Subject: [PATCH] Update CMakeLists.txt
+
+---
+ tests/CMakeLists.txt | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 21695a439..12b55c326 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -2,6 +2,8 @@ message(STATUS "zenoh-c tests")
+ 
+ add_custom_target(tests)
+ 
++find_package(Threads REQUIRED)
++
+ file(GLOB files "${CMAKE_CURRENT_SOURCE_DIR}/*.c")
+ foreach(file ${files})
+     get_filename_component(target ${file} NAME_WE)
+@@ -20,7 +22,7 @@ foreach(file ${files})
+     add_executable(${target} EXCLUDE_FROM_ALL ${file})
+     add_dependencies(tests ${target})
+     add_dependencies(${target} zenohc::lib)
+-    target_link_libraries(${target} PRIVATE zenohc::lib)
++    target_link_libraries(${target} PRIVATE zenohc::lib Threads::Threads)
+     copy_dlls(${target})
+     set_property(TARGET ${target} PROPERTY C_STANDARD 11)
+     add_test(NAME "${test_type}_${target}" COMMAND ${target})
+ 

--- a/recipes/zenoh-c/meta.yaml
+++ b/recipes/zenoh-c/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "libzenohc" %}
+{% set version = "0.11.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/eclipse-zenoh/zenoh-c/archive/refs/tags/{{ version }}.tar.gz
+    sha256: a0ed1c19eca3c0db5b4c140c2a9cd84b471f1a427599ddf12ee1b4005d860e71
+    patches:
+      - 469.patch
+      - 470.patch
+      - 471a.patch
+      - 471b.patch
+      - link_threads_in_tests.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+    - cmake
+    - ninja
+    - pkg-config
+  host:
+    - zenoh-rust-abi {{ version }}.*
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libzenohc${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\lib\\zenohc.dll.lib exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\bin\\zenohc.dll exit 1  # [win]
+    - cmake-package-check zenohc --targets zenohc::shared zenohc::lib
+  requires:
+    - cmake-package-check
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+about:
+  home: https://github.com/eclipse-zenoh/zenoh-c
+  license: Apache-2.0 OR EPL-2.0
+  license_file: 
+    - LICENSE
+    - THIRDPARTY.yml
+  summary:  C API for Zenoh
+
+extra:
+  # Stick to the repo name for the feedstock name
+  feedstock-name: zenoh-c
+  recipe-maintainers:
+    - traversaro

--- a/recipes/zenoh-plugin-webserver/bld.bat
+++ b/recipes/zenoh-plugin-webserver/bld.bat
@@ -1,0 +1,9 @@
+cargo build --locked --profile release
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+if not exist %LIBRARY_PREFIX%\bin mkdir %LIBRARY_PREFIX%\bin
+copy .\target\%CARGO_BUILD_TARGET%\release\zenoh_plugin_webserver.dll %LIBRARY_PREFIX%\bin\
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+cargo-bundle-licenses --format yaml --output %SRC_DIR%\THIRDPARTY.yml
+if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipes/zenoh-plugin-webserver/build.sh
+++ b/recipes/zenoh-plugin-webserver/build.sh
@@ -1,0 +1,5 @@
+cargo build --locked --profile release
+mkdir -p ${PREFIX}/lib
+cp ./target/${CARGO_BUILD_TARGET}/release/libzenoh_plugin_webserver${SHLIB_EXT} ${PREFIX}/lib/
+
+cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml

--- a/recipes/zenoh-plugin-webserver/conda_build_config.yaml
+++ b/recipes/zenoh-plugin-webserver/conda_build_config.yaml
@@ -1,0 +1,2 @@
+rust_compiler_version:
+    - '1.79.0'

--- a/recipes/zenoh-plugin-webserver/meta.yaml
+++ b/recipes/zenoh-plugin-webserver/meta.yaml
@@ -1,0 +1,40 @@
+{% set name = "zenoh-plugin-webserver" %}
+{% set version = "0.11.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/eclipse-zenoh/zenoh-plugin-webserver/archive/refs/tags/{{ version }}.tar.gz
+    sha256: 483cee2c6c15189219d663ff1353621b91941c10730e2381b724a3509b2917c5
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+    # required as on Linux unwind's rust functionality depends on gcc_s library
+    - {{ compiler('c') }}
+  host:
+    # for some reason  {{ version }}.{{ rust_compiler_version }} does not work
+    - zenoh-rust-abi {{ version }}.1.79.0
+test:
+  commands:
+    - test -f ${PREFIX}/lib/libzenoh_plugin_webserver${SHLIB_EXT}  # [unix]
+    - if not exist %PREFIX%\\Library\\bin\\zenoh_plugin_webserver.dll exit 1  # [win]
+
+about:
+  home: https://github.com/eclipse-zenoh/zenoh-plugin-webserver
+  license: Apache-2.0 OR EPL-2.0
+  license_file: 
+    - LICENSE
+    - THIRDPARTY.yml
+  summary:  A zenoh plug-in implementing an HTTP server mapping URLs to zenoh paths. This plugin can be used to set-up a Web server where the resources are retrieved from geo-distributed zenoh storages, each leveraging various backends (file system, database, memory...).
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/zenoh/bld_zenoh_plugin_rest.bat
+++ b/recipes/zenoh/bld_zenoh_plugin_rest.bat
@@ -1,0 +1,6 @@
+cargo build --locked --profile release --package zenoh-plugin-rest
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+if not exist %LIBRARY_PREFIX%\bin mkdir %LIBRARY_PREFIX%\bin
+copy .\target\%CARGO_BUILD_TARGET%\release\zenoh_plugin_rest.dll %LIBRARY_PREFIX%\bin\
+if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipes/zenoh/bld_zenoh_plugin_storage_manager.bat
+++ b/recipes/zenoh/bld_zenoh_plugin_storage_manager.bat
@@ -1,0 +1,6 @@
+cargo build --locked --profile release --package zenoh-plugin-storage-manager
+if %errorlevel% NEQ 0 exit /b %errorlevel%
+
+if not exist %LIBRARY_PREFIX%\bin mkdir %LIBRARY_PREFIX%\bin
+copy .\target\%CARGO_BUILD_TARGET%\release\zenoh_plugin_storage_manager.dll %LIBRARY_PREFIX%\bin\
+if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipes/zenoh/bld_zenoh_rust_abi.bat
+++ b/recipes/zenoh/bld_zenoh_rust_abi.bat
@@ -1,0 +1,2 @@
+cargo-bundle-licenses --format yaml --output %SRC_DIR%\THIRDPARTY.yml
+if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipes/zenoh/bld_zenohd.bat
+++ b/recipes/zenoh/bld_zenohd.bat
@@ -1,0 +1,2 @@
+cargo install --locked --bins --root %LIBRARY_PREFIX% --path .\zenohd
+if %errorlevel% NEQ 0 exit /b %errorlevel%

--- a/recipes/zenoh/build_zenoh_plugin_rest.sh
+++ b/recipes/zenoh/build_zenoh_plugin_rest.sh
@@ -1,0 +1,3 @@
+cargo build --locked --profile release --package zenoh-plugin-rest
+mkdir -p ${PREFIX}/lib
+cp ./target/${CARGO_BUILD_TARGET}/release/libzenoh_plugin_rest${SHLIB_EXT} ${PREFIX}/lib/

--- a/recipes/zenoh/build_zenoh_plugin_storage_manager.sh
+++ b/recipes/zenoh/build_zenoh_plugin_storage_manager.sh
@@ -1,0 +1,3 @@
+cargo build --locked --profile release --package zenoh-plugin-storage-manager
+mkdir -p ${PREFIX}/lib
+cp ./target/${CARGO_BUILD_TARGET}/release/libzenoh_plugin_storage_manager${SHLIB_EXT} ${PREFIX}/lib/

--- a/recipes/zenoh/build_zenoh_rust_abi.sh
+++ b/recipes/zenoh/build_zenoh_rust_abi.sh
@@ -1,0 +1,1 @@
+cargo-bundle-licenses --format yaml --output ${SRC_DIR}/THIRDPARTY.yml

--- a/recipes/zenoh/build_zenohd.sh
+++ b/recipes/zenoh/build_zenohd.sh
@@ -1,0 +1,1 @@
+cargo install --locked --bins --root ${PREFIX} --path ./zenohd

--- a/recipes/zenoh/conda_build_config.yaml
+++ b/recipes/zenoh/conda_build_config.yaml
@@ -1,0 +1,2 @@
+rust_compiler_version:
+    - '1.79.0'

--- a/recipes/zenoh/meta.yaml
+++ b/recipes/zenoh/meta.yaml
@@ -1,0 +1,109 @@
+{% set version = "0.11.0" %}
+package:
+  name: zenoh-split
+  version: {{ version }}
+
+source:
+  - url: https://github.com/eclipse-zenoh/zenoh/archive/refs/tags/{{ version }}.tar.gz
+    sha256: b616d6656b090ab7848dc96d7ff132d8645c7c95315178cdc35f5edb8ed7c3c6
+
+build:
+  number: 0
+
+outputs:
+  # This is just a meta packages used to capture the exact version of zenoh (to which a unique Cargo.lock
+  # used for all dependencies is associated) and the rust compiler version used, to capture the exacti ABI
+  # of the zenoh plugins, and ensure that at runtime incompatible zenohd and plugins are never installed.
+  - name: zenoh-rust-abi
+    version: {{ version }}.{{ rust_compiler_version }}
+    script: build_zenoh_rust_abi.sh  # [unix]
+    script: bld_zenoh_rust_abi.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage('zenoh-rust-abi', max_pin='x.x.x.x.x.x') }}
+    requirements:
+      build:
+        # In theory this is not necessary, but we exploit the fact that this is the first
+        # package built to generate the THIRDPARTY.yml file
+        - {{ compiler('rust') }}
+        - {{ stdlib('c') }}
+        - cargo-bundle-licenses
+    test:
+      commands:
+        - echo "Metapackage, no test required"
+
+  - name: zenohd
+    script: build_zenohd.sh  # [unix]
+    script: bld_zenohd.bat  # [win]
+    requirements:
+      build:
+        - {{ compiler('rust') }}
+        - {{ stdlib('c') }}
+        # required as on Linux unwind's rust functionality depends on gcc_s library
+        - {{ compiler('c') }}
+      host:
+        - zenoh-rust-abi {{ version }}.{{ rust_compiler_version }}
+    test:
+      commands:
+        - test -f ${PREFIX}/bin/zenohd  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\zenohd.exe exit 1  # [win]
+
+  - name: zenoh-plugin-rest
+    script: build_zenoh_plugin_rest.sh  # [unix]
+    script: bld_zenoh_plugin_rest.bat  # [win]
+    requirements:
+      build:
+        - {{ compiler('rust') }}
+        - {{ stdlib('c') }}
+        # required as on Linux unwind's rust functionality depends on gcc_s library
+        - {{ compiler('c') }}
+      host:
+        - zenoh-rust-abi {{ version }}.{{ rust_compiler_version }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libzenoh_plugin_rest${SHLIB_EXT}  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\zenoh_plugin_rest.dll exit 1  # [win]
+
+  - name: zenoh-plugin-storage-manager
+    script: build_zenoh_plugin_storage_manager.sh  # [unix]
+    script: bld_zenoh_plugin_storage_manager.bat  # [win]
+    requirements:
+      build:
+        - {{ compiler('rust') }}
+        - {{ stdlib('c') }}
+        # required as on Linux unwind's rust functionality depends on gcc_s library
+        - {{ compiler('c') }}
+      host:
+        - zenoh-rust-abi {{ version }}.{{ rust_compiler_version }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libzenoh_plugin_storage_manager${SHLIB_EXT}  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\zenoh_plugin_storage_manager.dll exit 1  # [win]
+
+  # The zenoh meta package is present in Debian and homebrew official packages and as of June 2024
+  # depends on zenohd, zenoh-plugin-rest and zenoh-plugin-storage-manager, if this changes in the future we need to keep aligned
+  # see https://github.com/eclipse-zenoh/homebrew-zenoh/blob/e29d4ac6b6848234ca596aaa1a2cce2090c43513/zenoh.rb#L9-L11
+  # https://github.com/eclipse-zenoh/homebrew-zenoh/blob/e29d4ac6b6848234ca596aaa1a2cce2090c43513/README.md#available-formulae
+  - name: zenoh
+    requirements:
+      run:
+        - {{ pin_subpackage('zenohd', exact=True) }}
+        - {{ pin_subpackage('zenoh-plugin-rest', exact=True) }}
+        - {{ pin_subpackage('zenoh-plugin-storage-manager', exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/bin/zenohd  # [unix]
+        - if not exist %PREFIX%\\Library\\bin\\zenohd.exe exit 1  # [win]
+
+about:
+  home: https://zenoh.io/
+  license: Apache-2.0 OR EPL-2.0
+  license_file: 
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: zenoh unifies data in motion, data in-use, data at rest and computations. It carefully blends traditional pub/sub with geo-distributed storages, queries and computations, while retaining a level of time and space efficiency that is well beyond any of the mainstream stacks. 
+
+extra:
+  feedstock-name: zenoh
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
Fix https://github.com/conda-forge/staged-recipes/issues/26053 .

## PR content

This PRs adds some initial recipes for Zenoh ecosystem (https://zenoh.io/).

In particular, it contains the following recipes that generate the following packages (structure and naming inspired by the [Debian](https://download.eclipse.org/zenoh/debian-repo/) and [homebrew](https://github.com/eclipse-zenoh/homebrew-zenoh) existing packages):

* `zenoh` recipe, corresponding to the https://github.com/eclipse-zenoh/zenoh repo, that generates the packages:
  * `zenoh-rust-abi`, meta-package that captures the Rust ABI used by `zenohd` and all the Rust plugins 
  * `zenohd`, containing the `zenohd` zenoh router executable
  * `zenoh-plugin-rest`, rust plugin that is dlopen-ed by `zenohd`
  * `zenoh-plugin-storage-manager`, rust plugin that is dlopen-ed by `zenohd`
  * `zenoh`, metapackage that depends on `zenohd`, `zenoh-plugin-rest` and `zenoh-plugin-storage-manager` for consistency with the equivalent package available for Debian and homebrew
* `zenoh-c` recipe, corresponding to the https://github.com/eclipse-zenoh/zenoh-c repo, that generates the packages:
  * `libzenohc` package, containing a C library implemented using rust
* `zenoh-plugin-webserver` recipe, corresponding to the https://github.com/eclipse-zenoh/zenoh-plugin-webserver repo, that generates the packages:
  * `zenoh-plugin-webserver`, rust plugin that is dlopen-ed by `zenohd`

I typically avoid to include multiple recipes in the same PR, but in this case this is useful to show how future `zenoh-*` packages may be packaged.

## Zenoh specificity

The most important thing is to distinguish two kind of `zenoh` packages:
* Packages that uses rust to build executables, or libraries that only expose a C/C++/Python interface: these packages can be built as other rust-based packages in conda-forge.
* Packages that create rust dynamics libraries that are loaded by `zenohd` (that typically are named `zenoh-plugin-*` or `zenoh-backend-*`). These packages need special care as they need to be compiled using exactly the same dependencies and rust compiler version used to compile `zenohd`, as otherwise ABI breakage could happen (see https://github.com/eclipse-zenoh/zenoh/tree/0.11.0?tab=readme-ov-file#plugins). The fact that all plugins of a given `zenoh` version are built with the same packages of the same release `zenohd` is ensured by the `Cargo.lock` files in zenoh repositories, that are appropriately aligned (see for example https://github.com/eclipse-zenoh/zenoh-plugin-webserver/commit/ec2380531d3500606a1afc1819efe8db0b0a277b). So to ensure that all `zenohd` and `zenoh` plugins installed in the same environment are compatible, we created the `zenoh-rust-abi` package on which `zenohd` and all `zenoh` plugins depend. The version of `zenoh-rust-abi` is defined as `{{ zenoh_version }}.{{ rust_compiler_version }}`, ensuring that if necessary a given zenoh release can be compiled for a newer rust compiler version.

An example of the first kind of package is `libzenohc` contained in this PR, it has a run dependency on `zenoh-rust-abi`, but just to ensure that `libzenohc` is installed with a `zenohd` with the same version:

~~~
  run:
    - zenoh-rust-abi {{ version }}.*
~~~



On anothe hand, an example of the second kind of package is `zenoh-plugin-webserver`, that needs to match the ABI that zenohd expects, and so has the following constraint on `zenoh-rust-abi`:
~~~
  host:
    - zenoh-rust-abi {{ version }}.{{ rust_compiler_version }}
~~~
(the hosts dependency becomes a run dependency thanks to `zenoh-rust-abi`'s `run_exports`.

## Alternatives considered

Possible modifications to the packaging strategies that I considered but eventually did not do:
* To avoid to have to manually bump the rust version used in all the packages, I considered that we could build all the `zenoh` packages that need to share the same rust abi (so basically `zenohd` and all the `zenoh-plugin-*` and `zenoh-backend-*` packages) in the same recipe/feedstock. I excluded this in the end as there are many such packages (see https://github.com/search?q=org%3Aeclipse-zenoh+zenoh-plugin&type=repositories and https://github.com/search?q=org%3Aeclipse-zenoh+zenoh-backend&type=repositories) and so it would be eventually be difficult to manage all of them in a single feedstock.
* I tried to avoid hardcoding the `rust_compiler_version` in `conda_build_config.yaml`, but without that I was unable to use the `{{ rust_compiler_version }}` in the recipes, so I found no other solution to be able to compute the version of the `zenoh-rust-abi`.
 
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
