### PR TITLE
adds `r-vcr`

### DIFF
--- a/recipes/r-vcr/bld.bat
+++ b/recipes/r-vcr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-vcr/build.sh
+++ b/recipes/r-vcr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-vcr/meta.yaml
+++ b/recipes/r-vcr/meta.yaml
@@ -1,0 +1,100 @@
+{% set version = '1.6.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-vcr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/vcr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/vcr/vcr_{{ version }}.tar.gz
+  sha256: aeebae06287a7c869590c1ffc88c2054cc16c77e63c1827d873a0b6f66bae64a
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-r6
+    - r-base64enc
+    - r-crul >=0.8.4
+    - r-httr
+    - r-httr2
+    - r-rprojroot
+    - r-urltools
+    - r-webmockr >=0.8.0
+    - r-yaml
+  run:
+    - r-base
+    - r-r6
+    - r-base64enc
+    - r-crul >=0.8.4
+    - r-httr
+    - r-httr2
+    - r-rprojroot
+    - r-urltools
+    - r-webmockr >=0.8.0
+    - r-yaml
+
+test:
+  commands:
+    - $R -e "library('vcr')"           # [not win]
+    - "\"%R%\" -e \"library('vcr')\""  # [win]
+
+about:
+  home: https://github.com/ropensci/vcr/, https://books.ropensci.org/http-testing/, https://docs.ropensci.org/vcr/
+  license: MIT
+  summary: Record test suite 'HTTP' requests and replays them during future runs. A port of the
+    Ruby gem of the same name (<https://github.com/vcr/vcr/>). Works by hooking into
+    the 'webmockr' R package for matching 'HTTP' requests by various rules ('HTTP' method,
+    'URL', query parameters, headers, body, etc.), and then caching real 'HTTP' responses
+    on disk in 'cassettes'. Subsequent 'HTTP' requests matching any previous requests
+    in the same 'cassette' use a cached 'HTTP' response.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: vcr
+# Title: Record 'HTTP' Calls to Disk
+# Description: Record test suite 'HTTP' requests and replays them during future runs. A port of the Ruby gem of the same name (<https://github.com/vcr/vcr/>). Works by hooking into the 'webmockr' R package for matching 'HTTP' requests by various rules ('HTTP' method, 'URL', query parameters, headers, body, etc.), and then caching real 'HTTP' responses on disk in 'cassettes'. Subsequent 'HTTP' requests matching any previous requests in the same 'cassette' use a cached 'HTTP' response.
+# Version: 1.6.0
+# Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"), email = "sckott@protonmail.com", comment = c(ORCID="0000-0003-1444-9135")), person("Aaron", "Wolen", role = "aut", comment = c(ORCID="0000-0003-2542-2202")), person("Maelle", "Salmon", role = "aut", comment = c(ORCID="0000-0002-2815-0399")), person("Daniel", "Possenriede", role = "aut", comment = c(ORCID="0000-0002-6738-9845")), person("rOpenSci", role = "fnd", comment = "https://ropensci.org"))
+# URL: https://github.com/ropensci/vcr/, https://books.ropensci.org/http-testing/, https://docs.ropensci.org/vcr/
+# BugReports: https://github.com/ropensci/vcr/issues
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# Language: en-US
+# LazyData: true
+# VignetteBuilder: knitr
+# Imports: crul (>= 0.8.4), httr, httr2, webmockr (>= 0.8.0), urltools, yaml, R6, base64enc, rprojroot
+# Suggests: roxygen2 (>= 7.2.1), jsonlite, testthat, knitr, rmarkdown, desc, crayon, cli, curl, withr, webfakes
+# X-schema.org-applicationCategory: Web
+# X-schema.org-keywords: http, https, API, web-services, curl, mock, mocking, http-mocking, testing, testing-tools, tdd
+# X-schema.org-isPartOf: https://ropensci.org
+# RoxygenNote: 7.3.2
+# NeedsCompilation: no
+# Packaged: 2024-07-23 20:47:01 UTC; sckott
+# Author: Scott Chamberlain [aut, cre] (<https://orcid.org/0000-0003-1444-9135>), Aaron Wolen [aut] (<https://orcid.org/0000-0003-2542-2202>), Maelle Salmon [aut] (<https://orcid.org/0000-0002-2815-0399>), Daniel Possenriede [aut] (<https://orcid.org/0000-0002-6738-9845>), rOpenSci [fnd] (https://ropensci.org)
+# Maintainer: Scott Chamberlain <sckott@protonmail.com>
+# Repository: CRAN
+# Date/Publication: 2024-07-23 21:40:02 UTC

--- a/recipes/r-vcr/meta.yaml
+++ b/recipes/r-vcr/meta.yaml
@@ -57,7 +57,9 @@ test:
     - "\"%R%\" -e \"library('vcr')\""  # [win]
 
 about:
-  home: https://github.com/ropensci/vcr/, https://books.ropensci.org/http-testing/, https://docs.ropensci.org/vcr/
+  home: https://books.ropensci.org/http-testing/
+  dev_url: https://github.com/ropensci/vcr/
+  doc_url: https://docs.ropensci.org/vcr/
   license: MIT
   summary: Record test suite 'HTTP' requests and replays them during future runs. A port of the
     Ruby gem of the same name (<https://github.com/vcr/vcr/>). Works by hooking into


### PR DESCRIPTION
Adds [CRAN package `vcr`](https://cran.r-project.org/package=vcr) as `r-vcr`. Recipe generated with `conda_r_skeleton_helper`.

Used in unit tests of https://github.com/conda-forge/r-spocc-feedstock/pull/15.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
