### PR TITLE
add zlib-ng in compatibility mode

### DIFF
--- a/recipes/zlib-ng-compat/bld.bat
+++ b/recipes/zlib-ng-compat/bld.bat
@@ -1,0 +1,27 @@
+setlocal EnableDelayedExpansion
+
+mkdir build
+if errorlevel 1 exit 1
+cd build
+if errorlevel 1 exit 1
+
+cmake -G "NMake Makefiles" ^
+      %CMAKE_ARGS% ^
+      -DCMAKE_BUILD_TYPE:STRING="Release" ^
+      -DCMAKE_INSTALL_PREFIX:PATH="%LIBRARY_PREFIX%" ^
+      -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
+      -DWITH_GTEST=OFF ^
+      -DBUILD_SHARED_LIBS=1 ^
+      -DZLIB_COMPAT=1 ^
+      ..
+
+if errorlevel 1 exit 1
+
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+ctest -C release
+if errorlevel 1 exit 1
+
+cmake --build . --target install --config Release
+if errorlevel 1 exit 1

--- a/recipes/zlib-ng-compat/build.sh
+++ b/recipes/zlib-ng-compat/build.sh
@@ -1,0 +1,21 @@
+set -ex
+
+mkdir build
+cd build
+
+cmake \
+    ${CMAKE_ARGS} \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_PREFIX_PATH=$PREFIX \
+    -DWITH_GTEST=OFF \
+    -DBUILD_SHARED_LIBS=1 \
+    -DZLIB_COMPAT=1 \
+    ..
+
+make -j${CPU_COUNT}
+if [[ "${target_platform}" == "${build_platform}" ]]; then
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
+    ctest
+fi
+fi
+make install

--- a/recipes/zlib-ng-compat/meta.yaml
+++ b/recipes/zlib-ng-compat/meta.yaml
@@ -56,4 +56,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - hmaarrfk
+    - morotti

--- a/recipes/zlib-ng-compat/meta.yaml
+++ b/recipes/zlib-ng-compat/meta.yaml
@@ -1,0 +1,59 @@
+{% set version = "2.2.4" %}
+
+package:
+  name: zlib-ng-compat-split
+  version: {{ version }}
+
+source:
+  url: https://codeload.github.com/zlib-ng/zlib-ng/tar.gz/refs/tags/{{ version }}
+  sha256: a73343c3093e5cdc50d9377997c3815b878fd110bf6511c2c7759f2afb90f5a3
+  fn: zstd-ng.tar.gz
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake
+    - make  # [unix]
+  host:
+
+outputs:
+  - name: libzlib-ng-compat
+    build:
+      run_exports:
+        # zlib-ng in compatibility mode is a replacement for zlib
+        - {{ pin_compatible('libzlib', max_pin='1') }}
+    requirements:
+      build:
+      - {{ compiler('c') }}
+      - {{ compiler('cxx') }}
+      - {{ stdlib('c') }}
+      host:
+      run:
+    files:
+      - lib/libz.so.*          # [linux]
+      - lib/libz.*.dylib       # [osx]
+      - Library/bin/zlib.dll   # [win]
+      - zlib.dll               # [win]
+    test:
+      commands:
+        - test ! -f ${PREFIX}/lib/libz.a            # [unix]
+        - test ! -f ${PREFIX}/lib/libz${SHLIB_EXT}  # [unix]
+        - test ! -f ${PREFIX}/include/zlib.h        # [unix]
+        - if not exist %LIBRARY_BIN%\zlib.dll exit 1  # [win]
+        - if not exist %PREFIX%\zlib.dll exit 1  # [win]
+
+about:
+  home: https://github.com/zlib-ng/zlib-ng
+  license: Zlib
+  license_family: Other
+  license_file: LICENSE.md
+  summary: zlib data compression library for the next generation systems
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk


### PR DESCRIPTION
Hello,

Can I offer you a package for zlib-ng built in compatibility mode?

It is meant to replace zlib in place.
It is about 2 or 3 times faster for compression/decompression. About 2 order of magnitude faster for crc calculations.

For reference, the python interpreter has replaced zlib with zlib-ng for the windows build. https://github.com/python/cpython/issues/91349
Trying to do it for the other builds.

| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| c/c++           | `@conda-forge/help-c-cpp`     |

@conda-forge/help-python-c

Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [NA] If static libraries are linked in, the license of the static library is packaged.
- [X] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
