### PR TITLE
Add recipe for placo C++ and Python library

### DIFF
--- a/recipes/placo/build_placo.bat
+++ b/recipes/placo/build_placo.bat
@@ -1,0 +1,39 @@
+mkdir build
+cd build
+
+cmake %CMAKE_ARGS% -G "Ninja" ^
+    -DBUILD_TESTING:BOOL=ON ^
+    -DPYTHON_EXECUTABLE=%PYTHON% ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+type CMakeCache.txt
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest --output-on-failure -C Release
+if errorlevel 1 exit 1
+
+REM The METADATA file is necessary to ensure that pip list shows the pip package installed by conda
+REM The INSTALLER file is necessary to ensure that pip list shows that the package is installed by conda
+REM See https://packaging.python.org/specifications/recording-installed-packages/
+REM and https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata
+
+mkdir "%SP_DIR%/placo-%PKG_VERSION%.dist-info"
+
+set metadata_file=%SP_DIR%\placo-%PKG_VERSION%.dist-info\METADATA
+echo>%metadata_file% Metadata-Version: 2.1
+echo>>%metadata_file% Name: placo
+echo>>%metadata_file% Version: %PKG_VERSION%
+echo>>%metadata_file% Summary: Rhoban Planning and Control
+
+set installer_file=%SP_DIR%\placo-%PKG_VERSION%.dist-info\INSTALLER
+echo>%installer_file% conda
+

--- a/recipes/placo/build_placo.sh
+++ b/recipes/placo/build_placo.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+rm -rf build
+mkdir -p build
+
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja -DPYTHON_EXECUTABLE=$PYTHON .. \
+    -DBUILD_TESTING:BOOL=ON
+cat CMakeCache.txt
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:-}" != "" ]]; then
+  ctest --output-on-failure -C Release
+fi
+
+# The METADATA file is necessary to ensure that pip list shows the pip package installed by conda
+# The INSTALLER file is necessary to ensure that pip list shows that the package is installed by conda
+# See https://packaging.python.org/specifications/recording-installed-packages/
+# and https://packaging.python.org/en/latest/specifications/core-metadata/#core-metadata
+
+mkdir $SP_DIR/placo-$PKG_VERSION.dist-info
+
+cat > $SP_DIR/placo-$PKG_VERSION.dist-info/METADATA <<METADATA_FILE
+Metadata-Version: 2.1
+Name: placo
+Version: $PKG_VERSION
+Summary: Rhoban Planning and Control
+METADATA_FILE
+
+cat > $SP_DIR/placo-$PKG_VERSION.dist-info/INSTALLER <<INSTALLER_FILE
+conda
+INSTALLER_FILE

--- a/recipes/placo/recipe.yaml
+++ b/recipes/placo/recipe.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
+context:
+  version: "0.9.14"
+  build_number: 0
+
+recipe:
+  name: placo-split
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/Rhoban/placo/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: a7f866063d564d3d50605e74b8097aeac7125e219970b9903ad72bd81e36401d
+
+  # In general conda-forge recipes only use tarballs. However, placo explicitly excluedes its
+  # tests from the tarball using export-ignore in .gitattributes, see 
+  # https://github.com/Rhoban/placo/blob/v0.9.14/.gitattributes#L1
+  # so we need to clone the git repository to get the tests.
+  - git: https://github.com/Rhoban/placo.git
+    tag: v${{ version }}
+    target_directory: placo-tests
+
+build:
+  number: ${{ build_number }}
+  # Once https://github.com/conda-forge/eiquadprog-feedstock/pull/15
+  # Windows support will be enabled
+  skip: win 
+
+outputs:
+  - package:
+      name: placo
+    build:
+      script:
+        - if: unix
+          then: build_placo.sh
+        - if: win
+          then: build_placo.bat
+    requirements:
+      build:
+        - if: build_platform != target_platform
+          then:
+            - python
+            - cross-python_${{ target_platform }}
+        - ${{ compiler('cxx') }}
+        - ${{ compiler('c') }}
+        - ${{ stdlib("c") }}
+        - cmake
+        - pkg-config
+        - ninja
+      host:
+        - python
+        - pip
+        - setuptools
+        - doxystub
+        - pinocchio
+        - numpy
+        - eigenpy
+        - eiquadprog
+        - jsoncpp
+      run:
+        - python
+        - meshcat-python
+      run_exports:
+        - ${{ pin_subpackage('placo', upper_bound='x.x.x') }}
+
+    tests:
+      - python:
+          imports:
+            - placo
+          pip_check: true
+
+  - package:
+      name: placo-tests
+    build:
+      script: ${{ 'true' if unix else 'exit /b 0' }}
+    requirements:
+      run:
+        - ${{ pin_subpackage('placo', upper_bound="x.x.x") }}
+    tests:
+      - files:
+          source:
+            - placo-tests/python/tests
+        requirements:
+          run:
+            - pytest
+            - matplotlib-base
+        script:
+          - python -m unittest discover placo-tests/python/tests/ "*_test.py"
+
+about:
+  homepage: https://github.com/Rhoban/placo
+  license: MIT
+  license_file:
+    - LICENSE
+  summary:  Rhoban Planning and Control.
+
+extra:
+  recipe-maintainers:
+    - traversaro
+  feedstock-name: placo


### PR DESCRIPTION
This PR proposes a package for the `placo` C++ and Python library, a prerequisite for https://github.com/conda-forge/staged-recipes/pull/30714 .

The proposed recipe follows a typical multiple-output structure, where the `placo` package contains the C++ and Python libraries (the upstream build system does not easily permit to split the C++ and Python parts), while the `placo-tests` package contains the tests, that has they contain heavy robot models and meshes, are splitted in a separate package. Furthermore, as test files are not included in the release tarballs using export-ignore in .gitattributes (see https://github.com/Rhoban/placo/blob/v0.9.14/.gitattributes#L1) so we need to clone the git repository to get the tests. However, I think this is relatively safe as the git repository is only used to get the test data, while the `placo` package itself is only built using the actual tarball.

Windows builds are currently skipped waiting for the https://github.com/conda-forge/eiquadprog-feedstock/pull/15 PR to be merged.

As the Python library is only built using CMake, we also manually install the required metadata files to ensure that `pip` is aware that the `placo` package is installed. Note that the upstream package contains a `pyproject.toml`, but it contains a lot of PyPI-specific details such as the use of [cmeel dependencies](https://github.com/cmake-wheel/cmeel), so it is not particularly useful in this context.

Repo: https://github.com/Rhoban/placo
PyPI page: https://pypi.org/project/placo/ 

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details). **Note by @traversaro: A `git_url` is indeed used just for the tests, see the OP for more details.**
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
