### PR TITLE
adds `r-xplorerr`

### DIFF
--- a/recipes/r-xplorerr/bld.bat
+++ b/recipes/r-xplorerr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-xplorerr/build.sh
+++ b/recipes/r-xplorerr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-xplorerr/meta.yaml
+++ b/recipes/r-xplorerr/meta.yaml
@@ -25,10 +25,12 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -51,14 +53,15 @@ test:
     - "\"%R%\" -e \"library('xplorerr')\""  # [win]
 
 about:
-  home: https://github.com/rsquaredacademy/xplorerr, https://xplorerr.rsquaredacademy.com/
+  home: https://xplorerr.rsquaredacademy.com/
+  dev_url: https://github.com/rsquaredacademy/xplorerr
   license: MIT
   summary: Tools for interactive data exploration built using 'shiny'. Includes apps for descriptive
     statistics, visualizing probability distributions, inferential statistics, linear
     regression, logistic regression and RFM analysis.
   license_family: MIT
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
     - LICENSE
 
 extra:

--- a/recipes/r-xplorerr/meta.yaml
+++ b/recipes/r-xplorerr/meta.yaml
@@ -1,0 +1,89 @@
+{% set version = '0.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-xplorerr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/xplorerr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/xplorerr/xplorerr_{{ version }}.tar.gz
+  sha256: 49e8f7aecddb5ad3d6684aebe433e7ee7732096d47171400e62fe6579e05ce61
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp
+    - r-shiny
+  run:
+    - r-base
+    - {{ native }}gcc-libs         # [win]
+    - r-rcpp
+    - r-shiny
+
+test:
+  commands:
+    - $R -e "library('xplorerr')"           # [not win]
+    - "\"%R%\" -e \"library('xplorerr')\""  # [win]
+
+about:
+  home: https://github.com/rsquaredacademy/xplorerr, https://xplorerr.rsquaredacademy.com/
+  license: MIT
+  summary: Tools for interactive data exploration built using 'shiny'. Includes apps for descriptive
+    statistics, visualizing probability distributions, inferential statistics, linear
+    regression, logistic regression and RFM analysis.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: xplorerr
+# Type: Package
+# Title: Tools for Interactive Data Exploration
+# Version: 0.2.0
+# Authors@R: person("Aravind", "Hebbali", email = "hebbali.aravind@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9220-9669"))
+# Description: Tools for interactive data exploration built using 'shiny'. Includes apps for descriptive statistics, visualizing probability distributions, inferential statistics, linear regression, logistic regression and RFM analysis.
+# Depends: R(>= 3.2.4)
+# Imports: Rcpp, shiny, utils
+# Suggests: blorr, data.table, descriptr, DT, haven, highcharter, jsonlite, magrittr, olsrr, plotly, readr, readxl, rfm, shinyBS, shinycssloaders, standby, tools, vistributions
+# URL: https://github.com/rsquaredacademy/xplorerr, https://xplorerr.rsquaredacademy.com/
+# BugReports: https://github.com/rsquaredacademy/xplorerr/issues
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.3.2
+# LinkingTo: Rcpp
+# NeedsCompilation: yes
+# Packaged: 2024-10-29 10:49:53 UTC; HP
+# Author: Aravind Hebbali [aut, cre] (<https://orcid.org/0000-0001-9220-9669>)
+# Maintainer: Aravind Hebbali <hebbali.aravind@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2024-10-29 11:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `xplorerr`](https://cran.r-project.org/package=xplorerr) as `r-xplorerr`. Recipe generated with `conda_r_skeleton_helper`, with stdlib's added and URLs split.

Needed as new dependency in https://github.com/conda-forge/r-olsrr-feedstock/pull/7.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
