### PR TITLE
create swapfiles also for CUDA jobs

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -78,6 +78,13 @@ jobs:
     displayName: Manage disk space
 
   - script: |
+      sudo fallocate -l 10GiB /swapfile || true
+      sudo chmod 600 /swapfile || true
+      sudo mkswap /swapfile || true
+      sudo swapon /swapfile || true
+    displayName: Create swap file
+
+  - script: |
       # sudo pip install --upgrade pip
       sudo pip install setuptools shyaml
     displayName: Install dependencies
@@ -120,6 +127,13 @@ jobs:
           sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
       done
     displayName: Manage disk space
+
+  - script: |
+      sudo fallocate -l 10GiB /swapfile || true
+      sudo chmod 600 /swapfile || true
+      sudo mkswap /swapfile || true
+      sudo swapon /swapfile || true
+    displayName: Create swap file
 
   - script: |
       # sudo pip install --upgrade pip


### PR DESCRIPTION
The regular linux job sets up a swapfile
https://github.com/conda-forge/staged-recipes/blob/6825bf2e185ac1c7931d6802790d2d070562ac04/.azure-pipelines/azure-pipelines-linux.yml#L24-L29

but the CUDA builds don't. Fix that