### PR TITLE
 Add recipe for libzenohcxx package 

### DIFF
--- a/recipes/zenoh-cpp/136.patch
+++ b/recipes/zenoh-cpp/136.patch
@@ -1,0 +1,36 @@
+From a64ede9cf4b3a4c78e026d28df3fdbc591dd5340 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Wed, 19 Jun 2024 11:56:47 +0200
+Subject: [PATCH] Rename ambiguous _iter_driver and pair_contained
+
+Signed-off-by: Silvio Traversaro <silvio@traversaro.it>
+---
+ include/zenohcxx/api.hxx | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/include/zenohcxx/api.hxx b/include/zenohcxx/api.hxx
+index c2c341a..8ce2ae2 100644
+--- a/include/zenohcxx/api.hxx
++++ b/include/zenohcxx/api.hxx
+@@ -709,8 +709,8 @@ struct AttachmentView : public Copyable<::z_attachment_t> {
+     AttachmentView(const AttachmentView::IterDriver& _iter_driver)
+         : Copyable({static_cast<const void*>(&_iter_driver),
+                     [](const void* data, z_attachment_iter_body_t body, void* ctx) -> int8_t {
+-                        const IterDriver* _iter_driver = static_cast<const IterDriver*>(data);
+-                        return (*_iter_driver)([&body, &ctx](const BytesView& key, const BytesView& value) {
++                        const IterDriver* _iter_driver_ptr = static_cast<const IterDriver*>(data);
++                        return (*_iter_driver_ptr)([&body, &ctx](const BytesView& key, const BytesView& value) {
+                             return body(key, value, ctx);
+                         });
+                     }}) {}
+@@ -722,8 +722,8 @@ struct AttachmentView : public Copyable<::z_attachment_t> {
+     AttachmentView(const T& pair_container)
+         : Copyable({static_cast<const void*>(&pair_container),
+                     [](const void* data, z_attachment_iter_body_t body, void* ctx) -> int8_t {
+-                        const T* pair_container = static_cast<const T*>(data);
+-                        for (const auto& it : *pair_container) {
++                        const T* pair_container_ptr = static_cast<const T*>(data);
++                        for (const auto& it : *pair_container_ptr) {
+                             int8_t ret = body(BytesView(it.first), BytesView(it.second), ctx);
+                             if (ret) {
+                                 return ret;

--- a/recipes/zenoh-cpp/bld.bat
+++ b/recipes/zenoh-cpp/bld.bat
@@ -1,0 +1,22 @@
+cd .\install
+rmdir /s /q build
+mkdir build
+cd build
+
+% tests are disabled as of 0.11.0 they depend on zenohc's static library
+% switch them on on 1.0.0 as they can be compiled against zenohc's shared library
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTING:BOOL=OFF ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/zenoh-cpp/build.sh
+++ b/recipes/zenoh-cpp/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+cd ./install
+rm -rf build
+mkdir build
+cd build
+
+# tests are disabled as of 0.11.0 they depend on zenohc's static library
+# switch them on on 1.0.0 as they can be compiled against zenohc's shared library
+cmake ${CMAKE_ARGS} -GNinja $SRC_DIR \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING:BOOL=OFF
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/zenoh-cpp/disable_tests_examples_and_docs.patch
+++ b/recipes/zenoh-cpp/disable_tests_examples_and_docs.patch
@@ -1,0 +1,24 @@
+From b648c05f0ebfb540f32df4e4b2102847600cdd8f Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Mon, 23 Sep 2024 22:24:50 +0200
+Subject: [PATCH] Disable tests, examples and docs
+
+---
+ CMakeLists.txt | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ddc12340..0bf197fc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -80,7 +80,7 @@ endif()
+ #
+ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+ 	add_subdirectory(install)
+-	add_subdirectory(tests)
+-	add_subdirectory(examples)
+-	add_subdirectory(docs)
++	#add_subdirectory(tests)
++	#add_subdirectory(examples)
++	#add_subdirectory(docs)
+ endif()

--- a/recipes/zenoh-cpp/disable_zenoh_pico.patch
+++ b/recipes/zenoh-cpp/disable_zenoh_pico.patch
@@ -1,0 +1,21 @@
+From 3cbea9adf2ac56d10a3083a4b82d9953a912c1b9 Mon Sep 17 00:00:00 2001
+From: Silvio Traversaro <silvio@traversaro.it>
+Date: Mon, 23 Sep 2024 22:36:34 +0200
+Subject: [PATCH] Disable zenoh-pico
+
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0bf197f..fcf3aa3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -19,7 +19,7 @@ include(helpers)
+ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+ 	enable_testing()
+ 	set_default_build_type(Release)
+-	configure_include_project(ZENOHCXX_ZENOHPICO zenohpico zenohpico "../zenoh-pico" zenohpico "https://github.com/eclipse-zenoh/zenoh-pico" ${zenoh_pico_branch})
++	#configure_include_project(ZENOHCXX_ZENOHPICO zenohpico zenohpico "../zenoh-pico" zenohpico "https://github.com/eclipse-zenoh/zenoh-pico" ${zenoh_pico_branch})
+ 	configure_include_project(ZENOHCXX_ZENOHC zenohc zenohc::lib "../zenoh-c" zenohc "https://github.com/eclipse-zenoh/zenoh-c" ${zenoh_c_branch})
+ endif()

--- a/recipes/zenoh-cpp/meta.yaml
+++ b/recipes/zenoh-cpp/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "libzenohcxx" %}
+{% set version = "0.11.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/eclipse-zenoh/zenoh-cpp/archive/refs/tags/{{ version }}.tar.gz
+    sha256: 62e9a51ced89130d7a49a1e8f801308338d972e62b90c5224f5801171bd90af0
+    patches:
+      - 136.patch
+      - disable_tests_examples_and_docs.patch
+      - disable_zenoh_pico.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - pkg-config
+    - ninja
+  host:
+    - libzenohc {{ version }}.*
+
+test:
+  commands:
+    - test -f ${PREFIX}/include/zenoh.hxx  # [unix]
+    - if not exist %LIBRARY_PREFIX%\\include\\zenoh.hxx exit 1  # [win]
+    # --disable-double-find passed as a workaround for https://github.com/eclipse-zenoh/zenoh-cpp/pull/232
+    # We need to first call find_package(zenohc) otherwise zenohcxx::zenohc::lib is not defined
+    - cmake-package-check zenohc zenohcxx --targets zenohcxx zenohcxx::zenohc::lib --disable-double-find
+  requires:
+    - cmake-package-check
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+
+about:
+  home: https://github.com/eclipse-zenoh/zenoh-cpp
+  license: Apache-2.0 OR EPL-2.0
+  license_file: LICENSE
+  summary:  C++ API for zenoh
+
+extra:
+  feedstock-name: zenoh-cpp
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
This PR fixes part of https://github.com/conda-forge/staged-recipes/issues/26053 . 

## PR content

This PRs adds some a recipe for the C++ bindings for the Zenoh ecosystem (https://zenoh.io/), it is a follow up of https://github.com/conda-forge/staged-recipes/pull/26736 .

In particular, it contains the a recipe for packages generated from the `zenoh-cpp` repository, that that generate the following packages (structure and naming inspired by the [Debian](https://download.eclipse.org/zenoh/debian-repo/) and [homebrew](https://github.com/eclipse-zenoh/homebrew-zenoh) existing packages):
* `libzenohcxx` package, a header-only C++ library (no rust involved in it), that wraps either the zenoh-c rust library with a C interface packaged in `libzenohc` package, or the zenoh-pico C library (https://github.com/eclipse-zenoh/zenoh-pico, currently not packaged in conda-forge).

As this is an header-only library, there is no rust involved, so `zenoh-rust-abi` package is not used here.
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
