### PR TITLE
adds r-eoffice

### DIFF
--- a/recipes/r-eoffice/bld.bat
+++ b/recipes/r-eoffice/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-eoffice/build.sh
+++ b/recipes/r-eoffice/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-eoffice/meta.yaml
+++ b/recipes/r-eoffice/meta.yaml
@@ -1,0 +1,99 @@
+{% set version = '0.2.2' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-eoffice
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/eoffice_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/eoffice/eoffice_{{ version }}.tar.gz
+  sha256: 44b31804cd6aef8ca9bec1535b9c4a9ec46d429ffb8c8e045ec5f6a732a5be5b
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-r.devices
+    - r-broom
+    - r-devemf
+    - r-dplyr
+    - r-flextable
+    - r-ggplot2
+    - r-ggplotify
+    - r-htmlwidgets
+    - r-magick
+    - r-magrittr
+    - r-officer
+    - r-plotly
+    - r-rvg
+  run:
+    - r-base
+    - r-r.devices
+    - r-broom
+    - r-devemf
+    - r-dplyr
+    - r-flextable
+    - r-ggplot2
+    - r-ggplotify
+    - r-htmlwidgets
+    - r-magick
+    - r-magrittr
+    - r-officer
+    - r-plotly
+    - r-rvg
+
+test:
+  commands:
+    - $R -e "library('eoffice')"           # [not win]
+    - "\"%R%\" -e \"library('eoffice')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=eoffice
+  license: GPL-2.0-only
+  summary: Provides wrap functions to export and import graphics and data frames in R to 'microsoft'
+    office. And This package also provide write out figures with lots of different formats.
+    Since people may work on the platform without GUI support, the package also provide
+    function to easily write out figures to lots of different type of formats. Now this
+    package provide function to extract colors from all types of figures and pdf files.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: eoffice
+# Type: Package
+# Title: Export or Graph and Tables to 'Microsoft' Office and Import Figures and Tables
+# Version: 0.2.2
+# Authors@R: person("Kai", "Guo", email = "guokai8@gmail.com", role = c("aut", "cre"))
+# Description: Provides wrap functions to export and import graphics and data frames in R to 'microsoft' office. And This package also provide write out figures with lots of different formats. Since people may work on the platform without GUI support, the package also provide function to easily write out figures to lots of different type of formats. Now this package provide function to extract colors from all types of figures and pdf files.
+# License: GPL-2
+# Imports: officer, rvg, flextable, broom, dplyr, magrittr, ggplotify, R.devices, devEMF, magick, ggplot2, htmlwidgets, plotly
+# Depends:
+# Encoding: UTF-8
+# Suggests: knitr, markdown, rmarkdown
+# VignetteBuilder: knitr
+# RoxygenNote: 7.1.1
+# NeedsCompilation: no
+# Packaged: 2022-10-05 07:16:00 UTC; bioguo
+# Author: Kai Guo [aut, cre]
+# Maintainer: Kai Guo <guokai8@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2022-10-05 07:30:02 UTC


### PR DESCRIPTION
Adds [CRAN package `eoffice`](https://cran.r-project.org/package=eoffice) as `r-eoffice`. Recipe generated with `conda_r_skeleton_helper`.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
