### PR TITLE
Revert "Live tests for https://github.com/conda-forge/conda-smithy/pull/2120"

### DIFF
--- a/.github/workflows/scripts/create_feedstocks
+++ b/.github/workflows/scripts/create_feedstocks
@@ -48,13 +48,7 @@ conda install --yes --quiet \
   "pygithub>=2.1.1" \
   "rattler-build-conda-compat>=1.2.0,<2.0.0a0" \
   "conda-forge-feedstock-ops>=0.5.0" \
-  "conda-forge-metadata>=0.8.1" \
-  pygit2
-
-# Live tests for https://github.com/conda-forge/conda-smithy/pull/2120
-# Remove once merged and released
-conda remove --force conda-smithy
-SETUPTOOLS_SCM_PRETEND_VERSION=3.44.10 pip install https://github.com/mgorny/conda-smithy/archive/pygit2.tar.gz --no-deps
+  "conda-forge-metadata>=0.8.1"
 
 conda info
 mamba info


### PR DESCRIPTION
Reverts conda-forge/staged-recipes#28547. Tests are passing so we can just wait for the actual conda-smithy release.