### PR TITLE
Add ndvi2gif feedstock

### DIFF
--- a/recipes/ndvi2gif/meta.yaml
+++ b/recipes/ndvi2gif/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "ndvi2gif" %}
+{% set version = "0.4.1" %}
+{% set python_min = "3.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0a62c8f3f99bf0cbedba02b6e5e3b34da72de5d5520218893f61b838e8c5067f
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install . -vv
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools
+  run:
+    - python >={{ python_min }}
+    - numpy <2.0
+    - matplotlib-base
+    - pillow
+    - imageio
+    - tqdm
+    - geemap >=0.29.5
+    - earthengine-api >=0.1.347
+    - geopandas
+    - fiona
+    - ipyleaflet
+    - folium
+    - ipywidgets
+    - deims
+
+test:
+  imports:
+    - ndvi2gif
+  requires:
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/Digdgeo/Ndvi2Gif
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: Generate seasonal composites based on statistical summaries of available indices using Google Earth Engine and Geemap
+  description: |
+    NDVI2GIF allows researchers to generate multi seasonal composites based on statistical summaries of available Earth Observation indices. The package is not limited to vegetation indices and can work with any compatible remote sensing index available in GEE.
+  doc_url: https://github.com/Digdgeo/Ndvi2Gif
+  dev_url: https://github.com/Digdgeo/Ndvi2Gif
+
+extra:
+  recipe-maintainers:
+    - Digdgeo


### PR DESCRIPTION
## Summary
This PR adds the ndvi2gif package to conda-forge.

## Description
NDVI2GIF allows researchers to generate multi-seasonal composites based on statistical summaries of available Earth Observation indices using Google Earth Engine and Geemap.

## Checklist
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (if the version is unchanged)
- [x] Reset the build number to 0 (if the version changed)
- [x] Re-rendered the feedstock after version/build changes
- [x] Ensured the license file is being packaged
