### PR TITLE
Check for conda_build_config.yaml in recipes dir for rattler-build recipes

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -293,6 +293,12 @@ def build_folders_rattler_build(
             os.path.abspath(os.path.expanduser(os.path.expandvars(f))), config
         )
 
+    recipes_config = os.path.join(recipes_dir, "conda_build_config.yaml")
+    if os.path.isfile(recipes_config):
+        specs[recipes_config] = conda_build.variants.parse_config_file(
+            os.path.abspath(recipes_config), config
+        )
+
     # Combine all the variant config files together
     combined_spec = conda_build.variants.combine_specs(specs, log_output=config.verbose)
     combined_spec["channel_sources"] = [",".join(channel_urls)]


### PR DESCRIPTION
From what I can tell, it is currently not possible to set a custom `c_stdlib_version` using `rattler-build`/`recipe.yaml` for staged-recipes PRs. If you place a `conda_build_config.yaml` in your recipes directory it currently doesn't get taken in account. 

`rattler-build` in theory automatically picks up `variants.yaml` and `conda_build_config.yaml` files, but these get overwritten using the [`--variant-config` parameter](https://github.com/conda-forge/staged-recipes/blob/main/.ci_support/build_all.py#L318):

Example invocation: 
```
rattler-build build --recipe-dir /home/conda/staged-recipes-copy/recipes --target-platform linux-64 --variant-config /tmp/tmpb4anznk1
```

`rattler-build` picks up the `variants.yaml` - which then gets overwritten again with `/tmp/tmpb4anznk1` since the `--variant-config` parameter is set. 

```
...
 ╭─ Finding outputs from recipe
 │ Loading variant config file: "/tmp/tmpb4anznk1"
 │ Loading variant config file: "/home/conda/staged-recipes-copy/recipes/webkit2gtk4.1/variants.yaml"
 │ Loading variant config file: "/tmp/tmpb4anznk1"
 │ Found 1 variants
 │ 
...
```

Therefore I suggest to include the `conda_build_config.yaml` in the [`combined_specs`](https://github.com/conda-forge/staged-recipes/blob/main/.ci_support/build_all.py#L297) so it'll be part of the combined file in `/tmp`. 

Related:
- https://github.com/prefix-dev/rattler-build/issues/1774



