### PR TITLE
Adding geoschem-gcpy 1.6.0 to conda forge

### DIFF
--- a/recipes/geoschem-gcpy/meta.yaml
+++ b/recipes/geoschem-gcpy/meta.yaml
@@ -71,6 +71,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - yantosca
-    - msulprizio
-    - lizziel
+    - yantosca   # I am willing to be a maintainer (@yantosca, 30 Jan 2025)

--- a/recipes/geoschem-gcpy/meta.yaml
+++ b/recipes/geoschem-gcpy/meta.yaml
@@ -55,7 +55,7 @@ test:
     - pip
 
 about:
-  summary: GCPy: The GEOS-Chem Python toolkit
+  summary: "GCPy: The GEOS-Chem Python toolkit"
   home: https://github.com/geoschem/gcpy
   license: MIT
   license_family: MIT

--- a/recipes/geoschem-gcpy/meta.yaml
+++ b/recipes/geoschem-gcpy/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "geoschem-gcpy" %}
+{% set version = "1.6.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/geoschem_gcpy-{{ version }}.tar.gz
+  sha256: 67240a50862e00295f939648aa85d8605b9b80cd20849c3325367f9597bcdf7d
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python ==3.12.0
+    - cartopy ==0.23.0
+    - cf_xarray ==0.9.1
+    - dask-core ==2024.5.2
+    - esmf ==8.6.1
+    - esmpy ==8.6.1
+    - gridspec ==0.1.0
+    - ipython ==8.25.0
+    - joblib ==1.4.2
+    - jupyter ==1.0.0
+    - matplotlib-base ==3.8.4
+    - netcdf4 ==1.6.5
+    - netcdf-fortran ==4.6.1
+    - numpy ==1.26.4
+    - pandas ==2.2.2
+    - pip ==24.0
+    - pylint ==3.2.2
+    - pyproj ==3.6.1
+    - pypdf ==4.2.0
+    - requests ==2.32.3
+    - scipy ==1.13.1
+    - sparselt ==0.1.3
+    - tabulate ==0.9.0
+    - tk ==8.6.13
+    - xarray ==2024.5.0
+    - xesmf ==0.8.5
+
+test:
+  imports:
+    - gcpy
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: GCPy: The GEOS-Chem Python toolkit
+  home: https://pypi.org/project/geoschem-gcpy/
+  dev_url: https://github.com/geoschem/gcpy
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - yantosca
+    - msulprizio
+    - lizziel

--- a/recipes/geoschem-gcpy/meta.yaml
+++ b/recipes/geoschem-gcpy/meta.yaml
@@ -56,10 +56,18 @@ test:
 
 about:
   summary: GCPy: The GEOS-Chem Python toolkit
-  home: https://pypi.org/project/geoschem-gcpy/
-  dev_url: https://github.com/geoschem/gcpy
+  home: https://github.com/geoschem/gcpy
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
+  description: |
+    GCPy is a Python-based toolkit containing useful functions
+    for working specifically with the GEOS-Chem model of
+    atmospheric chemistry and composition. GCPy is primarily
+    used for plotting/tabling GEOS-Chem output and regridding
+    input files in special cases.  GCPy is also used to create
+    evaluation plots and tables for GEOS-Chem benchmark
+    simulations.
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## Overview

This PR adds a recipe for the geoschem-gcpy package version 1.6.0, which is already published on PyPI:

- https://pypi.org/project/geoschem-gcpy/

GCPy is a Python-based toolkit containing useful functions for working specifically with the GEOS-Chem model of atmospheric chemistry and composition. GCPy is primarily used for plotting/tabling GEOS-Chem output and regridding input files in special cases.

Relevant links:

Source code
- https://github.com/geoschem/gcpy 
- https://pypi.org/project/geoschem-gcpy/

Documentation
- https://gcpy.readthedocs.io

## PR Checklist
- [x[ Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
