### PR TITLE
Adding recipe for anvio

### DIFF
--- a/recipes/anvio/meta.yaml
+++ b/recipes/anvio/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "anvio" %}
+{% set version = "8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/merenlab/anvio/archive/v{{ version }}.tar.gz
+  sha256: 3e041fc18a4047ae40dd188317d7e2b35c4a91fc015a75e8222318fd6afbde82
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy <=1.24
+    - scipy
+    - bottle
+    - pysam
+    - ete3
+    - scikit-learn ==1.2.2
+    - django
+    - requests
+    - mistune
+    - six
+    - matplotlib-base
+    - statsmodels
+    - colored
+    - illumina-utils
+    - tabulate
+    - rich-argparse
+    - numba
+    - paste
+    - pyani
+    - psutil
+    - pandas ==1.4.4
+    - snakemake
+    - multiprocess
+    - plotext
+    - networkx
+
+test:
+  commands:
+    - pip check
+    - anvi-self-test --no-interactive
+  requires:
+    - pip
+
+about:
+  home: https://merenlab.org/projects/anvio/
+  license: GPL-3.0
+  license_file:
+    - LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - Ge0rges
+    - meren
+
+channels:
+  - conda-forge
+  - bioconda


### PR DESCRIPTION
`@conda-forge/help-python`  hi folks, I was wondering if I could get some help understanding why this error occurs at build time:

```
Extracting download                                                                                                                                  [110/138]
source tree in: /Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/work
export PREFIX=/Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold
_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_
export BUILD_PREFIX=/Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/_build_env
export SRC_DIR=/Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/work
/Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/work/conda_build.sh: line 4: /Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/_h_env_placeh
old_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac
ehold_placehold_placehold_/bin/python: No such file or directory

# >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<

    Traceback (most recent call last):
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda/exception_handler.py", line 17, in __call__
        return func(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda/cli/main.py", line 83, in main_subshell
        exit_code = do_call(args, parser)
                    ^^^^^^^^^^^^^^^^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda/cli/conda_argparse.py", line 172, in do_call
        result = plugin_subcommand.action(getattr(args, "_args", args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/plugin.py", line 14, in build
        return execute(args)
               ^^^^^^^^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/cli/main_build.py", line 581, in execute
        api.build(
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/api.py", line 255, in build
        return build_tree(
               ^^^^^^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/build.py", line 3782, in build_tree
        packages_from_this = build(
                             ^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/build.py", line 2654, in build
        utils.check_call_env(
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/utils.py", line 406, in check_call_env
        return _func_defaulting_env_to_os_environ("call", *popenargs, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/Accounts/gkanaan/anaconda3/lib/python3.11/site-packages/conda_build/utils.py", line 382, in _func_defaulting_env_to_os_environ
        raise subprocess.CalledProcessError(proc.returncode, _args)
    subprocess.CalledProcessError: Command '['/bin/bash', '-o', 'errexit', '/Accounts/gkanaan/anaconda3/conda-bld/anvio_1724925541476/work/conda_build.sh']' r
eturned non-zero exit status 127.
```

The `meta.yaml` file was generated for [v8](https://github.com/merenlab/anvio/releases/tag/v8) of [anvio](https://anvio.org/install/linux/stable/) using gray skull then slightly modified with appropriate tests and required channels. Thanks for any pointers.
