### PR TITLE
fix: update linter workflow to include issue_comment event for PRs

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,7 @@ on:
       - reopened
       - labeled
       - unlabeled
-  issue_comment: nll
+  issue_comment: null
 
 permissions: read-all
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,6 +12,9 @@ on:
       - reopened
       - labeled
       - unlabeled
+  issue_comment: nll
+
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,6 +24,7 @@ jobs:
   linter:
     name: linter
     runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request' }}
     defaults:
       run:
         shell: bash -leo pipefail {0}


### PR DESCRIPTION
This PR ensures the staged-recipes linter runs when folks comment on issues to check for maintainers approving.