### PR TITLE
backports.zstd (with noarch: generic no-op package for python 3.14+)

### DIFF
--- a/recipes/backports.zstd/conda_build_config.yaml
+++ b/recipes/backports.zstd/conda_build_config.yaml
@@ -1,8 +1,0 @@
-# This would ideally use CFEP-25 `python_min`, but `staged-recipes` doesn't
-# yet build python 3.14 by default.
-is_noop:
-  - "false"
-  - "true"
-# python_min:
-#  - "3.10"  # this would need to be updated yearly
-#  - "3.14"

--- a/recipes/backports.zstd/recipe.yaml
+++ b/recipes/backports.zstd/recipe.yaml
@@ -19,20 +19,16 @@ build:
 # on `backports.zstd` without having their _own_ variants, this builds multiple
 # `outputs` with the same name, but different build strings, per upstream release:
 #
-# - one build that links against `zstd` and `python` per {platform x architecture x python }
+# - one build that links against `zstd` and `python` per {platform x architecture x python}
 #   for python 3.10-3.13
 # - a single, empty, `noarch: generic` build (built on `linux-64`) which can be
 #   installed on python 3.14+
-#
-# After being merged and migrated to python 3.14, it is possible only CFEP-25's
-# `python_min` would be needed, with potential `skip`s suggested below.
 
 outputs:
   - package:
       name: backports.zstd
     build:
-      # skip: match(python_min, "3.14.*")
-      skip: is_noop == "true" or match(python, ">=3.14")
+      skip: match(python, ">=3.14")
       script:
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --config-settings=--build-option=--system-zstd --disable-pip-version-check
     requirements:
@@ -54,11 +50,10 @@ outputs:
   - package:
       name: backports.zstd
     build:
-      # skip: not match(python_min, "3.14.*")
-      skip: is_noop == "false"
+      skip: not (build_platform == "linux-64" and match(python, python_min ~ ".*"))
       noarch: generic
     requirements:
-      run_constraints:
+      run:
         - python >=3.14
     tests:
       - python:


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

References:
- alternative to (and contains #31124)