### PR TITLE
Bump `vmImage` to `macos-13` 

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -6,7 +6,7 @@ jobs:
 - job: osx
   condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
-    vmImage: macOS-12
+    vmImage: macOS-13
   strategy:
     matrix:
       osx_64:


### PR DESCRIPTION
`macos-12` is starting its deprecation period next Monday, and will be removed by December, with brownouts in between. See details at https://github.com/actions/runner-images/issues/10721.

Opening this up to see if we find issues.