### PR TITLE
Add writescore recipe

### DIFF
--- a/recipes/writescore/meta.yaml
+++ b/recipes/writescore/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "writescore" %}
+{% set version = "6.4.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 118ebd7ff109790b427d7e3fe5a04fb41291a4ac927fe6a9cbe5ca29f766e4ea
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - writescore = writescore.cli.main:cli
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=3.9
+    - click >=8.0.0
+    - marko >=2.0.0
+    - nltk >=3.8
+    - numpy >=1.24.0
+    - pytorch >=2.0.0
+    - scikit-learn >=1.3.0
+    - scipy >=1.11.0
+    - spacy >=3.7.0
+    - spacy-model-en_core_web_sm
+    - textacy >=0.13.0
+    - textstat >=0.7.3
+    - transformers >=4.35.0
+
+test:
+  imports:
+    - writescore
+    - writescore.cli
+    - writescore.core
+    - writescore.dimensions
+    - writescore.scoring
+  commands:
+    - writescore --help
+    - writescore --version
+
+about:
+  home: https://github.com/BOHICA-LABS/writescore
+  summary: AI writing pattern analysis and scoring tool
+  description: |
+    WriteScore analyzes 12+ writing dimensions to identify specific patterns
+    that make text sound AI-generated, then provides actionable recommendations
+    for improvement.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/BOHICA-LABS/writescore
+  doc_url: https://github.com/BOHICA-LABS/writescore#readme
+
+extra:
+  recipe-maintainers:
+    - BOHICA-LABS


### PR DESCRIPTION
## Description

Adding recipe for [writescore](https://github.com/BOHICA-LABS/writescore) - an AI writing pattern analysis and scoring tool.

WriteScore analyzes 12+ writing dimensions to identify specific patterns that make text sound AI-generated, then provides actionable recommendations for improvement.

## Package Info

- **PyPI**: https://pypi.org/project/writescore/
- **GitHub**: https://github.com/BOHICA-LABS/writescore
- **License**: MIT
- **Version**: 6.4.0

## Checklist

- [x] License file is included in the recipe
- [x] Recipe builds and runs tests successfully locally
- [x] Upstream has a stable release on PyPI
- [x] I am willing to maintain this recipe

## Notes

- The package has ML dependencies (pytorch, transformers, spacy)
- Uses spacy-model-en_core_web_sm for NLP
- NLTK data downloads automatically on first use