### PR TITLE
adds r-tailor

### DIFF
--- a/recipes/r-tailor/bld.bat
+++ b/recipes/r-tailor/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tailor/build.sh
+++ b/recipes/r-tailor/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tailor/meta.yaml
+++ b/recipes/r-tailor/meta.yaml
@@ -1,0 +1,97 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-tailor
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/tailor_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/tailor/tailor_{{ version }}.tar.gz
+  sha256: 3a20c19f1afb8814ad14f525142986daf36cfe0a9e9f1fdc00a822c1579c01ea
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-cli
+    - r-dplyr
+    - r-generics
+    - r-hardhat
+    - r-purrr
+    - r-rlang >=1.1.0
+    - r-tibble
+    - r-tidyselect
+    - r-vctrs
+  run:
+    - r-base
+    - r-cli
+    - r-dplyr
+    - r-generics
+    - r-hardhat
+    - r-purrr
+    - r-rlang >=1.1.0
+    - r-tibble
+    - r-tidyselect
+    - r-vctrs
+
+test:
+  commands:
+    - $R -e "library('tailor')"           # [not win]
+    - "\"%R%\" -e \"library('tailor')\""  # [win]
+
+about:
+  home: https://github.com/tidymodels/tailor, https://tailor.tidymodels.org
+  license: MIT
+  summary: Postprocessors refine predictions outputted from machine learning models to improve
+    predictive performance or better satisfy distributional limitations. This package
+    introduces 'tailor' objects, which compose iterative adjustments to model predictions.
+    A number of pre-written adjustments are provided with the package, such as calibration.
+    See Lichtenstein, Fischhoff, and Phillips (1977) <doi:10.1007/978-94-010-1276-8_19>.
+    Other methods and utilities to compose new adjustments are also included. Tailors
+    are tightly integrated with the 'tidymodels' framework.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: tailor
+# Title: Iterative Steps for Postprocessing Model Predictions
+# Version: 0.1.0
+# Authors@R: c( person("Simon", "Couch", , "simon.couch@posit.co", role = "aut"), person("Hannah", "Frick", , "hannah@posit.co", role = "aut"), person("Emil", "HvitFeldt", , "emil.hvitfeldt@posit.co", role = "aut"), person("Max", "Kuhn", , "max@posit.co", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2402-136X")), person("Posit Software, PBC", role = c("cph", "fnd"), comment = c(ROR = "03wc8by49")) )
+# Description: Postprocessors refine predictions outputted from machine learning models to improve predictive performance or better satisfy distributional limitations. This package introduces 'tailor' objects, which compose iterative adjustments to model predictions. A number of pre-written adjustments are provided with the package, such as calibration. See Lichtenstein, Fischhoff, and Phillips (1977) <doi:10.1007/978-94-010-1276-8_19>. Other methods and utilities to compose new adjustments are also included. Tailors are tightly integrated with the 'tidymodels' framework.
+# License: MIT + file LICENSE
+# URL: https://github.com/tidymodels/tailor, https://tailor.tidymodels.org
+# BugReports: https://github.com/tidymodels/tailor/issues
+# Depends: R (>= 4.1)
+# Imports: cli, dplyr, generics, hardhat, purrr, rlang (>= 1.1.0), tibble, tidyselect, vctrs
+# Suggests: betacal, dials (>= 1.4.1), mgcv, modeldata, probably (>= 1.1.0), testthat (>= 3.0.0)
+# Config/Needs/website: tidyverse/tidytemplate
+# Config/testthat/edition: 3
+# Config/usethis/last-upkeep: 2025-04-29
+# Encoding: UTF-8
+# RoxygenNote: 7.3.2
+# NeedsCompilation: no
+# Packaged: 2025-08-19 17:16:06 UTC; max
+# Author: Simon Couch [aut], Hannah Frick [aut], Emil HvitFeldt [aut], Max Kuhn [aut, cre] (ORCID: <https://orcid.org/0000-0003-2402-136X>), Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)
+# Maintainer: Max Kuhn <max@posit.co>
+# Repository: CRAN
+# Date/Publication: 2025-08-25 07:50:03 UTC


### PR DESCRIPTION
Adds [CRAN package `tailor`](https://cran.r-project.org/package=tailor) as `r-tailor`. Recipe generated with `conda_r_skeleton_helper`.

Needed for https://github.com/conda-forge/r-tidymodels-feedstock/pull/22.

## Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
