### PR TITLE
Add fastlowess recipe

### DIFF
--- a/recipes/fastlowess/meta.yaml
+++ b/recipes/fastlowess/meta.yaml
@@ -1,0 +1,42 @@
+{% set name = "fastlowess" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: aa608392742dda4f0a181ee09419a7eda3aad2c04bc07142334b38fd1bf3ec95
+
+build:
+  number: 0
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.0,<2.0
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - fastlowess
+
+about:
+  home: https://github.com/thisisamirv/fastLowess-py
+  license: AGPL-3.0-only
+  license_file: LICENSE
+  summary: Fast LOWESS implementation in Rust with Python bindings
+
+extra:
+  recipe-maintainers:
+    - thisisamirv


### PR DESCRIPTION
Adding fastlowess - a fast LOWESS (Locally Weighted Scatterplot Smoothing) implementation in Rust with Python bindings.

**PyPI:** https://pypi.org/project/fastlowess/
**Home:** https://github.com/thisisamirv/fastLowess-py

---

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.