### PR TITLE
Fix syntax error in `nvmolkit`'s variant name ( change `-` to `_` )

### DIFF
--- a/recipes/nvmolkit/variants.yaml
+++ b/recipes/nvmolkit/variants.yaml
@@ -1,3 +1,3 @@
-librdkit-dev:
+librdkit_dev:
   - "2024.9.6"
   - "2025.3.1"


### PR DESCRIPTION
Fix a syntax error in the variant name `librdkit_dev` used in the `nvmolkit` recipe. It was using a `-`. This fixes it to `_`.

xref: https://github.com/conda-forge/staged-recipes/pull/31202/files