### PR TITLE
Add fastlowess recipe

### DIFF
--- a/recipes/fastlowess/meta.yaml
+++ b/recipes/fastlowess/meta.yaml
@@ -11,8 +11,9 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation
+  script:
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - {{ PYTHON }} -m pip install . -vv --no-build-isolation
 
 requirements:
   build:
@@ -26,7 +27,7 @@ requirements:
     - maturin >=1.0,<2.0
   run:
     - python
-    - numpy
+    - numpy >=1.20.0
 
 test:
   imports:
@@ -35,7 +36,9 @@ test:
 about:
   home: https://github.com/thisisamirv/fastLowess-py
   license: AGPL-3.0-only
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: Fast LOWESS implementation in Rust with Python bindings
 
 extra:


### PR DESCRIPTION
Adding fastlowess - a fast LOWESS (Locally Weighted Scatterplot Smoothing) implementation in Rust with Python bindings.

**PyPI:** https://pypi.org/project/fastlowess/
**Home:** https://github.com/thisisamirv/fastLowess-py

---

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
