### PR TITLE
add wis2downloader

### DIFF
--- a/recipes/wis2downloader/meta.yaml
+++ b/recipes/wis2downloader/meta.yaml
@@ -48,6 +48,7 @@ test:
     - pip
 
 about:
+  home: https://github.com/World-Meteorological-Organization/wis2downloader
   summary: Python package to manage subscriptions and downloads from the WIS2.0
   license: Apache-2.0
   license_file: LICENSE

--- a/recipes/wis2downloader/meta.yaml
+++ b/recipes/wis2downloader/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "wis2downloader" %}
+{% set version = "0.3.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/wis2downloader-{{ version }}.tar.gz
+  sha256: 482f58f17a95ef9412bf9331ec57c7999f7f4ca777e7e317d73e1c1141644812
+
+build:
+  entry_points:
+    - wis2downloader = wis2downloader:cli.cli
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools
+    - wheel
+    - pip
+  run:
+    - python >={{ python_min }}
+    - click
+    - certifi >=2024.2.2
+    - flask >=3.0.3
+    - flask-cors >=4.0.0
+    - paho-mqtt >=2.0.0
+    - prometheus_client >=0.20.0
+    - requests
+    - urllib3 >=2.2.1
+    - pywis-topics >=0.3.2
+    - pyyaml
+
+test:
+  imports:
+    - dist
+    - docker
+    - wis2downloader
+  commands:
+    - pip check
+    - wis2downloader --help
+  requires:
+    - python {{ python_min }}
+    - pip
+
+about:
+  summary: Python package to manage subscriptions and downloads from the WIS2.0
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - akrherz

--- a/recipes/wis2downloader/meta.yaml
+++ b/recipes/wis2downloader/meta.yaml
@@ -37,8 +37,6 @@ requirements:
 
 test:
   imports:
-    - dist
-    - docker
     - wis2downloader
   commands:
     - pip check


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
-  If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Package for managing subscriptions and downloads from WMO WIS2 Node.  Requires #29907 for pywis-topics dep.