### PR TITLE
fix: update deprecated PyGitHub method calls

### DIFF
--- a/.github/workflows/scripts/linter.py
+++ b/.github/workflows/scripts/linter.py
@@ -151,7 +151,7 @@ def _lint_recipes(gh, pr):
 
             bio = gh.get_user("bioconda").get_repo("bioconda-recipes")
             try:
-                bio.get_dir_contents(f"recipes/{recipe_name}")
+                bio.get_contents(f"recipes/{recipe_name}")
             except github.GithubException as e:
                 _test_and_raise_besides_file_not_exists(e)
             else:


### PR DESCRIPTION
# PR Summary
This small PR resolves the PyGitHub deprecation warnings of `get_dir_contents`:
```python
/home/runner/work/staged-recipes/staged-recipes/.github/workflows/scripts/linter.py:154: DeprecationWarning: Call to deprecated method get_dir_contents
```

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
