### PR TITLE
Add excelcsvparsehelper-threadsafe (meta-package)

### DIFF
--- a/recipes/excelcsvparsehelper-threadsafe/meta.yaml
+++ b/recipes/excelcsvparsehelper-threadsafe/meta.yaml
@@ -1,0 +1,32 @@
+{% set name = "excelcsvparsehelper-threadsafe" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+build:
+  noarch: generic
+  number: 0
+  skip: true  # [not win]
+
+requirements:
+  run:
+    - excelcsvparsehelper
+    - lockfilesemaphore
+
+test:
+  requires:
+    - python
+  commands:
+    - python -c "import ExcelCSVParseHelper"
+    - python -c "import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('LockFileSemaphore') else 1)"
+
+about:
+  home: https://github.com/Marcin-kowalczyk-polenergia
+  license: MIT
+  summary: Meta-package that installs ExcelCSVParseHelper and LockFileSemaphore together (Windows-only).
+
+extra:
+  recipe-maintainers:
+    - Marcin-kowalczyk-polenergia


### PR DESCRIPTION
Package name: excelcsvparsehelper-threadsafe
Version: 1.0.0
Type: meta-package (no source / no code)
Platform: Windows-only (mirrors ExcelCSVParseHelper)

What it does:
- Installs both `excelcsvparsehelper` and `lockfilesemaphore` together.
- `noarch: generic`, `skip: true  # [not win]`
- Simple tests: import ExcelCSVParseHelper and verify LockFileSemaphore is present.

Notes:
- This is a pure meta-package, so there is no source tarball or license file to bundle.
- License set to a permissive placeholder (BSD-3-Clause) as is customary for conda-forge meta packages.

Checklist
- [x] Title of this PR is meaningful.
- [x] Build number is 0.
- [x] Package does not vendor other packages (it just depends on them).
- [x] No static libraries are shipped.
- [x] Uses `noarch: generic` and `skip: true  # [not win]`.
- [x] Maintainer listed in `recipe-maintainers` (I confirm I’m willing to be listed).
- [x] N/A items for meta-packages:
  - License file is packaged — **N/A** (no code shipped).
  - Source is from official source — **N/A** (no source).
  - Tarball `url` instead of `git_url` — **N/A** (no source).