### PR TITLE
fail_git_url recipe (DO NOT MERGE)

### DIFF
--- a/recipes/fail_git_url/recipe.yaml
+++ b/recipes/fail_git_url/recipe.yaml
@@ -1,0 +1,26 @@
+context:
+  name: katago
+  version: 1.15.3
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  git: https://github.com/lightvector/KataGo.git
+  tag: v${{ version }}
+
+build:
+  number: 0
+  script:
+    - touch hello.txt
+
+about:
+  summary: GTP engine and self-play learning in Go
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/lightvector/KataGo
+
+extra:
+  recipe-maintainers:
+    - hadim


### PR DESCRIPTION
**DO NOT MERGE THIS PR**

---

Trying to reproduce an error seen at https://github.com/conda-forge/katago-feedstock/pull/11 where using a git URL fails on Windows with a v1 recipe (rattler-build) with this error:

```
Error: 
  × Failed to run git command: Git clone failed for source: Cloning into '/d/
  │ bld/src_cache/KataGo.git'...
  │ fatal: unable to access 'https://github.com/lightvector/KataGo.git/':
  │ error setting certificate file: /usr/ssl/certs/ca-bundle.crt
```