### PR TITLE
Add jupytercad-urdf feedstock recipe

### DIFF
--- a/recipes/jupytercad-urdf/meta.yaml
+++ b/recipes/jupytercad-urdf/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "jupytercad-urdf" %}
+{% set version = "0.1.3" %}
+{% set python_min = "3.8" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/jupytercad/JupyterCAD-urdf/releases/download/v{{ version }}/jupytercad_urdf-{{ version }}.tar.gz
+  sha256: f5ff66e3583d271b1608906dda34a742b56bde937969f8ec6d06029d667c7897
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python >={{ python_min }}
+    - hatchling
+    - nodejs
+    - hatch-nodejs-version
+    - hatch-jupyter-builder
+  run:
+    - python >={{ python_min }}
+
+test:
+  imports:
+    - jupytercad_urdf
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/jupytercad/JupyterCAD-urdf
+  summary: JupyterCAD plugin to export URDF files.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Yahiewi


### PR DESCRIPTION
This is the first PR I submitted. This is for a jupyterlab extension called jupytercad_urdf. I already released it on Github, npm and PyPi and now I want to release it on conda-forge.

I confirm I'm okay being listed as a maintainer of this package.

@conda-forge/help-python, ready for review!
@conda-forge/help-nodejs

