### PR TITLE
CI: add missing config argument to _get_or_render_metadata

### DIFF
--- a/.ci_support/compute_build_graph.py
+++ b/.ci_support/compute_build_graph.py
@@ -453,7 +453,7 @@ def _buildable(name, version, recipes_dir, worker, config, finalize):
                     packagename_re.match(dirname)))
     metadata_tuples = [m for path in likely_dirs
                         for (m, _, _) in _get_or_render_metadata(os.path.join(recipes_dir,
-                                                                 path), worker, finalize=finalize)]
+                                                                 path), worker, config=config, finalize=finalize)]
 
     # this is our target match
     ms = MatchSpec(" ".join([name, _fix_any(version, config)]))


### PR DESCRIPTION
Within `.ci_support/compute_build_graph.py`,`_get_or_render_metadata` is called from two sites, but when called from `_buildable`, the `config` argument was not passed along. Apparently, it's not possible to build multiple interdependent `noarch: python` packages in one PR without this `config` argument, but the build seems to work when applying the change as proposed in this PR.

I have to admit, that I'm new to conda-forge and didn't yet understand what exactly is passed along in this `config` argument, but I guessed that the `python_min` variable would be part of it.
I also have to admit, that I don't know if a PR to this repo would actually be the right way to fix this issue, I'd be glad for some guidelines if there'd be a better place.

Fixes #28445