### PR TITLE
Add Oracle SQLcl package

### DIFF
--- a/recipes/sqlcl/recipe.yaml
+++ b/recipes/sqlcl/recipe.yaml
@@ -18,7 +18,12 @@ build:
     - mkdir -p $PREFIX/opt/sqlcl
     - cp -r sqlcl/* $PREFIX/opt/sqlcl/
     - mkdir -p $PREFIX/bin
-    - ln -s $PREFIX/opt/sqlcl/bin/sql $PREFIX/bin/sql
+    - |
+      cat > $PREFIX/bin/sql << 'EOF'
+      #!/bin/bash
+      exec "$PREFIX/opt/sqlcl/bin/sql" "$@"
+      EOF
+    - chmod +x $PREFIX/bin/sql
     - chmod +x $PREFIX/opt/sqlcl/bin/sql
 
 requirements:


### PR DESCRIPTION
## Summary
Add conda-forge recipe for Oracle SQLcl (SQL Developer Command Line), a Java-based command line interface for Oracle Database.

## Package Details
- **Version:** 25.2.2.199.0918  
- **License:** Oracle Free Use Terms and Conditions + Third-party licenses
- **Platform:** Unix-only (Linux, macOS) via `__unix` dependency
- **Size:** ~85.6 MiB
- **Dependencies:** OpenJDK >=11

## Key Features
- Cross-platform Java-based CLI for Oracle Database
- SQL*Plus compatibility with enhanced features
- Installs to `$PREFIX/opt/sqlcl/` with symlink at `$PREFIX/bin/sql`
- Unix-only installation (Linux, macOS) - no Windows support
- Conflicts with GNU Parallel to prevent `/bin/sql` collision
- Comprehensive license file inclusion (Oracle + third-party)

## Build Configuration
- Uses `target_directory` for clean source organization
- Modern `package_contents` file testing instead of shell commands
- Unix-only build with `__unix` virtual package dependency
- Conflict resolution via `run_constraints` for GNU Parallel
- Built and tested successfully with rattler-build

## Dependencies & Constraints
```yaml
requirements:
  run:
    - __unix                    # Unix-only (Linux, macOS)
    - openjdk >=11
  run_constraints:
    - parallel ==99999999999    # Conflicts with GNU Parallel (/bin/sql collision)
```

## Test Plan
- [x] Local build completes successfully with rattler-build
- [x] Package contents verified (`opt/sqlcl/bin/sql`, `bin/sql`)
- [x] Command execution tested (`sql -version` works)
- [x] All automated tests pass
- [x] Proper file structure with `target_directory`
- [x] License files included (Oracle + third-party)

🤖 Generated with [Claude Code](https://claude.ai/code)