### PR TITLE
Add mcrnmf 0.1.0 recipe

### DIFF
--- a/recipes/mcrnmf/meta.yaml
+++ b/recipes/mcrnmf/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: {{ name|lower }}
-  version: {{version}}
+  version: {{ version }}
 
 source:
   url: https://files.pythonhosted.org/packages/source/m/mcrnmf/mcrnmf-{{ version }}.tar.gz

--- a/recipes/mcrnmf/meta.yaml
+++ b/recipes/mcrnmf/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "mcrnmf" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -16,18 +17,28 @@ build:
 
 requirements:
   host:
-    - python >=3.11.9,<3.14
+    - python {{ python_min }}
     - pip
     - setuptools >=61.0
   run:
-    - python >=3.11.9,<3.14
+    - python >={{ python_min }},<3.14
     - numba >=0.61.2
     - numpy >=1.24,<2.3
+
+test:
+  requires:
+    - python {{ python_min }}
+    - pip
+  imports:
+    - mcrnmf
+  commands:
+    - pip check
 
 about:
   home: https://github.com/siddarthVasudevan/mcrnmf
   doc_url: https://siddarthvasudevan.github.io/mcrnmf/
   license: MIT
+  license_file: LICENSE
   summary: "Multivariate Curve Resolution using Nonnegative Matrix Factorization"
 
 extra:

--- a/recipes/mcrnmf/meta.yaml
+++ b/recipes/mcrnmf/meta.yaml
@@ -1,0 +1,35 @@
+{% set name = "mcrnmf" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{version}}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/m/mcrnmf/mcrnmf-{{ version }}.tar.gz
+  sha256: f119c760b9fc3a2847fe3005312a0d2c725c13b54da002915254ba5bc13b4c1c
+
+build:
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11.9,<3.14
+    - pip
+    - setuptools >=61.0
+  run:
+    - python >=3.11.9,<3.14
+    - numba >=0.61.2
+    - numpy >=1.24,<2.3
+
+about:
+  home: https://github.com/siddarthVasudevan/mcrnmf
+  doc_url: https://siddarthvasudevan.github.io/mcrnmf/
+  license: MIT
+  summary: "Multivariate Curve Resolution using Nonnegative Matrix Factorization"
+
+extra:
+  recipe-maintainers:
+    - siddarthVasudevan


### PR DESCRIPTION
This PR adds the conda-forge recipe for mcrnmf version 0.1.0.

- I have test locally with `conda render recipes/mcrnmf/meta.yaml` and `conda build recipes/mcrnmf`.
- The package is available on PyPI at https://pypi.org/project/mcrnmf/0.1.0/
- Dependencies: numba>=0.61.2, numpy>=1.24,<2.3
