### PR TITLE
adds `r-unigd`

### DIFF
--- a/recipes/r-unigd/bld.bat
+++ b/recipes/r-unigd/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-unigd/build.sh
+++ b/recipes/r-unigd/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-unigd/meta.yaml
+++ b/recipes/r-unigd/meta.yaml
@@ -1,0 +1,95 @@
+{% set version = '0.1.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-unigd
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/unigd_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/unigd/unigd_{{ version }}.tar.gz
+  sha256: 27f3315ef93848f72653662e14d2c95d69da5c44d5424b56f64a66149d96d347
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - {{ posix }}pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-cpp11 >=0.2.4
+    - r-systemfonts >=1.0.0
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-cpp11 >=0.2.4
+    - r-systemfonts >=1.0.0
+
+test:
+  commands:
+    - $R -e "library('unigd')"           # [not win]
+    - "\"%R%\" -e \"library('unigd')\""  # [win]
+
+about:
+  home: https://github.com/nx10/unigd, https://nx10.github.io/unigd/
+  license: GPL-2.0-only
+  summary: A unified R graphics backend. Render R graphics fast and easy to many common file
+    formats. Provides a thread safe 'C' interface for asynchronous rendering of R graphics.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: unigd
+# Type: Package
+# Title: Universal Graphics Device
+# Version: 0.1.2
+# Authors@R: c( person(given = "Florian", family = "Rupprecht", email = "floruppr@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-1795-8624")), person(given = "Kun", family = "Ren", role = "ctb", email = "mail@renkun.me"), person(given = "Tatsuya", family = "Shima", role = "ctb", email = "ts1s1andn@gmail.com"), person("Jeroen", "Ooms", role = c("ctb"), email = "jeroen@berkeley.edu", comment = c(ORCID = "0000-0002-4035-0289")), person("Hadley", "Wickham", email = "hadley@rstudio.com", role = "cph", comment = "Author of included svglite code"), person("Lionel", "Henry", email = "lionel@rstudio.com", role = "cph", comment = "Author of included svglite code"), person("Thomas Lin", "Pedersen", email = "thomas.pedersen@rstudio.com", role = "cph", comment = "Author and creator of included svglite code"), person("T Jake", "Luciani", email = "jake@apache.org", role = "cph", comment = "Author of included svglite code"), person("Matthieu", "Decorde", email = "matthieu.decorde@ens-lyon.fr", role = "cph", comment = "Author of included svglite code"), person("Vaudor", "Lise", email = "lise.vaudor@ens-lyon.fr", role = "cph", comment = "Author of included svglite code"), person("Tony", "Plate", role = "cph", comment = "Contributor to included svglite code"), person("David", "Gohel", role = "cph", comment = "Contributor to included svglite code"), person("Yixuan", "Qiu", role = "cph", comment = "Contributor to included svglite code"), person("Hakon", "Malmedal", role = "cph", comment = "Contributor to included svglite code"), person("RStudio", role = "cph", comment = "Copyright holder of included svglite code"), person("Brett", "Robinson", role = "cph", comment = "Author of included belle library"), person("Google", role = "cph", comment = "Copyright holder of included material design icons"), person("Victor", "Zverovich", role = "cph", comment = "Author of included fmt library"), person("Andrzej", "Krzemienski", role = "cph", comment = "Author of included std::experimental::optional library") )
+# Description: A unified R graphics backend. Render R graphics fast and easy to many common file formats. Provides a thread safe 'C' interface for asynchronous rendering of R graphics.
+# License: GPL (>= 2)
+# Depends: R (>= 3.2.0)
+# Imports: systemfonts (>= 1.0.0)
+# LinkingTo: cpp11 (>= 0.2.4), systemfonts
+# Encoding: UTF-8
+# SystemRequirements: libpng, cairo, freetype2, fontconfig
+# RoxygenNote: 7.3.0
+# URL: https://github.com/nx10/unigd, https://nx10.github.io/unigd/
+# BugReports: https://github.com/nx10/unigd/issues
+# Suggests: testthat (>= 3.0.0), xml2 (>= 1.0.0), fontquiver (>= 0.2.0), covr, knitr, rmarkdown
+# Config/testthat/edition: 3
+# Config/Needs/website: tidyverse/tidytemplate
+# VignetteBuilder: knitr
+# NeedsCompilation: yes
+# Packaged: 2024-06-05 20:30:05 UTC; floru
+# Author: Florian Rupprecht [aut, cre] (<https://orcid.org/0000-0002-1795-8624>), Kun Ren [ctb], Tatsuya Shima [ctb], Jeroen Ooms [ctb] (<https://orcid.org/0000-0002-4035-0289>), Hadley Wickham [cph] (Author of included svglite code), Lionel Henry [cph] (Author of included svglite code), Thomas Lin Pedersen [cph] (Author and creator of included svglite code), T Jake Luciani [cph] (Author of included svglite code), Matthieu Decorde [cph] (Author of included svglite code), Vaudor Lise [cph] (Author of included svglite code), Tony Plate [cph] (Contributor to included svglite code), David Gohel [cph] (Contributor to included svglite code), Yixuan Qiu [cph] (Contributor to included svglite code), Hakon Malmedal [cph] (Contributor to included svglite code), RStudio [cph] (Copyright holder of included svglite code), Brett Robinson [cph] (Author of included belle library), Google [cph] (Copyright holder of included material design icons), Victor Zverovich [cph] (Author of included fmt library), Andrzej Krzemienski [cph] (Author of included std::experimental::optional library)
+# Maintainer: Florian Rupprecht <floruppr@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2024-06-05 21:40:02 UTC

--- a/recipes/r-unigd/meta.yaml
+++ b/recipes/r-unigd/meta.yaml
@@ -22,6 +22,7 @@ build:
     - '*/R.dll'        # [win]
     - '*/Rblas.dll'    # [win]
     - '*/Rlapack.dll'  # [win]
+  skip: True  # [win]
 
 requirements:
   build:
@@ -52,7 +53,6 @@ requirements:
     - libzlib
   run:
     - r-base
-    - {{ native }}gcc-libs         # [win]
     - r-cpp11 >=0.2.4
     - r-systemfonts >=1.0.0
 

--- a/recipes/r-unigd/meta.yaml
+++ b/recipes/r-unigd/meta.yaml
@@ -25,25 +25,31 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
     - {{ posix }}autoconf
     - {{ posix }}automake          # [not win]
     - {{ posix }}automake-wrapper  # [win]
-    - {{ posix }}pkg-config
+    - pkg-config
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
     - r-cpp11 >=0.2.4
     - r-systemfonts >=1.0.0
+    - cairo
+    - libpng
+    - libtiff
+    - libzlib
   run:
     - r-base
     - {{ native }}gcc-libs         # [win]
@@ -56,13 +62,17 @@ test:
     - "\"%R%\" -e \"library('unigd')\""  # [win]
 
 about:
-  home: https://github.com/nx10/unigd, https://nx10.github.io/unigd/
-  license: GPL-2.0-only
+  home: https://nx10.github.io/unigd/
+  dev_url: https://github.com/nx10/unigd
+  license: GPL-2.0-or-later
   summary: A unified R graphics backend. Render R graphics fast and easy to many common file
     formats. Provides a thread safe 'C' interface for asynchronous rendering of R graphics.
   license_family: GPL2
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
+    - {{ environ["SRC_DIR"] }}/inst/licenses/fmt-MIT.txt
+    - {{ environ["SRC_DIR"] }}/inst/licenses/svglite-GPL-2.txt
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
This adds [CRAN package `unigd`](https://cran.r-project.org/package=unigd) as `r-unigd`. Recipe created with `conda_r_skeleton_helper` with adjustments for stdlib, extra dependencies, and packing third-party licenses.

Required for https://github.com/conda-forge/r-httpgd-feedstock/pull/6 (original package split and this is a now a component).

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] ~~Package does not vendor other packages.~~ (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged). **Vendored packages have licenses packaged.**
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
