### PR TITLE
Add recipe for icub-firmware-shared packages

### DIFF
--- a/recipes/icub-firmware-shared/bld_cxx.bat
+++ b/recipes/icub-firmware-shared/bld_cxx.bat
@@ -1,0 +1,19 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_SHARED_LIBS=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/icub-firmware-shared/build_cxx.sh
+++ b/recipes/icub-firmware-shared/build_cxx.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+rm -rf build
+mkdir build
+cd build
+
+if [[ "${target_platform}" == osx-* ]]; then
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS:BOOL=ON \
+      -DBUILD_TESTING:BOOL=ON \
+      ..
+
+cmake --build . --config Release
+
+if [[ ("${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "") ]]; then
+  ctest --output-on-failure  -C Release 
+fi
+
+cmake --build . --config Release --target install

--- a/recipes/icub-firmware-shared/meta.yaml
+++ b/recipes/icub-firmware-shared/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = "1.40.0" %}
+
+package:
+  name: icub-firmware-shared-split
+  version: {{ version }}
+
+source:
+  - url: https://github.com/robotology/icub-firmware-shared/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: b02927971ca5da5708db55d239dd0bcca0cd0aa32e93d97161298187f7b23d8e
+
+build:
+  number: 0
+
+outputs:
+  - name: libicub-firmware-shared
+    script: build_cxx.sh  # [unix]
+    script: bld_cxx.bat  # [win]
+    build:
+      run_exports:
+        - {{ pin_subpackage("libicub-firmware-shared", max_pin='x.x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ stdlib("c") }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - pkg-config
+        - ninja
+      host:
+        - ycm-cmake-modules
+
+    test:
+      commands:
+        - test -f $PREFIX/lib/libembobj$SHLIB_EXT  # [unix]
+        - if not exist %LIBRARY_LIB%\\embobj.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\\embobj.dll exit 1  # [win]
+        - cmake-package-check icub_firmware_shared --targets icub_firmware_shared::embobj icub_firmware_shared::canProtocolLib icub_firmware_shared::embot
+      requires:
+        - cmake-package-check
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+
+  - name: icub-firmware-shared
+    build:
+      run_exports:
+        - {{ pin_subpackage("libicub-firmware-shared", max_pin='x.x.x') }}
+    requirements:
+      run:
+        - {{ pin_subpackage("libicub-firmware-shared", exact=True) }}
+    test:
+      commands:
+        - test -f $PREFIX/lib/libembobj$SHLIB_EXT  # [unix]
+        - if not exist %LIBRARY_LIB%\\embobj.lib exit 1  # [win]
+        - if not exist %LIBRARY_BIN%\\embobj.dll exit 1  # [win]
+        - cmake-package-check icub_firmware_shared --targets icub_firmware_shared::embobj icub_firmware_shared::canProtocolLib icub_firmware_shared::embot
+      requires:
+        - cmake-package-check
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+
+about:
+  home: https://github.com/robotology/icub-firmware-shared
+  license: LGPL-2.1-or-later
+  license_file: LICENSE
+  summary: 'Protocols and Other Stuff Used both by iCub Firmware and iCub Software.'
+
+extra:
+  feedstock-name: icub-firmware-shared
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
[icub-firmware-shared](https://github.com/icub-tech-iit/icub-firmware-shared) is a set of C++ libraries shared among the firmware and the high level software used to control the [iCub](https://icub.iit.it/) and [ergoCub](https://ergocub.eu/robot)  humanoid robots.

It is not particularly useful by itself, but I want to package it as it is a dependency of the icub-main C++ library used in the [iCub](https://icub.iit.it/) and [ergoCub](https://ergocub.eu/robot)  humanoid robots, see https://github.com/conda-forge/staged-recipes/pull/27672 .

The proposed recipe adds two different packages:

* `libicub-firmware-shared`: This is the package that is meant to be used if the package is consumed as a C/C++ library, and linked to a downstream project. To do so, the package contains a `run_exports` section. This package name contains the `lib` prefix as requested in https://github.com/conda-forge/staged-recipes/pull/19764#pullrequestreview-1085836936 for C/C++ libraries.
* `icub-firmware-shared`: This is the package is an empty package that depends on `libicub-firmware-shared` and that is meant to simplify the transition from the `robotology` channel in which the `icub-firmware-shared` used to be called only `icub-firmware-shared`, without the `lib` prefix: https://anaconda.org/robotology/icub-firmware-shared .

The feedstock is named `icub-firmware-shared` to match the repo name and support different package outputs names in the future.


<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Gitter channel][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://gitter.im/conda-forge/conda-forge.github.io

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
