### PR TITLE
fix: do not relint comments on closed or merged PRs

### DIFF
--- a/.github/workflows/scripts/linter_issue_comment.py
+++ b/.github/workflows/scripts/linter_issue_comment.py
@@ -18,6 +18,9 @@ if __name__ == "__main__":
     repo = gh.get_repo(f"{args.owner}/staged-recipes")
     pr = repo.get_pull(args.pr_num)
 
+    if pr.state == "closed" or pr.merged = True:
+        return
+
     commit = repo.get_commit(pr.head.sha)
 
     linter_check_suite = None


### PR DESCRIPTION
This PR stops the linter from relinting merged or closed PRs.

closes #31506 