### PR TITLE
Add recipe.yaml for draccus package

### DIFF
--- a/recipes/draccus/recipe.yaml
+++ b/recipes/draccus/recipe.yaml
@@ -1,0 +1,44 @@
+context:
+  name: draccus
+  version: "0.10.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: b82e2c2027030ae1a0f105515125f914e050c0766ab518df3a0560a07d10ddc9
+
+build:
+  script: python -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - mergedeep >=1.3,<2.dev0
+    - pyyaml >=6.0,<7.dev0
+    - pyyaml-include >=1.4,<2.dev0
+    - toml >=0.10,<1.dev0
+    - typing_inspect >=0.9.0,<0.10.dev0
+
+tests:
+  - python:
+      imports:
+      - draccus
+      pip_check: true
+
+about:
+  homepage: https://github.com/dlwh/draccus
+  summary: 'A slightly opinionated framework for simple dataclass-based configurations based on Pyrallis.'
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
This is simple pure python package, the recipe was mostly automatically generated from PyPI metadata using grayskull recipe generation, and modifying it to be compliant with conda-forge guidelines for pure python packages.

PyPI page: https://pypi.org/project/draccus/
Repo: https://github.com/dlwh/draccus

Checklist
- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
