### PR TITLE
Add promptprep recipe

### DIFF
--- a/recipes/promptprep/meta.yaml
+++ b/recipes/promptprep/meta.yaml
@@ -1,0 +1,74 @@
+{% set name = "promptprep" %}
+{% set version = "0.1.12" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ef05e678bf0284aba8e4394a36df5683de07309eb93b076b4b06567432b7a485
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - promptprep = promptprep.cli:main
+  noarch: python
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=42
+    - wheel
+  run:
+    - python >=3.10
+    - tqdm
+    - tiktoken
+
+test:
+  imports:
+    - promptprep
+  # commands:
+  #   - promptprep --help
+  requires:
+    - pip
+    - tqdm
+    - tiktoken
+    - pygments
+outputs:
+  - name: promptprep
+  - name: promptprep-highlighting
+    requirements:
+      host:
+        - {{ pin_subpackage('promptprep', exact=True) }}
+      run:
+        - {{ pin_subpackage('promptprep', exact=True) }}
+        - pygments >=2.10.0
+  - name: promptprep-all
+    requirements:
+      host:
+        - {{ pin_subpackage('promptprep', exact=True) }}
+      run:
+        - {{ pin_subpackage('promptprep', exact=True) }}
+        - {{ pin_subpackage('promptprep-highlighting', exact=True) }}
+
+about:
+  home: https://github.com/kartikmandar/promptprep
+  license: MIT
+  license_file: LICENSE
+  summary: A code aggregator tool for consolidating code files into a single file with an ASCII directory tree
+  description: |
+    PromptPrep is a handy command-line tool to help you bundle your code from 
+    multiple files into one neat, well-organized output file. It creates a visual 
+    map of your project structure and brings together all your selected files, making 
+    it perfect for working with AI models, creating documentation snapshots,
+    analyzing your project, and code reviews.
+  doc_url: https://promptprep.readthedocs.io/en/latest/index.html
+  dev_url: https://github.com/kartikmandar/promptprep
+
+extra:
+  recipe-maintainers:
+    - kartikmandar
+  feedstock-name: promptprep


### PR DESCRIPTION
Adding promptprep - A code aggregator tool for consolidating code files with ASCII directory tree

PromptPrep is a command-line tool that bundles code from multiple files into one organized output file with a visual project structure. It's useful for working with AI models, creating documentation snapshots, analyzing projects, and code reviews.

Features:

Combine multiple source files with directory tree visualization
Smart file selection with filtering options
Interactive file selection interface
Multiple output formats (plain, markdown, html, highlighted)
Code metadata and analysis
Token counting for LLM context limits
The recipe creates three packages:

promptprep - The base package
promptprep-highlighting - Adding syntax highlighting support
promptprep-all - Meta-package with all features
Checklist

 Title of this PR is meaningful: "Adding promptprep"
 License file is packaged (MIT license included)
 Source is from official PyPI release
 Package does not vendor other packages
 No static libraries linked or shipped
 Build number is 0
 A tarball (PyPI URL) is used in the recipe
 I (GitHub user kartikmandar) confirm I am willing to be listed as a maintainer