### PR TITLE
adds `r-genio`

### DIFF
--- a/recipes/r-genio/bld.bat
+++ b/recipes/r-genio/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-genio/build.sh
+++ b/recipes/r-genio/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-genio/meta.yaml
+++ b/recipes/r-genio/meta.yaml
@@ -1,0 +1,94 @@
+{% set version = '1.1.2' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-genio
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/genio_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/genio/genio_{{ version }}.tar.gz
+  sha256: f4ad6737a9f5cdfea8ac4f9ed8df33fac3c01b15d75e6c71ebceee8ab647fd47
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp
+    - r-dplyr
+    - r-readr >=2.0.0
+    - r-tibble
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-dplyr
+    - r-readr >=2.0.0
+    - r-tibble
+
+test:
+  commands:
+    - $R -e "library('genio')"           # [not win]
+    - "\"%R%\" -e \"library('genio')\""  # [win]
+
+about:
+  home: https://github.com/OchoaLab/genio
+  license: GPL-3
+  summary: Implements readers and writers for file formats associated with genetics data.  Reading
+    and writing Plink BED/BIM/FAM and GCTA binary GRM formats is fully supported, including
+    a lightning-fast BED reader and writer implementations.  Other functions are 'readr'
+    wrappers that are more constrained, user-friendly, and efficient for these particular
+    applications; handles Plink and Eigenstrat tables (FAM, BIM, IND, and SNP files).  There
+    are also make functions for FAM and BIM tables with default values to go with simulated
+    genotype data.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: genio
+# Title: Genetics Input/Output Functions
+# Version: 1.1.2
+# Authors@R: person(given = "Alejandro", family = "Ochoa", role = c("aut", "cre"), email = "alejandro.ochoa@duke.edu", comment = c(ORCID = "0000-0003-4928-3403"))
+# Description: Implements readers and writers for file formats associated with genetics data.  Reading and writing Plink BED/BIM/FAM and GCTA binary GRM formats is fully supported, including a lightning-fast BED reader and writer implementations.  Other functions are 'readr' wrappers that are more constrained, user-friendly, and efficient for these particular applications; handles Plink and Eigenstrat tables (FAM, BIM, IND, and SNP files).  There are also make functions for FAM and BIM tables with default values to go with simulated genotype data.
+# License: GPL-3
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: readr (>= 2.0.0), tibble, dplyr, Rcpp
+# LinkingTo: Rcpp
+# Suggests: testthat, knitr, rmarkdown, BEDMatrix, snpStats, lobstr
+# VignetteBuilder: knitr
+# URL: https://github.com/OchoaLab/genio
+# BugReports: https://github.com/OchoaLab/genio/issues
+# NeedsCompilation: yes
+# Packaged: 2023-01-06 16:24:30 UTC; viiia
+# Author: Alejandro Ochoa [aut, cre] (<https://orcid.org/0000-0003-4928-3403>)
+# Maintainer: Alejandro Ochoa <alejandro.ochoa@duke.edu>
+# Repository: CRAN
+# Date/Publication: 2023-01-06 23:00:05 UTC

--- a/recipes/r-genio/meta.yaml
+++ b/recipes/r-genio/meta.yaml
@@ -25,10 +25,12 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -56,7 +58,7 @@ test:
 
 about:
   home: https://github.com/OchoaLab/genio
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Implements readers and writers for file formats associated with genetics data.  Reading
     and writing Plink BED/BIM/FAM and GCTA binary GRM formats is fully supported, including
     a lightning-fast BED reader and writer implementations.  Other functions are 'readr'
@@ -66,7 +68,7 @@ about:
     genotype data.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `genio`](https://cran.r-project.org/package=genio) as `r-genio`. Recipe generated with `conda_r_skeleton_helper`, adjusting for SPDX and `stdlib` lint.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
