### PR TITLE
adds `r-mwcsr`

### DIFF
--- a/recipes/r-mwcsr/bld.bat
+++ b/recipes/r-mwcsr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mwcsr/build.sh
+++ b/recipes/r-mwcsr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mwcsr/meta.yaml
+++ b/recipes/r-mwcsr/meta.yaml
@@ -23,25 +23,29 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - r-igraph                     # [build_platform != target_platform]
+    - r-rcpp                       # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-rcpp
     - r-igraph
+    - r-rcpp
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
-    - r-rcpp
     - r-igraph
+    - r-rcpp
 
 test:
   commands:

--- a/recipes/r-mwcsr/meta.yaml
+++ b/recipes/r-mwcsr/meta.yaml
@@ -1,0 +1,91 @@
+{% set version = '0.1.8' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mwcsr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:     {{ cran_mirror }}/src/contrib/Archive/mwcsr/mwcsr_{{ version }}.tar.gz
+  sha256: 170d312ec68905c86e760551d7a35db8bce8246ace6a2ec5405530040eefdb6f
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp
+    - r-igraph
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-igraph
+
+test:
+  commands:
+    - $R -e "library('mwcsr')"           # [not win]
+    - "\"%R%\" -e \"library('mwcsr')\""  # [win]
+
+about:
+  home: https://github.com/ctlab/mwcsr
+  license: MIT
+  summary: "Algorithms for solving various Maximum Weight Connected Subgraph Problems, including
+    variants with budget constraints, cardinality constraints, weighted edges and signals.
+    The package represents an R interface to high-efficient solvers based on relax-and-cut
+    approach (\xC1lvarez-Miranda E., Sinnl M. (2017) <doi:10.1016/j.cor.2017.05.015>)
+    mixed-integer programming (Loboda A., Artyomov M., and Sergushichev A. (2016) <doi:10.1007/978-3-319-43681-4_17>)
+    and simulated annealing."
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: mwcsr
+# Title: Solvers for Maximum Weight Connected Subgraph Problem and Its Variants
+# Version: 0.1.8
+# Authors@R: c(person("Alexander", "Loboda", email = "aleks.loboda@gmail.com", role = c("aut", "cre")), person("Nikolay", "Poperechnyi", email = "n.poperechnyi@gmail.com", role = "aut"), person("Eduardo", "Alvarez-Miranda", email = "ealvarez@utalca.cl", role = "aut"), person("Markus", "Sinnl", email = "markus.sinnl@univie.ac.at", role = "aut"), person("Alexey", "Sergushichev", email = "alsergbox@gmail.com", role = "aut"), person("Paul", "Hosler Jr.", role = "cph", comment = "Bundled JOpt Simple package"), person("www.hamcrest.org", role = "cph", comment = "Bundled hamcrest package"), person("Barak Naveh and Contributors", role = "cph", comment = "Bundled JGraphT package"), person("The Apache Software Foundation", role = "cph", comment = "Bundled Apache Commons Math package"))
+# Description: Algorithms for solving various Maximum Weight Connected Subgraph Problems, including variants with budget constraints, cardinality constraints, weighted edges and signals. The package represents an R interface to high-efficient solvers based on relax-and-cut approach (Alvarez-Miranda E., Sinnl M. (2017) <doi:10.1016/j.cor.2017.05.015>) mixed-integer programming (Loboda A., Artyomov M., and Sergushichev A. (2016) <doi:10.1007/978-3-319-43681-4_17>) and simulated annealing.
+# Depends: R (>= 3.5)
+# Imports: methods, igraph, Rcpp
+# Suggests: knitr, rmarkdown, mathjaxr, testthat, BioNet, roxygen2, DLBCL
+# SystemRequirements: Java (>=8)
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.2.2
+# VignetteBuilder: knitr
+# URL: https://github.com/ctlab/mwcsr
+# BugReports: https://github.com/ctlab/mwcsr/issues
+# LinkingTo: Rcpp
+# NeedsCompilation: yes
+# Packaged: 2024-03-02 09:20:48 UTC; aloboda
+# Author: Alexander Loboda [aut, cre], Nikolay Poperechnyi [aut], Eduardo Alvarez-Miranda [aut], Markus Sinnl [aut], Alexey Sergushichev [aut], Paul Hosler Jr. [cph] (Bundled JOpt Simple package), www.hamcrest.org [cph] (Bundled hamcrest package), Barak Naveh and Contributors [cph] (Bundled JGraphT package), The Apache Software Foundation [cph] (Bundled Apache Commons Math package)
+# Maintainer: Alexander Loboda <aleks.loboda@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2024-03-02 10:40:02 UTC


### PR DESCRIPTION
Adds [CRAN package `mwcsr`](https://cran.r-project.org/package=mwcsr) as `r-mwcsr`. Recipe generated with `conda_r_skeleton_helper` with `stdlib` entries and cross-compilation dependencies added.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
