### PR TITLE
Workaround for https://github.com/conda/conda-build/pull/5458

### DIFF
--- a/recipes/kegalign/meta.yaml
+++ b/recipes/kegalign/meta.yaml
@@ -25,7 +25,9 @@ requirements:
     - cmake
     - make
   host:
+    {% if cuda_compiler_version is not undefined %}
     - cuda-version {{ cuda_compiler_version }}
+    {% endif %}
     - libboost-devel
     - tbb-devel {{ kegalign_tbb_version }}
     - zlib


### PR DESCRIPTION
This is breaking the feedstock creation workflow in admin-requests due to a bug in conda-build: https://github.com/conda/conda-build/pull/5458

See [traceback](https://github.com/conda-forge/admin-requests/actions/runs/10610937091/job/29409389836#step:6:1232):

```
conda_build.exceptions.CondaBuildUserError: Failed to render jinja template in /tmp/tmpd2qu3gia__feedstocks/kegalign-feedstock/recipe/meta.yaml:
'cuda_compiler_version' is undefined
```