### PR TITLE
Add liveimport

### DIFF
--- a/recipes/liveimport/meta.yaml
+++ b/recipes/liveimport/meta.yaml
@@ -31,6 +31,7 @@ test:
     - pip check
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/escreven/liveimport

--- a/recipes/liveimport/meta.yaml
+++ b/recipes/liveimport/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "liveimport" %}
+{% set version = "1.2.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/liveimport-{{ version }}.tar.gz
+  sha256: 9b60069380537874415dce125c2f416819fdd28c1de08be2adaf538503e91012
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - setuptools
+    - pip
+  run:
+    - python >=3.10
+    - ipython >=7.23.1
+
+test:
+  imports:
+    - liveimport
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/escreven/liveimport
+  summary: Automatically reload modified Python modules in notebooks and scripts.
+  description: |
+    LiveImport reloads are well-defined, deterministic operations that follow
+    the semantics of a developer's import statements exactly. It maintains
+    consistency between modules by automatically reloading dependent modules as
+    needed, ensuring up-to-date references across a notebook and its modules.
+    LiveImport is designed for developers who interactively build Jupyter
+    notebooks together with external Python code, and who want predictable
+    reloading with minimal mystery.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://liveimport.readthedocs.io/en/stable
+  dev_url: https://github.com/escreven/liveimport
+
+extra:
+  recipe-maintainers:
+    - escreven

--- a/recipes/liveimport/meta.yaml
+++ b/recipes/liveimport/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "liveimport" %}
 {% set version = "1.2.2" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - setuptools
     - pip
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - ipython >=7.23.1
 
 test:


### PR DESCRIPTION
This PR adds a recipe for the liveimport Python package.

PyPI: https://pypi.org/project/liveimport/
Upstream repository: https://github.com/escreven/liveimport

I am the upstream author. The package is pure Python and is packaged as noarch: python.

Maintainers:

* @escreven

Please let me know if anything needs to be adjusted.
