### PR TITLE
Add lockfilesemaphore

### DIFF
--- a/recipes/lockfilesemaphore/meta.yaml
+++ b/recipes/lockfilesemaphore/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "lockfilesemaphore" %}
-{% set version = "3.0.1" %}
+{% set version = "3.0.2" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d0209e63d4ba639561780f9157dd807a166f7af31cdf4ee44cc7a35f443fe197
+  sha256: 81900a030129bc4ec1bf73859497c998c6ab08e15600219e18dc43bb91ba6fb6
 
 build:
   noarch: python


### PR DESCRIPTION
Package name: lockfilesemaphore
Version: 3.0.1
Build: number 0
Source: PyPI sdist
Arch: noarch: python

Notes:
- Pure Python, no compiled code.
- Simple import test included (accepts "LockFileSemaphore" or "lockfilesemaphore").
- Maintainer: @Marcin-kowalczyk-polenergia

Checklist
- [x] Title of this PR is meaningful: "add lockfilesemaphore".
- [x] License file is packaged (`license_file: LICENSE` in recipe).
- [x] Source is from official source (PyPI sdist + sha256).
- [x] Package does not vendor other packages.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo is used.
- [x] Maintainer listed in `recipe-maintainers` (confirmation comment below).
