### PR TITLE
Add bvalcalc

### DIFF
--- a/recipes/bvalcalc/bld.bat
+++ b/recipes/bvalcalc/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" -m pip install . -vv
+if errorlevel 1 exit 1

--- a/recipes/bvalcalc/build.sh
+++ b/recipes/bvalcalc/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$PYTHON -m pip install . -vv

--- a/recipes/bvalcalc/meta.yaml
+++ b/recipes/bvalcalc/meta.yaml
@@ -14,6 +14,7 @@ build:
   noarch: python
   entry_points:
     - bvalcalc = Bvalcalc.cli:main
+    - Bvalcalc = Bvalcalc.cli:main
 
 requirements:
   host:
@@ -36,6 +37,7 @@ test:
   commands:
     - pip check
     - bvalcalc --help
+    - Bvalcalc --help
   requires:
     - pip
 

--- a/recipes/bvalcalc/meta.yaml
+++ b/recipes/bvalcalc/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "Bvalcalc" %}
+{% set name = "bvalcalc" %}
 {% set version = "0.6.1" %}
 
 package:
@@ -13,7 +13,7 @@ build:
   number: 0
   noarch: python
   entry_points:
-    - Bvalcalc = Bvalcalc.cli:main
+    - bvalcalc = Bvalcalc.cli:main
 
 requirements:
   host:
@@ -35,7 +35,7 @@ test:
     - Bvalcalc.utils
   commands:
     - pip check
-    - Bvalcalc --help
+    - bvalcalc --help
   requires:
     - pip
 

--- a/recipes/bvalcalc/meta.yaml
+++ b/recipes/bvalcalc/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "Bvalcalc" %}
+{% set version = "0.6.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: # This will be filled in by conda-forge
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - Bvalcalc = Bvalcalc.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=3.10
+    - numpy >=1.22
+    - scipy >=1.13
+    - matplotlib
+    - seaborn >=0.13.2,<0.14.0
+
+test:
+  imports:
+    - Bvalcalc
+    - Bvalcalc.core
+    - Bvalcalc.utils
+  commands:
+    - pip check
+    - Bvalcalc --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/JohriLab/Bvalcalc
+  license: GPL-3.0-only
+  license_family: GPL
+  summary: Calculate relative diversity (B) under background selection
+  doc_url: https://JohriLab.github.io/Bvalcalc/
+  dev_url: https://github.com/JohriLab/Bvalcalc
+
+extra:
+  recipe-maintainers:
+    - jacobimarsh


### PR DESCRIPTION
Add bvalcalc package

Bvalcalc is a tool for calculating relative diversity (B) under background selection, mostly from as a CLI. 

- Homepage: https://github.com/JohriLab/Bvalcalc
- Documentation: https://JohriLab.github.io/Bvalcalc/
- License: GPL-3.0-only
- Supports both `bvalcalc` and `Bvalcalc` commands for consistency with literature