### PR TITLE
fix: example lint

### DIFF
--- a/recipes/example-v1/recipe.yaml
+++ b/recipes/example-v1/recipe.yaml
@@ -59,6 +59,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
 

--- a/recipes/example-v1/recipe.yaml
+++ b/recipes/example-v1/recipe.yaml
@@ -6,7 +6,7 @@
 # The main differences with the old format is that no preprocessing is required for the file to be valid YAML.
 # This means:
 # - No "selectors", use YAML if-then-else expressions instead (https://prefix-dev.github.io/rattler-build/latest/selectors/)
-# - Jinja expressions are formatted with `${{}}`
+# - Jinja expressions are formatted with a leading `$` to make them valid YAML
 
 # Note: there are many handy hints in comments in this example -- remove them when you've finalized your recipe
 

--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -46,6 +46,7 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
 


### PR DESCRIPTION
@beckermr - this fixes the lint for the two example recipes. Turns our jinja evaluation wasn't dealing well with an empty `${{ }}`.

