### PR TITLE
Add AlveolEye v0.1.5 to conda-forge

### DIFF
--- a/recipes/alveoleye/meta.yaml
+++ b/recipes/alveoleye/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "AlveolEye" %}
+{% set version = "0.1.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/SucreLab/AlveolEye/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 5aece6c5a283bbfb0baab04a69a96ae6837fc29d1b6803cd9bb18b7cd89bed5d
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+  run:
+    - python >=3.10
+    - torch
+    - torchvision >=0.16.2, <=0.17.2
+    - napari >=0.4.17
+    - pyqt <5.16.0
+    - qtpy
+    - pillow >=10.2.0
+    - gdown
+    - numpy <2.0.0
+    - matplotlib
+    - opencv
+    - pydantic >=2.7.4
+
+test:
+  imports:
+    - alveoleye
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/SucreLab/AlveolEye
+  summary: "A deep learning tool for automated analysis of lung tissue architecture."
+  description: |
+    AlveolEye is a Napari plugin that uses computer vision and classical image processing 
+    to calculate mean linear intercept (MLI) and airspace volume density (ASVD) of histologic images.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  dev_url: https://github.com/SucreLab/AlveolEye
+
+extra:
+  recipe-maintainers:
+    - nimne
+    - shawshir
+    - Joseph-Hirsh
+    - srhirsh


### PR DESCRIPTION
This PR adds AlveolEye (v0.1.5) to conda-forge.

AlveolEye is a Napari plugin that uses computer vision and classical image processing to calculate the mean linear intercept (MLI) and airspace volume density (ASVD) of histologic images.

### Info
- Source: https://github.com/SucreLab/AlveolEye
- License: BSD-3-Clause
- PyPI: Not yet published
- Maintainers: @nimne, @shawshir, @Joseph-Hirsh, @srhirsh

### Note
- AlveolEye is a platform-independent Python package.
- The package does include static assets (e.g. CSS, PNG, YAML).
- It is pip-installable from a GitHub release tarball. 
- The recipe uses `noarch: python` and supports cross-platform builds.

Maintainers will confirm in comments below.