### PR TITLE
Add lazyimread recipe

### DIFF
--- a/recipes/lazyimread/meta.yaml
+++ b/recipes/lazyimread/meta.yaml
@@ -40,7 +40,7 @@ tests:
 
 about:
   homepage: https://github.com/lyehe/lazyimread
-  summary: 'A lazy image reading library for various file formats'
+  summary: "A lazy image reading library for various file formats"
   description: |
     Lazyimread is a Python library that simplifies working with large, 
     multi-dimensional image datasets. It can handle importing of various 
@@ -53,3 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - lyehe
+

--- a/recipes/lazyimread/meta.yaml
+++ b/recipes/lazyimread/meta.yaml
@@ -1,5 +1,3 @@
-# Recipe for lazyimread package
-
 {% set name = "lazyimread" %}
 {% set version = "0.1.3" %}
 

--- a/recipes/lazyimread/meta.yaml
+++ b/recipes/lazyimread/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/lyehe/lazyimread/archive/v{{ version }}.tar.gz
-  sha256: 650b679e12b87fd00ee3918bec4db57ce49a2bcd67caafc79979f319e2717e9a
+  sha256: 631254519efd938e24a49aeb469d0b83060ebcdcbbbc940882f2586f10a92337
 
 build:
   noarch: python

--- a/recipes/lazyimread/meta.yaml
+++ b/recipes/lazyimread/meta.yaml
@@ -1,0 +1,55 @@
+# Recipe for lazyimread package
+
+context:
+  name: lazyimread
+  version: "0.1.3"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/lyehe/lazyimread/archive/v${{ version }}.tar.gz
+  sha256: 650b679e12b87fd00ee3918bec4db57ce49a2bcd67caafc79979f319e2717e9a
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - numpy
+    - opencv
+    - tifffile
+    - h5py
+    - zarr
+    - xmltodict
+    - pyyaml
+
+tests:
+  - python:
+      imports:
+        - lazyimread
+      pip_check: true
+
+about:
+  homepage: https://github.com/lyehe/lazyimread
+  summary: 'A lazy image reading library for various file formats'
+  description: |
+    Lazyimread is a Python library that simplifies working with large, 
+    multi-dimensional image datasets. It can handle importing of various 
+    image file formats such as TIFF, HDF5, Zarr, image sequences, and 
+    video files without writing boilerplate code for each format.
+  license: CC0-1.0
+  license_family: CC
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - lyehe

--- a/recipes/lazyimread/meta.yaml
+++ b/recipes/lazyimread/meta.yaml
@@ -1,21 +1,20 @@
 # Recipe for lazyimread package
 
-context:
-  name: lazyimread
-  version: "0.1.3"
+{% set name = "lazyimread" %}
+{% set version = "0.1.3" %}
 
 package:
-  name: ${{ name|lower }}
-  version: ${{ version }}
+  name: {{ name|lower }}
+  version: {{ version }}
 
 source:
-  url: https://github.com/lyehe/lazyimread/archive/v${{ version }}.tar.gz
+  url: https://github.com/lyehe/lazyimread/archive/v{{ version }}.tar.gz
   sha256: 650b679e12b87fd00ee3918bec4db57ce49a2bcd67caafc79979f319e2717e9a
 
 build:
   noarch: python
   number: 0
-  script: python -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
@@ -32,15 +31,17 @@ requirements:
     - xmltodict
     - pyyaml
 
-tests:
-  - python:
-      imports:
-        - lazyimread
-      pip_check: true
+test:
+  imports:
+    - lazyimread
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
-  homepage: https://github.com/lyehe/lazyimread
-  summary: "A lazy image reading library for various file formats"
+  home: https://github.com/lyehe/lazyimread
+  summary: A lazy image reading library for various file formats
   description: |
     Lazyimread is a Python library that simplifies working with large, 
     multi-dimensional image datasets. It can handle importing of various 
@@ -53,4 +54,3 @@ about:
 extra:
   recipe-maintainers:
     - lyehe
-


### PR DESCRIPTION
Lazyimread is a Python library designed to streamline the handling of large, multi-dimensional image datasets. It offers a unified interface for importing various image file formats, including TIFF, HDF5, Zarr, image sequences, and video files. Lazyimread simplifies the process of working with diverse image data sources by eliminating the need for format-specific boilerplate code.

The library ensures efficient memory usage and flexible dimension order handling. These features make Lazyimread particularly useful for researchers and developers dealing with large variants of imaging data. Additionally, the package provides asynchronous loading capabilities and GUI utilities, further enhancing its versatility in both scripted and interactive environments.

By adding Lazyimread to conda-forge, we aim to make this powerful tool more accessible to the scientific Python community, facilitating easier installation and integration into existing workflows.
