### PR TITLE
Add recipe for numba-cuda

### DIFF
--- a/recipes/numba-cuda/recipe.yaml
+++ b/recipes/numba-cuda/recipe.yaml
@@ -1,0 +1,46 @@
+context:
+  name: numba-cuda
+  sdist_name: numba_cuda
+  version: "0.0.15"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/${{ name[0] }}/${{ name }}/${{ sdist_name }}-${{ version }}.tar.gz
+  sha256: 42d3919d006421510004c89ac2de03222da95e4fc59cfc7c3c736891e38ea307
+
+build:
+  noarch: python
+  script: python -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - numba >=0.59.1
+
+tests:
+  - python:
+      imports:
+      - numba_cuda
+      pip_check: true
+
+about:
+  homepage: https://github.com/NVIDIA/numba-cuda
+  summary: 'A CUDA target for Numba'
+  description: |
+    A Numba target for compiling Python code to excute on CUDA GPUs.
+  license: BSD-2-Clause
+  license_file: LICENSE
+  documentation: https://nvidia.github.io/numba-cuda
+  repository: https://github.com/NVIDIA/numba-cuda
+
+extra:
+  recipe-maintainers:
+    - gmarkall


### PR DESCRIPTION
[numba-cuda](https://github.com/nvidia/numba-cuda) is where the [Numba](https://numba.pydata.org/) CUDA target is being migrated to out of the upstream repository (as per [this announcement](https://numba.discourse.group/t/rfc-moving-the-cuda-target-to-a-new-package-maintained-by-nvidia/2628)).

Note that although it enables Numba to support CUDA, the package is pure Python and supports a range of CUDA versions and methods of installation (e.g. it can use a system-installed CUDA toolkit) so there is no explicit dependence / requirement for a CUDA version or package to be installed.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] ~~If static libraries are linked in, the license of the static library is packaged.~~
- [X] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
