### PR TITLE
Set channel_sources in combined_spec manually

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -295,6 +295,7 @@ def build_folders_rattler_build(
 
     # Combine all the variant config files together
     combined_spec = conda_build.variants.combine_specs(specs, log_output=config.verbose)
+    combined_spec["channel_sources"] = [",".join(channel_urls)]
     variant_config = yaml.dump(combined_spec)
 
     # Define the arguments for rattler-build


### PR DESCRIPTION
The channel sources don't get propagated from `config.exclusive_config_files` so i manually added channel_sources instead.

needed for #30179 and #29975

follow-up of #29895

closes https://github.com/prefix-dev/rattler-build/issues/1688