### PR TITLE
Adding aeventkit

### DIFF
--- a/recipes/aeventkit/meta.yaml
+++ b/recipes/aeventkit/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/aeventkit-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aeventkit-{{ version }}.tar.gz
   sha256: 4e7d81bb0a67227121da50a23e19e5bbf13eded541a9f4857eeb6b7b857b738a
 
 build:
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - poetry-core
     - pip
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - numpy
 
 test:
@@ -29,6 +29,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:
@@ -47,4 +48,3 @@ about:
 extra:
   recipe-maintainers:
     - alphasierrahotel
-


### PR DESCRIPTION
## Summary

Add `aeventkit` package to conda-forge. This is the new PyPI name for the `eventkit` package (import name remains `eventkit`).

## Details

- **Package name:** aeventkit
- **Version:** 2.1.0
- **PyPI:** https://pypi.org/project/aeventkit/
- **GitHub:** https://github.com/ib-api-reloaded/eventkit
- **Python:** >=3.10
- **License:** BSD-2-Clause

## Background

The original `eventkit` PyPI package is locked to the previous maintainer's account. The project has been renamed to `aeventkit` on PyPI while maintaining `eventkit` as the import name for backward compatibility.

This package is a dependency for `ib_async` v2.0+, which currently has a blocked update PR (conda-forge/ib_async-feedstock#4) in conda-forge/ib_async-feedstock waiting for this package.

## Checklist
- [x] Title of this PR is meaningful
- [x] License file is packaged
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in this recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
