### PR TITLE
adds `r-dashboardthemes`

### DIFF
--- a/recipes/r-dashboardthemes/bld.bat
+++ b/recipes/r-dashboardthemes/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dashboardthemes/build.sh
+++ b/recipes/r-dashboardthemes/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dashboardthemes/meta.yaml
+++ b/recipes/r-dashboardthemes/meta.yaml
@@ -1,0 +1,78 @@
+{% set version = '1.1.6' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-dashboardthemes
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/dashboardthemes_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/dashboardthemes/dashboardthemes_{{ version }}.tar.gz
+  sha256: cc80bcd4b66d2418fe08636a25425083574d406e4bd9dfa8d170663aeb23717a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-htmltools >=0.3.5
+  run:
+    - r-base
+    - r-htmltools >=0.3.5
+
+test:
+  commands:
+    - $R -e "library('dashboardthemes')"           # [not win]
+    - "\"%R%\" -e \"library('dashboardthemes')\""  # [win]
+
+about:
+  home: https://github.com/nik01010/dashboardthemes
+  license: MIT
+  summary: Allows manual creation of themes and logos to be used in applications created using
+    the 'shinydashboard' package. Removes the need to change the underlying css code
+    by wrapping it into a set of convenient R functions.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: dashboardthemes
+# Type: Package
+# Title: Customise the Appearance of 'shinydashboard' Applications using Themes
+# Version: 1.1.6
+# Authors@R: person("Nik", "Lilovski", email = "nik.lilovski@outlook.com", role = c("aut", "cre"))
+# Maintainer: Nik Lilovski <nik.lilovski@outlook.com>
+# Description: Allows manual creation of themes and logos to be used in applications created using the 'shinydashboard' package. Removes the need to change the underlying css code by wrapping it into a set of convenient R functions.
+# URL: https://github.com/nik01010/dashboardthemes
+# BugReports: https://github.com/nik01010/dashboardthemes/issues
+# Depends: R (>= 3.2.3)
+# Imports: htmltools (>= 0.3.5)
+# Suggests: testthat, lintr, knitr, rmarkdown, glue, covr
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# RoxygenNote: 7.2.0
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2022-07-13 17:57:45 UTC; Nik
+# Author: Nik Lilovski [aut, cre]
+# Repository: CRAN
+# Date/Publication: 2022-07-13 18:20:02 UTC


### PR DESCRIPTION
Adds [CRAN package `dashboardthemes`](https://cran.r-project.org/package=dashboardthemes) as `r-dashboardthemes`. Recipe generated with `conda_r_skeleton_helper`.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
