### PR TITLE
adds `r-microbiomestat`

### DIFF
--- a/recipes/r-microbiomestat/bld.bat
+++ b/recipes/r-microbiomestat/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-microbiomestat/build.sh
+++ b/recipes/r-microbiomestat/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-microbiomestat/meta.yaml
+++ b/recipes/r-microbiomestat/meta.yaml
@@ -14,6 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
+  noarch: generic
   number: 0
   rpaths:
     - lib/R/lib/
@@ -29,23 +30,23 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-mass
-    - r-matrix
     - r-foreach
     - r-ggplot2
     - r-ggrepel
     - r-lmertest
+    - r-mass
+    - r-matrix
     - r-matrixstats
     - r-modeest
     - r-statmod
   run:
     - r-base
-    - r-mass
-    - r-matrix
     - r-foreach
     - r-ggplot2
     - r-ggrepel
     - r-lmertest
+    - r-mass
+    - r-matrix
     - r-matrixstats
     - r-modeest
     - r-statmod
@@ -57,14 +58,14 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=MicrobiomeStat
-  license: GPL-3
+  license: GPL-3.0-only
   summary: A suite of methods for powerful and robust microbiome data analysis addressing zero-inflation,
     phylogenetic structure and compositional effects (Zhou et al. (2022)<doi:10.1186/s13059-022-02655-5>).  The
     methods can be applied to the analysis of other (high-dimensional) compositional
     data arising from sequencing experiments.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-microbiomestat/meta.yaml
+++ b/recipes/r-microbiomestat/meta.yaml
@@ -1,0 +1,89 @@
+{% set version = '1.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-microbiomestat
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/MicrobiomeStat_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/MicrobiomeStat/MicrobiomeStat_{{ version }}.tar.gz
+  sha256: f851d71a008a768457a3c8ea797406dd03abfa1bcee4e33b01610e433532ecce
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-mass
+    - r-matrix
+    - r-foreach
+    - r-ggplot2
+    - r-ggrepel
+    - r-lmertest
+    - r-matrixstats
+    - r-modeest
+    - r-statmod
+  run:
+    - r-base
+    - r-mass
+    - r-matrix
+    - r-foreach
+    - r-ggplot2
+    - r-ggrepel
+    - r-lmertest
+    - r-matrixstats
+    - r-modeest
+    - r-statmod
+
+test:
+  commands:
+    - $R -e "library('MicrobiomeStat')"           # [not win]
+    - "\"%R%\" -e \"library('MicrobiomeStat')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=MicrobiomeStat
+  license: GPL-3
+  summary: A suite of methods for powerful and robust microbiome data analysis addressing zero-inflation,
+    phylogenetic structure and compositional effects (Zhou et al. (2022)<doi:10.1186/s13059-022-02655-5>).  The
+    methods can be applied to the analysis of other (high-dimensional) compositional
+    data arising from sequencing experiments.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: MicrobiomeStat
+# Type: Package
+# Title: Statistical Methods for Microbiome Compositional Data
+# Version: 1.2
+# Date: 2024-03-13
+# Authors@R: c( person("Xianyang", "Zhang", role = "aut", email = "zhangxiany@stat.tamu.edu"), person("Jun", "Chen", role = c("aut", "cre"), email = "chen.jun2@mayo.edu"), person("Huijuan", "Zhou", role = "ctb"))
+# Author: Xianyang Zhang [aut], Jun Chen [aut, cre], Huijuan Zhou [ctb]
+# Maintainer: Jun Chen <chen.jun2@mayo.edu>
+# Description: A suite of methods for powerful and robust microbiome data analysis addressing zero-inflation, phylogenetic structure and compositional effects (Zhou et al. (2022)<doi:10.1186/s13059-022-02655-5>).  The methods can be applied to the analysis of other (high-dimensional) compositional data arising from sequencing experiments.
+# Depends: R (>= 3.5.0)
+# Imports: ggplot2, matrixStats, parallel, stats, utils, Matrix, statmod, MASS, ggrepel, lmerTest, foreach, modeest
+# NeedsCompilation: yes
+# License: GPL-3
+# Encoding: UTF-8
+# Packaged: 2024-04-01 22:00:40 UTC; m123485
+# Repository: CRAN
+# Date/Publication: 2024-04-01 22:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `MicrobiomeStat`](https://cran.r-project.org/package=MicrobiomeStat) as `r-microbiomestat`. Recipe generated with `conda_r_skeleton_helper` with license conformed to SPDX. Note that while this package has `NeedsCompilation: yes`, there is no `src/` directory, so I think that is an error in the metadata and is actually `noarch`.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
