### PR TITLE
Add recipe for rocm-core

### DIFF
--- a/recipes/rocm-core/build.sh
+++ b/recipes/rocm-core/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# ROCM_VERSION needs to be explicitly defined from the CMake command line,
+# see:
+#  * https://github.com/spack/spack-packages/blob/d37780746a17e19848365a3090dd20071fe48012/repos/spack_repo/builtin/packages/rocm_core/package.py#L79
+#  * https://github.com/ROCm/rocm-core/blob/rocm-6.4.3/CMakeLists.txt#L63
+
+cmake -GNinja ${CMAKE_ARGS} -DROCM_VERSION=${PKG_VERSION} -Bbuild -S.
+cmake --build ./build
+cmake --install ./build

--- a/recipes/rocm-core/recipe.yaml
+++ b/recipes/rocm-core/recipe.yaml
@@ -1,0 +1,48 @@
+context:
+  name: rocm-core
+  version: "6.4.3"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  - url: "https://github.com/ROCm/rocm-core/archive/refs/tags/rocm-${{ version }}.tar.gz"
+    sha256: dae6e06739882a3ce7be13ac300c22ab35ce80b4e853a21a1a3237fdc0411eb9
+
+build:
+  number: 0
+  skip: not linux
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+
+tests:
+  - requirements:
+      run:
+        - cmake-package-check
+        - ${{ compiler('c') }}
+        - ${{ compiler('cxx') }}
+    script:
+      - cmake-package-check rocm-core
+  - package_contents:
+      include:
+        - rocm-core/rocm_version.h
+      lib:
+        - rocm-core
+
+about:
+  homepage: https://github.com/ROCm/rocm-core
+  license: MIT
+  license_family: MIT
+  license_file: copyright
+  summary: "ROCm core package"
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
[rocm-core](https://github.com/ROCm/rocm-core) is a basic library of the ROCm stack, currently not packaged in conda-forge, see https://github.com/conda-forge/conda-forge.github.io/issues/1923 for a related discussion.

The repo is marked as deprecated, but only because the library have been moved in the https://github.com/ROCm/rocm-systems monorepo. However, the current release 6.4.3 is only available in rocm-core, I guess the releases will start being done from the rocm-systems monorepo from ROCm 7.0.0 .

Repology: https://repology.org/project/rocm-core/versions
Spack: https://github.com/spack/spack-packages/blob/d37780746a17e19848365a3090dd20071fe48012/repos/spack_repo/builtin/packages/rocm_core/package.py



<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| java            | `@conda-forge/help-java`      |
| nodejs          | `@conda-forge/help-nodejs`    |
| c/c++           | `@conda-forge/help-c-cpp`     |
| perl            | `@conda-forge/help-perl`      |
| Julia           | `@conda-forge/help-julia`     |
| ruby            | `@conda-forge/help-ruby`      |
| Rust            | `@conda-forge/help-rust`      |
| Go              | `@conda-forge/help-go`        |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
