### PR TITLE
Add cellucid

### DIFF
--- a/recipes/cellucid/meta.yaml
+++ b/recipes/cellucid/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "cellucid" %}
+{% set version = "0.0.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cellucid-{{ version }}.tar.gz
+  sha256: 486d0bdd015f8a77a92c76f8fd28a5fe105f1f542366c1f337d6c3a1053567fc
+
+build:
+  entry_points:
+    - cellucid = cellucid.cli:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - setuptools >=68
+    - pip
+  run:
+    - python >=3.10
+    - numpy >=1.21
+    - pandas >=1.4
+    - scipy >=1.7
+    - tqdm >=4.45
+    - anndata >=0.8
+    - ipython >=7.23
+    - jupyter-server-proxy >=4.1
+
+test:
+  imports:
+    - cellucid
+  commands:
+    - pip check
+    - cellucid --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/theislab/cellucid-python
+  summary: Interactive Single-Cell Data Visualization
+  description: See every cell. Query any gene. Fly through millions. GPU-accelerated WebGL rendering for 2D/3D embeddings with AnnData-first workflow and Jupyter integration.
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  dev_url: https://github.com/theislab/cellucid-python
+  doc_url: https://cellucid.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - inecik


### PR DESCRIPTION
Cellucid is a browser-first viewer for exploring large single-cell datasets in real time: fly through 2D/3D embeddings (UMAP/t-SNE/PCA), color by genes or metadata, filter and compare populations, and share reproducible views with collaborators.