### PR TITLE
Add recipe for castxml executable

### DIFF
--- a/recipes/castxml/build.bat
+++ b/recipes/castxml/build.bat
@@ -1,0 +1,22 @@
+mkdir build
+cd build
+
+cmake %CMAKE_ARGS% ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTING:BOOL=ON ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipes/castxml/build.sh
+++ b/recipes/castxml/build.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING:BOOL=ON
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
+  ctest --output-on-failure -C Release ${CTEST_OPTIONS}
+fi

--- a/recipes/castxml/recipe.yaml
+++ b/recipes/castxml/recipe.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+
+context:
+  name: castxml
+  version: 0.6.11
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/CastXML/CastXML/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: 231faca9ab71fa63d6c1e0da18bda0c365f82d9bef1cfd4b3d3d6784c8d5fb96
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - ninja
+    - cmake
+  host:
+    - clangdev
+    # only used for tests
+    - libxml2
+  ignore_run_exports:
+      from_package:
+        - libxml2
+
+tests:
+  - package_contents:
+      bin:
+        - castxml
+  - script:
+      - castxml --help
+
+about:
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: C-family Abstract Syntax Tree XML Output.
+  homepage: https://github.com/CastXML/CastXML
+
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
Add recipe for the `castxml` executable.

Homepage: https://github.com/CastXML/CastXML
Repology page: https://repology.org/project/castxml/versions
Example homebrew build recipe: https://github.com/Homebrew/homebrew-core/blob/50e9fb6727ca1bf5a62131d0a132ddf169002d67/Formula/c/castxml.rb

This is requirement for https://github.com/conda-forge/ompl-feedstock/pull/54#issuecomment-2935519875, fyi @david-dorf . 

A previous attempt for packaging was done in https://github.com/conda-forge/staged-recipes/pull/25773 .


Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
