### PR TITLE
adds r-mendelianrandomization

### DIFF
--- a/recipes/r-mendelianrandomization/bld.bat
+++ b/recipes/r-mendelianrandomization/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mendelianrandomization/build.sh
+++ b/recipes/r-mendelianrandomization/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mendelianrandomization/meta.yaml
+++ b/recipes/r-mendelianrandomization/meta.yaml
@@ -1,0 +1,105 @@
+{% set version = '0.10.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mendelianrandomization
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/MendelianRandomization_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/MendelianRandomization/MendelianRandomization_{{ version }}.tar.gz
+  sha256: 0851e91f826424f20fd4a58348ffe161d147bdc091d24d676e14d4cd6180e13c
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-matrix >=1.2
+    - r-rcpp
+    - r-rcpparmadillo
+    - r-ggplot2 >=1.0.1
+    - r-glmnet
+    - r-iterpc >=0.3
+    - r-knitr
+    - r-numderiv
+    - r-plotly >=3.6.0
+    - r-quantreg >=5.01
+    - r-rjson
+    - r-rmarkdown
+    - r-robustbase >=0.92_6
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-matrix >=1.2
+    - r-rcpp
+    - r-rcpparmadillo
+    - r-ggplot2 >=1.0.1
+    - r-glmnet
+    - r-iterpc >=0.3
+    - r-knitr
+    - r-numderiv
+    - r-plotly >=3.6.0
+    - r-quantreg >=5.01
+    - r-rjson
+    - r-rmarkdown
+    - r-robustbase >=0.92_6
+
+test:
+  commands:
+    - $R -e "library('MendelianRandomization')"           # [not win]
+    - "\"%R%\" -e \"library('MendelianRandomization')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=MendelianRandomization
+  license: GPL-2 | GPL-3
+  summary: Encodes several methods for performing Mendelian randomization analyses with summarized
+    data. Summarized data on genetic associations with the exposure and with the outcome
+    can be obtained from large consortia. These data can be used for obtaining causal
+    estimates using instrumental variable methods.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: MendelianRandomization
+# Type: Package
+# Title: Mendelian Randomization Package
+# Version: 0.10.0
+# Date: 2024-04-12
+# Authors@R: c(person(given="Stephen", family="Burgess", role=c("aut", "cre"), email="sb452@medschl.cam.ac.uk", comment = c(ORCID = "0000-0001-5365-8760")), person(given="Olena", family="Yavorska", role="aut"), person(given="James", family="Staley", role="ctb", comment = c(ORCID = "0009-0001-9520-5011")), person(given="Fernando", family="Hartwig", role="ctb", comment = c(ORCID = "0000-0003-3729-0710")), person(given="Jim", family="Broadbent", role="ctb", comment = c(ORCID = "0000-0002-5685-6241")), person(given="Christopher", family="Foley", role="ctb", comment = c(ORCID = "0000-0002-0970-2610")), person(given="Andrew", family="Grant", role="ctb"), person(given="Amy", family="Mason", role="ctb", comment = c(ORCID = "0000-0002-8019-0777")), person(given="Ting", family="Ye", role="ctb", comment = c(ORCID = "0000-0001-6009-641X")), person(given="Haoran", family="Xue", role="ctb", comment = c(ORCID = "0000-0001-7923-6128")), person(given="Zhaotong", family="Lin", role="ctb", comment = c(ORCID = "0000-0001-8723-4392")), person(given="Siqi", family="Xu", role="ctb"), person(given="Ashish", family="Patel", role="ctb", comment = c(ORCID = "0000-0002-0350-4365")), person(given="Hyunseung", family="Kang", role="ctb"), person(given="Sheng", family="Wang", role="ctb"), person(given="Ville", family="Karhunen", role="ctb", comment = c(ORCID = "0000-0001-6064-1588")))
+# Maintainer: Stephen Burgess <sb452@medschl.cam.ac.uk>
+# Description: Encodes several methods for performing Mendelian randomization analyses with summarized data. Summarized data on genetic associations with the exposure and with the outcome can be obtained from large consortia. These data can be used for obtaining causal estimates using instrumental variable methods.
+# License: GPL-2 | GPL-3
+# Depends: R (>= 3.0.1), methods
+# Imports: knitr, rmarkdown, plotly (>= 3.6.0), ggplot2 (>= 1.0.1), robustbase (>= 0.92-6), Matrix (>= 1.2), iterpc (>= 0.3), quantreg (>= 5.01), rjson, glmnet, numDeriv, Rcpp
+# LinkingTo: Rcpp, RcppArmadillo
+# VignetteBuilder: knitr
+# RoxygenNote: 7.3.1
+# NeedsCompilation: yes
+# Packaged: 2024-04-12 09:48:50 UTC; sb452
+# Author: Stephen Burgess [aut, cre] (<https://orcid.org/0000-0001-5365-8760>), Olena Yavorska [aut], James Staley [ctb] (<https://orcid.org/0009-0001-9520-5011>), Fernando Hartwig [ctb] (<https://orcid.org/0000-0003-3729-0710>), Jim Broadbent [ctb] (<https://orcid.org/0000-0002-5685-6241>), Christopher Foley [ctb] (<https://orcid.org/0000-0002-0970-2610>), Andrew Grant [ctb], Amy Mason [ctb] (<https://orcid.org/0000-0002-8019-0777>), Ting Ye [ctb] (<https://orcid.org/0000-0001-6009-641X>), Haoran Xue [ctb] (<https://orcid.org/0000-0001-7923-6128>), Zhaotong Lin [ctb] (<https://orcid.org/0000-0001-8723-4392>), Siqi Xu [ctb], Ashish Patel [ctb] (<https://orcid.org/0000-0002-0350-4365>), Hyunseung Kang [ctb], Sheng Wang [ctb], Ville Karhunen [ctb] (<https://orcid.org/0000-0001-6064-1588>)
+# Repository: CRAN
+# Date/Publication: 2024-04-12 10:10:02 UTC

--- a/recipes/r-mendelianrandomization/meta.yaml
+++ b/recipes/r-mendelianrandomization/meta.yaml
@@ -21,44 +21,46 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-matrix >=1.2
-    - r-rcpp
-    - r-rcpparmadillo
     - r-ggplot2 >=1.0.1
     - r-glmnet
     - r-iterpc >=0.3
     - r-knitr
+    - r-matrix >=1.2
     - r-numderiv
     - r-plotly >=3.6.0
     - r-quantreg >=5.01
+    - r-rcpp
+    - r-rcpparmadillo
     - r-rjson
     - r-rmarkdown
     - r-robustbase >=0.92_6
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
-    - r-matrix >=1.2
-    - r-rcpp
-    - r-rcpparmadillo
     - r-ggplot2 >=1.0.1
     - r-glmnet
     - r-iterpc >=0.3
     - r-knitr
+    - r-matrix >=1.2
     - r-numderiv
     - r-plotly >=3.6.0
     - r-quantreg >=5.01
+    - r-rcpp
+    - r-rcpparmadillo
     - r-rjson
     - r-rmarkdown
     - r-robustbase >=0.92_6
@@ -70,12 +72,12 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=MendelianRandomization
-  license: GPL-2 | GPL-3
+  license: GPL-2.0-or-later
   summary: Encodes several methods for performing Mendelian randomization analyses with summarized
     data. Summarized data on genetic associations with the exposure and with the outcome
     can be obtained from large consortia. These data can be used for obtaining causal
     estimates using instrumental variable methods.
-  license_family: GPL3
+  license_family: GPL
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'


### PR DESCRIPTION
Adds [CRAN package `MendelianRandomization`](https://cran.r-project.org/package=MendelianRandomization) as `r-mendelianrandomization`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
