### PR TITLE
adds `r-dalextra`

### DIFF
--- a/recipes/r-dalextra/bld.bat
+++ b/recipes/r-dalextra/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dalextra/build.sh
+++ b/recipes/r-dalextra/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dalextra/meta.yaml
+++ b/recipes/r-dalextra/meta.yaml
@@ -43,8 +43,9 @@ test:
     - "\"%R%\" -e \"library('DALEXtra')\""  # [win]
 
 about:
-  home: https://ModelOriented.github.io/DALEXtra/, https://github.com/ModelOriented/DALEXtra
-  license: GPL-3
+  home: https://ModelOriented.github.io/DALEXtra/
+  dev_url: https://github.com/ModelOriented/DALEXtra
+  license: GPL-2.0-or-later
   summary: Provides wrapper of various machine learning models. In applied machine learning,
     there is a strong belief that we need to strike a balance between interpretability
     and accuracy. However, in field of the interpretable machine learning, there are
@@ -54,9 +55,10 @@ about:
     libraries, and 'java' 'h2o' library. Important part of the package is Champion-Challenger
     analysis and innovative approach to model performance across subsets of test data
     presented in Funnel Plot.
-  license_family: GPL3
+  license_family: GPL
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:

--- a/recipes/r-dalextra/meta.yaml
+++ b/recipes/r-dalextra/meta.yaml
@@ -1,0 +1,83 @@
+{% set version = '2.3.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-dalextra
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/DALEXtra_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/DALEXtra/DALEXtra_{{ version }}.tar.gz
+  sha256: 0ef35a8d51114cb2bb5b729c5ea41890a2f044bea56f61b83a0c665c9999bafb
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dalex >=2.4.0
+    - r-ggplot2
+  run:
+    - r-base
+    - r-dalex >=2.4.0
+    - r-ggplot2
+
+test:
+  commands:
+    - $R -e "library('DALEXtra')"           # [not win]
+    - "\"%R%\" -e \"library('DALEXtra')\""  # [win]
+
+about:
+  home: https://ModelOriented.github.io/DALEXtra/, https://github.com/ModelOriented/DALEXtra
+  license: GPL-3
+  summary: Provides wrapper of various machine learning models. In applied machine learning,
+    there is a strong belief that we need to strike a balance between interpretability
+    and accuracy. However, in field of the interpretable machine learning, there are
+    more and more new ideas for explaining black-box models, that are implemented in
+    'R'. 'DALEXtra' creates 'DALEX' Biecek (2018) <arXiv:1806.08915> explainer for many
+    type of models including those created using 'python' 'scikit-learn' and 'keras'
+    libraries, and 'java' 'h2o' library. Important part of the package is Champion-Challenger
+    analysis and innovative approach to model performance across subsets of test data
+    presented in Funnel Plot.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: DALEXtra
+# Title: Extension for 'DALEX' Package
+# Version: 2.3.0
+# Authors@R: c(person(given = "Szymon", family = "Maksymiuk", role = c("aut", "cre"), email = "sz.maksymiuk@gmail.com", comment = c(ORCID = "0000-0002-3120-1601")), person(given = "Przemyslaw", family = "Biecek", email = "przemyslaw.biecek@gmail.com", role = c("aut"), comment = c(ORCID = "0000-0001-8423-1823")), person("Hubert", "Baniecki", role = "aut"), person("Anna", "Kozak", role = "ctb"))
+# Description: Provides wrapper of various machine learning models. In applied machine learning, there is a strong belief that we need to strike a balance between interpretability and accuracy. However, in field of the interpretable machine learning, there are more and more new ideas for explaining black-box models, that are implemented in 'R'. 'DALEXtra' creates 'DALEX' Biecek (2018) <arXiv:1806.08915> explainer for many type of models including those created using 'python' 'scikit-learn' and 'keras' libraries, and 'java' 'h2o' library. Important part of the package is Champion-Challenger analysis and innovative approach to model performance across subsets of test data presented in Funnel Plot.
+# Depends: R (>= 3.5.0), DALEX (>= 2.4.0)
+# License: GPL
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Imports: ggplot2
+# Suggests: auditor, gbm, ggrepel, h2o, iml, ingredients, lime, localModel, mlr, mlr3, ranger, recipes, reticulate, rmarkdown, rpart, stacks, xgboost, testthat, tidymodels
+# URL: https://ModelOriented.github.io/DALEXtra/, https://github.com/ModelOriented/DALEXtra
+# BugReports: https://github.com/ModelOriented/DALEXtra/issues
+# NeedsCompilation: no
+# Packaged: 2023-05-25 23:48:32 UTC; 01131304
+# Author: Szymon Maksymiuk [aut, cre] (<https://orcid.org/0000-0002-3120-1601>), Przemyslaw Biecek [aut] (<https://orcid.org/0000-0001-8423-1823>), Hubert Baniecki [aut], Anna Kozak [ctb]
+# Maintainer: Szymon Maksymiuk <sz.maksymiuk@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-05-26 00:10:02 UTC


### PR DESCRIPTION
Adds [CRAN package `DALEXtra`](https://cran.r-project.org/package=DALEXtra) as `r-dalextra`. Recipe generated with `conda_r_skeleton_helper`, with license adjust to SPDX and URLs split.

Needed for https://github.com/conda-forge/staged-recipes/pull/28195.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
