### PR TITLE
adds `r-ieugwasr`

### DIFF
--- a/recipes/r-ieugwasr/bld.bat
+++ b/recipes/r-ieugwasr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-ieugwasr/build.sh
+++ b/recipes/r-ieugwasr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-ieugwasr/meta.yaml
+++ b/recipes/r-ieugwasr/meta.yaml
@@ -43,7 +43,8 @@ test:
     - "\"%R%\" -e \"library('ieugwasr')\""  # [win]
 
 about:
-  home: https://github.com/MRCIEU/ieugwasr, https://mrcieu.github.io/ieugwasr/
+  home: https://mrcieu.github.io/ieugwasr/
+  dev_url: https://github.com/MRCIEU/ieugwasr
   license: MIT
   summary: Interface to the 'OpenGWAS' database API <https://gwas-api.mrcieu.ac.uk/>. Includes
     a wrapper to make generic calls to the API, plus convenience functions for specific

--- a/recipes/r-ieugwasr/meta.yaml
+++ b/recipes/r-ieugwasr/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = '1.0.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-ieugwasr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/ieugwasr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/ieugwasr/ieugwasr_{{ version }}.tar.gz
+  sha256: 39dfcc1d90eb71a513f2865f88cf46f4128a44293af146a22ea781b2e5722c4e
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dplyr
+    - r-httr
+    - r-jsonlite
+    - r-magrittr
+  run:
+    - r-base
+    - r-dplyr
+    - r-httr
+    - r-jsonlite
+    - r-magrittr
+
+test:
+  commands:
+    - $R -e "library('ieugwasr')"           # [not win]
+    - "\"%R%\" -e \"library('ieugwasr')\""  # [win]
+
+about:
+  home: https://github.com/MRCIEU/ieugwasr, https://mrcieu.github.io/ieugwasr/
+  license: MIT
+  summary: Interface to the 'OpenGWAS' database API <https://gwas-api.mrcieu.ac.uk/>. Includes
+    a wrapper to make generic calls to the API, plus convenience functions for specific
+    queries.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: ieugwasr
+# Title: Interface to the 'OpenGWAS' Database API
+# Version: 1.0.1
+# Authors@R: c( person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0003-0920-1055")), person("Ben", "Elsworth", , "Ben.Elsworth@bristol.ac.uk", role = "aut", comment = c(ORCID = "0000-0001-7328-4233")), person("Tom", "Palmer", , "tom.palmer@bristol.ac.uk", role = "aut", comment = c(ORCID = "0000-0003-4655-4511")), person("Rita", "Rasteiro", , "rita.rasteiro@bristol.ac.uk", role = "aut", comment = c(ORCID = "0000-0002-4217-3060")) )
+# Description: Interface to the 'OpenGWAS' database API <https://gwas-api.mrcieu.ac.uk/>. Includes a wrapper to make generic calls to the API, plus convenience functions for specific queries.
+# License: MIT + file LICENSE
+# URL: https://github.com/MRCIEU/ieugwasr, https://mrcieu.github.io/ieugwasr/
+# BugReports: https://github.com/MRCIEU/ieugwasr/issues
+# Depends: R (>= 4.0)
+# Imports: dplyr, httr, jsonlite, magrittr, stats
+# Suggests: knitr, utils, rmarkdown, testthat
+# VignetteBuilder: knitr
+# Encoding: UTF-8
+# RoxygenNote: 7.3.1
+# NeedsCompilation: no
+# Packaged: 2024-06-27 19:42:43 UTC; gh13047
+# Author: Gibran Hemani [aut, cre, cph] (<https://orcid.org/0000-0003-0920-1055>), Ben Elsworth [aut] (<https://orcid.org/0000-0001-7328-4233>), Tom Palmer [aut] (<https://orcid.org/0000-0003-4655-4511>), Rita Rasteiro [aut] (<https://orcid.org/0000-0002-4217-3060>)
+# Maintainer: Gibran Hemani <g.hemani@bristol.ac.uk>
+# Repository: CRAN
+# Date/Publication: 2024-07-01 23:10:02 UTC


### PR DESCRIPTION
Adds [CRAN package `ieugwasr`](https://cran.r-project.org/package=ieugwasr) as `r-ieugwasr`. Recipe generated with `conda_r_skeleton_helper` with URLs split.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
