### PR TITLE
fix: remove lint for maintainer teams

### DIFF
--- a/.github/workflows/scripts/linter.py
+++ b/.github/workflows/scripts/linter.py
@@ -192,24 +192,25 @@ def _lint_recipes(gh, pr):
         # 5. Ensure all maintainers have commented that they approve of being listed
         if maintainers:
             # Get PR author, issue comments, and review comments
-            pr_author = pr.user.login
+            pr_author = pr.user.login.lower()
             issue_comments = pr.get_issue_comments()
             review_comments = pr.get_reviews()
 
             # Combine commenters from both issue comments and review comments
-            commenters = {comment.user.login for comment in issue_comments}
-            commenters.update({review.user.login for review in review_comments})
+            commenters = {comment.user.login.lower() for comment in issue_comments}
+            commenters.update({review.user.login.lower() for review in review_comments})
 
             # Check if all maintainers have either commented or are the PR author
             non_participating_maintainers = set()
-            for maintainer in maintainers:
+            for orig_maintainer in maintainers:
+                maintainer = orig_maintainer.lower()
                 if (
                     maintainer not in commenters
                     and maintainer != pr_author
                     and maintainer not in NOCOMMENT_REQ_TEAMS
                     and ("/" not in maintainer or maintainer.split("/", 1)[0] != "conda-forge")
                 ):
-                    non_participating_maintainers.add(maintainer)
+                    non_participating_maintainers.add(orig_maintainer)
 
             # Add a lint message if there are any non-participating maintainers
             if non_participating_maintainers:

--- a/.github/workflows/scripts/linter.py
+++ b/.github/workflows/scripts/linter.py
@@ -208,7 +208,7 @@ def _lint_recipes(gh, pr):
                     maintainer not in commenters
                     and maintainer != pr_author
                     and maintainer not in NOCOMMENT_REQ_TEAMS
-                    and ("/" not in maintainer or maintainer.split("/", 1)[0] != "conda-forge")
+                    and "/" not in maintainer
                 ):
                     non_participating_maintainers.add(orig_maintainer)
 

--- a/.github/workflows/scripts/linter.py
+++ b/.github/workflows/scripts/linter.py
@@ -207,6 +207,7 @@ def _lint_recipes(gh, pr):
                     maintainer not in commenters
                     and maintainer != pr_author
                     and maintainer not in NOCOMMENT_REQ_TEAMS
+                    and ("/" not in maintainer or maintainer.split("/", 1)[0] != "conda-forge")
                 ):
                     non_participating_maintainers.add(maintainer)
 


### PR DESCRIPTION
This PR removes linting for maintainer teams. We could check team membership, but this would involve token permissions the workflow does not have. So I am going to punt.

cc @h-vetinari 

closes #29583 
closes #29626
