### PR TITLE
Add support for `recipe.yaml` files using rattler-build

### DIFF
--- a/.github/workflows/scripts/.gitignore
+++ b/.github/workflows/scripts/.gitignore
@@ -1,0 +1,4 @@
+# pixi environments
+.pixi
+pixi.toml
+pixi.lock

--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -45,7 +45,8 @@ conda install --yes --quiet \
   "gitpython>=3.0.8,<3.1.20" \
   requests \
   ruamel.yaml \
-  "pygithub>=2.1.1"
+  "pygithub>=2.1.1" \
+  "rattler-build-conda-compat>=0.0.6,<0.1"
 
 conda info
 mamba info


### PR DESCRIPTION
[Support for `recipe.yaml` has landed in `conda-smithy`](https://github.com/conda-forge/conda-smithy/pull/1876). This PR adds detection of `recipe.yaml` if a `meta.yaml` file is not present.

This PR is a draft because we need a new conda-smithy release.
