### PR TITLE
Add linux-aarch64 and osx-arm64 configs for local debugging

### DIFF
--- a/.ci_support/linux_aarch64.yaml
+++ b/.ci_support/linux_aarch64.yaml
@@ -1,0 +1,28 @@
+c_stdlib_version:
+- 2.17
+c_stdlib:
+- sysroot
+cdt_name:
+- cos7
+c_compiler:
+- gcc
+cxx_compiler:
+- gxx
+fortran_compiler:
+- gfortran
+go_compiler:
+- go-nocgo
+cgo_compiler:
+- go-cgo
+target_platform:
+- linux-aarch64
+channel_sources:
+- conda-forge
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+cuda_compiler:
+- None
+cuda_compiler_version:
+- None
+cuda_compiler_version_min:
+- None

--- a/.ci_support/osx_arm64.yaml
+++ b/.ci_support/osx_arm64.yaml
@@ -1,0 +1,20 @@
+c_compiler:
+  - clang
+cxx_compiler:
+  - clangxx
+c_stdlib:
+  - macosx_deployment_target
+c_stdlib_version:
+  - 11.0
+MACOSX_DEPLOYMENT_TARGET:
+  - 11.0
+fortran_compiler:
+  - gfortran
+go_compiler:
+  - go-nocgo
+cgo_compiler:
+  - go-cgo
+channel_sources:
+  - conda-forge
+target_platform:
+  - osx-arm64


### PR DESCRIPTION
We won't use these in our CI, but it's nice to have for local debugging if you are running Apple Silicon. This way you don't have to pay the emulation cost for `linux-64` on Docker. 