### PR TITLE
adds `r-tca`

### DIFF
--- a/recipes/r-tca/bld.bat
+++ b/recipes/r-tca/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tca/build.sh
+++ b/recipes/r-tca/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tca/meta.yaml
+++ b/recipes/r-tca/meta.yaml
@@ -1,0 +1,108 @@
+{% set version = '1.2.1' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-tca
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/TCA_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/TCA/TCA_{{ version }}.tar.gz
+  sha256: 8bd3ab276b966802b0022cccefead65d2c3f85ef43e775ff629b907c2ad0d7bf
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-matrix
+    - r-config
+    - r-data.table
+    - r-futile.logger
+    - r-gmodels
+    - r-matrixstats
+    - r-matrixcalc
+    - r-nloptr
+    - r-pbapply
+    - r-pracma
+    - r-quadprog
+    - r-rsvd
+  run:
+    - r-base
+    - r-matrix
+    - r-config
+    - r-data.table
+    - r-futile.logger
+    - r-gmodels
+    - r-matrixstats
+    - r-matrixcalc
+    - r-nloptr
+    - r-pbapply
+    - r-pracma
+    - r-quadprog
+    - r-rsvd
+
+test:
+  commands:
+    - $R -e "library('TCA')"           # [not win]
+    - "\"%R%\" -e \"library('TCA')\""  # [win]
+
+about:
+  home: https://www.nature.com/articles/s41467-019-11052-9
+  license: GPL-3
+  summary: Tensor Composition Analysis (TCA) allows the deconvolution of two-dimensional data
+    (features by observations) coming from a mixture of heterogeneous sources into a
+    three-dimensional matrix of signals (features by observations by sources). The TCA
+    framework further allows to test the features in the data for different statistical
+    relations with an outcome of interest while modeling source-specific effects; particularly,
+    it allows to look for statistical relations between source-specific signals and
+    an outcome. For example, TCA can deconvolve bulk tissue-level DNA methylation data
+    (methylation sites by individuals) into a three-dimensional tensor of cell-type-specific
+    methylation levels for each individual (i.e. methylation sites by individuals by
+    cell types) and it allows to detect cell-type-specific statistical relations (associations)
+    with phenotypes. For more details see Rahmani et al. (2019) <DOI:10.1038/s41467-019-11052-9>.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: TCA
+# Type: Package
+# Title: Tensor Composition Analysis
+# Version: 1.2.1
+# Authors@R: c( person("Elior", "Rahmani", role=c("aut", "cre"), email = "elior.rahmani@gmail.com"), person("Brandon", "Jew", role=c("ctb")) )
+# Description: Tensor Composition Analysis (TCA) allows the deconvolution of two-dimensional data (features by observations) coming from a mixture of heterogeneous sources into a three-dimensional matrix of signals (features by observations by sources). The TCA framework further allows to test the features in the data for different statistical relations with an outcome of interest while modeling source-specific effects; particularly, it allows to look for statistical relations between source-specific signals and an outcome. For example, TCA can deconvolve bulk tissue-level DNA methylation data (methylation sites by individuals) into a three-dimensional tensor of cell-type-specific methylation levels for each individual (i.e. methylation sites by individuals by cell types) and it allows to detect cell-type-specific statistical relations (associations) with phenotypes. For more details see Rahmani et al. (2019) <DOI:10.1038/s41467-019-11052-9>.
+# License: GPL-3
+# Encoding: UTF-8
+# LazyData: true
+# Imports: config, data.table, futile.logger, gmodels, matrixcalc, matrixStats, nloptr, parallel, pbapply, pracma, rsvd, stats, quadprog, Matrix
+# RoxygenNote: 7.1.1
+# Depends: R (>= 3.5.0)
+# Suggests: testthat, knitr, rmarkdown
+# URL: https://www.nature.com/articles/s41467-019-11052-9
+# BugReports: https://github.com/cozygene/TCA/issues
+# VignetteBuilder: knitr
+# NeedsCompilation: no
+# Packaged: 2021-02-14 17:40:34 UTC; erahmani
+# Author: Elior Rahmani [aut, cre], Brandon Jew [ctb]
+# Maintainer: Elior Rahmani <elior.rahmani@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2021-02-14 21:50:06 UTC

--- a/recipes/r-tca/meta.yaml
+++ b/recipes/r-tca/meta.yaml
@@ -30,11 +30,11 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-matrix
     - r-config
     - r-data.table
     - r-futile.logger
     - r-gmodels
+    - r-matrix
     - r-matrixstats
     - r-matrixcalc
     - r-nloptr
@@ -44,11 +44,11 @@ requirements:
     - r-rsvd
   run:
     - r-base
-    - r-matrix
     - r-config
     - r-data.table
     - r-futile.logger
     - r-gmodels
+    - r-matrix
     - r-matrixstats
     - r-matrixcalc
     - r-nloptr
@@ -63,8 +63,9 @@ test:
     - "\"%R%\" -e \"library('TCA')\""  # [win]
 
 about:
-  home: https://www.nature.com/articles/s41467-019-11052-9
-  license: GPL-3
+  home: https://github.com/cozygene/TCA
+  doc_url: https://www.nature.com/articles/s41467-019-11052-9
+  license: GPL-3.0-only
   summary: Tensor Composition Analysis (TCA) allows the deconvolution of two-dimensional data
     (features by observations) coming from a mixture of heterogeneous sources into a
     three-dimensional matrix of signals (features by observations by sources). The TCA

--- a/recipes/r-tca/meta.yaml
+++ b/recipes/r-tca/meta.yaml
@@ -64,7 +64,6 @@ test:
 
 about:
   home: https://github.com/cozygene/TCA
-  doc_url: https://www.nature.com/articles/s41467-019-11052-9
   license: GPL-3.0-only
   summary: Tensor Composition Analysis (TCA) allows the deconvolution of two-dimensional data
     (features by observations) coming from a mixture of heterogeneous sources into a


### PR DESCRIPTION
Adds [CRAN package `TCA`](https://cran.r-project.org/package=TCA) as `r-tca`. Recipe generated with `conda_r_skeleton_helper` with license adjusted to SPDX.

Needed for [Bioconductor 3.19](https://github.com/bioconda/bioconda-recipes/issues/49778).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
