### PR TITLE
Fix CI failing in every PR

### DIFF
--- a/.ci_support/requirements.txt
+++ b/.ci_support/requirements.txt
@@ -1,6 +1,6 @@
 conda>=23.7.3
 conda-libmamba-solver>=23.7.0
-conda-build>=24.3
+conda-build>=24.3,<24.7
 conda-index>=0.3.0
 conda-forge-ci-setup=4.*
 conda-forge-pinning


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Fix staged-reciped CI failing on every PR by pinning conda_build to <24.7.
[.ci_support/compute_build_graph.py](https://github.com/conda-forge/staged-recipes/blob/main/.ci_support/compute_build_graph.py) import `HashableDict` from conda_build. This has been [removed](https://github.com/conda/conda-build/pull/5333) in 24.7 and has been deprecated since 24.5. They recommend using `frozendict` instead.
Until the code has been updated to not use `HashableDict` we can just pin `conda_build` to an older version.

I don't have permission to add the `maintainance` tag to this PR, so linter complains about changing non-recipe files.

Closes https://github.com/conda-forge/conda-forge-ci-setup-feedstock/issues/332