### PR TITLE
added endf package

### DIFF
--- a/recipes/endf/meta.yaml
+++ b/recipes/endf/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "endf" %}
+{% set version = "0.1.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/endf-{{ version }}.tar.gz
+  sha256: f93ca71e612be5fc7dff3bddd4b29891efb3bc105f55e342b41cb1233ce1d780
+
+build:
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ compiler('c') }}
+  host:
+    - python >=3.8
+    - setuptools >=61
+    - pybind11 >=2.10.0
+    - setuptools-scm >=6.0
+    - pip
+  run:
+    - python >=3.8
+    - numpy
+    - uncertainties
+
+test:
+  imports:
+    - endf
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Python interface to ENDF-6 files
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - paulromano
+    - shimwell

--- a/recipes/endf/meta.yaml
+++ b/recipes/endf/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pip
 
 about:
-  home: https://openmc.org/
+  home: https://github.com/paulromano/endf-python
   summary: Python interface to ENDF-6 files
   license: MIT
   license_file: LICENSE

--- a/recipes/endf/meta.yaml
+++ b/recipes/endf/meta.yaml
@@ -18,14 +18,15 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ compiler('c') }}
+    - {{ stdlib("c") }}
   host:
-    - python >=3.8
-    - setuptools >=61
-    - pybind11 >=2.10.0
-    - setuptools-scm >=6.0
+    - python
+    - setuptools
+    - pybind11
+    - setuptools-scm
     - pip
   run:
-    - python >=3.8
+    - python
     - numpy
     - uncertainties
 
@@ -38,6 +39,7 @@ test:
     - pip
 
 about:
+  home: https://openmc.org/
   summary: Python interface to ENDF-6 files
   license: MIT
   license_file: LICENSE


### PR DESCRIPTION
Dear Conda forge maintainers please consider this PR that adds the python package ```endf``` to the conda forge channel.

This package is very useful for opening and parsing endf files.

It would be particularly good to add this package to conda forge as openmc would then be able to make use this package as a dependency and openmc is already on conda forge so it would be very useful if this potential future dependence is also on conda-forge.

[greytskull](https://github.com/conda/grayskull) was used to generate the meta.yaml

@paulromano hope you don't mind me making a conda forge package for this, I've added you to the maintainers in the meta.yaml if that is ok?

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
