### PR TITLE
adds `r-rbeta2009`

### DIFF
--- a/recipes/r-rbeta2009/bld.bat
+++ b/recipes/r-rbeta2009/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rbeta2009/build.sh
+++ b/recipes/r-rbeta2009/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rbeta2009/meta.yaml
+++ b/recipes/r-rbeta2009/meta.yaml
@@ -15,7 +15,6 @@ source:
 build:
   merge_build_host: True  # [win]
   number: 0
-  noarch: generic
   rpaths:
     - lib/R/lib/
     - lib/
@@ -26,8 +25,18 @@ build:
 
 requirements:
   build:
-    - {{ posix }}zip               # [win]
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib("c") }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib("m2w64_c") }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
   host:
     - r-base
   run:

--- a/recipes/r-rbeta2009/meta.yaml
+++ b/recipes/r-rbeta2009/meta.yaml
@@ -1,0 +1,66 @@
+{% set version = '1.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-rbeta2009
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rBeta2009_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rBeta2009/rBeta2009_{{ version }}.tar.gz
+  sha256: d8be1df85ff880a2849013b0c4ab80138b1ae32273e803a9196a25db2ced5f52
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('rBeta2009')"           # [not win]
+    - "\"%R%\" -e \"library('rBeta2009')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=rBeta2009
+  license: GPL-2.0-only
+  summary: The package contains functions to generate random numbers from the beta distribution
+    and random vectors from the Dirichlet distribution.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rBeta2009
+# Type: Package
+# Title: The Beta Random Number and Dirichlet Random Vector Generating Functions
+# Version: 1.0
+# Date: 2012-02-25
+# Author: Ching-Wei Cheng, Ying-Chao Hung, Narayanaswamy Balakrishnan
+# Maintainer: Ching-Wei Cheng <aks43725@gmail.com>
+# Description: The package contains functions to generate random numbers from the beta distribution and random vectors from the Dirichlet distribution.
+# License: GPL-2
+# LazyLoad: yes
+# Packaged: 2012-03-01 09:14:15 UTC; Cheng
+# Repository: CRAN
+# Date/Publication: 2012-03-01 09:33:12


### PR DESCRIPTION
Adds [CRAN package `rBeta2009`](https://cran.r-project.org/package=rBeta2009) as `r-rbeta2009`. Recipe generated with `conda_r_skeleton_helper`. The DESCRIPTION does not list `NeedsCompilation: yes`, however it does contain `src/` and CRAN logs show compilation, so recipe is adjusted for compilation.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
