### PR TITLE
Add recipe for tea (Gitea CLI)

### DIFF
--- a/recipes/tea/recipe.yaml
+++ b/recipes/tea/recipe.yaml
@@ -1,13 +1,12 @@
 context:
-  name: tea
   version: "0.11.1"
 
 package:
-  name: ${{ name }}
+  name: tea
   version: ${{ version }}
 
 source:
-  - url: https://gitea.com/gitea/${{ name }}/archive/v${{ version }}.tar.gz
+  - url: https://gitea.com/gitea/tea/archive/v${{ version }}.tar.gz
     sha256: 1da6b6d2534bd6ffb0931400014bbdef26242cf4d35d4ba44c24928811825805
     target_directory: src
   - if: win


### PR DESCRIPTION
This PR adds a recipe for [tea](https://gitea.com/gitea/tea), the official CLI for Gitea.

**Summary:**
- tea is a command line tool to interact with Gitea servers
- Version: 0.11.1
- License: MIT

**Build tested locally with:**
```
rattler-build build -r recipes/tea -m .ci_support/osx_arm64.yaml
```

All tests passed.