### PR TITLE
add more local workflows for pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ If the issue persists, support can be found [on Gitter](https://gitter.im/conda-
 3. Open a pull request. Building of your package will be tested on Windows, Mac and Linux.
 4. When your pull request is merged a new repository, called a feedstock, will be created in the github conda-forge organization, and build/upload of your package will automatically be triggered. Once complete, the package is available on conda-forge.
 
+### `pixi`
+
+`pixi` is a project based environment and task runner optimized for `conda`. Several of
+the local workflows and their dependencies described below are captured in
+`pixi.toml`. Install `pixi` via the [documented approaches](https://pixi.sh/latest/#installation),
+or via `conda`/`mamba`/`micromamba`:
+
+```bash
+$CONDA_EXE install -c conda-forge pixi
+```
+
+See the available tasks with `pixi task list`.
 
 ## Local debugging with `build-locally.py`
 
@@ -32,7 +44,7 @@ macOS and Windows:
 
 On Linux, everything runs in a Docker container. The `staged-recipes` directory is mounted as a volume. The resulting artifacts will be available under `build_artifacts` in the repository directory.
 
-`build-locally.py` can be run with any recent Python, or via a Pixi task. Assuming you have already [installed Pixi](https://pixi.sh/latest/#installation), you can do:
+`build-locally.py` can be run with any recent Python, or via a [`pixi`](#pixi) task:
 
 * `pixi run build-linux`: will launch a Docker container, provision all the necessary tools and build your recipe for Linux.
 * `pixi run build-osx`: will provision a conda environment with the necessary tools to build your recipe for macOS. This involves fetching and caching the necessary Apple SDKs.
@@ -41,14 +53,43 @@ On Linux, everything runs in a Docker container. The `staged-recipes` directory 
 These tasks will pass any extra arguments to `build-locally.py`, including `--help`. The resulting
 artifacts will be available under `build_artifacts`.
 
-## Grayskull - recipe generator for Python packages on `pypi`
+## Generating recipes with `grayskull`
 
-For Python packages available on `pypi` it is possible to use [grayskull](https://github.com/conda-incubator/grayskull) to generate the recipe. The user should review the recipe generated, specially the license and dependencies.
+[grayskull](https://github.com/conda-incubator/grayskull) can generate recipes from
+Python packages on [PyPI](https://pypi.org) or R packages on [CRAN](https://cran.r-project.org/).
+The user should review the recipe generated, specially the license and dependencies.
 
-Installing `grayskull`: `conda install -c conda-forge grayskull`
+Use one of:
 
-Generating recipe: `grayskull pypi PACKAGE_NAME_HERE`
+- manually
+  - install `grayskull`: `conda install -c conda-forge grayskull`
+  - generate recipe:
+    - `cd recipes && grayskull pypi PACKAGE_NAME_ON_PYPI_HERE`
+    - `cd recipes && grayskull cran PACKAGE_NAME_ON_CRAN_HERE`
+- with [`pixi`](#pixi):
+  - generate recipe `pixi run grayskull pypi PACKAGE_NAME_ON_PYPI_HERE`
+  - generate recipe `pixi run grayskull cran PACKAGE_NAME_ON_CRAN_HERE`
 
+## Linting recipes with `conda-smithy`
+
+The [`conda-smithy`](https://github.com/conda-forge/conda-smithy) package provides
+helpful linters that can save CI resources by catching known issues up-front.
+
+Use one of:
+- manually
+  - install `conda-smithy`: `conda install -c conda-forge conda-smithy`
+  - lint recipes: `conda-smithy recipe-lint --conda-forge recipes/*`
+- with [`pixi`](#pixi):
+  - lint recipes: `pixi run recipe-lint`
+
+> **NOTE**
+>
+> `conda-smithy` is
+> [frequently updated](https://github.com/conda-forge/conda-smithy/blob/main/CHANGELOG.rst)
+> with current best practices. Ensure using the latest with:
+>
+> - `$CONDA_EXE upgrade conda-smithy`
+> - `pixi upgrade --feature lint`
 
 ## FAQ
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,10 +1,15 @@
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
 [project]
 name = "staged-recipes"
 description = "The entry point to conda-forge"
 version = "0.1.0"
+license = "BSD-3-Clause"
+license-file = "LICENSE.txt"
 authors = ["@conda-forge/core"]
 channels = ["conda-forge"]
-platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"] # , "win-arm64"]
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
 
 [feature.python.dependencies]
 python = "3.12.*"
@@ -23,20 +28,45 @@ rattler-build-conda-compat = ">=1.2.0,<2.0.0a0"
 [feature.linux]
 # The linux feature runs on every platform that can run Docker.
 platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
-[feature.linux.tasks]
-build-linux = { cmd = "python build-locally.py", env = { BUILD_LOCALLY_FILTER = "linux*" } }
+[feature.linux.tasks.build-linux]
+description = "build for Linux inside a docker container"
+cmd = "python build-locally.py"
+env = { BUILD_LOCALLY_FILTER = "linux*" }
 
 # The osx env will run conda-build directly on the machine.
 [feature.osx]
 platforms = ["osx-64", "osx-arm64"]
-[feature.osx.tasks]
-build-osx = { cmd = "python build-locally.py", env = { BUILD_LOCALLY_FILTER = "osx*", OSX_SDK_DIR = "$PIXI_PROJECT_ROOT/.pixi/macOS-SDKs", MINIFORGE_HOME = "$CONDA_PREFIX", CONDA_BLD_PATH = "$PIXI_PROJECT_ROOT/build_artifacts" } }
+[feature.osx.tasks.build-osx]
+description = "build directly on a MacOS host machine"
+cmd = "python build-locally.py"
+[feature.osx.tasks.build-osx.env]
+BUILD_LOCALLY_FILTER = "osx*"
+CONDA_BLD_PATH = "$PIXI_PROJECT_ROOT/build_artifacts"
+MINIFORGE_HOME = "$CONDA_PREFIX"
+OSX_SDK_DIR = "$PIXI_PROJECT_ROOT/.pixi/macOS-SDKs"
 
 # The windows env will run conda-build directly on the machine.
 [feature.win]
-platforms = ["win-64"] # , "win-arm64"]
-[feature.win.tasks]
-build-win = { cmd = "python build-locally.py", env = { BUILD_LOCALLY_FILTER = "win*", MINIFORGE_HOME = "$CONDA_PREFIX", CONDA_BLD_PATH = "$PIXI_PROJECT_ROOT/build_artifacts" } }
+platforms = ["win-64"]
+[feature.win.tasks.build-win]
+description = "build directly on a Windows host machine"
+cmd = "python build-locally.py"
+[feature.win.tasks.build-win.env]
+BUILD_LOCALLY_FILTER = "win*"
+CONDA_BLD_PATH = "$PIXI_PROJECT_ROOT/build_artifacts"
+MINIFORGE_HOME = "$CONDA_PREFIX"
+
+[feature.grayskull.dependencies]
+grayskull = ">=2.7.3"
+[feature.grayskull.tasks.grayskull]
+description = "build a recipe from a PyPI or CRAN package name with `grayskull`"
+cmd = "cd recipes && grayskull"
+
+[feature.lint.dependencies]
+conda-smithy = ">=3.44.6,<4"
+[feature.lint.tasks.recipe-lint]
+description = "validate all recipes with `conda-smithy`"
+cmd = "conda-smithy recipe-lint --conda-forge recipes/*"
 
 [environments]
 # linux only needs Python to run build-locally.py. Everything else happens in Docker.
@@ -45,3 +75,5 @@ linux = ["linux", "python"]
 osx = ["osx", "python", "build"]
 win = ["win", "python", "build"]
 build = ["python", "build"]
+grayskull = ["python", "grayskull"]
+lint = ["python", "lint"]


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

References:
- continues #27754

Changes:
- [x] `pixi.toml`
  - [x] add `$schema` with a suggested minimum `pixi` version
    - >  this can help local IDEs
    - > using `latest` is... dicey
  - [x] add `description` to all tasks
    - > improves `pixi run` and  `pixi task list` output 
  - [x] adds `pixi run`
    - [x] `grayskull`
    - [x] `recipe-lint`
- [x] `README.md`
  - [x] update/add sections for new tasks