### PR TITLE
Preserve the field types in the YAML config for `rattler-build`

### DIFF
--- a/.ci_support/build_all.py
+++ b/.ci_support/build_all.py
@@ -290,7 +290,7 @@ def build_folders_rattler_build(
     specs = OrderedDict()
     for f in config.exclusive_config_files:
         specs[f] = conda_build.variants.parse_config_file(
-            os.path.abspath(os.path.expanduser(os.path.expandvars(f))), config
+            os.path.abspath(os.path.expanduser(os.path.expandvars(f))), config, loader=yaml.SafeLoader
         )
 
     variants = list(Path(recipes_dir).glob(f"**/conda_build_config.yaml")) \
@@ -302,7 +302,7 @@ def build_folders_rattler_build(
         )
     if variants and os.path.isfile(variants[0]):
         specs[variants[0]] = conda_build.variants.parse_config_file(
-            os.path.abspath(variants[0]), config
+            os.path.abspath(variants[0]), config, loader=yaml.SafeLoader
         )
 
     # Combine all the variant config files together


### PR DESCRIPTION
Currently, when `conda_build` loads the default configs in `staged-recipes`' `build_all.py`, it converts the Boolean values into strings before being parsed by `rattler-build` because it uses the `yaml.BaseLoader` loader by default. This does not match the behavior of the feedstock, which uses `rattler-build` directly and reads the original Boolean values.

The latest release of `conda-build` allows us to override the default YAML loader so that we can preserve the types.

Resolving this issue will unblock https://github.com/conda-forge/staged-recipes/pull/31062.

As mentioned in https://github.com/conda-forge/staged-recipes/pull/31062#issuecomment-3344112981, this fix has been tested to work (logs are in the linked comment), and it allows the original values to be parsed with the correct types.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
