### PR TITLE
Add ofxclient 2.0.3 via Grayskull

### DIFF
--- a/recipes/ofxclient/argparse.patch
+++ b/recipes/ofxclient/argparse.patch
@@ -1,0 +1,25 @@
+This package lists `argparse` as a separate dep, apparently from the days of
+yore before it became part of the standard library. This messes up modern
+`pip check` commands.
+
+diff --git a/setup.py b/setup.py
+index 696ab5fa27..851376c6fe 100644
+--- a/setup.py
++++ b/setup.py
+@@ -40,7 +40,6 @@ setup(name='ofxclient',
+           ]
+       },
+       install_requires=[
+-          "argparse",
+           "keyring",
+           "lxml",
+           "ofxhome",
+diff --git a/ofxclient.egg-info/requires.txt b/ofxclient.egg-info/requires.txt
+index c6c7b4591a..4caef3fdd8 100644
+--- a/ofxclient.egg-info/requires.txt
++++ b/ofxclient.egg-info/requires.txt
+@@ -1,4 +1,3 @@
+-argparse
+ keyring
+ lxml
+ ofxhome

--- a/recipes/ofxclient/meta.yaml
+++ b/recipes/ofxclient/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "ofxclient" %}
+{% set version = "2.0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ofxclient-{{ version }}.tar.gz
+  sha256: 6894e30b25879e09050321e56d2e2dbb08860ab59a57d3811dd6934197c6b049
+  patches:
+    - argparse.patch
+
+build:
+  entry_points:
+    - ofxclient = ofxclient.cli:run
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+    - setuptools
+  run:
+    - python >=3.6
+    - keyring
+    - lxml
+    - ofxhome
+    - ofxparse >0.8
+    - beautifulsoup4
+
+test:
+  imports:
+    - ofxclient
+  commands:
+    - pip check
+    - ofxclient --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/captin411/ofxclient
+  summary: OFX client for dowloading transactions from banks
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - pkgw


### PR DESCRIPTION
This is another pure-Python package that should be straightforward to build. We do need to patch the build metadata since the `setup.py` erroneously lists `argparse` as an external dependency!

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
