### PR TITLE
Add ta-numba v0.2.2 recipe

### DIFF
--- a/recipes/ta-numba/LICENSE
+++ b/recipes/ta-numba/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Trade-Matrix-Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/ta-numba/meta.yaml
+++ b/recipes/ta-numba/meta.yaml
@@ -1,0 +1,43 @@
+package:
+  name: ta-numba
+  version: "0.2.2"
+
+source:
+  url: https://pypi.io/packages/source/t/ta-numba/ta_numba-0.2.2.tar.gz
+  sha256: f3b06db354ed0e31651590e433a88f6f163ec6ff3fda12380f464bf100e5604c
+
+build:
+  noarch: python
+  script: python -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+  run:
+    - python >=3.11
+    - numba >=0.61.0
+    - numpy >=2.0.0
+
+test:
+  imports:
+    - ta_numba
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/JadenJ09/ta-numba
+  license: MIT
+  license_file: LICENSE
+  summary: "Technical analysis indicators powered by numba and pandas"
+  description: |
+    ta-numba is a Python library that provides a collection of technical analysis indicators
+    optimized for performance using Numba.
+  doc_url: https://github.com/JadenJ09/ta-numba
+  dev_url: https://github.com/JadenJ09/ta-numba
+
+extra:
+  recipe-maintainers:
+    - JadenJ09


### PR DESCRIPTION

This PR adds the recipe for [`ta-numba`](https://pypi.org/project/ta-numba/) version 0.2.2.

✅ Pure-Python technical analysis indicators  
⚡️ Optimized with Numba for high performance  
📦 Source verified from PyPI (`.tar.gz` + SHA256)  
🔗 GitHub: https://github.com/JadenJ09/ta-numba  

Recipe tested locally and linted with `conda-smithy`.  
@conda-forge/help-python, ready for review!
