### PR TITLE
adds `r-webmockr`

### DIFF
--- a/recipes/r-webmockr/bld.bat
+++ b/recipes/r-webmockr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-webmockr/build.sh
+++ b/recipes/r-webmockr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-webmockr/meta.yaml
+++ b/recipes/r-webmockr/meta.yaml
@@ -1,0 +1,94 @@
+{% set version = '1.0.0' %}
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
+
+package:
+  name: r-webmockr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/webmockr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/webmockr/webmockr_{{ version }}.tar.gz
+  sha256: 7352a2c08f2af95d2d11180b072d1c375e7fc76c4cfdf3bed4e033605a914626
+
+build:
+  merge_build_host: True  # [win]
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-r6 >=2.1.3
+    - r-base64enc
+    - r-crul >=0.7.0
+    - r-curl
+    - r-fauxpas
+    - r-jsonlite
+    - r-magrittr >=1.5
+    - r-urltools >=1.6.0
+  run:
+    - r-base
+    - r-r6 >=2.1.3
+    - r-base64enc
+    - r-crul >=0.7.0
+    - r-curl
+    - r-fauxpas
+    - r-jsonlite
+    - r-magrittr >=1.5
+    - r-urltools >=1.6.0
+
+test:
+  commands:
+    - $R -e "library('webmockr')"           # [not win]
+    - "\"%R%\" -e \"library('webmockr')\""  # [win]
+
+about:
+  home: https://github.com/ropensci/webmockr, https://books.ropensci.org/http-testing/, https://docs.ropensci.org/webmockr/
+  license: MIT
+  summary: Stubbing and setting expectations on 'HTTP' requests. Includes tools for stubbing
+    'HTTP' requests, including expected request conditions and response conditions.
+    Match on 'HTTP' method, query parameters, request body, headers and more. Can be
+    used for unit tests or outside of a testing context.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: webmockr
+# Title: Stubbing and Setting Expectations on 'HTTP' Requests
+# Description: Stubbing and setting expectations on 'HTTP' requests. Includes tools for stubbing 'HTTP' requests, including expected request conditions and response conditions. Match on 'HTTP' method, query parameters, request body, headers and more. Can be used for unit tests or outside of a testing context.
+# Version: 1.0.0
+# Authors@R: c( person("Scott", "Chamberlain", role = c("aut", "cre"), email = "myrmecocystus+r@gmail.com", comment = c(ORCID="0000-0003-1444-9135")), person("Aaron", "Wolen", role = "ctb", comment = c(ORCID="0000-0003-2542-2202")), person("rOpenSci", role = "fnd", comment = "https://ropensci.org") )
+# License: MIT + file LICENSE
+# URL: https://github.com/ropensci/webmockr, https://books.ropensci.org/http-testing/, https://docs.ropensci.org/webmockr/
+# BugReports: https://github.com/ropensci/webmockr/issues
+# Encoding: UTF-8
+# Language: en-US
+# Imports: curl, jsonlite, magrittr (>= 1.5), R6 (>= 2.1.3), urltools (>= 1.6.0), fauxpas, crul (>= 0.7.0), base64enc
+# Suggests: testthat, xml2, vcr, httr, httr2
+# RoxygenNote: 7.3.2
+# X-schema.org-applicationCategory: Web
+# X-schema.org-keywords: http, https, API, web-services, curl, mock, mocking, fakeweb, http-mocking, testing, testing-tools, tdd
+# X-schema.org-isPartOf: https://ropensci.org
+# NeedsCompilation: no
+# Packaged: 2024-07-22 15:53:03 UTC; sckott
+# Author: Scott Chamberlain [aut, cre] (<https://orcid.org/0000-0003-1444-9135>), Aaron Wolen [ctb] (<https://orcid.org/0000-0003-2542-2202>), rOpenSci [fnd] (https://ropensci.org)
+# Maintainer: Scott Chamberlain <myrmecocystus+r@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2024-07-23 05:50:02 UTC

--- a/recipes/r-webmockr/meta.yaml
+++ b/recipes/r-webmockr/meta.yaml
@@ -55,7 +55,9 @@ test:
     - "\"%R%\" -e \"library('webmockr')\""  # [win]
 
 about:
-  home: https://github.com/ropensci/webmockr, https://books.ropensci.org/http-testing/, https://docs.ropensci.org/webmockr/
+  home: https://books.ropensci.org/http-testing/
+  dev_url: https://github.com/ropensci/webmockr
+  doc_url: https://docs.ropensci.org/webmockr/
   license: MIT
   summary: Stubbing and setting expectations on 'HTTP' requests. Includes tools for stubbing
     'HTTP' requests, including expected request conditions and response conditions.
@@ -63,7 +65,7 @@ about:
     used for unit tests or outside of a testing context.
   license_family: MIT
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
     - LICENSE
 
 extra:


### PR DESCRIPTION
Adds [CRAN package `webmockr`](https://cran.r-project.org/package=webmockr) as `r-webmockr`. Recipe generated with `conda_r_skeleton_helper`.

Needed for #28434.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
