### PR TITLE
adds `r-tidydr`

### DIFF
--- a/recipes/r-tidydr/bld.bat
+++ b/recipes/r-tidydr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tidydr/build.sh
+++ b/recipes/r-tidydr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tidydr/meta.yaml
+++ b/recipes/r-tidydr/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = '0.0.5' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tidydr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/tidydr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/tidydr/tidydr_{{ version }}.tar.gz
+  sha256: 3c72a53922365a043f34bf50ecfaf9f0ab332a13c17d0910199ca948da826f9b
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-ggfun
+    - r-ggplot2
+    - r-rlang
+  run:
+    - r-base
+    - r-ggfun
+    - r-ggplot2
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('tidydr')"           # [not win]
+    - "\"%R%\" -e \"library('tidydr')\""  # [win]
+
+about:
+  home: https://github.com/YuLab-SMU/tidydr/
+  license: Artistic-2.0
+  summary: Dimensionality reduction (DR) is widely used in many domain for analyzing and visualizing
+    high-dimensional data. 'tidydr' provides uniform output and is compatible with multiple
+    methods, including 'prcomp', 'mds', 'Rtsne'. etc.
+  license_family: OTHER
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/Artistic-2.0'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: tidydr
+# Title: Unify Dimensionality Reduction Results
+# Version: 0.0.5
+# Authors@R: c( person("Guangchuang", "Yu", , "guangchuangyu@gmail.com", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781")), person("Shuangbin", "Xu", , "xshuangbin@163.com", role = "aut", comment = c(ORCID = "0000-0003-3513-5362")), person("Erqiang", "Hu", , "13766876214@163.com", role = "ctb") )
+# Description: Dimensionality reduction (DR) is widely used in many domain for analyzing and visualizing high-dimensional data. 'tidydr' provides uniform output and is compatible with multiple methods, including 'prcomp', 'mds', 'Rtsne'. etc.
+# Imports: ggfun, ggplot2, grid, rlang, utils
+# Suggests: knitr, rmarkdown, prettydoc, SingleCellExperiment, SummarizedExperiment
+# VignetteBuilder: knitr
+# ByteCompile: true
+# License: Artistic-2.0
+# URL: https://github.com/YuLab-SMU/tidydr/
+# BugReports: https://github.com/YuLab-SMU/tidydr/issues
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# NeedsCompilation: no
+# Packaged: 2023-03-08 08:44:33 UTC; ygc
+# Author: Guangchuang Yu [aut, cre, cph] (<https://orcid.org/0000-0002-6485-8781>), Shuangbin Xu [aut] (<https://orcid.org/0000-0003-3513-5362>), Erqiang Hu [ctb]
+# Maintainer: Guangchuang Yu <guangchuangyu@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-03-08 09:20:02 UTC


### PR DESCRIPTION
Adds [CRAN package `tidydr`](https://cran.r-project.org/package=tidydr) as `r-tidydr`. Recipe generated with `conda_r_skeleton_helper`.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
