### PR TITLE
adds `r-iterpc`

### DIFF
--- a/recipes/r-iterpc/bld.bat
+++ b/recipes/r-iterpc/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-iterpc/build.sh
+++ b/recipes/r-iterpc/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-iterpc/meta.yaml
+++ b/recipes/r-iterpc/meta.yaml
@@ -42,6 +42,7 @@ test:
 
 about:
   home: https://randy3k.github.io/iterpc
+  dev_url: https://github.com/randy3k/iterpc
   license: GPL-2.0-only
   summary: 'Iterator for generating permutations and combinations. They can be either drawn with
     or without replacement, or with distinct/ non-distinct items (multiset). The generated

--- a/recipes/r-iterpc/meta.yaml
+++ b/recipes/r-iterpc/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '0.4.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-iterpc
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/iterpc_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/iterpc/iterpc_{{ version }}.tar.gz
+  sha256: 38bd464042a27536f676e889263eb2c257a431b59083f58cb54473f42ba2071b
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-arrangements >=1.0.0
+    - r-gmp >=0.5_12
+    - r-iterators
+  run:
+    - r-base
+    - r-arrangements >=1.0.0
+    - r-gmp >=0.5_12
+    - r-iterators
+
+test:
+  commands:
+    - $R -e "library('iterpc')"           # [not win]
+    - "\"%R%\" -e \"library('iterpc')\""  # [win]
+
+about:
+  home: https://randy3k.github.io/iterpc
+  license: GPL-2.0-only
+  summary: 'Iterator for generating permutations and combinations. They can be either drawn with
+    or without replacement, or with distinct/ non-distinct items (multiset). The generated
+    sequences are in lexicographical order (dictionary order). The algorithms to generate
+    permutations and combinations are memory efficient. These iterative algorithms enable
+    users to process all sequences without putting all results in the memory at the
+    same time. The algorithms are written in C/C++ for faster performance. Note: ''iterpc''
+    is no longer being maintained. Users are recommended to switch to ''arrangements''.'
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: iterpc
+# Type: Package
+# Title: Efficient Iterator for Permutations and Combinations
+# Version: 0.4.2
+# Date: 2020-01-08
+# Author: Randy Lai [aut, cre]
+# Maintainer: Randy Lai <randy.cs.lai@gmail.com>
+# Authors@R: c( person("Randy", "Lai", , "randy.cs.lai@gmail.com", role = c("aut", "cre")) )
+# Description: Iterator for generating permutations and combinations. They can be either drawn with or without replacement, or with distinct/ non-distinct items (multiset). The generated sequences are in lexicographical order (dictionary order). The algorithms to generate permutations and combinations are memory efficient. These iterative algorithms enable users to process all sequences without putting all results in the memory at the same time. The algorithms are written in C/C++ for faster performance. Note: 'iterpc' is no longer being maintained. Users are recommended to switch to 'arrangements'.
+# URL: https://randy3k.github.io/iterpc
+# License: GPL-2
+# Depends: R (>= 3.0.0)
+# Imports: iterators, gmp (>= 0.5-12), arrangements (>= 1.0.0)
+# Suggests: foreach, testthat, knitr, rmarkdown
+# ByteCompile: yes
+# RoxygenNote: 6.1.1
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2020-01-08 23:22:25 UTC; randy
+# Repository: CRAN
+# Date/Publication: 2020-01-10 12:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `iterpc`](https://cran.r-project.org/package=iterpc) as `r-iterpc`. Recipe generated with `conda_r_skeleton_helper` with dev URL added.

Needed for #26989.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
