### PR TITLE
Add recipe for daffy

### DIFF
--- a/recipes/daffy/meta.yaml
+++ b/recipes/daffy/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "daffy" %}
-{% set version = "2.0.1" %}
+{% set version = "2.2.0" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/daffy-{{ version }}.tar.gz
-  sha256: d00b7b4161329fab5eca7b69c4c357c0b8f8a69bfc5fe4761815d72d1e097933
+  sha256: bc6c6afc10e62a5b5e7cf066aa760b8c853dab79af444086ca2a31ffcd054d17
 
 build:
   noarch: python
@@ -42,7 +42,7 @@ about:
   summary: Function decorators for DataFrame validation - columns, data types, and row-level validation with Pydantic. Supports Pandas, Polars, Modin, and PyArrow.
   license: MIT
   license_file: LICENSE
-  doc_url: https://github.com/vertti/daffy#readme
+  doc_url: https://daffy.readthedocs.io
   dev_url: https://github.com/vertti/daffy
 
 extra:


### PR DESCRIPTION
Add conda-forge recipe for [daffy](https://github.com/vertti/daffy), a DataFrame validation library providing decorators (`@df_in`, `@df_out`, `@df_log`) for Pandas, Polars, Modin, and PyArrow.

- **PyPI**: https://pypi.org/project/daffy/
- **Docs**: https://daffy.readthedocs.io
- **License**: MIT

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.