### PR TITLE
Adding  newuoa-cpp v0.1.2

### DIFF
--- a/recipes/newuoa-cpp/fix_dll_install.patch
+++ b/recipes/newuoa-cpp/fix_dll_install.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c4808cb..b754972 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -28,6 +28,7 @@ install(TARGETS newuoa
+ 	EXPORT newuoaTargets
+ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+ 	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+ 
+ install(EXPORT newuoaTargets

--- a/recipes/newuoa-cpp/fix_dll_install.patch
+++ b/recipes/newuoa-cpp/fix_dll_install.patch
@@ -1,12 +1,41 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index c4808cb..b754972 100644
+index c4808cb..d8603c3 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -28,6 +28,7 @@ install(TARGETS newuoa
+@@ -17,6 +17,10 @@ add_library(newuoa::newuoa ALIAS newuoa)
+ 
+ set_target_properties(newuoa PROPERTIES POSITION_INDEPENDENT_CODE ON)
+ 
++if(WIN32 AND BUILD_SHARED_LIBS)
++	set_target_properties(newuoa PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
++endif()
++
+ target_include_directories(newuoa
+ 	PUBLIC
+ 	"$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"
+@@ -28,6 +32,7 @@ install(TARGETS newuoa
  	EXPORT newuoaTargets
  	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
  	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
  	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
  
  install(EXPORT newuoaTargets
+diff --git a/CMakeLists.txt.patch b/CMakeLists.txt.patch
+new file mode 100644
+index 0000000..ae3f59b
+--- /dev/null
++++ b/CMakeLists.txt.patch
+@@ -0,0 +1,12 @@
++diff --git a/CMakeLists.txt b/CMakeLists.txt
++index c4808cb..b754972 100644
++--- a/CMakeLists.txt
+++++ b/CMakeLists.txt
++@@ -28,6 +28,7 @@ install(TARGETS newuoa
++ 	EXPORT newuoaTargets
++ 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++ 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+++    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++ 	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
++ 
++ install(EXPORT newuoaTargets

--- a/recipes/newuoa-cpp/recipe.yaml
+++ b/recipes/newuoa-cpp/recipe.yaml
@@ -1,0 +1,62 @@
+context:
+  name: newuoa-cpp
+  version: "0.1.2"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/elsid/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 660274f2ab2188bdf096c0ed0eefa8e10fe563e440064bc4e48ce547a8ef90a4
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - set -exo pipefail
+        - cmake -S . -B build ${CMAKE_ARGS} -DBUILD_SHARED_LIBS=ON
+        - cmake --build build --config Release --parallel ${CPU_COUNT}
+        - cmake --install build
+      else:
+        - echo on
+        - cmake -S . -B build %CMAKE_ARGS% -DBUILD_SHARED_LIBS=ON
+        - if errorlevel 1 exit 1
+        - cmake --build build --config Release --parallel %CPU_COUNT%
+        - if errorlevel 1 exit 1
+        - cmake --install build
+        - if errorlevel 1 exit 1
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - if: unix
+      then: make
+    - pkg-config
+  run_exports:
+    - ${{ pin_subpackage(name, upper_bound="x.x") }}
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - test -f ${PREFIX}/include/newuoa.h
+          - test -f ${PREFIX}/lib/libnewuoa${SHLIB_EXT}
+        else:
+          - if not exist "%LIBRARY_PREFIX%\include\newuoa.h" exit /b 1
+          - if not exist "%LIBRARY_PREFIX%\bin\newuoa%SHLIB_EXT%" exit /b 1
+
+about:
+  homepage: https://github.com/elsid/newuoa-cpp
+  repository: https://github.com/elsid/newuoa-cpp
+  license: MIT
+  license_file: LICENSE
+  summary: "C++ implementation of NEWUOA algorithm with C interface"
+
+extra:
+  recipe-maintainers:
+    - eunos-1128

--- a/recipes/newuoa-cpp/recipe.yaml
+++ b/recipes/newuoa-cpp/recipe.yaml
@@ -9,24 +9,26 @@ package:
 source:
   url: https://github.com/elsid/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 660274f2ab2188bdf096c0ed0eefa8e10fe563e440064bc4e48ce547a8ef90a4
+  patches:
+    - fix_dll_install.patch
 
 build:
   number: 0
   script:
     - if: unix
-      then:
-        - set -exo pipefail
-        - cmake -S . -B build ${CMAKE_ARGS} -DBUILD_SHARED_LIBS=ON
-        - cmake --build build --config Release --parallel ${CPU_COUNT}
-        - cmake --install build
-      else:
-        - echo on
-        - cmake -S . -B build %CMAKE_ARGS% -DBUILD_SHARED_LIBS=ON
-        - if errorlevel 1 exit 1
-        - cmake --build build --config Release --parallel %CPU_COUNT%
-        - if errorlevel 1 exit 1
-        - cmake --install build
-        - if errorlevel 1 exit 1
+      then: |
+        set -exo pipefail
+        cmake -S . -B build ${CMAKE_ARGS} -DBUILD_SHARED_LIBS=ON
+        cmake --build build --config Release --parallel ${CPU_COUNT}
+        cmake --install build
+      else: |
+        @echo on
+        cmake -S . -B build %CMAKE_ARGS% -DBUILD_SHARED_LIBS=ON
+        if errorlevel 1 exit 1
+        cmake --build build --config Release --parallel %CPU_COUNT%
+        if errorlevel 1 exit 1
+        cmake --install build
+        if errorlevel 1 exit 1
 
 requirements:
   build:
@@ -48,6 +50,7 @@ tests:
           - test -f ${PREFIX}/lib/libnewuoa${SHLIB_EXT}
         else:
           - if not exist "%LIBRARY_PREFIX%\include\newuoa.h" exit /b 1
+          - if not exist "%LIBRARY_PREFIX%\lib\newuoa.lib" exit /b 1
           - if not exist "%LIBRARY_PREFIX%\bin\newuoa%SHLIB_EXT%" exit /b 1
 
 about:

--- a/recipes/newuoa-cpp/recipe.yaml
+++ b/recipes/newuoa-cpp/recipe.yaml
@@ -27,6 +27,7 @@ build:
         if errorlevel 1 exit 1
         cmake --build build --config Release --parallel %CPU_COUNT%
         if errorlevel 1 exit 1
+        dir build\Release
         cmake --install build
         if errorlevel 1 exit 1
 


### PR DESCRIPTION
This pull request adds a new recipe for the `newuoa-cpp` project to the repository. The recipe defines the package metadata, build process, dependencies, and testing steps for the `newuoa-cpp` library, which is a C++ implementation of the NEWUOA algorithm with a C interface.

### New recipe creation:

* **Package metadata and source definition**: Added metadata for the `newuoa-cpp` package, including its name, version, homepage, repository, license, and summary. The source URL and checksum for downloading the package are also included. (`recipes/newuoa-cpp/recipe.yaml` - [recipes/newuoa-cpp/recipe.yamlR1-R61](diffhunk://#diff-38651436b9c6e818221d5903d78fcd6c627f5f0ae7779ab8af44a277a0d538c0R1-R61))

* **Build process**: Defined the build process for Unix and Windows systems using CMake, including steps for configuring, building, and installing the library. (`recipes/newuoa-cpp/recipe.yaml` - [recipes/newuoa-cpp/recipe.yamlR1-R61](diffhunk://#diff-38651436b9c6e818221d5903d78fcd6c627f5f0ae7779ab8af44a277a0d538c0R1-R61))

* **Dependencies**: Specified build requirements such as a C++ compiler, C standard library, CMake, and platform-specific tools like `make` for Unix systems. (`recipes/newuoa-cpp/recipe.yaml` - [recipes/newuoa-cpp/recipe.yamlR1-R61](diffhunk://#diff-38651436b9c6e818221d5903d78fcd6c627f5f0ae7779ab8af44a277a0d538c0R1-R61))

* **Testing**: Added tests to verify the presence of the library's header files and compiled binaries in the installation directory for both Unix and Windows systems. (`recipes/newuoa-cpp/recipe.yaml` - [recipes/newuoa-cpp/recipe.yamlR1-R61](diffhunk://#diff-38651436b9c6e818221d5903d78fcd6c627f5f0ae7779ab8af44a277a0d538c0R1-R61))

---

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
