### PR TITLE
fix 'pixi run lint'

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,14 @@ The user should review the recipe generated, especially the license and dependen
 Use one of:
 
 - manually
-  - install `grayskull`: `conda install -c conda-forge grayskull`
-  - generate recipe:
+  1. install `grayskull`: `conda install -c conda-forge grayskull`
+  2. generate recipe:
     - `cd recipes && grayskull pypi PACKAGE_NAME_ON_PYPI_HERE [PACKAGE_NAME_ON_PYPI_HERE...]`
     - `cd recipes && grayskull cran PACKAGE_NAME_ON_CRAN_HERE [PACKAGE_NAME_ON_CRAN_HERE...]`
 - with [`pixi`](#pixi):
-  - generate recipe `pixi run pypi PACKAGE_NAME_ON_PYPI_HERE [PACKAGE_NAME_ON_PYPI_HERE...]`
-  - generate recipe `pixi run cran PACKAGE_NAME_ON_CRAN_HERE [PACKAGE_NAME_ON_CRAN_HERE...]`
+  1. generate recipe:
+    - `pixi run pypi PACKAGE_NAME_ON_PYPI_HERE [PACKAGE_NAME_ON_PYPI_HERE...]`
+    - `pixi run cran PACKAGE_NAME_ON_CRAN_HERE [PACKAGE_NAME_ON_CRAN_HERE...]`
 
 ## Linting recipes with `conda-smithy`
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -73,9 +73,7 @@ cmd = "cd recipes && grayskull cran --strict-conda-forge"
 conda-smithy = ">=3.44.6,<4"
 [feature.conda-smithy.tasks.lint]
 description = "validate all recipes with `conda-smithy`"
-cmd = """python .github/workflows/scripts/linter.py
-    && conda-smithy recipe-lint --conda-forge recipes/*
-"""
+cmd = "conda-smithy recipe-lint --conda-forge recipes/*"
 
 [environments]
 # linux only needs Python to run build-locally.py. Everything else happens in Docker.


### PR DESCRIPTION
Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

References:
- fixes #28321

Changes:
- [x] remove broken `linter.py` invocation (needs a separate issue)
- [x] review and update `grayskull` invocation