### PR TITLE
add excelcsvparsehelper (win-only)

### DIFF
--- a/recipes/excelcsvparsehelper/meta.yaml
+++ b/recipes/excelcsvparsehelper/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >=3.10
+    - python
     - pandas >=2.0
     - openpyxl >=3.1.5
     - psutil  # [win]


### PR DESCRIPTION
Package name: excelcsvparsehelper
Version: 1.1.0
Build: number 0
Source: PyPI sdist + sha256
Platform: Windows only (recipe has `skip: true  # [not win]`)
Tests: simple import of `ExcelCSVParseHelper`

Notes
- Pure Python package (no compiled extensions in this repo); depends on pywin32 at runtime.
- Minimal import test included.
- Maintainer: @Marcin-kowalczyk-polenergia

Checklist
- [x] Title of this PR is meaningful.
- [x] License file is packaged via `license_file: LICENSE`.
- [x] Source is the official PyPI sdist (with `sha256`).
- [x] Package does not vendor other packages.
- [x] Build number is 0.
- [x] A tarball (`url`) is used rather than a VCS repo.
- [x] Maintainer listed in `recipe-maintainers` (confirmation comment below).