### PR TITLE
Delete recipes/conda_build_config.yaml

### DIFF
--- a/recipes/conda_build_config.yaml
+++ b/recipes/conda_build_config.yaml
@@ -1,2 +1,0 @@
-c_stdlib_version:
-  - 2.34


### PR DESCRIPTION
Looks like someone accidentally merged a file outside of a specific recipe folder to staged-recipes/recipes. I thought we had a linter bot which checked for this!?

Accidentally introduced: https://github.com/conda-forge/staged-recipes/pull/30699

Closes #30788