### PR TITLE
update recipe v1 README; mark as fully supported

### DIFF
--- a/recipes/example-v1/README.md
+++ b/recipes/example-v1/README.md
@@ -1,5 +1,13 @@
 # V1 recipe format
 
-This recipe is an example of the v1 recipe format that was defined by [CEP 13](https://github.com/conda/ceps/blob/main/cep-13.md). The v1 recipe format is fully functional when built with rattler-build, but is not yet fully supported by conda-forge's automation.
+This recipe is an example of the v1 recipe format that was defined by
+[CEP 13](https://github.com/conda/ceps/blob/main/cep-0013.md) and
+[CEP 14](https://github.com/conda/ceps/blob/main/cep-0014.md).
+The v1 recipe format currently requires rattler-build as a build tool.
+
+Conda-forge's infrastructure has seen a steady stream of effort to ensure things work as usual with v1 recipes.
+As of late 2025, v1 recipes are integrated without any major restrictions. The biggest missing feature is the
+lack of [support](https://github.com/conda/ceps/pull/102) for a shared build step between multiple outputs,
+though this is not relevant for most recipes.
 
 See https://github.com/conda-forge/conda-forge.github.io/issues/2308 for progress on general support for this new format.


### PR DESCRIPTION
The readme for the v1 example recipe currently says (my bold)
> The v1 recipe format is fully functional when built with rattler-build, but is _**not yet fully supported**_ by conda-forge's automation.

That was true in the second half of 2024 (https://github.com/conda-forge/staged-recipes/commit/f47d93e66404515ebcb14ee3cc1b85e114803ac1), but in the meantime, I think we can take off the "not fully supported" label.

CC @conda-forge/core 