### PR TITLE
Add recipe for torchcodec

### DIFF
--- a/recipes/torchcodec/build.bat
+++ b/recipes/torchcodec/build.bat
@@ -1,0 +1,12 @@
+if not "%cuda_compiler_version%" == "None" (
+    set USE_CUDA=1
+) else (
+    set USE_CUDA=0
+)
+
+:: We explicitly depend on lgpl's variant of ffmpeg in the recipe.yaml to ensure that
+:: we do not have license violation due to linking a GPL project
+set I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1
+
+pip install . --no-deps --no-build-isolation -vv
+if %ERRORLEVEL% neq 0 exit 1

--- a/recipes/torchcodec/build.sh
+++ b/recipes/torchcodec/build.sh
@@ -1,0 +1,17 @@
+set -ex
+
+if [[ ${cuda_compiler_version} != "None" ]]; then
+   export ENABLE_CUDA=1
+else
+   export ENABLE_CUDA=0
+fi
+
+# We explicitly depend on lgpl's variant of ffmpeg in the recipe.yaml to ensure that
+# we do not have license violation due to linking a GPL project
+export I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION=1
+
+pip install . --no-deps --no-build-isolation -vv
+
+# Remove spurious files created by gtk post-link activation script,
+# that should not be included as part of the installed files
+rm -f $PREFIX/lib/gdk-pixbuf-2.0/*/loaders.cache

--- a/recipes/torchcodec/recipe.yaml
+++ b/recipes/torchcodec/recipe.yaml
@@ -1,0 +1,132 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
+context:
+  name: torchcodec
+  version: "0.2.1"
+  build_number: 0
+  torch_proc_type: ${{ "cuda" ~ cuda_compiler_version | version_to_buildstring if cuda_compiler_version != "None" else "cpu" }}
+  string_prefix: ${{ cuda_build_string if cuda == "true" else "cpu_" }}
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/pytorch/torchcodec/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: b142ef4fef1e9ddb6dde70dda6ac4d12a02a010065230468eadbf37478621927
+
+build:
+  number: ${{ build_number }}
+  skip: 
+    # temporarily, we are running out of space in staged-recipes and will fix this in the feedstock
+    - cuda_compiler_version != "None"
+    # PyTorch does not support cuda 11
+    - cuda_compiler_version == "11.8"
+    # Upstream does not support Windows at the moment https://github.com/pytorch/torchcodec/issues/522
+    - win
+  string: ${{ torch_proc_type }}_py${{ python | version_to_buildstring }}_h${{ hash }}_${{ build_number }}
+  script:
+    file: build
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - pytorch
+        - if: cuda_compiler_version != "None"
+          then:
+            - cuda-driver-dev
+            - cuda-cudart-dev
+            - cuda-nvrtc-dev
+            - cuda-nvtx-dev
+            - cuda-nvml-dev
+            - cuda-profiler-api
+            - libcublas-dev
+            - libcufft-dev
+            - libcurand-dev
+            - libcusolver-dev
+            - libcusparse-dev
+    - ${{ compiler('cxx') }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib("c") }}
+    - if: cuda_compiler_version != "None"
+      then:
+        - ${{ compiler('cuda') }}
+    - cmake
+    - pkg-config
+    - make
+
+  host:
+    - python
+    - pip
+    - setuptools
+    - ffmpeg
+    # During the build, we link against the lgpl version of ffmpeg, to avoid license violation (and so we pass 
+    # I_CONFIRM_THIS_IS_NOT_A_LICENSE_VIOLATION to the wheel build to confirm that we want indeed to link to conda-forge's
+    # ffmpeg. At runtime the user can install either lgpl or gpl ffmpeg as preferred
+    - ffmpeg * [build=lgpl_*]
+    # This explicit pinning is a workaround for the fact that torchcodec 0.2.1 requires torch 2.6, but the pinned version is still 2.5.1
+    - libtorch 2.6.*
+    - libtorch * [build=${{ torch_proc_type }}*]
+    - pytorch 2.6.*
+    - pytorch * [build=${{ torch_proc_type }}*]
+
+    - if: cuda_compiler_version != "None"
+      then:
+        # These are transitive dependency of the libtorch cuda package
+        - cuda-driver-dev
+        - cuda-cudart-dev
+        - cuda-nvrtc-dev
+        - cuda-nvtx-dev
+        - cuda-nvml-dev
+        - cuda-profiler-api
+        - libcublas-dev
+        - libcufft-dev
+        - libcurand-dev
+        - libcusolver-dev
+        - libcusparse-dev
+        - magma
+        - nccl
+        - nvtx-c
+        # These are actual torchcodec deps
+        - libnpp-dev
+  run:
+    - python
+    - pytorch * [build=${{ torch_proc_type }}*]
+
+
+tests:
+  - python:
+      imports:
+        - torchcodec
+      pip_check: true
+
+  # test runs fine, but they increase the package size a lot as the
+  # test include big videos. So for now they are skipped, and it will
+  # be re-enabled in the feedstock with an appropriate strategy (such as
+  # packaging them as a separate `torchcodec-testdata`), for the time being the
+  # tests are just run as part of the build recipe
+  # - requirements:
+  #    run:
+  #      - pytest
+  #      - numpy
+  #      - pillow
+  #      - torchvision
+  #  files:
+  #    source:
+  #      - test/
+  #  script:
+  #    - pytest test
+
+about:
+  homepage: https://github.com/pytorch/torchcodec
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+  summary: TorchCodec is a Python library for decoding videos into PyTorch tensors, on CPU and CUDA GPU. 
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/torchcodec/recipe.yaml
+++ b/recipes/torchcodec/recipe.yaml
@@ -75,7 +75,7 @@ requirements:
 
     - if: cuda_compiler_version != "None"
       then:
-        # These are transitive dependency of the libtorch cuda package
+        # These are dev packages (headers etc.) for transitive dependencies of libtorch
         - cuda-driver-dev
         - cuda-cudart-dev
         - cuda-nvrtc-dev
@@ -106,7 +106,7 @@ tests:
   # test runs fine, but they increase the package size a lot as the
   # test include big videos. So for now they are skipped, and it will
   # be re-enabled in the feedstock with an appropriate strategy (such as
-  # packaging them as a separate `torchcodec-testdata`), for the time being the
+  # packaging them as a separate `torchcodec-tests`), for the time being the
   # tests are just run as part of the build recipe
   # - requirements:
   #    run:


### PR DESCRIPTION
This PR adds a package for [`torchcodec`](https://github.com/pytorch/torchcodec), taking ispiration from existing downstream `torch*` packages like `torchvision` and `torchaudio`.

The recipe is ready for review, both from @conda-forge/help-python and @conda-forge/help-python-c, and I guess also maintainers from @conda-forge/pytorch-cpu @conda-forge/torchvision @conda-forge/torchaudio may be interested in having a look.

The full Python testsuite have been run locally on both CUDA and CPU, and it is working fine. At the moment it has not been included in the `test` section of the recipe, as it would require to include the full test files in the package, and this is not ideal as the test files include some big video files, so they idea is to split the test files in a different output once the feedstock is rendered.

The CUDA builds on staged-recipes runs out of disk space, so the idea is to re-enable once the recipe is rendered by setting the `free_disk_space: False` option in `conda-forge.yml` (see https://conda-forge.org/docs/maintainer/conda_forge_yml/#azure).

Windows is skipped as it is currently not supported upstream (https://github.com/pytorch/torchcodec/issues/522).

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
