### PR TITLE
Add polylith-cli

### DIFF
--- a/recipes/polylith-cli/recipe.yaml
+++ b/recipes/polylith-cli/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
     name: polylith-cli
-    version: 1.38.2
+    version: 1.39.0
 
 package:
     name: ${{ name|lower }}
@@ -10,7 +10,7 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/polylith_cli-${{ version }}.tar.gz
-    sha256: ac8bbb5ba6f0f2307cc14302d5b5732d229420d9e43b4c7a77e9b68a3eef77dc
+    sha256: c69766f9c657a8eb8b5bd59e0361f3946570a2865bd24075646c4697db1f9d50
   - url: https://raw.githubusercontent.com/DavidVujic/python-polylith/refs/heads/main/LICENSE
     sha256: cb206b34b119d5e0f3ed4634fa8cafa73b0ef64f390772ee2211880e0730c4a7
 


### PR DESCRIPTION
Supersedes  #29059 by using V1 recipe format.

# Checklist
- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

@conda-forge-admin, please ping team

EDIT: package description below

# Summary

This PR adds a recipe for the polylith-cli package, a Python tool to support the Polylith Architecture in Python. 

# Package Information

- Package name: polylith-cli
- Version: 1.35.2
- PyPI URL: https://pypi.org/project/polylith-cli/
- Source code: https://github.com/davidvujic/python-polylith
- License: MIT

# Description (from the package doc)

Polylith is an architecture, with tooling support, originally built for Clojure. This project brings Polylith to Python. Polylith is using a components-first architecture. You can think of it as building blocks, very much like LEGO bricks. All code lives in a Monorepo, available for reuse. Python code - the bricks - is separated from the infrastructure and the actual packaging or building of the deployable artifacts.

# Dependencies

- python >=3.8
- tomlkit >=0, <1
- rich >=13,<15
- typer >=0, <1
- pyyaml

# Notes

- This is a pure Python package (noarch)
- All dependencies are available on conda-forge
- The recipe follows the V1 format