### PR TITLE
Add beangulp 0.1.1 via grayskull, plus corrections

### DIFF
--- a/recipes/beangulp/bld.bat
+++ b/recipes/beangulp/bld.bat
@@ -1,0 +1,10 @@
+setlocal EnableDelayedExpansion
+@echo on
+
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if %ERRORLEVEL% neq 0 exit 1
+
+REM These support files get installed as if they were freestanding Python
+REM packages!
+rmdir /s /q %SP_DIR%\examples %SP_DIR%\tools
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/beangulp/build.sh
+++ b/recipes/beangulp/build.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+set -xeuo pipefail
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation
+
+# These support files get installed as if they were freestanding Python
+# packages!
+rm -rf $SP_DIR/examples $SP_DIR/tools

--- a/recipes/beangulp/meta.yaml
+++ b/recipes/beangulp/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "beangulp" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/beangulp-{{ version }}.tar.gz
+  sha256: 1fd131c76e5fda8c056efcc2f8a0d2bf5cd8141ef29060762601358f80f4a9b5
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python
+    - setuptools >=60.0
+    - pip
+  run:
+    - python
+    - beancount >=2.3.5
+    - beautifulsoup4
+    - chardet
+    - click >8.0
+    - lxml
+    - petl
+    - python-magic >=0.4.12  # [not win]
+
+# This package comes with pytest fixtures, but they require data files that
+# aren't included in the source distribution.
+test:
+  imports:
+    - beangulp
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Importers Framework for Beancount
+  home: https://github.com/beancount/beangulp
+  license: GPL-2.0-only
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - pkgw


### PR DESCRIPTION
This is basic pure-Python package although it accidentally installs some extra packages that we need to get rid of.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
