### PR TITLE
infra: improve macOS local build experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 # macOS folder metadata
 .DS_Store
 
+# macOS specific files
+MacOSX*.sdk.tar.xz
+SDKs/
+
 # User builds
 build_artifacts
+miniforge3/
 
 # Compiled Python code
 __pycache__
@@ -21,3 +26,6 @@ __pycache__
 .pixi
 pixi.toml
 pixi.lock
+
+# rattler-build outputs files
+output/

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -44,7 +44,7 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done"
 rm -f "$DONE_CANARY"
 
-DOCKER_RUN_ARGS="-it"
+DOCKER_RUN_ARGS="-it ${CONDA_FORGE_DOCKER_RUN_ARGS}"
 
 if [ "${AZURE}" == "True" ]; then
     DOCKER_RUN_ARGS=""

--- a/build-locally.py
+++ b/build-locally.py
@@ -27,6 +27,10 @@ def setup_environment(ns):
             os.path.dirname(__file__), "SDKs"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = "-e XDG_CACHE_HOME=/tmp/rattler_cache"
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length=88


### PR DESCRIPTION
This PR improves the local build experience from a macOS machine when building for `osx64` and also `linux64` (with docker).

- Add various temp files to gitignore
- Support `CONDA_FORGE_DOCKER_RUN_ARGS` in `run_docker_build.sh` (already available in all the feedstock repos).
- Remove `setup.cfg` as I don't think it's used anymore (but let me know if I am wrong).
- Add `CONDA_FORGE_DOCKER_RUN_ARGS"] = "-e XDG_CACHE_HOME=/tmp/rattler_cache"` in `build-locally.py` when building a linux build on macOS host machine with docker. It prevents an error with docker permissions on macOS:

```
Error:   × Failed to resolve dependencies: failed to acquire a lock on the repodata cache
  ├─▶ failed to acquire a lock on the repodata cache
  ├─▶ failed to open: /home/conda/.cache/rattler/cache/repodata/3018e552.lock
  ╰─▶ Permission denied (os error 13)
```

ping @conda-forge/core 

