### PR TITLE
Add lgatr

### DIFF
--- a/recipes/lgatr/meta.yaml
+++ b/recipes/lgatr/meta.yaml
@@ -33,7 +33,6 @@ test:
     - lgatr
   commands:
     - pip check
-    - python -c "import lgatr; print(lgatr.__version__)"
   requires:
     - pip
     - python {{ python_min }}

--- a/recipes/lgatr/meta.yaml
+++ b/recipes/lgatr/meta.yaml
@@ -32,10 +32,14 @@ test:
     - lgatr
   commands:
     - pip check
+    - python -c "import lgatr; print(lgatr.__version__)"
   requires:
     - pip
 
 about:
+  home: https://github.com/heidelberg-hepml/lgatr
+  doc_url: https://heidelberg-hepml.github.io/lgatr/
+  dev_url: https://github.com/heidelberg-hepml/lgatr
   summary: Lorentz-Equivariant Geometric Algebra Transformer for High-Energy Physics
   license: BSD-3-Clause
   license_file: LICENSE

--- a/recipes/lgatr/meta.yaml
+++ b/recipes/lgatr/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "lgatr" %}
 {% set version = "1.3.0" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - setuptools >=68
     - wheel >=0.42
     - pip
   run:
-    - python >=3.10
+    - python {{ python_min }}
     - pytorch >=2.0
     - numpy
     - einops
@@ -35,6 +36,7 @@ test:
     - python -c "import lgatr; print(lgatr.__version__)"
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/heidelberg-hepml/lgatr

--- a/recipes/lgatr/meta.yaml
+++ b/recipes/lgatr/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "lgatr" %}
+{% set version = "1.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lgatr-{{ version }}.tar.gz
+  sha256: dce13ade9e2cbd8f05c2ac008aaa1089f023784f65d80e546c2b95df45158f6e
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - setuptools >=68
+    - wheel >=0.42
+    - pip
+  run:
+    - python >=3.10
+    - pytorch >=2.0
+    - numpy
+    - einops
+    - opt_einsum
+
+test:
+  imports:
+    - lgatr
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  summary: Lorentz-Equivariant Geometric Algebra Transformer for High-Energy Physics
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - spinjo


### PR DESCRIPTION
Pure-Python package; installs from PyPI sdist.
All runtime deps available on conda-forge.
Noarch: python; basic import tests included.

Maintainers:
- @spinjo 

Based on heidelberg-hepml/lgatr#6, thanks @matthewfeickert 