### PR TITLE
adds `r-truncexpfam`

### DIFF
--- a/recipes/r-truncexpfam/bld.bat
+++ b/recipes/r-truncexpfam/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-truncexpfam/build.sh
+++ b/recipes/r-truncexpfam/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-truncexpfam/meta.yaml
+++ b/recipes/r-truncexpfam/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '1.1.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-truncexpfam
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/TruncExpFam_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/TruncExpFam/TruncExpFam_{{ version }}.tar.gz
+  sha256: caf776f70573d65ae304749f5e821b7fe7c020095a8dccab82d7055cb6a3bb78
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-invgamma
+    - r-rmutil
+  run:
+    - r-base
+    - r-invgamma
+    - r-rmutil
+
+test:
+  commands:
+    - $R -e "library('TruncExpFam')"           # [not win]
+    - "\"%R%\" -e \"library('TruncExpFam')\""  # [win]
+
+about:
+  home: https://ocbe-uio.github.io/TruncExpFam/
+  license: GPL-3
+  summary: Handles truncated members from the exponential family of probability distributions.
+    Contains functions such as rtruncnorm() and dtruncpois(), which are truncated versions
+    of rnorm() and dpois() from the stats package that also offer richer output containing,
+    for example, the distribution parameters. It also provides functions to retrieve
+    the original distribution parameters from a truncated sample by maximum-likelihood
+    estimation.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: TruncExpFam
+# Title: Truncated Exponential Family
+# Version: 1.1.1
+# Date: 2024-02-26
+# Authors@R: c( person( given = "Rene", family = "Holst", role = "aut", email = "rene.holst@medisin.uio.no" ), person( given = "Waldir", family = "Leoncio", role = c("cre", "aut"), email = "w.l.netto@medisin.uio.no" ) )
+# Description: Handles truncated members from the exponential family of probability distributions. Contains functions such as rtruncnorm() and dtruncpois(), which are truncated versions of rnorm() and dpois() from the stats package that also offer richer output containing, for example, the distribution parameters. It also provides functions to retrieve the original distribution parameters from a truncated sample by maximum-likelihood estimation.
+# License: GPL-3
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: methods, invgamma, rmutil
+# Suggests: knitr, rmarkdown, testthat
+# URL: https://ocbe-uio.github.io/TruncExpFam/
+# BugReports: https://github.com/ocbe-uio/TruncExpFam/issues
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2024-02-26 15:11:48 UTC; waldir
+# Author: Rene Holst [aut], Waldir Leoncio [cre, aut]
+# Maintainer: Waldir Leoncio <w.l.netto@medisin.uio.no>
+# Repository: CRAN
+# Date/Publication: 2024-02-26 15:30:02 UTC

--- a/recipes/r-truncexpfam/meta.yaml
+++ b/recipes/r-truncexpfam/meta.yaml
@@ -44,6 +44,7 @@ test:
 
 about:
   home: https://ocbe-uio.github.io/TruncExpFam/
+  dev_url: https://github.com/ocbe-uio/TruncExpFam
   license: GPL-3
   summary: Handles truncated members from the exponential family of probability distributions.
     Contains functions such as rtruncnorm() and dtruncpois(), which are truncated versions
@@ -53,7 +54,7 @@ about:
     estimation.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-truncexpfam/meta.yaml
+++ b/recipes/r-truncexpfam/meta.yaml
@@ -45,7 +45,7 @@ test:
 about:
   home: https://ocbe-uio.github.io/TruncExpFam/
   dev_url: https://github.com/ocbe-uio/TruncExpFam
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Handles truncated members from the exponential family of probability distributions.
     Contains functions such as rtruncnorm() and dtruncpois(), which are truncated versions
     of rnorm() and dpois() from the stats package that also offer richer output containing,


### PR DESCRIPTION
Adds [CRAN package `TruncExpFam`](https://cran.r-project.org/package=TruncExpFam) as `r-truncexpfam`. Recipe generated with `conda_r_skeleton_helper`, with license conformed to SPDX and added dev URL.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
