### PR TITLE
add python-taplo

### DIFF
--- a/recipes/python-taplo/0000-no-rust.patch
+++ b/recipes/python-taplo/0000-no-rust.patch
@@ -1,0 +1,21 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 7619914..636c3dc 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ [build-system]
+-requires      = ["maturin>=1.4"]
+-build-backend = "maturin"
++requires = ["setuptools"]
++build-backend = "setuptools.build_meta"
+ 
+ [project]
+ name = "taplo"
+@@ -22,7 +22,6 @@ classifiers = [
+   "Programming Language :: Rust",
+   "Topic :: Software Development :: Quality Assurance",
+ ]
+-dynamic = ["version"]
+ 
+ [tool.maturin]
+ bindings      = "bin"

--- a/recipes/python-taplo/patch_pyproject.py
+++ b/recipes/python-taplo/patch_pyproject.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+import os
+import sys
+
+UTF8 = {"encoding": "utf-8"}
+PPT = Path("pyproject.toml")
+PKG_VERSION = os.environ["PKG_VERSION"]
+NEW_PROJECT = f"""[project]
+version = "{PKG_VERSION}"
+"""
+
+def main() -> int:
+    old_text = PPT.read_text(**UTF8)
+    new_text = old_text.replace("[project]", NEW_PROJECT)
+    print("-" * 80)
+    print(new_text)
+    print(f"new {PPT}")
+    print("-" * 80)
+    PPT.write_text(new_text, **UTF8)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/python-taplo/recipe.yaml
+++ b/recipes/python-taplo/recipe.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  version: 0.9.3
+
+package:
+  name: python-taplo
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/t/taplo/taplo-${{ version }}.tar.gz
+    sha256: 6b73b45b9adbd20189d8981ac9055d5465227c58bbe1b0646a7588a1a5c07a1a
+    patches:
+      - 0000-no-rust.patch
+  - url: https://raw.githubusercontent.com/tamasfe/taplo/refs/tags/${{ version }}/LICENSE.md
+    sha256: 552604656340642782345c47dda89218136f141a25aaecdfd1501180841ff98b
+
+build:
+  number: 0
+  noarch: python
+  script:
+    - python ${{ RECIPE_DIR }}/patch_pyproject.py
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  host:
+    - pip
+    - python ${{ python_min }}.*
+    # maturin is replaced with setuptools
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - taplo ${{ version }}.*
+
+tests:
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+        - if: win
+          then:
+            - m2-grep
+    script:
+      # provides no importable python name
+      - pip check
+      - taplo --version
+      - taplo --version | grep -iE "${{ version | replace('.', '\\.') }}"
+
+about:
+  homepage: https://taplo.tamasfe.dev
+  license_file: LICENSE.md
+  license: MIT
+  summary: A CLI for Taplo TOML toolkit (for PyPI compatibility)
+  repository: https://github.com/tamasfe/taplo
+
+extra:
+  recipe-maintainers:
+    - bollwyvl


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Notes:
- shouldn't need to exist, but am starting to see  (and likely promote) `taplo` in `pyproject.toml#/project.dependencies`
  - the upstream wheels only ship a `scripts/taplo(.exe)` (the compiled binary)
  - but we want to keep `pip check` working
- this strips out the `maturin` dependency and all build metadata, relying on @conda-forge/taplo to provide the actual item on `$PATH`
- it will fail loudly if `pyproject.toml` changes significantly, but that's _good_ in this case