### PR TITLE
Add recipe for janitor-rs

### DIFF
--- a/recipes/janitor-rs/meta.yaml
+++ b/recipes/janitor-rs/meta.yaml
@@ -10,7 +10,9 @@ source:
   sha256: 02bac0dfc7edb6105c60c4e5f9c3bd2d879ed26db7bd17462eb11af05ec871fc
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
   number: 0
 
 requirements:


### PR DESCRIPTION
## Summary
- Add conda-forge recipe for `janitor-rs`, a fast complementary sequence generation library for Python, written in Rust using PyO3/maturin

## Package Details
- **PyPI**: https://pypi.org/project/janitor-rs/
- **Source**: https://github.com/ericmjl/janitor-rs
- **Version**: 0.3.0
- **License**: MIT

## Checklist
- [x] License file included
- [x] Recipe uses `{{ compiler('rust') }}` for Rust extension
- [x] Recipe uses maturin build system