### PR TITLE
add viskores package

### DIFF
--- a/recipes/viskores/recipe.yaml
+++ b/recipes/viskores/recipe.yaml
@@ -1,0 +1,127 @@
+# This recipe uses the v1 YAML format introduced by CEP 13
+# For more information see: https://prefix-dev.github.io/rattler-build/latest/reference/recipe_file/
+
+context:
+  name: viskores
+  version: "1.0.0"
+  soversion: ${{ (version | split('.'))[:2] | join('.') }}
+  viskores_modules: |
+    cont
+    filter_clean_grid
+    filter_connected_components
+    filter_contour
+    filter_core
+    filter_density_estimate
+    filter_entity_extraction
+    filter_field_conversion
+    filter_field_transform
+    filter_flow
+    filter_geometry_refinement
+    filter_image_processing
+    filter_mesh_info
+    filter_multi_block
+    filter_resampling
+    filter_scalar_topology
+    filter_vector_analysis
+    filter_zfp
+    io
+    rendering
+    source
+    worklet
+  common_flags:
+    -DCMAKE_BUILD_TYPE=Release
+    -DViskores_ENABLE_HDF5_IO=ON
+
+package:
+  name: ${{ name | lower }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Viskores/viskores/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 5bff5bbd747b7662bb4630889960371d06fcc5e5a962d974a898d1883f196eba
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - cmake -GNinja -S $SRC_DIR -B build -DCMAKE_INSTALL_PREFIX=$PREFIX ${{ common_flags }}
+        - cmake --build build -j
+        - cmake --install build
+        - Viskores_DIR=$PREFIX cmake -GNinja -S $SRC_DIR/examples/smoke_test/ -B smoke_test_build
+        - cmake --build smoke_test_build
+        - ./smoke_test_build/smoke_test
+    - if: win
+      then:
+        - cmake -GNinja -S %SRC_DIR% -B build -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ${{ common_flags }}
+        - cmake --build build -j
+        - cmake --install build
+
+requirements:
+  run_exports:
+    - ${{ pin_subpackage(name|lower, upper_bound='x.x') }}
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - cmake >=3.23
+    - gnuconfig
+    - if: linux
+      then: libgomp
+    - if: osx
+      then: llvm-openmp
+    - ninja
+    - pkg-config
+  host:
+    - freeglut
+    - glew
+    - hdf5
+    - mesalib
+    - zfp
+    - if: linux
+      then: libgomp
+    - if: osx
+      then: llvm-openmp
+
+tests:
+  - script:
+    - if: linux
+      then:
+        - for: ${{ viskores_modules | split }}
+          then:
+            - test -f $PREFIX/lib/libviskores_${{ each }}-${{ soversion }}.so.${{ version }}
+    - if: osx
+      then:
+        - for: ${{ viskores_modules | split }}
+          then:
+            - test -f $PREFIX/lib/libviskores_${{ each }}-${{ soversion }}.${{ version }}.dylib
+    - if: win
+      then:
+        - for: ${{ viskores_modules | split }}
+          then:
+            - if not exist %LIBRARY_PREFIX%\bin\viskores_${{ each }}-${{ soversion }}.dll exit 1
+            - if not exist %LIBRARY_PREFIX%\lib\viskores_${{ each }}-${{ soversion }}.lib exit 1
+        - if not exist %LIBRARY_PREFIX%\include\viskores-${{ soversion }} exit 1
+
+about:
+  homepage: https://github.com/Viskores/viskores
+  summary: 'Visualization ToolKit for Many-cores (viskores)'
+  description: |
+    Viskores is a toolkit of scientific visualization algorithms for emerging
+    processor architectures. Viskores supports the fine-grained concurrency for
+    data analysis and visualization algorithms required to drive extreme scale
+    computing by providing abstract models for data and execution that can be
+    applied to a variety of algorithms across many different processor
+    architectures.
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE.txt
+    - viskores/thirdparty/diy/viskoresdiy/LICENSE.txt
+    - viskores/thirdparty/lcl/viskoreslcl/LICENSE.md
+    - viskores/thirdparty/lodepng/viskoreslodepng/LICENSE
+  documentation: https://viskores.readthedocs.io/
+  repository: https://github.com/Viskores/viskores
+
+extra:
+  recipe-maintainers:
+    - vicentebolea


### PR DESCRIPTION
This PR adds the Viskores package which is the succesor of VTK-m (https://github.com/conda-forge/vtk-m-feedstock). VTK-m is no longer maintaned and its team moved to Viskores (https://github.com/Viskores/viskores).

This recipe uses the new rattle format.

