### PR TITLE
Add epydemix 1.0.2 to conda-forge

### DIFF
--- a/recipes/epydemix/meta.yaml
+++ b/recipes/epydemix/meta.yaml
@@ -41,7 +41,7 @@ test:
 about:
   home: https://github.com/epistorm/epydemix
   summary: A Python package for epidemic modeling, simulation, and calibration
-  license: GPL-3.0
+  license: GPL-3.0-or-later
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Add epydemix 1.0.2

`epydemix` — a Python package for epidemic modeling, simulation, and calibration.  
It provides tools for implementing, simulating, and calibrating epidemic models using Approximate Bayesian Computation (ABC) and related inference methods.

---

### Checklist

- [x] Title of this PR is meaningful: "Add epydemix 1.0.2".
- [x] License file is packaged (`LICENSE` included in the source tarball).
- [x] Source is from official source (PyPI tarball).
- [x] Package does not vendor other packages.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a git repo is used.
- [x] GitHub user `ngozzi` confirms willingness to be listed as maintainer.
- [x] Local build test with `conda mambabuild` passed successfully.

---

@conda-forge-admin, please ping team
