### PR TITLE
adds `r-mashr`

### DIFF
--- a/recipes/r-mashr/bld.bat
+++ b/recipes/r-mashr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mashr/build.sh
+++ b/recipes/r-mashr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mashr/meta.yaml
+++ b/recipes/r-mashr/meta.yaml
@@ -1,0 +1,116 @@
+{% set version = '0.2.79' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-mashr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/mashr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/mashr/mashr_{{ version }}.tar.gz
+  sha256: 158b3670277523fa3168a46a9d80a1f6dd7063091b54584cd170eb70bf85f886
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp >=1.0.8
+    - r-rcpparmadillo
+    - r-rcppgsl >=0.3.8
+    - r-abind
+    - r-ashr >=2.2_22
+    - r-assertthat
+    - r-mvtnorm
+    - r-plyr
+    - r-rmeta
+    - r-softimpute
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp >=1.0.8
+    - r-rcpparmadillo
+    - r-rcppgsl >=0.3.8
+    - r-abind
+    - r-ashr >=2.2_22
+    - r-assertthat
+    - r-mvtnorm
+    - r-plyr
+    - r-rmeta
+    - r-softimpute
+
+test:
+  commands:
+    - $R -e "library('mashr')"           # [not win]
+    - "\"%R%\" -e \"library('mashr')\""  # [win]
+
+about:
+  home: https://github.com/stephenslab/mashr
+  license: BSD_3_clause
+  summary: Implements the multivariate adaptive shrinkage (mash) method of Urbut et al (2019)
+    <DOI:10.1038/s41588-018-0268-8> for estimating and testing large numbers of effects
+    in many conditions (or many outcomes). Mash takes an empirical Bayes approach to
+    testing and effect estimation; it estimates patterns of similarity among conditions,
+    then exploits these patterns to improve accuracy of the effect estimates. The core
+    linear algebra is implemented in C++ for fast model fitting and posterior computation.
+  license_family: BSD
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: mashr
+# Type: Package
+# Encoding: UTF-8
+# Title: Multivariate Adaptive Shrinkage
+# Version: 0.2.79
+# Date: 2023-10-18
+# Authors@R: c(person("Matthew","Stephens",role="aut"), person("Sarah","Urbut",role="aut"), person("Gao","Wang",role="aut"), person("Yuxin","Zou",role="aut"), person("Yunqi","Yang",role="ctb"), person("Sam","Roweis",role="cph"), person("David","Hogg",role="cph"), person("Jo","Bovy",role="cph"), person("Peter","Carbonetto",role=c("aut","cre"), email="peter.carbonetto@gmail.com"))
+# Description: Implements the multivariate adaptive shrinkage (mash) method of Urbut et al (2019) <DOI:10.1038/s41588-018-0268-8> for estimating and testing large numbers of effects in many conditions (or many outcomes). Mash takes an empirical Bayes approach to testing and effect estimation; it estimates patterns of similarity among conditions, then exploits these patterns to improve accuracy of the effect estimates. The core linear algebra is implemented in C++ for fast model fitting and posterior computation.
+# URL: https://github.com/stephenslab/mashr
+# BugReports: https://github.com/stephenslab/mashr/issues
+# License: BSD_3_clause + file LICENSE
+# Copyright: file COPYRIGHTS
+# Depends: R (>= 3.3.0), ashr (>= 2.2-22)
+# Imports: assertthat, utils, stats, plyr, rmeta, Rcpp (>= 1.0.8), mvtnorm, abind, softImpute
+# LinkingTo: Rcpp, RcppArmadillo, RcppGSL (>= 0.3.8)
+# Suggests: MASS, REBayes, corrplot (>= 0.90), testthat, kableExtra, knitr, rmarkdown, profmem, flashier, ebnm
+# VignetteBuilder: knitr
+# NeedsCompilation: yes
+# Biarch: true
+# RoxygenNote: 7.2.3
+# Packaged: 2023-10-18 13:05:18 UTC; pcarbo
+# Author: Matthew Stephens [aut], Sarah Urbut [aut], Gao Wang [aut], Yuxin Zou [aut], Yunqi Yang [ctb], Sam Roweis [cph], David Hogg [cph], Jo Bovy [cph], Peter Carbonetto [aut, cre]
+# Maintainer: Peter Carbonetto <peter.carbonetto@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-10-18 16:20:02 UTC

--- a/recipes/r-mashr/meta.yaml
+++ b/recipes/r-mashr/meta.yaml
@@ -25,10 +25,23 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - r-abind                      # [build_platform != target_platform]
+    - r-ashr                       # [build_platform != target_platform]
+    - r-assertthat                 # [build_platform != target_platform]
+    - r-mvtnorm                    # [build_platform != target_platform]
+    - r-plyr                       # [build_platform != target_platform]
+    - r-rcpp                       # [build_platform != target_platform]
+    - r-rcpparmadillo              # [build_platform != target_platform]
+    - r-rcppgsl                    # [build_platform != target_platform]
+    - r-rmeta                      # [build_platform != target_platform]
+    - r-softimpute                 # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
@@ -39,30 +52,29 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-rcpp >=1.0.8
-    - r-rcpparmadillo
-    - r-rcppgsl >=0.3.8
     - r-abind
     - r-ashr >=2.2_22
     - r-assertthat
     - r-mvtnorm
     - r-plyr
+    - r-rcpp >=1.0.8
+    - r-rcpparmadillo
+    - r-rcppgsl >=0.3.8
     - r-rmeta
     - r-softimpute
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
-    - r-rcpp >=1.0.8
-    - r-rcpparmadillo
-    - r-rcppgsl >=0.3.8
     - r-abind
     - r-ashr >=2.2_22
     - r-assertthat
     - r-mvtnorm
     - r-plyr
+    - r-rcpp >=1.0.8
+    - r-rcpparmadillo
+    - r-rcppgsl >=0.3.8
     - r-rmeta
     - r-softimpute
 
@@ -73,7 +85,7 @@ test:
 
 about:
   home: https://github.com/stephenslab/mashr
-  license: BSD_3_clause
+  license: BSD-3-Clause
   summary: Implements the multivariate adaptive shrinkage (mash) method of Urbut et al (2019)
     <DOI:10.1038/s41588-018-0268-8> for estimating and testing large numbers of effects
     in many conditions (or many outcomes). Mash takes an empirical Bayes approach to
@@ -82,7 +94,7 @@ about:
     linear algebra is implemented in C++ for fast model fitting and posterior computation.
   license_family: BSD
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/BSD_3_clause
     - LICENSE
 
 extra:


### PR DESCRIPTION
Adds [CRAN package `mashr`](https://cran.r-project.org/package=mashr) as `r-mashr`. Recipe generated with `conda_r_skeleton_helper` with `stdlib` entries, cross-compilation dependencies, and SPDX license added.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
