### PR TITLE
Adding pyladoc python package for HTML and PDF rendering

### DIFF
--- a/recipes/pyladoc/meta.yaml
+++ b/recipes/pyladoc/meta.yaml
@@ -1,0 +1,54 @@
+{% set name = "pyladoc" %}
+{% set version = "1.2.0" %}
+{% set python_min = "3.8" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0655c7ada8b6b6e0fad24bb938f955d7d811c8a6c1e23c98de60c13d81b6ec57
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - setuptools
+    - python {{ python_min }}
+    - pip
+  run:
+    - python >={{ python_min }}
+    - markdown >3.3.0
+
+test:
+  imports:
+    - pyladoc
+  requires:
+    - python {{ python_min }}
+    - pip
+    - pytest
+    - tectonic
+    - pandas
+    - Jinja2
+    - matplotlib
+  source_files:
+    - pyproject.toml
+    - tests/*.py
+  commands:
+    - pip check
+    - pytest
+
+about:
+  home: https://github.com/Nonannet/pyladoc
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: "Package for generating HTML and PDF/latex from python code"
+
+extra:
+  recipe-maintainers:
+    - Nonannet


### PR DESCRIPTION
- [x] License file is packaged (MIT)
- [x] Source is from official repository (https://github.com/Nonannet/pyladoc)
- [x] Package does not vendor other packages.
- [x] No static libraries are linked in
- [x] Package does not ship static libraries.
- [x] A tarball rather than a repo is used in recipe (latest from https://pypi.org/project/pyladoc/#files)
- [x] I'm listed in the maintainer section myself