### PR TITLE
add stdlib to example recipe

### DIFF
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -41,8 +41,10 @@ build:
 requirements:
   build:
     # If your project compiles code (such as a C extension) then add the required compilers as separate entries here.
-    # Compilers are named 'c', 'cxx' and 'fortran'.
+    # Compilers are named 'c', 'cxx', 'fortran', among others
     - {{ compiler('c') }}
+    # this is necessary for all compiled recipes
+    - {{ stdlib('c') }}
   host:
     - python
     - pip


### PR DESCRIPTION
Noticed that the example for v0 recipes was missing this