### PR TITLE
Add hydromodpy recipe

### DIFF
--- a/recipes/hydromodpy/conda_build_config.yaml
+++ b/recipes/hydromodpy/conda_build_config.yaml
@@ -1,0 +1,7 @@
+python:
+  - 3.11
+  - 3.12
+  - 3.13
+
+channel_targets:
+  - conda-forge main

--- a/recipes/hydromodpy/meta.yaml
+++ b/recipes/hydromodpy/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "hydromodpy" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/h/hydromodpy/hydromodpy-0.3.0.tar.gz
+  sha256: a28f552a7c5fc6328dac99011581a9f144eae7fb70b5e27d5d97ef41c7260a8c
+
+build:
+  noarch: python
+  binary_relocation: false  # ship upstream binaries (mf6, mfnwt, etc.) without patching
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python >=3.11
+    - colormap
+    - contextily
+    - flopy
+    - geopandas
+    - h5py
+    - imageio
+    - ipykernel
+    - ipython
+    - matplotlib
+    - matplotlib-scalebar
+    - netcdf4
+    - numpy
+    - pandas
+    - plotly
+    - pyproj
+    - pyshp
+    - rasterio
+    - rioxarray
+    - selenium
+    - vedo
+    - whitebox
+    - xarray
+    - pysheds
+    - pyside6
+    - spyder-kernels
+
+test:
+  requires:
+    - python
+  commands:
+    - python -c "import hydromodpy; import importlib; importlib.import_module('hydromodpy.watershed'); print(hydromodpy.__version__)"
+
+about:
+  summary: A Python toolbox for deploying catchment-scale shallow groundwater models.
+  description: |
+    HydroModPy fournit des outils pour créer, calibrer et déployer des modèles hydrologiques
+    et hydrogéologiques à l’échelle du bassin versant, incluant la préparation de données,
+    l’analyse et la visualisation.
+  home: https://hydromod.readthedocs.io/
+  doc_url: https://hydromod.readthedocs.io/
+  dev_url: https://gitlab.com/Alex-Gauvain/HydroModPy
+  license: Eclipse-2.0
+  license_file: ../LICENSE
+
+extra:
+  recipe-maintainers:
+    - alex-gauvain
+    - ronan-abherve
+    - bastien-boivin


### PR DESCRIPTION
Add HydromodPy v0.3.0 recipe (pure-Python core with upstream MODFLOW executables).
Build verified via conda mambabuild and import smoke test
binaries are shipped unmodified with binary_relocation: false.