### PR TITLE
SPEC0 package

### DIFF
--- a/recipes/spec0/LICENSE
+++ b/recipes/spec0/LICENSE
@@ -1,0 +1,19 @@
+Copyright 2025, Mark Harfouche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/spec0/build.sh
+++ b/recipes/spec0/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+echo "Using PKG_VERSION: $PKG_VERSION"
+
+cp ${RECIPE_DIR}/drop_packages.py drop_packages.py
+cp ${RECIPE_DIR}/recipe.yaml recipe.yaml
+
+cp recipe.yaml recipe.yaml.backup
+
+${PYTHON} drop_packages.py "$PKG_VERSION"
+
+if ! diff -q recipe.yaml.backup recipe.yaml > /dev/null 2>&1; then
+    echo "Error: recipe.yaml was modified by drop_packages.py"
+    echo ""
+    echo "Changes detected:"
+    diff recipe.yaml.backup recipe.yaml || true
+    echo ""
+    echo "The recipe.yaml file should be up-to-date. Please run:"
+    echo "  ${PYTHON} drop_packages.py $PKG_VERSION"
+    echo "  git add recipe.yaml"
+    echo "  git commit -m 'Update minimum versions'"
+    mv recipe.yaml.backup recipe.yaml
+    exit 1
+fi
+
+rm recipe.yaml.backup
+echo "recipe.yaml is up-to-date"

--- a/recipes/spec0/drop_packages.py
+++ b/recipes/spec0/drop_packages.py
@@ -1,0 +1,147 @@
+import sys
+import requests
+import collections
+from datetime import datetime, timedelta
+
+import pandas as pd
+from packaging.version import Version, InvalidVersion
+from ruamel.yaml import YAML
+
+
+core_packages = [
+    "numpy",
+    "scipy",
+    "matplotlib",
+    "pandas",
+    "scikit-image",
+    "networkx",
+    "scikit-learn",
+    "xarray",
+    "ipython",
+    "zarr",
+]
+plus24 = timedelta(days=int(365 * 2))
+
+if len(sys.argv) > 1:
+    version_str = sys.argv[1]
+    year, month = version_str.split(".")
+    current_date = pd.Timestamp(int(year), int(month), 1)
+else:
+    current_date = pd.Timestamp.now()
+
+current_quarter_start = pd.Timestamp(
+    current_date.year, (current_date.quarter - 1) * 3 + 1, 1
+)
+cutoff = current_quarter_start - pd.DateOffset(months=9)
+
+
+def get_release_dates(package, support_time=plus24):
+    releases = {}
+
+    print(f"Querying pypi.org for {package} versions...", end="", flush=True)
+    response = requests.get(
+        f"https://pypi.org/simple/{package}",
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+    ).json()
+    print("OK")
+
+    file_date = collections.defaultdict(list)
+    for f in response["files"]:
+        filename = f["filename"]
+        if not filename.startswith(f"{package}-"):
+            continue
+        ver_with_ext = filename[len(f"{package}-"):]
+        extensions = [".tar.gz", ".zip", ".tar.bz2", ".whl", ".tar"]
+        ver = ver_with_ext
+        for ext in extensions:
+            if ver_with_ext.endswith(ext):
+                ver = ver_with_ext[:-len(ext)]
+                break
+        else:
+            if "." in ver:
+                ver = ver.rsplit(".", 1)[0]
+        try:
+            version = Version(ver)
+        except InvalidVersion:
+            continue
+
+        if version.is_prerelease or version.micro != 0:
+            continue
+
+        release_date = None
+        for format in ["%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"]:
+            try:
+                release_date = datetime.strptime(f["upload-time"], format)
+            except ValueError:
+                pass
+
+        if not release_date:
+            continue
+
+        file_date[version].append(release_date)
+
+    release_date = {v: min(file_date[v]) for v in file_date}
+
+    for ver, release_date in sorted(release_date.items()):
+        drop_date = release_date + support_time
+        if drop_date >= cutoff:
+            releases[ver] = {
+                "release_date": release_date,
+                "drop_date": drop_date,
+            }
+
+    return releases
+
+
+package_releases = {package: get_release_dates(package) for package in core_packages}
+
+package_releases = {
+    package: {
+        version: dates
+        for version, dates in releases.items()
+        if dates["drop_date"] > current_date
+    }
+    for package, releases in package_releases.items()
+}
+
+minimum_versions = {}
+for package, releases in package_releases.items():
+    if releases:
+        versions = sorted(releases.keys())
+        min_version = min(versions)
+        minimum_versions[package] = str(min_version)
+
+print("Updating recipe.yaml with minimum versions...")
+yaml = YAML()
+yaml.preserve_quotes = True
+yaml.width = 4096
+
+with open("recipe.yaml", "r") as fh:
+    recipe = yaml.load(fh)
+
+if "requirements" not in recipe:
+    recipe["requirements"] = {}
+
+if "run_constraints" not in recipe["requirements"]:
+    recipe["requirements"]["run_constraints"] = []
+
+run_constraints = recipe["requirements"]["run_constraints"]
+existing_packages = {}
+for i, constraint in enumerate(run_constraints):
+    if isinstance(constraint, str):
+        parts = constraint.split(">=")
+        if len(parts) == 2:
+            package = parts[0].strip()
+            existing_packages[package] = i
+
+for package, min_version in minimum_versions.items():
+    constraint_str = f"{package} >={min_version}"
+    if package in existing_packages:
+        run_constraints[existing_packages[package]] = constraint_str
+    else:
+        run_constraints.append(constraint_str)
+
+with open("recipe.yaml", "w") as fh:
+    yaml.dump(recipe, fh)
+
+print("Successfully updated recipe.yaml")

--- a/recipes/spec0/recipe.yaml
+++ b/recipes/spec0/recipe.yaml
@@ -1,0 +1,66 @@
+context:
+  version: "2025.12"
+  # Update as defined in
+  # https://scientific-python.org/specs/spec-0000/#support-window
+  python_min: "3.12"
+
+package:
+  name: spec0
+  version: ${{ version }}
+
+build:
+  noarch: python
+  number: 0
+
+requirements:
+  host:
+  - python ${{ python_min }}.*
+  - pandas
+  - requests
+  - packaging
+  - ruamel.yaml
+  run:
+  - python >=${{ python_min }}
+  run_constraints:
+  - numpy >=2.0.0
+  - scipy >=1.12.0
+  - matplotlib >=3.9.0
+  - pandas >=2.2.0
+  - scikit-image >=0.23.0
+  - networkx >=3.3
+  - scikit-learn >=1.4.0
+  - xarray >=2023.12.0
+  - ipython >=8.19.0
+  - zarr >=2.17.0
+  run_exports:
+  - spec0 >=${{ version }}
+
+tests:
+- script: |
+    echo "No meaningful tests"
+
+about:
+  homepage: https://scientific-python.org/specs/spec-0000/
+  summary: 'Minimum Supported Dependencies'
+  description: |
+    This package helps packagers implement SPEC-0000 as a means to drop minimum
+    supported dependencies.
+
+    It is designed in a way that is Opt-in for packagers and not globally defined
+    accross all of conda-forge.
+
+    Add it to your run requirements, and it will export minimum versions for all
+    packages that are listed as core dependencies.
+
+    Once a new version of this package is released, make a PR to update the global
+    pin in https://github.com/conda-forge/conda-forge-pinning-feedstock/
+
+    One may override the "time bound" by simply pinning the spec0 package to the desired
+    version for their pckage. However, we strongly encourage packagers to simply use
+    the latest version of this package.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+  - hmaarrfk


### PR DESCRIPTION
I'm advocating for a SPEC0 package to be added to help package maintainers opt-in to being more agressive than conda-forge's much longer support window.

https://scientific-python.org/specs/spec-0000/

I think that it will just help shed alot of the "support" for new packages, and historical packages.

It should:
1. Automatically export itself as a dependency
2. This should help "lift" the oldest version of packages as time moves forward.

