### PR TITLE
Revert "temporarily update the docker image name"

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -41,7 +41,7 @@ jobs:
 
       export CI=azure
       export CONFIG=linux64
-      export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-alma-x86_64:8
+      export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-cos7-x86_64
       export AZURE=True
       .scripts/run_docker_build.sh
 

--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -19,7 +19,7 @@ target_platform:
 channel_sources:
 - conda-forge
 docker_image:
-- quay.io/condaforge/linux-anvil-alma-x86_64:8
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 cuda_compiler:
 - None
 cuda_compiler_version:


### PR DESCRIPTION
This should have been reverted in the PR.