### PR TITLE
Adding pyTCR package

### DIFF
--- a/recipes/pyTCR/meta.yaml
+++ b/recipes/pyTCR/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "pyTCR" %}
+{% set version = "1.2.1" %}
+{% set python_min = "3.9" %}
+
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pytcr-{{ version }}.tar.gz
+  sha256: 0e9530344b7e2d6b59c4e6583c72d06f73d90bbb72e906124302a97f153189bf
+
+build:
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - hatchling
+    - pip
+  run:
+    - python >={{ python_min }}
+    - cartopy
+    - colorcet
+    - geopandas
+    - jupyter
+    - matplotlib-base
+    - netcdf4
+    - pyproj
+    - requests
+    - scipy
+    - shapely
+    - xarray
+    - beautifulsoup4
+  
+test:
+  imports:
+    - tcr
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/levuvietphong/pyTCR
+  summary: A tropical cyclone rainfall model for python
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - levuvietphong


### PR DESCRIPTION
This PR adds the recipe for pyTCR.

Version: 1.2.1
Source: https://pypi.org/project/pyTCR/
Maintainers: @levuvietphong
This package provides a tropical cyclone rainfall model for Python.