### PR TITLE
adds r-nmfbin

### DIFF
--- a/recipes/r-nmfbin/bld.bat
+++ b/recipes/r-nmfbin/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-nmfbin/build.sh
+++ b/recipes/r-nmfbin/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-nmfbin/meta.yaml
+++ b/recipes/r-nmfbin/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = '0.2.1' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-nmfbin
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/nmfbin_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/nmfbin/nmfbin_{{ version }}.tar.gz
+  sha256: 18394d37322cdcb6e40ba0e6d1913beffb1f25ec02c74e6803cd85f0c4825ebc
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('nmfbin')"           # [not win]
+    - "\"%R%\" -e \"library('nmfbin')\""  # [win]
+
+about:
+  home: https://michalovadek.github.io/nmfbin/
+  license: MIT
+  summary: "Factorize binary matrices into rank-k components using the logistic function in the
+    updating process. See e.g. Tom\xE9 et al (2015) <doi:10.1007/s11045-013-0240-9>
+    ."
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: nmfbin
+# Title: Non-Negative Matrix Factorization for Binary Data
+# Version: 0.2.1
+# Authors@R: c(person(given = "Michal", family = "Ovadek", role = c("aut", "cre", "cph"), email = "michal.ovadek@gmail.com", comment = c(ORCID = "0000-0002-2552-2580")))
+# Description: Factorize binary matrices into rank-k components using the logistic function in the updating process. See e.g. Tome et al (2015) <doi:10.1007/s11045-013-0240-9> .
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# Language: en-GB
+# RoxygenNote: 7.2.3
+# URL: https://michalovadek.github.io/nmfbin/
+# Suggests: knitr, rmarkdown, testthat (>= 3.0.0)
+# VignetteBuilder: knitr
+# Config/testthat/edition: 3
+# NeedsCompilation: no
+# Packaged: 2023-09-20 19:16:47 UTC; uctqova
+# Author: Michal Ovadek [aut, cre, cph] (<https://orcid.org/0000-0002-2552-2580>)
+# Maintainer: Michal Ovadek <michal.ovadek@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-09-21 13:40:02 UTC


### PR DESCRIPTION
Adds [CRAN package `nmfbin`](https://cran.r-project.org/package=nmfbin) as `r-nmfbin`. Recipe generated with `conda_r_skeleton_helper`.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
