### PR TITLE
adds `r-rworkflows`

### DIFF
--- a/recipes/r-rworkflows/bld.bat
+++ b/recipes/r-rworkflows/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rworkflows/build.sh
+++ b/recipes/r-rworkflows/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rworkflows/meta.yaml
+++ b/recipes/r-rworkflows/meta.yaml
@@ -51,7 +51,7 @@ test:
 about:
   home: https://neurogenomics.github.io/rworkflows/
   dev_url: https://github.com/neurogenomics/rworkflows
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Reproducibility is essential to the progress of research, yet achieving it remains
     elusive even in computational fields. Continuous Integration (CI) platforms offer
     a powerful way to launch automated workflows to check and document code, but often

--- a/recipes/r-rworkflows/meta.yaml
+++ b/recipes/r-rworkflows/meta.yaml
@@ -1,0 +1,93 @@
+{% set version = '1.0.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rworkflows
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rworkflows_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rworkflows/rworkflows_{{ version }}.tar.gz
+  sha256: 0cdfd9e4b89be8a2e054a8bedb879707a50c11e0fda2bfff5cc1cc42593346fb
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-biocmanager
+    - r-badger
+    - r-data.table
+    - r-desc
+    - r-here
+    - r-renv
+    - r-yaml
+  run:
+    - r-base
+    - r-biocmanager
+    - r-badger
+    - r-data.table
+    - r-desc
+    - r-here
+    - r-renv
+    - r-yaml
+
+test:
+  commands:
+    - $R -e "library('rworkflows')"           # [not win]
+    - "\"%R%\" -e \"library('rworkflows')\""  # [win]
+
+about:
+  home: https://github.com/neurogenomics/rworkflows, https://CRAN.R-project.org/package=rworkflows
+  license: GPL-3
+  summary: Reproducibility is essential to the progress of research, yet achieving it remains
+    elusive even in computational fields. Continuous Integration (CI) platforms offer
+    a powerful way to launch automated workflows to check and document code, but often
+    require considerable time, effort, and technical expertise to setup. We therefore
+    developed the rworkflows suite to make robust CI workflows easy and freely accessible
+    to all R package developers. rworkflows consists of 1) a CRAN/Bioconductor-compatible
+    R package template, 2) an R package to quickly implement a standardised workflow,
+    and 3) a centrally maintained GitHub Action.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+# biocViews: Software, WorkflowManagement
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rworkflows
+# Type: Package
+# Title: Test, Document, Containerise, and Deploy R Packages
+# Version: 1.0.1
+# Authors@R: c(person(given = "Brian", family = "Schilder", role = c("aut","cre"), email = "brian_schilder@alumni.brown.edu", comment = c(ORCID = "0000-0001-5949-2191")), person(given = "Alan", family = "Murphy", role = c("aut","ctb"), email = "alanmurph94@hotmail.com", comment = c(ORCID = "0000-0002-2487-8753")), person(given = "Nathan", family = "Skene", role = c("aut"), email = "n.skene@imperial.ac.uk", comment = c(ORCID = "0000-0002-6807-3180")) )
+# Description: Reproducibility is essential to the progress of research, yet achieving it remains elusive even in computational fields. Continuous Integration (CI) platforms offer a powerful way to launch automated workflows to check and document code, but often require considerable time, effort, and technical expertise to setup. We therefore developed the rworkflows suite to make robust CI workflows easy and freely accessible to all R package developers. rworkflows consists of 1) a CRAN/Bioconductor-compatible R package template, 2) an R package to quickly implement a standardised workflow, and 3) a centrally maintained GitHub Action.
+# URL: https://github.com/neurogenomics/rworkflows, https://CRAN.R-project.org/package=rworkflows
+# BugReports: https://github.com/neurogenomics/rworkflows/issues
+# Encoding: UTF-8
+# Depends: R (>= 4.1)
+# Imports: stats, here, yaml, utils, desc, badger, renv, tools, methods, BiocManager, data.table
+# Suggests: markdown, rmarkdown, remotes, knitr, covr, testthat (>= 3.0.0), htmltools, jsonlite, BiocStyle, BiocPkgTools, biocViews, reticulate, rvest
+# VignetteBuilder: knitr
+# License: GPL-3
+# Config/testthat/edition: 3
+# LazyData: true
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Packaged: 2024-01-18 20:41:03 UTC; bms20
+# Author: Brian Schilder [aut, cre] (<https://orcid.org/0000-0001-5949-2191>), Alan Murphy [aut, ctb] (<https://orcid.org/0000-0002-2487-8753>), Nathan Skene [aut] (<https://orcid.org/0000-0002-6807-3180>)
+# Maintainer: Brian Schilder <brian_schilder@alumni.brown.edu>
+# Repository: CRAN
+# Date/Publication: 2024-01-18 21:10:03 UTC

--- a/recipes/r-rworkflows/meta.yaml
+++ b/recipes/r-rworkflows/meta.yaml
@@ -49,7 +49,8 @@ test:
     - "\"%R%\" -e \"library('rworkflows')\""  # [win]
 
 about:
-  home: https://github.com/neurogenomics/rworkflows, https://CRAN.R-project.org/package=rworkflows
+  home: https://neurogenomics.github.io/rworkflows/
+  dev_url: https://github.com/neurogenomics/rworkflows
   license: GPL-3
   summary: Reproducibility is essential to the progress of research, yet achieving it remains
     elusive even in computational fields. Continuous Integration (CI) platforms offer
@@ -61,8 +62,7 @@ about:
     and 3) a centrally maintained GitHub Action.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
-# biocViews: Software, WorkflowManagement
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `rworkflows`](https://cran.r-project.org/package=rworkflows) as `r-rworkflows`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
