### PR TITLE
Add pyTCR recipe

### DIFF
--- a/recipes/pyTCR/meta.yaml
+++ b/recipes/pyTCR/meta.yaml
@@ -6,30 +6,29 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pyTCR/pyTCR-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyTCR-{{ version }}.tar.gz
   sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python >=3.8
     - pip
+
   run:
-    - python >=3.8
-    - numpy
-    - pandas
-    - xarray
-    - scipy
-    - matplotlib
-    - cartopy
+    - python 
 
 test:
   imports:
     - pyTCR
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/levuvietphong/pyTCR

--- a/recipes/pyTCR/meta.yaml
+++ b/recipes/pyTCR/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pyTCR" %}
+{% set version = "1.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/p/pyTCR/pyTCR-{{ version }}.tar.gz
+  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+  run:
+    - python >=3.8
+    - numpy
+    - pandas
+    - xarray
+    - scipy
+    - matplotlib
+    - cartopy
+
+test:
+  imports:
+    - pyTCR
+
+about:
+  home: https://github.com/levuvietphong/pyTCR
+  summary: "A Tropical Cyclone Rainfall model for Python"
+  license: MIT
+  license_file: LICENSE
+  documentation: pytcr.readthedocs.io/en/latest/
+  repository: https://github.com/levuvietphong/pyTCR
+
+extra:
+  recipe-maintainers:
+    - levuvietphong

--- a/recipes/pyTCR/meta.yaml
+++ b/recipes/pyTCR/meta.yaml
@@ -6,37 +6,49 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/project/{{ name }}/pyTCR-{{ version }}.tar.gz
-  sha256: aa7261397b39ae202abcfc337b8307c7d2532a9b7ee721f7a87a6f25aa59608d
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pytcr-{{ version }}.tar.gz
+  sha256: 0e9530344b7e2d6b59c4e6583c72d06f73d90bbb72e906124302a97f153189bf
 
 build:
   noarch: python
-  number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
 
 requirements:
   host:
-    - python >=3.8
+    - python
+    - hatchling
     - pip
-
   run:
-    - python 
+    - python
+    - cartopy
+    - colorcet
+    - geopandas
+    - jupyter
+    - matplotlib-base
+    - netcdf4
+    - pyproj
+    - requests
+    - scipy
+    - shapely
+    - xarray
+    - beautifulsoup4
 
+build:
+  noarch: python
+  
 test:
   imports:
-    - pyTCR
+    - tcr
   commands:
     - pip check
   requires:
     - pip
 
 about:
-  home: https://github.com/levuvietphong/pyTCR
-  summary: "A Tropical Cyclone Rainfall model for Python"
+  summary: A tropical cyclone rainfall model for python
   license: MIT
   license_file: LICENSE
-  documentation: pytcr.readthedocs.io/en/latest/
-  repository: https://github.com/levuvietphong/pyTCR
 
 extra:
   recipe-maintainers:

--- a/recipes/pyTCR/meta.yaml
+++ b/recipes/pyTCR/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyTCR-{{ version }}.tar.gz
-  sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  url: https://pypi.org/project/{{ name }}/pyTCR-{{ version }}.tar.gz
+  sha256: aa7261397b39ae202abcfc337b8307c7d2532a9b7ee721f7a87a6f25aa59608d
 
 build:
   noarch: python


### PR DESCRIPTION
This PR adds the recipe for pyTCR.

- Version: 1.2.1
- Source: https://pypi.org/project/pyTCR/
- Maintainers: @levuvietphong

This package provides a tropical cyclone rainfall model for Python.