### PR TITLE
add conda-managed-env

### DIFF
--- a/recipes/conda-managed-env/EXTERNALLY-MANAGED
+++ b/recipes/conda-managed-env/EXTERNALLY-MANAGED
@@ -1,0 +1,7 @@
+[externally-managed]
+Error=This conda environment has been marked as externally managed.
+ Please use conda to install packages into this environment.
+
+ If you wish to install packages using other tools, consider creating
+ a new environment or remove the conda-managed-env package from
+ this environment.

--- a/recipes/conda-managed-env/LICENSE.txt
+++ b/recipes/conda-managed-env/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2024 conda-forge
+Copyright 2025 conda-forge
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/recipes/conda-managed-env/LICENSE.txt
+++ b/recipes/conda-managed-env/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2024 conda-forge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/recipes/conda-managed-env/meta.yaml
+++ b/recipes/conda-managed-env/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: "1.0.0"
 
 build:
+  number: 0
   script:
     - cp  ${RECIPE_DIR}/EXTERNALLY-MANAGED ${STDLIB_DIR}/EXTERNALLY-MANAGED  # [unix]
     - copy %RECIPE_DIR%\EXTERNALLY-MANAGED  %STDLIB_DIR%\EXTERNALLY-MANAGED || exit 1  # [win]
@@ -21,7 +22,7 @@ test:
 about:
   home: https://packaging.python.org/en/latest/specifications/externally-managed-environments/
   summary: 'Mark an environment as externally managed, prevents pip from installing packages'
-  descriptions: |
+  description: |
     Install this package to mark an environment as externally managed.
     Conda will still be able to install and remove packages from the environment.
     Other tools, including pip, will not be able to modify the environment.

--- a/recipes/conda-managed-env/meta.yaml
+++ b/recipes/conda-managed-env/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: conda-managed-env
+  version: "1.0.0"
+
+build:
+  script:
+    - cp  ${RECIPE_DIR}/EXTERNALLY-MANAGED ${STDLIB_DIR}/EXTERNALLY-MANAGED  # [unix]
+    - copy %RECIPE_DIR%\EXTERNALLY-MANAGED  %STDLIB_DIR%\EXTERNALLY-MANAGED || exit 1  # [win]
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+test:
+  commands:
+    - test -f ${STDLIB_DIR}/EXTERNALLY-MANAGED  # [unix]
+    - if not exist %STDLIB_DIR%\EXTERNALLY-MANAGED exit 1  # [win]
+
+about:
+  home: https://packaging.python.org/en/latest/specifications/externally-managed-environments/
+  summary: 'Mark an environment as externally managed, prevents pip from installing packages'
+  descriptions: |
+    Install this package to mark an environment as externally managed.
+    Conda will still be able to install and remove packages from the environment.
+    Other tools, including pip, will not be able to modify the environment.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - jjhelmus


### PR DESCRIPTION
When the `conda-managed-env` package is installed into an environment, pip and other tools are blocked from installing packages as documented in [Externally Managed Environments](https://packaging.python.org/en/latest/specifications/externally-managed-environments/)

For example:
```
❯ conda list conda-
# packages in environment at /Users/jhelmus/mc/envs/test:
#
# Name                    Version                   Build  Channel
conda-managed-env         1.0.0                   py310_0    local

❯ python -m pip install imagesize
error: externally-managed-environment

× This environment is externally managed
╰─> This conda environment has been marked as externally managed.
    Please use conda to install packages into this environment.

    If you wish to install packages using other tools, consider creating
    a new environment or remove the conda-managed-env package from
    this environment.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
