### PR TITLE
CRYSTALpytools initial release on conda-forge

### DIFF
--- a/recipes/CRYSTALpytools/LICENSE.txt
+++ b/recipes/CRYSTALpytools/LICENSE.txt
@@ -1,0 +1,7 @@
+The MIT License (MIT) Copyright (c) 2011-2012 MIT & The Regents of the University of California, through Lawrence Berkeley National Laboratory
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/CRYSTALpytools/LICENSE.txt
+++ b/recipes/CRYSTALpytools/LICENSE.txt
@@ -1,7 +1,0 @@
-The MIT License (MIT) Copyright (c) 2011-2012 MIT & The Regents of the University of California, through Lawrence Berkeley National Laboratory
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -15,18 +15,9 @@ build:
 
 requirements:
   host:
-    - ase >=3.22.1
-    - basis_set_exchange >=0.9.1
-    - matplotlib-base
-    - mendeleev >=0.14.0
-    - numpy <2.0
-    - pandas
+    - python >=3.7
+    - setuptools >=43.0
     - pip
-    - pymatgen >=2022.7.25
-    - python ==3.9
-    - pyyaml
-    - scipy <1.14.0
-    - sympy
   run:
     - ase >=3.22.1
     - basis_set_exchange >=0.9.1

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -37,7 +37,7 @@ test:
     - CRYSTALpytools.base
 
 about:
-  home: "https://github.com/crystal-code-tools/CRYSTALpytools"
+  home: https://github.com/crystal-code-tools/CRYSTALpytools
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: "{{ version }}"
 
 source:
-  url: "https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz"
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
   sha256: dd473bde720062931f35abd34881ddf490e83bf9b184a75851998f9c23a61b05
 
 build:

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -2,46 +2,51 @@
 {% set version = "2024.8.15" %}
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/crystalpytools-{{ version }}.tar.gz
   sha256: dd473bde720062931f35abd34881ddf490e83bf9b184a75851998f9c23a61b05
 
 build:
-  number: 0
+  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
 
 requirements:
   host:
     - python >=3.7
     - setuptools >=43.0
+    - wheel
     - pip
   run:
+    - python >=3.7
+    - numpy <2.0
+    - sympy
+    - scipy <1.14.0
+    - matplotlib-base
+    - pandas
+    - pyyaml
+    - mendeleev >=0.14.0
+    - pymatgen >=2022.7.25
     - ase >=3.22.1
     - basis_set_exchange >=0.9.1
-    - matplotlib-base
-    - mendeleev >=0.14.0
-    - numpy <2.0
-    - pandas
-    - pymatgen >=2022.7.25
-    - python =>3.7
-    - pyyaml
-    - scipy <1.14.0
-    - sympy
 
 test:
   imports:
     - CRYSTALpytools
-    - CRYSTALpytools.base
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/crystal-code-tools/CRYSTALpytools
+  summary: Python tools for the CRYSTAL code developed and mantained by the CRYSTAL code developers.
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: Python tools for the CRYSTAL code developed and mantained by the CRYSTAL code developers.
   doc_url: https://crystal-code-tools.github.io/CRYSTALpytools/
   dev_url: https://github.com/crystal-code-tools/CRYSTALpytools
 

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -41,7 +41,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
-  summary: "Python tools for the CRYSTAL code developed and mantained by the CRYSTAL code developers."
+  summary: Python tools for the CRYSTAL code developed and mantained by the CRYSTAL code developers.
   doc_url: https://crystal-code-tools.github.io/CRYSTALpytools/
   dev_url: https://github.com/crystal-code-tools/CRYSTALpytools
 

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -17,25 +17,25 @@ requirements:
   host:
     - ase >=3.22.1
     - basis_set_exchange >=0.9.1
-    - matplotlib
+    - matplotlib-base
     - mendeleev >=0.14.0
     - numpy <2.0
     - pandas
     - pip
     - pymatgen >=2022.7.25
-    - python==3.9
+    - python ==3.9
     - pyyaml
     - scipy <1.14.0
     - sympy
   run:
     - ase >=3.22.1
     - basis_set_exchange >=0.9.1
-    - matplotlib
+    - matplotlib-base
     - mendeleev >=0.14.0
     - numpy <2.0
     - pandas
     - pymatgen >=2022.7.25
-    - python==3.9
+    - python ==3.9
     - pyyaml
     - scipy <1.14.0
     - sympy

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "CRYSTALpytools" %}
+{% set version = "2024.8.15" %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  url: "https://pypi.io/packages/source/{{ name[0]|lower }}/{{ name|lower }}/{{ name|lower }}-{{ version }}.tar.gz"
+  sha256: dd473bde720062931f35abd34881ddf490e83bf9b184a75851998f9c23a61b05
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
+
+requirements:
+  host:
+    - ase >=3.22.1
+    - basis_set_exchange >=0.9.1
+    - matplotlib
+    - mendeleev >=0.14.0
+    - numpy <2.0
+    - pandas
+    - pip
+    - pymatgen >=2022.7.25
+    - python==3.9
+    - pyyaml
+    - scipy <1.14.0
+    - sympy
+  run:
+    - ase >=3.22.1
+    - basis_set_exchange >=0.9.1
+    - matplotlib
+    - mendeleev >=0.14.0
+    - numpy <2.0
+    - pandas
+    - pymatgen >=2022.7.25
+    - python==3.9
+    - pyyaml
+    - scipy <1.14.0
+    - sympy
+
+test:
+  imports:
+    - CRYSTALpytools
+    - CRYSTALpytools.base
+
+about:
+  home: "https://github.com/crystal-code-tools/CRYSTALpytools"
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: "Python tools for the CRYSTAL code developed and mantained by the CRYSTAL code developers."
+  doc_url: https://crystal-code-tools.github.io/CRYSTALpytools/
+  dev_url: https://github.com/crystal-code-tools/CRYSTALpytools
+
+extra:
+  recipe-maintainers:
+    - crystal-code-tools

--- a/recipes/CRYSTALpytools/meta.yaml
+++ b/recipes/CRYSTALpytools/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - numpy <2.0
     - pandas
     - pymatgen >=2022.7.25
-    - python ==3.9
+    - python =>3.7
     - pyyaml
     - scipy <1.14.0
     - sympy


### PR DESCRIPTION
@conda-forge-admin,  please ping team
@conda-forge/python-helper

To whom it may concern, 

CRYSTALpytools has been released on PyPI and now doing its release on conda-forge. Recipe and licence files are attached. It is purely based on Python.

Kind regards
CRYSTALpytools developing team