### PR TITLE
replace CUDA 12.0 with 12.6; adopt cdt_name pinning update

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -98,7 +98,7 @@ jobs:
   - publish: build_artifacts/linux-64/
     artifact: conda_pkgs_linux_64_cuda118
 
-- job: linux_64_cuda_120
+- job: linux_64_cuda_126
   dependsOn: linux_64
   condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
   pool:
@@ -133,11 +133,11 @@ jobs:
       mkdir -p build_artifacts/linux-64/
 
       export CI=azure
-      export CONFIG=linux64_cuda120
+      export CONFIG=linux64_cuda126
       export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-x86_64:alma9
       export AZURE=True
       .scripts/run_docker_build.sh
 
-    displayName: Run docker build for CUDA 12.0
+    displayName: Run docker build for CUDA 12.6
   - publish: build_artifacts/linux-64/
-    artifact: conda_pkgs_linux_64_cuda120
+    artifact: conda_pkgs_linux_64_cuda126

--- a/.ci_support/linux64.yaml
+++ b/.ci_support/linux64.yaml
@@ -3,7 +3,7 @@ c_stdlib_version:
 c_stdlib:
 - sysroot
 cdt_name:
-- cos7
+- conda
 c_compiler:
 - gcc
 cxx_compiler:

--- a/.ci_support/linux64_cuda118.yaml
+++ b/.ci_support/linux64_cuda118.yaml
@@ -19,7 +19,7 @@ c_stdlib:
 c_stdlib_version:
 - 2.17
 cdt_name:
-- cos7
+- conda
 target_platform:
 - linux-64
 channel_sources:

--- a/.ci_support/linux64_cuda126.yaml
+++ b/.ci_support/linux64_cuda126.yaml
@@ -9,17 +9,17 @@ go_compiler:
 cgo_compiler:
 - go-cgo
 c_compiler_version:
-- 12
+- 13
 cxx_compiler_version:
-- 12
+- 13
 fortran_compiler_version:
-- 12
+- 13
 c_stdlib:
 - sysroot
 c_stdlib_version:
 - 2.17
 cdt_name:
-- cos7
+- conda
 target_platform:
 - linux-64
 channel_sources:
@@ -29,6 +29,6 @@ docker_image:
 cuda_compiler:
 - cuda-nvcc
 cuda_compiler_version:
-- 12.0
+- 12.6
 cuda_compiler_version_min:
 - 11.8


### PR DESCRIPTION
This was forgotten in the context of https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/6630