### PR TITLE
Adding r-kaggler

### DIFF
--- a/recipes/r-kaggler/bld.bat
+++ b/recipes/r-kaggler/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-kaggler/build.sh
+++ b/recipes/r-kaggler/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-kaggler/meta.yaml
+++ b/recipes/r-kaggler/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "0.0.0.9000" %}
+
+package:
+  name: r-kaggler
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - https://github.com/mkearney/kaggler/archive/530b3af593d44b3e28400b8f581e55a6e09b027a.tar.gz
+  sha256: bf9fee9fa868814d3206cedca46a9b708ddf79876c45b3cabd676f7be46ab981
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - m2-zip # [win]
+  host:
+    - r-base
+    - r-glue
+    - r-httr
+    - r-jsonlite
+    - r-tibble
+  run:
+    - r-base
+    - r-glue
+    - r-httr
+    - r-jsonlite
+    - r-tibble
+
+test:
+  commands:
+    - $R -e "library('kaggler')"           # [not win]
+    - "\"%R%\" -e \"library('kaggler')\""  # [win]
+
+about:
+  license: MIT
+  summary: |
+    An interface for interacting with the public API offered by
+    \href{https://www.kaggle.com}{Kaggle}, a machine learning competition
+    platform.
+  license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
+    - LICENSE
+  homepage: https://github.com/mkearney/kaggler
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - notPlancha

--- a/recipes/r-kaggler/meta.yaml
+++ b/recipes/r-kaggler/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.0.0.9000" %}
+{% set posix = 'm2-' if win else '' %}
 
 package:
   name: r-kaggler
@@ -18,7 +19,7 @@ build:
 
 requirements:
   build:
-    - m2-zip # [win]
+    - {{ posix }}zip               # [win]
   host:
     - r-base
     - r-glue
@@ -38,15 +39,13 @@ test:
     - "\"%R%\" -e \"library('kaggler')\""  # [win]
 
 about:
+  home: https://github.com/mkearney/kaggler
   license: MIT
-  summary: |
-    An interface for interacting with the public API offered by
-    \href{https://www.kaggle.com}{Kaggle}, a machine learning competition
-    platform.
+  summary: An interface for interacting with the public API offered by \href{https://www.kaggle.com}{Kaggle}, a machine learning competition platform.
+  license_family: MIT
   license_file:
     - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
     - LICENSE
-  homepage: https://github.com/mkearney/kaggler
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
kaggler is an (unofficial) R client for accessing [Kaggle](https://www.kaggle.com/)’s API (not available on CRAN)


Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
