### PR TITLE
Add packages for `metatomic-torch`

### DIFF
--- a/recipes/libmetatomic-torch/LICENSE
+++ b/recipes/libmetatomic-torch/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, metatomic developers
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/libmetatomic-torch/bld.bat
+++ b/recipes/libmetatomic-torch/bld.bat
@@ -1,0 +1,8 @@
+cmake -G Ninja %CMAKE_ARGS% -DBUILD_SHARED_LIBS=ON . || goto :error
+cmake --build . --config Release --target install || goto :error
+
+goto :EOF
+
+:error
+echo Failed with error #%errorlevel%.
+exit 1

--- a/recipes/libmetatomic-torch/build.sh
+++ b/recipes/libmetatomic-torch/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+cmake -G Ninja $CMAKE_ARGS -DBUILD_SHARED_LIBS=ON .
+cmake --build . --config Release --target install

--- a/recipes/libmetatomic-torch/conda_build_config.yaml
+++ b/recipes/libmetatomic-torch/conda_build_config.yaml
@@ -1,0 +1,2 @@
+c_stdlib_version:              # [osx and x86_64]
+  - 10.15                      # [osx and x86_64]

--- a/recipes/libmetatomic-torch/meta.yaml
+++ b/recipes/libmetatomic-torch/meta.yaml
@@ -1,0 +1,60 @@
+{% set version = "0.1.2" %}
+
+package:
+  name: libmetatomic-torch
+  version: {{ version | replace('-', '') }}
+
+source:
+  url: https://github.com/metatensor/metatomic/releases/download/metatomic-torch-v{{ version }}/metatomic-torch-cxx-{{ version }}.tar.gz
+  sha256: 432c8adb3185f4f2f958328fda2a7551c7cdac6224024cbe2e9f1b9f63bf3aaa
+
+build:
+  number: 0
+  run_exports:
+    - {{ pin_subpackage('libmetatomic-torch', max_pin='x.x') }}
+
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - cmake
+    - ninja
+  host:
+    - libmetatensor >=0.1.14,<0.2
+    - libmetatensor-torch >=0.7.5,<0.8
+    # We build against the CPU version of torch to not have to deal with CUDA
+    # compilers (torch's CMake targets tries to find CUDA compilers even when
+    # there is no CUDA code to build). This does not impact the `run`
+    # dependency, since libtorch `run_exports` are variant agnostic
+    - libtorch * cpu*
+
+test:
+  requires:
+    - cmake
+    - ninja
+    - {{ compiler('cxx') }}
+    - libtorch * cpu*
+  files:
+    - test-project/
+  commands:
+    - test -f $PREFIX/lib/libmetatomic_torch$SHLIB_EXT  # [not win]
+    - if not exist %PREFIX%\\Library\\bin\\metatomic_torch.dll exit 1  # [win]
+    - cmake -G Ninja -S test-project -B test-project
+    - cmake --build test-project
+    - ctest --verbose --output-on-failure --test-dir test-project
+
+about:
+  home: https://github.com/metatensor/metatomic
+  summary: Atomistic machine learning models you can use everywhere for everything
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+    - _deps/nlohmann_json-src/LICENSE.MIT
+  doc_url: https://docs.metatensor.org/metatomic/
+
+extra:
+  recipe-maintainers:
+    - Luthaf
+    - PicoCentauri
+    - Haozeke

--- a/recipes/libmetatomic-torch/test-project/CMakeLists.txt
+++ b/recipes/libmetatomic-torch/test-project/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
+project(test-metatensor-torch CXX)
+
+find_package(metatomic_torch)
+
+add_executable(main main.cpp)
+target_link_libraries(main metatomic_torch)
+
+enable_testing()
+add_test(NAME main COMMAND main)

--- a/recipes/libmetatomic-torch/test-project/main.cpp
+++ b/recipes/libmetatomic-torch/test-project/main.cpp
@@ -1,0 +1,9 @@
+#include <iostream>
+
+#include <metatomic/torch.hpp>
+
+int main() {
+    std::cout << " ++++ Found metatomic-torch v" << metatomic_torch::version() << " in test" <<  std::endl;
+
+    return 0;
+}

--- a/recipes/python-metatomic-torch/LICENSE
+++ b/recipes/python-metatomic-torch/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2025, metatomic developers
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/recipes/python-metatomic-torch/meta.yaml
+++ b/recipes/python-metatomic-torch/meta.yaml
@@ -1,0 +1,73 @@
+{% set name = "metatomic-torch" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: python-{{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/metatomic_torch-{{ version }}.tar.gz
+  sha256: 0d793b16b3d6eee915c89e9b1a385143ec2dbb6dc451bed8feee3a2445b3f63e
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  script_env:
+    # Don't build metatomic-torch, but use the already compiled `libmetatomic-torch`
+    # package
+    - METATOMIC_TORCH_PYTHON_USE_EXTERNAL_LIB='ON'
+  ignore_run_exports:
+    # pytorch is only used as a Python package, all the pytorch version pinning
+    # is happening in libmetatomic-torch
+    - libtorch
+    - pytorch
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    # Nothing will be built but we need a correct env to make pip happy
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - cmake
+    - make
+  host:
+    - python
+    - pip
+    - setuptools >=77
+    - packaging >=23
+    # We build against the CPU version of torch to not have to deal with CUDA compilers
+    # (torch's CMake targets tries to find CUDA compilers even when there is no CUDA
+    # code to build). This does not impact the `run` dependency, since torch's
+    # `run_exports` are variant agnostic
+    - libtorch * cpu*
+    - libmetatomic-torch {{ version }}
+    - python-metatensor-torch >=0.7.6,<0.8
+  run:
+    - python
+    - pytorch
+    - libmetatomic-torch {{ version }}
+    - python-metatensor-torch >=0.7.6,<0.8
+    - python-metatensor-operations >=0.3.3,<0.4.0
+    - python-vesin
+
+test:
+  imports:
+    - metatomic.torch
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/metatensor/metatomic
+  summary: Python bindings for metatomic-torch
+  license: BSD-3-Clause
+  license_file: LICENSE
+  doc_url: https://docs.metatensor.org/metatomic/
+
+extra:
+  recipe-maintainers:
+    - PicoCentauri
+    - Luthaf
+    - Haozeke


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

This adds the recipe for `libmetatomic-torch` (the C++ library), `python-metatomic-torch`(the corresponding Python bindings) and `metatomic-torch` (a meta-package for user-convenience). This follow the same pattern as in https://github.com/conda-forge/metatensor-feedstock/issues/2

The code comes from `metatensor-torch` which is already on conda-forge, and is being extracted into its own separate package. We anticipate the existence of a separate `metatomic` package which is not based on PyTorch, hence the `-torch` suffix in the names.

~This PR still uses the release candidate to make sure it builds fine on conda-forge, I'll update to a full release before asking for review.~

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] ~If static libraries are linked in, the license of the static library is packaged.~
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
