### PR TITLE
Add recipe for yarp-device-realsense2 package

### DIFF
--- a/recipes/yarp-device-realsense2/build.sh
+++ b/recipes/yarp-device-realsense2/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+rm -rf build
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DBUILD_SHARED_LIBS:BOOL=ON \
+      ..
+
+cmake --build . --config Release
+
+if [[ ("${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "") ]]; then
+  ctest --output-on-failure  -C Release
+fi
+
+cmake --build . --config Release --target install

--- a/recipes/yarp-device-realsense2/meta.yaml
+++ b/recipes/yarp-device-realsense2/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "yarp-device-realsense2" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/robotology/yarp-device-realsense2/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 28426e67b610874bbf8fd71fae982921aafe42310ef674c86aa6ec1181472ad0
+
+build:
+  number: 0
+  # librealsense conda package is not available on Windows
+  skip: True  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ stdlib('c') }}
+    - {{ compiler('cxx') }}
+    - cmake
+    - pkg-config
+    - ninja
+  host:
+    - librealsense
+    - libyarp
+
+test:
+  commands:
+    - test -f ${PREFIX}/lib/yarp/yarp_realsense2${SHLIB_EXT}  # [not win]
+    - test -f ${PREFIX}/lib/yarp/yarp_realsense2withIMU${SHLIB_EXT}  # [not win]
+
+about:
+  home: https://github.com/robotology/yarp-device-realsense2
+  license: BSD-3-Clause
+  license_file: 
+    - LICENSE
+  summary: realsense2 device for YARP.
+
+extra:
+  feedstock-name: yarp-device-realsense2
+  recipe-maintainers:
+    - traversaro

--- a/recipes/yarp-device-realsense2/meta.yaml
+++ b/recipes/yarp-device-realsense2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/robotology/yarp-device-realsense2/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 28426e67b610874bbf8fd71fae982921aafe42310ef674c86aa6ec1181472ad0
+  sha256: 5a2a4e169ef58a4214f0176bb6c7845c2726d5c49bcad98ffe12f75eeb535d20
 
 build:
   number: 0

--- a/recipes/yarp-device-realsense2/meta.yaml
+++ b/recipes/yarp-device-realsense2/meta.yaml
@@ -28,8 +28,11 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/yarp/yarp_realsense2${SHLIB_EXT}  # [not win]
-    - test -f ${PREFIX}/lib/yarp/yarp_realsense2withIMU${SHLIB_EXT}  # [not win]
+    # Note: the devices are added in CMake add_library(... MODULE),
+    # so also on macos they have the .so extension, instead of the .dylib
+    # extension that add_library(... SHARED) typically have
+    - test -f ${PREFIX}/lib/yarp/yarp_realsense2.so  # [not win]
+    - test -f ${PREFIX}/lib/yarp/yarp_realsense2withIMU.so  # [not win]
 
 about:
   home: https://github.com/robotology/yarp-device-realsense2


### PR DESCRIPTION
The PR adds a package for the YARP plugins contained in https://github.com/robotology/yarp-device-realsense2 . The package contains two libraries that can only be loaded via the YARP plugin system (i.e. `dlopen`), so no headers nor `run_exports` information is added to the recipe.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
