### PR TITLE
[pixi] add shellcheck for conda-smithy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,19 +78,31 @@ helpful linters that can save CI resources by catching known issues up-front.
 
 Use one of:
 - manually
-  - install `conda-smithy`: `conda install -c conda-forge conda-smithy`
+  - install `conda-smithy`: `conda install -c conda-forge conda-smithy shellcheck`
   - lint recipes: `conda-smithy recipe-lint --conda-forge recipes/*`
 - with [`pixi`](#pixi):
   - lint recipes: `pixi run lint`
 
-> **NOTE**
+> **NOTES**
 >
-> `conda-smithy` is
+> - `conda-smithy` is
 > [frequently updated](https://github.com/conda-forge/conda-smithy/blob/main/CHANGELOG.rst)
 > with current best practices. Ensure using the latest with:
+>   - `$CONDA_EXE upgrade conda-smithy shellcheck`
+>   - or `pixi upgrade --feature conda-smithy`
 >
-> - `$CONDA_EXE upgrade conda-smithy`
-> - `pixi upgrade --feature conda-smithy`
+> - to enable most [`shellcheck`](https://www.shellcheck.net/) [rules](https://www.shellcheck.net/wiki)
+>    - create a [`conda-forge.yml`](https://conda-forge.org/docs/maintainer/conda_forge_yml)
+>      next to your new recipe (and any `.sh` scripts):
+>      ```yaml
+>      # recipes/your-new-recipe/conda-forge.yml
+>      shellcheck:
+>        enabled: true
+>      ```
+>    - run the linter using your preferred method, as described above
+>    - if committed and pushed, this will be checked in CI during the review process,
+>      then merged into the defaults in the root of the rendered feedstock.
+
 
 ## FAQ
 
@@ -158,6 +170,9 @@ This should be the default install line for most Python packages. This is prefer
 ### 8. **Do I need `bld.bat` and/or `build.sh`?**
 
 In many cases, no. Python packages almost never need it. If the build can be done with one line you can put it in the `script` line of the `build` section.
+
+If you _would_ like help with `.sh` best practices, see more information about
+[linting with `conda-smithy`](#linting-recipes-with-conda-smithy) and `shellcheck`.
 
 ### 9. What does being a conda-forge feedstock maintainer entail?
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -71,6 +71,7 @@ cmd = "cd recipes && grayskull cran --strict-conda-forge"
 
 [feature.conda-smithy.dependencies]
 conda-smithy = ">=3.44.6,<4"
+shellcheck = "*"
 [feature.conda-smithy.tasks.lint]
 description = "validate all recipes with `conda-smithy`"
 cmd = "conda-smithy recipe-lint --conda-forge recipes/*"


### PR DESCRIPTION

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Changes:
- [x] adds `shellcheck` to the local `conda-smithy` feature
  - enables the [`conda-forge.yml#shellcheck`](https://conda-forge.org/docs/maintainer/conda_forge_yml/#shellcheck) setting
- [x] add a note to the linter README section and link in FAQ

My quick test (not comitted):

- comment out the line in `example/meta.yaml`

```diff
diff --git a/recipes/example/meta.yaml b/recipes/example/meta.yaml
index f095288e58..f1ea661f03 100644
--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -35,7 +35,6 @@ build:
   # Add the line "skip: True  # [py<35]" (for example) to limit to Python 3.5 and newer, or "skip: True  # [not win]" to limit to Windows.
   # More info about selectors can be found in the conda-build docs:
   # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#preprocessing-selectors
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
```

Make an innocuous `build.sh`:

```bash
#!/usr/bin/env bash
$PYTHON -m pip install . -vv
```

Then:

```bash
(base) ~/staged-recipes$ pixi r lint
✨ Pixi task (lint in conda-smithy): conda-smithy recipe-lint --conda-forge recipes/*: (validate all recipes with `conda-smithy`)
recipes/example has some suggestions:
  Whenever possible fix all shellcheck findings ('shellcheck --enable=all --shell=bash --exclude=SC2154 recipe/*.sh -f diff | git apply' helps)
  
  In ~/staged-recipes/recipes/example/build.sh line 1:
  $PYTHON -m pip install . -vv
  ^-----^ SC2250 (style): Prefer putting braces around variable references even when not strictly required.
  
  Did you mean: 
  ${PYTHON} -m pip install . -vv
  
  For more information:
    https://www.shellcheck.net/wiki/SC2250 -- Prefer putting braces around vari...
```