### PR TITLE
Add recipe for qpsolvers-eigen

### DIFF
--- a/recipes/qpsolvers-eigen/bld_core.bat
+++ b/recipes/qpsolvers-eigen/bld_core.bat
@@ -1,0 +1,22 @@
+rmdir /S /Q build
+mkdir build
+cd build
+
+cmake %CMAKE_ARGS% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -G "Ninja" ^
+    -DBUILD_TESTING:BOOL=OFF ^
+    -DQPSOLVERSEIGEN_USES_SYSTEM_SHAREDLIBPP:BOOL=ON ^
+    -DQPSOLVERSEIGEN_USES_SYSTEM_YCM:BOOL=ON ^
+    -DQPSOLVERSEIGEN_ENABLE_OSQP:BOOL=OFF ^
+    -DQPSOLVERSEIGEN_ENABLE_PROXQP:BOOL=OFF ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/qpsolvers-eigen/bld_osqp.bat
+++ b/recipes/qpsolvers-eigen/bld_osqp.bat
@@ -1,0 +1,18 @@
+rmdir /S /Q build_osqp
+mkdir build_osqp
+cd build_osqp
+
+cmake %CMAKE_ARGS% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -G "Ninja" ^
+    -DBUILD_TESTING:BOOL=ON ^
+    %SRC_DIR%\plugins\osqp
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/qpsolvers-eigen/bld_proxqp.bat
+++ b/recipes/qpsolvers-eigen/bld_proxqp.bat
@@ -1,0 +1,23 @@
+rmdir /S /Q build_proxqp
+mkdir build_proxqp
+cd build_proxqp
+
+:: proxqp requires clang-cl on VS2019,
+:: see https://github.com/conda-forge/proxsuite-feedstock/blob/f72cea3da7297181ce0ff8733dd998b5bd675d02/recipe/bld.bat#L4
+set "CC=clang-cl.exe"
+set "CXX=clang-cl.exe"
+
+cmake %CMAKE_ARGS% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -G "Ninja" ^
+    -DBUILD_TESTING:BOOL=ON ^
+    %SRC_DIR%\plugins\proxqp
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/qpsolvers-eigen/build_core.sh
+++ b/recipes/qpsolvers-eigen/build_core.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+rm -rf build
+mkdir build
+cd build
+
+if [[ "${target_platform}" == osx-* ]]; then
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+fi
+
+# The enable options are set to OFF as each plugins is built as its own package
+cmake ${CMAKE_ARGS} -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING:BOOL=OFF \
+      -DQPSOLVERSEIGEN_USES_SYSTEM_SHAREDLIBPP:BOOL=ON \
+      -DQPSOLVERSEIGEN_USES_SYSTEM_YCM:BOOL=ON \
+      -DQPSOLVERSEIGEN_ENABLE_OSQP:BOOL=OFF \
+      -DQPSOLVERSEIGEN_ENABLE_PROXQP:BOOL=OFF \
+      ..
+
+cmake --build . --config Release
+
+cmake --build . --config Release --target install

--- a/recipes/qpsolvers-eigen/build_osqp.sh
+++ b/recipes/qpsolvers-eigen/build_osqp.sh
@@ -1,0 +1,13 @@
+rm -rf build_osqp
+mkdir build_osqp
+cd build_osqp
+
+# The enable options are set to OFF as each plugins is built as its own package
+cmake ${CMAKE_ARGS} -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING:BOOL=ON \
+      ${SRC_DIR}/plugins/osqp
+
+cmake --build . --config Release
+
+cmake --build . --config Release --target install

--- a/recipes/qpsolvers-eigen/build_proxqp.sh
+++ b/recipes/qpsolvers-eigen/build_proxqp.sh
@@ -1,0 +1,13 @@
+rm -rf build_proxqp
+mkdir build_proxqp
+cd build_proxqp
+
+# The enable options are set to OFF as each plugins is built as its own package
+cmake ${CMAKE_ARGS} -GNinja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING:BOOL=ON \
+      ${SRC_DIR}/plugins/proxqp
+
+cmake --build . --config Release
+
+cmake --build . --config Release --target install

--- a/recipes/qpsolvers-eigen/meta.yaml
+++ b/recipes/qpsolvers-eigen/meta.yaml
@@ -1,0 +1,134 @@
+{% set name = "qpsolvers-eigen" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  - url: https://github.com/ami-iit/qpsolvers-eigen/archive/refs/tags/v{{ version }}.tar.gz
+    sha256: 149eb35d9729aedd8236bf5ad3511a0605dd4411213460f1a490e834a71edc63
+
+build:
+  number: 0
+
+outputs:
+  - name: libqpsolvers-eigen
+    script: build_core.sh  # [unix]
+    script: bld_core.bat  # [win]
+    build:
+      run_exports:
+        # Upstream compatibility documented in https://github.com/ami-iit/qpsolvers-eigen?tab=readme-ov-file#versioning-policy
+        - {{ pin_subpackage('libqpsolvers-eigen', max_pin='x.x') }}
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        - cmake
+        - pkg-config
+        - ninja
+        - ycm-cmake-modules
+      host:
+        - libsharedlibpp
+        - eigen
+
+    test:
+      commands:
+        - test -f ${PREFIX}/include/QpSolversEigen/QpSolversEigen.hpp  # [not win]
+        - test -f ${PREFIX}/lib/libqpsolvers-eigen${SHLIB_EXT}  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\QpSolversEigen\\QpSolversEigen.hpp exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\qpsolvers-eigen.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\qpsolvers-eigen.dll exit 1  # [win]
+        - cmake-package-check QpSolversEigen
+      requires:
+        - cmake-package-check
+        - eigen
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+
+  - name: libqpsolvers-eigen-osqp
+    script: build_osqp.sh  # [unix]
+    script: bld_osqp.bat  # [win]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        - ninja
+        - cmake
+        - pkg-config
+      host:
+        - libqpsolvers-eigen
+        - libosqp
+        - osqp-eigen
+          # Workaround as run_exports for some reason do not work correctly for multiple-output recipes
+        - {{ pin_subpackage('libqpsolvers-eigen', max_pin='x.x') }}
+      run:
+        - {{ pin_subpackage('libqpsolvers-eigen', max_pin='x.x') }}
+
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libqpsolvers-eigen-osqp${SHLIB_EXT}  # [not win]
+        - if not exist %PREFIX%\\Library\\bin\\qpsolvers-eigen-osqp.dll exit 1  # [win]
+
+  - name: libqpsolvers-eigen-proxqp
+    script: build_proxqp.sh  # [unix]
+    script: bld_proxqp.bat  # [win]
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ stdlib('c') }}
+        - {{ compiler('cxx') }}
+        - ninja
+        - cmake
+        - pkg-config
+        # proxqp requires clang-cl on VS2019,
+        # see https://github.com/conda-forge/proxsuite-feedstock/blob/f72cea3da7297181ce0ff8733dd998b5bd675d02/recipe/bld.bat#L4
+        - clang  # [win]
+      host:
+        - libqpsolvers-eigen
+        - proxsuite
+        # Workaround as run_exports for some reason do not work correctly for multiple-output recipes
+        - {{ pin_subpackage('libqpsolvers-eigen', max_pin='x.x') }}
+      run:
+        - {{ pin_subpackage('libqpsolvers-eigen', max_pin='x.x') }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libqpsolvers-eigen-proxqp${SHLIB_EXT}  # [not win]
+        - if not exist %PREFIX%\\Library\\bin\\qpsolvers-eigen-proxqp.dll exit 1  # [win]
+
+
+  - name: {{ name }}
+    build:
+      run_exports:
+        - {{ pin_subpackage('libqpsolvers-eigen', max_pin='x') }}
+    requirements:
+      run:
+        - {{ pin_subpackage('libqpsolvers-eigen', exact=True) }}
+        - {{ pin_subpackage('libqpsolvers-eigen-osqp', max_pin='x.x.x') }}
+        - {{ pin_subpackage('libqpsolvers-eigen-proxqp', max_pin='x.x.x') }}
+    test:
+      commands:
+        - test -f ${PREFIX}/include/QpSolversEigen/QpSolversEigen.hpp  # [not win]
+        - test -f ${PREFIX}/lib/libqpsolvers-eigen${SHLIBEXT}  # [not win]
+        - if not exist %PREFIX%\\Library\\include\\QpSolversEigen\\QpSolversEigen.hpp exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\lib\\qpsolvers-eigen.lib exit 1  # [win]
+        - if not exist %PREFIX%\\Library\\bin\\qpsolvers-eigen.dll exit 1  # [win]
+        - cmake-package-check QpSolversEigen
+      requires:
+        - cmake-package-check
+        - eigen
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+
+about:
+  home: https://github.com/gazebosim/gz-math
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: General purpose math library for robot applications.
+
+extra:
+  feedstock-name: qpsolvers-eigen
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
[qpsolvers-eigen](https://github.com/ami-iit/qpsolvers-eigen) is a simple C++ abstraction layer for quadratic programming solvers using [Eigen](https://eigen.tuxfamily.org). 
The proposed recipe adds four different packages:
 * `libqpsolvers-eigen`: the core library, the dependency to use for any package needs to link again qpsolvers-eigen, it does not include any solver,
 * `libqpsolvers-eigen-osqp`: the [OSQP](https://osqp.org/) solver plugin for qpsolvers-eigen,
 * `libqpsolvers-eigen-proxqp`: the [ProxQP](https://github.com/Simple-Robotics/proxsuite) solver plugin for qpsolvers-eigen.
  * `qpsolvers-eigen`: a metapackage that depends on all the above packages.

The feedstock is named `qpsolvers-eigen` to match the repo name and the main meta-packages output to install all the outputs.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
