### PR TITLE
Add recipe for jdisk v0.2.3

### DIFF
--- a/recipes/jdisk/meta.yaml
+++ b/recipes/jdisk/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "jdisk" %}
+{% set version = "0.2.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/jdisk-{{ version }}.tar.gz
+  sha256: 548816e5a22c8b8c4916ca09fe79ca554dbaf37312204d9730b5276f0b66c94d
+
+build:
+  entry_points:
+    - jdisk = jdisk.jdisk:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - hatchling
+    - pip
+  run:
+    - python >=3.9
+    - requests
+    - qrcode
+    - websocket-client
+
+test:
+  imports:
+    - jdisk
+  commands:
+    - pip check
+    - jdisk --help
+  requires:
+    - pip
+
+about:
+  summary: SJTU Netdisk command line interface
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - chengjilai


### PR DESCRIPTION
This PR adds a conda recipe for jdisk, a SJTU Netdisk command line interface.

## Summary
- Package: jdisk v0.2.3
- Source: PyPI
- Dependencies: requests, qrcode, websocket-client
- License: MIT

## Test plan
- [x] Recipe builds successfully on all platforms
- [x] Tests pass (imports and CLI help command)
- [x] Dependencies are available on conda-forge

@conda-forge/help-python, ready for review!