### PR TITLE
Update README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This repo is a holding area for recipes destined for a conda-forge feedstock repo. To find out more about conda-forge, see https://github.com/conda-forge/conda-smithy.
 
-[![Join the chat at https://gitter.im/conda-forge/conda-forge.github.io](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/conda-forge/conda-forge.github.io)
-
+[![Join the chat at https://conda-forge.zulipchat.com](https://img.shields.io/badge/Zulip-join_chat-53bfad.svg)](https://conda-forge.zulipchat.com)
 
 ## Feedstock conversion status
 


### PR DESCRIPTION
Noticed this badge was still pointing to Gitter.im