### PR TITLE
Bump to macos-15

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -6,7 +6,7 @@ jobs:
 - job: osx
   condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
-    vmImage: macOS-15-intel
+    vmImage: macOS-15
   strategy:
     matrix:
       osx_64:


### PR DESCRIPTION
macos-13 is deprecated: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/