### PR TITLE
add wrapt_timeout_decorator

### DIFF
--- a/recipes/wrapt_timeout_decorator/LICENSE.txt
+++ b/recipes/wrapt_timeout_decorator/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 1990-2024 Robert Nowotny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/wrapt_timeout_decorator/meta.yaml
+++ b/recipes/wrapt_timeout_decorator/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "wrapt_timeout_decorator" %}
+{% set version = "1.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/wrapt_timeout_decorator-{{ version }}.tar.gz
+  sha256: 00f15646db89c629aa1b1566f4c1cf00ae6da0beece2905039f1cd7a60506a67
+
+build:
+  entry_points:
+    - wrapt_timeout_decorator = wrapt_timeout_decorator.wrapt_timeout_decorator_cli:cli_main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  run_exports:
+    - {{ pin_subpackage("wrapt_timeout_decorator", max_pin="x.x.x") }}
+
+requirements:
+  host:
+    - python >=3.8.0
+    - setuptools
+    - setuptools-scm
+    - pip
+  run:
+    - python >=3.8.0
+    - cli-exit-tools
+    - dill  # [not win]
+    - dill >0.3.0,!=0.3.5,!=0.3.5.1  # [win]
+    - lib-detect-testenv
+    - multiprocess
+    - psutil
+    - wrapt
+
+test:
+  imports:
+    - wrapt_timeout_decorator
+  commands:
+    - pip check
+    - wrapt_timeout_decorator --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/bitranox/wrapt_timeout_decorator
+  summary: The better timout decorator
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - nilchia


### PR DESCRIPTION
adds wrapt_timeout_decorator

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
