### PR TITLE
add `label-studio`

### DIFF
--- a/recipes/attr/meta.yaml
+++ b/recipes/attr/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "attr" %}
+{% set version = "0.3.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/attr-{{ version }}.tar.gz
+  sha256: 1ceebca768181cdcce9827611b1d728e592be5d293911539ea3d0b0bfa1146f4
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - attr
+    - dry_attr
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/denis-ryzhkov/attr
+  summary: Simple decorator to set attributes of target function or class in a DRY way.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - moritzwilksch

--- a/recipes/django-csp/meta.yaml
+++ b/recipes/django-csp/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "django-csp" %}
+{% set version = "3.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/django_csp-{{ version }}.tar.gz
+  sha256: ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - setuptools >=61.2
+    - pip
+  run:
+    - python
+    - django >=3.2
+
+test:
+  imports:
+    - csp
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Django Content Security Policy support.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - moritzwilksch

--- a/recipes/humansignal-drf-yasg/meta.yaml
+++ b/recipes/humansignal-drf-yasg/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "humansignal-drf-yasg" %}
+{% set version = "1.21.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/humansignal-drf-yasg-{{ version }}.tar.gz
+  sha256: bc330542f5a5bf926f993fde3fa111ff45d8d6965fffb6c1d4c39f30edf844a4
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - setuptools >=40.6.3
+    - wheel
+    - setuptools-scm >=3.0.3
+    - pip
+  run:
+    - python >=3.6
+    - djangorestframework >=3.10.3
+    - django >=2.2.16
+    - pyyaml >=5.1
+    - inflection >=0.3.1
+    - packaging >=21.0
+    - pytz >=2021.1
+    - uritemplate >=3.0.0
+
+test:
+  imports:
+    - drf_yasg
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/axnsan12/drf-yasg
+  summary: Automated generation of real Swagger/OpenAPI 2.0 schemas from Django Rest Framework code.
+  license: BSD-4.3TAHOE AND BSD-3-Clause AND Apache-2.0 AND MIT
+  license_file:
+    - LICENSE.rst
+    - src/drf_yasg/static/drf-yasg/redoc-old/LICENSE
+    - src/drf_yasg/static/drf-yasg/redoc/LICENSE
+    - src/drf_yasg/static/drf-yasg/swagger-ui-dist/NOTICE
+    - src/drf_yasg/static/drf-yasg/swagger-ui-dist/LICENSE
+
+extra:
+  recipe-maintainers:
+    - moritzwilksch

--- a/recipes/label-studio-converter/meta.yaml
+++ b/recipes/label-studio-converter/meta.yaml
@@ -1,0 +1,49 @@
+{% set name = "label-studio-converter" %}
+{% set version = "0.0.58" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/label-studio-converter-{{ version }}.tar.gz
+  sha256: 027101d949c42daa630a1900b08185433b3fb45d36217e7b2c25267126c53ee4
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - ujson
+    - ijson
+    - pillow >=10.0.1
+  run:
+    - python >=3.6
+    - pandas >=0.24.0
+    - requests <3,>=2.22.0
+    - pillow >=10.0.1
+    - nltk ==3.6.7
+    - label-studio-tools >=0.0.3
+    - ujson
+
+test:
+  imports:
+    - label_studio_converter
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/heartexlabs/label-studio-converter
+  summary: Format converter add-on for Label Studio
+  license: ''
+  license_file: PLEASE_ADD_LICENSE_FILE
+
+extra:
+  recipe-maintainers:
+    - moritzwilksch

--- a/recipes/label-studio/meta.yaml
+++ b/recipes/label-studio/meta.yaml
@@ -1,0 +1,125 @@
+{% set name = "label-studio" %}
+{% set version = "1.12.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/label_studio-{{ version }}.tar.gz
+  sha256: 12edefd370ac751d5fafa81cd58ea48977d65484a1e63c290764d6726d14ad65
+
+build:
+  entry_points:
+    - label-studio = label_studio.server:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8,<4.0
+    - poetry-core
+    - pip
+  run:
+    - python >=3.8,<4.0
+    - wheel <=0.40.0,>=0.38.1
+    - appdirs >=1.4.3
+    # - attr 0.3.1
+    - attrs >=19.2.0
+    - pyyaml >=6.0.0
+    - azure-storage-blob >=12.6.0
+    - boto >=2.49.0,<3.0.0
+    - boto3 >=1.28.58,<2.0.0
+    - botocore >=1.31.58,<2.0.0
+    - bleach >=5.0.0,<6.0.0
+    - django >=3.2.24,<3.3.0
+    - django-storages 1.12.3
+    - django-annoying 0.10.6
+    - django-debug-toolbar 3.2.1
+    - django-environ 0.10.0
+    - django-filter 2.4.0
+    - django-model-utils >=4.1.1
+    - django-rq 2.5.1
+    - django-cors-headers >=3.6.0
+    - django-extensions 3.1.0
+    - django-user-agents 0.4.0
+    - django-ranged-fileresponse >=0.1.2
+    - drf-dynamic-fields >=0.3.0
+    - djangorestframework 3.13.1
+    - drf-flex-fields >=0.9.5
+    - humansignal-drf-yasg >=1.21.9
+    - drf-generators >=0.3.0
+    - htmlmin 0.1.12
+    - jsonschema 3.2.0
+    - lockfile >=0.12.0
+    - lxml >=4.2.5
+    - defusedxml >=0.7.1
+    - numpy >=1.24.3,<2.0.0
+    - ordered-set 4.0.2
+    - pandas >=0.24.0
+    - psycopg2-binary 2.9.9
+    - pydantic <=1.11.0,>=1.7.3
+    - python-dateutil >=2.8.1
+    - pytz >=2022.1.0,<2022.2.0
+    - requests 2.31.0
+    - urllib3 >=1.26.18,<2.0.0
+    - rq >=1.10.1
+    - rules >=2.2
+    - ujson >=3.0.0
+    - xmljson >=0.2.0
+    - colorama >=0.4.4
+    - boxing >=0.1.4
+    # - redis-py >=3.5.0,<3.6.0
+    - redis-py >=4.0.0
+    - sentry-sdk >=1.1.0
+    - launchdarkly-server-sdk >=8.2.1
+    - python-json-logger 2.0.4
+    - label-studio-converter 0.0.58
+    - google-cloud-storage >=2.13.0,<3.0.0
+    - google-cloud-logging >=3.10.0,<4.0.0
+    - django-csp 3.7
+    - openai >=1.10.0,<2.0.0
+  run_constrained:
+    - mysqlclient *
+
+test:
+  imports:
+    - label_studio
+  commands:
+    - pip check
+    - label-studio --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/heartexlabs/label-studio
+  summary: Label Studio annotation tool
+  license: MIT AND Apache-2.0
+  license_file:
+    - NOTICE
+    - LICENSE
+    - label_studio/core/static_build/drf-yasg/redoc-old/LICENSE.e4e5f59c85dc
+    - label_studio/core/static_build/drf-yasg/redoc-old/LICENSE
+    - label_studio/core/static_build/drf-yasg/redoc/LICENSE
+    - label_studio/core/static_build/drf-yasg/redoc/LICENSE.cf2d48dc6713
+    - label_studio/core/static_build/drf-yasg/swagger-ui-dist/NOTICE.342625133694
+    - label_studio/core/static_build/drf-yasg/swagger-ui-dist/LICENSE.3b83ef96387f
+    - label_studio/core/static_build/drf-yasg/swagger-ui-dist/NOTICE
+    - label_studio/core/static_build/drf-yasg/swagger-ui-dist/LICENSE
+    - label_studio/core/static_build/admin/js/vendor/select2/LICENSE.f94142512c91.md
+    - label_studio/core/static_build/admin/js/vendor/select2/LICENSE.md
+    - label_studio/core/static_build/admin/js/vendor/jquery/LICENSE.75308107741f.txt
+    - label_studio/core/static_build/admin/js/vendor/jquery/LICENSE.txt
+    - label_studio/core/static_build/admin/js/vendor/xregexp/LICENSE.bf79e414957a.txt
+    - label_studio/core/static_build/admin/js/vendor/xregexp/LICENSE.txt
+    - label_studio/core/static_build/admin/fonts/LICENSE.d273d63619c9.txt
+    - label_studio/core/static_build/admin/fonts/LICENSE.txt
+    - label_studio/core/static_build/admin/img/LICENSE.2c54f4e1ca1c
+    - label_studio/core/static_build/admin/img/LICENSE
+    - label_studio/core/static_build/admin/css/vendor/select2/LICENSE-SELECT2.f94142512c91.md
+    - label_studio/core/static_build/admin/css/vendor/select2/LICENSE-SELECT2.md
+
+extra:
+  recipe-maintainers:
+    - moritzwilksch


### PR DESCRIPTION
... and a bunch of its dependencies

this isn't quite there yet. The initial build yields:

```
Could not solve for environment specs
The following packages are incompatible
├─ django-cors-headers 3.6.0.*  does not exist (perhaps a typo or a missing channel);
├─ django-csp 3.7.*  does not exist (perhaps a typo or a missing channel);
├─ django-model-utils 4.1.1.*  does not exist (perhaps a typo or a missing channel);
├─ django-rq 2.5.1.*  does not exist (perhaps a typo or a missing channel);
├─ drf-dynamic-fields 0.3.0.*  does not exist (perhaps a typo or a missing channel);
├─ drf-flex-fields 0.9.5.*  does not exist (perhaps a typo or a missing channel);
├─ drf-generators 0.3.0.*  does not exist (perhaps a typo or a missing channel);
├─ humansignal-drf-yasg >=1.21.9  does not exist (perhaps a typo or a missing channel);
├─ label-studio-converter 0.0.58.*  does not exist (perhaps a typo or a missing channel);
├─ launchdarkly-server-sdk 8.2.1.*  does not exist (perhaps a typo or a missing channel);
├─ rq 1.10.1.*  does not exist (perhaps a typo or a missing channel);
├─ rules 2.2.*  does not exist (perhaps a typo or a missing channel);
└─ xmljson 0.2.0.*  does not exist (perhaps a typo or a missing channel).
```

## Bumps
TBD: does this break everything?
- bump `django-cors-headers >=3.6.0` (older version not on conda forge)
- bump `django-model-utils >= 4.1.1` (`4.1.1` version not on conda forge, `4.0.0` -> `4.3.1`)
- bump `drf-dynamic-fileds >= 0.3.0` (only version on conda forge is `0.4.0`)
- bump `drf-flex-fields >= 0.9.5` (older version not on conda forge, oldest one on CF is `1.0.0`)
- bump `drf-generators >= 0.3.0` (older version not on conda forge, oldest one on CF is `0.5.0`)
- bump `launchdarkly-server-sdk >= 8.2.1` (older version not on conda forge, oldest one on CF is `9.0.0`)
- bump `rq >= 1.10.1` (`1.10.1` version not on conda forge, `1.9.0` -> `1.15.1`)
- bump `rules >= 2.2.*` (older version not on conda forge, oldest one on CF is `3.3`)
- bump `xmljson >= 0.2.0` (older version not on conda forge, oldest one on CF is `0.2.1`)
- bump `redis-py >=3.5.0,<3.6.0` to `>= 4.0.0` due to minimum requirements by `rq`
## Blockers
- `django-rq` feedstock has not been updated for years, maintainers unresponsive
	- add maintainer: https://github.com/conda-forge/django-rq-feedstock/issues/13
- `label-studio-convert` doesn't build yet
## To Check
- `humansignal-drf-yasg` is a weird release of https://github.com/axnsan12/drf-yasg?


<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

## Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
