### PR TITLE
adds `r-shinycyjs`

### DIFF
--- a/recipes/r-shinycyjs/bld.bat
+++ b/recipes/r-shinycyjs/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-shinycyjs/build.sh
+++ b/recipes/r-shinycyjs/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-shinycyjs/meta.yaml
+++ b/recipes/r-shinycyjs/meta.yaml
@@ -1,0 +1,76 @@
+{% set version = '1.0.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-shinycyjs
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/shinyCyJS_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/shinyCyJS/shinyCyJS_{{ version }}.tar.gz
+  sha256: c65bb019369ce4c7d096e3cadae15a2daa616e1d38bdc9411f613c1fcf94f9f5
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-htmlwidgets
+  run:
+    - r-base
+    - r-htmlwidgets
+
+test:
+  commands:
+    - $R -e "library('shinyCyJS')"           # [not win]
+    - "\"%R%\" -e \"library('shinyCyJS')\""  # [win]
+
+about:
+  home: https://github.com/jhk0530/shinyCyJS
+  license: MIT
+  summary: Create Interactive Graph (Network) Visualizations. 'shinyCyJS' can be used in 'Shiny'
+    apps or viewed from 'Rstudio' Viewer. 'shinyCyJS' includes API to build Graph model
+    like node or edge with customized attributes for R. 'shinyCyJS' is built with 'cytoscape.js'
+    and 'htmlwidgets' R package.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: shinyCyJS
+# Title: Create Interactive Network Visualizations in R and 'shiny'
+# Version: 1.0.0
+# Authors@R: c( person("Jinhwan", "Kim", , email = "hwanistic@gmail.com", role = c("aut", "cre", "cph")) )
+# Description: Create Interactive Graph (Network) Visualizations. 'shinyCyJS' can be used in 'Shiny' apps or viewed from 'Rstudio' Viewer. 'shinyCyJS' includes API to build Graph model like node or edge with customized attributes for R. 'shinyCyJS' is built with 'cytoscape.js' and 'htmlwidgets' R package.
+# License: MIT + file LICENSE
+# URL: https://github.com/jhk0530/shinyCyJS
+# BugReports: https://github.com/jhk0530/shinyCyJS/issues
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: htmlwidgets
+# Suggests: testthat (>= 2.1.0), rmarkdown
+# NeedsCompilation: no
+# Packaged: 2023-09-26 01:56:42 UTC; jinhwan
+# Author: Jinhwan Kim [aut, cre, cph]
+# Maintainer: Jinhwan Kim <hwanistic@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-09-26 02:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `shinyCyJS`](https://cran.r-project.org/package=shinyCyJS) as `r-shinycyjs`. Recipe generated with `conda_r_skeleton_helper`.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
