### PR TITLE
Adds r-dfdr

### DIFF
--- a/recipes/r-dfdr/bld.bat
+++ b/recipes/r-dfdr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dfdr/build.sh
+++ b/recipes/r-dfdr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dfdr/meta.yaml
+++ b/recipes/r-dfdr/meta.yaml
@@ -1,0 +1,76 @@
+{% set version = '0.2.0' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-dfdr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/dfdr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/dfdr/dfdr_{{ version }}.tar.gz
+  sha256: cabbe7b9c5760945defbd7716a71b7667e3b01237ef5f77c860055437508f1e8
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-r6
+    - r-pryr
+    - r-purrr
+    - r-rlang
+  run:
+    - r-base
+    - r-r6
+    - r-pryr
+    - r-purrr
+    - r-rlang
+
+test:
+  commands:
+    - $R -e "library('dfdr')"           # [not win]
+    - "\"%R%\" -e \"library('dfdr')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=dfdr
+  license: GPL-3
+  summary: Implementation of automatically computing derivatives of functions (see Mailund Thomas
+    (2017) <doi:10.1007/978-1-4842-2881-4>). Moreover, calculating gradients, Hessian
+    and Jacobian matrices is possible.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: dfdr
+# Type: Package
+# Title: Automatic Differentiation of Simple Functions
+# Version: 0.2.0
+# Authors@R: c(person("Thomas", "Mailund", role = "aut"), person("Konrad", "Kramer", role = c("aut", "cre"), email = "konrad_kraemer@yahoo.de") )
+# Description: Implementation of automatically computing derivatives of functions (see Mailund Thomas (2017) <doi:10.1007/978-1-4842-2881-4>). Moreover, calculating gradients, Hessian and Jacobian matrices is possible.
+# License: GPL-3
+# Encoding: UTF-8
+# Imports: methods, purrr, rlang, R6, pryr
+# Suggests: tinytest
+# NeedsCompilation: no
+# Packaged: 2023-02-23 07:11:23 UTC; konrad
+# Author: Thomas Mailund [aut], Konrad Kramer [aut, cre]
+# Maintainer: Konrad Kramer <konrad_kraemer@yahoo.de>
+# Repository: CRAN
+# Date/Publication: 2023-02-23 10:30:02 UTC

--- a/recipes/r-dfdr/meta.yaml
+++ b/recipes/r-dfdr/meta.yaml
@@ -46,13 +46,13 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=dfdr
-  license: GPL-3
+  license: GPL-3.0-only
   summary: Implementation of automatically computing derivatives of functions (see Mailund Thomas
     (2017) <doi:10.1007/978-1-4842-2881-4>). Moreover, calculating gradients, Hessian
     and Jacobian matrices is possible.
   license_family: GPL3
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds [CRAN package `dfdr`](https://cran.r-project.org/package=dfdr) as `r-dfdr`. Recipe generated with `conda_r_skeleton_helper`; license conformed to SPDX.

Needed for https://github.com/conda-forge/staged-recipes/pull/29670.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
