### PR TITLE
add r-devemf

### DIFF
--- a/recipes/r-devemf/bld.bat
+++ b/recipes/r-devemf/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-devemf/build.sh
+++ b/recipes/r-devemf/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-devemf/meta.yaml
+++ b/recipes/r-devemf/meta.yaml
@@ -1,0 +1,79 @@
+{% set version = '4.5' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-devemf
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/devEMF_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/devEMF/devEMF_{{ version }}.tar.gz
+  sha256: ead1cb3dbb41bf4caacc77335452c6575b1b5e620aac1205c3a80467a0a13c0e
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}sed               # [win]
+    - {{ posix }}grep              # [win]
+    - {{ posix }}autoconf
+    - {{ posix }}automake          # [not win]
+    - {{ posix }}automake-wrapper  # [win]
+    - pkg-config
+    - {{ posix }}make
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('devEMF')"           # [not win]
+    - "\"%R%\" -e \"library('devEMF')\""  # [win]
+
+about:
+  home: https://github.com/plfjohnson/devEMF
+  license: GPL-3
+  summary: Output graphics to EMF+/EMF.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: devEMF
+# Type: Package
+# Title: EMF Graphics Output Device
+# Version: 4.5
+# Date: 2024-07-26
+# Author: Philip Johnson
+# Maintainer: Philip Johnson <plfj@umd.edu>
+# Depends: R (>= 2.10.1)
+# SystemRequirements: fontconfig or zlib (only needed for platforms other than modern OSX and Windows)
+# Description: Output graphics to EMF+/EMF.
+# License: GPL-3
+# URL: https://github.com/plfjohnson/devEMF
+# BugReports: https://github.com/plfjohnson/devEMF/issues
+# NeedsCompilation: yes
+# Packaged: 2024-07-26 15:53:10 UTC; pjohnson
+# Repository: CRAN
+# Date/Publication: 2024-07-26 20:00:01 UTC

--- a/recipes/r-devemf/meta.yaml
+++ b/recipes/r-devemf/meta.yaml
@@ -23,10 +23,11 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ compiler('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}sed               # [win]
     - {{ posix }}grep              # [win]
@@ -37,7 +38,6 @@ requirements:
     - {{ posix }}make
     - {{ posix }}coreutils         # [win]
     - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
   run:
@@ -50,11 +50,11 @@ test:
 
 about:
   home: https://github.com/plfjohnson/devEMF
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Output graphics to EMF+/EMF.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `devEMF`](https://cran.r-project.org/package=devEMF) as `r-devemf`. Recipe generated with `conda_r_skeleton_helper` with license adjusted for SPDX.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
