### PR TITLE
Add functionality for automated maintenance label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,6 +38,9 @@ vary depending on the number of reviewers on a given language team and may be da
 or weeks. We are always looking for more staged-recipe reviewers. If you are
 interested in volunteering, please contact a member of @conda-forge/core.
 We'd love to have the help!
+
+If your PR is aimed at updating the staged-recipes repository itself, mention `@conda-forge/staged-recipes`
+and the word "maintenance" in a comment to get the PR labeled as 'maintenance'.
 -->
 
 Checklist

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,9 @@ sequenceDiagram
             alt team is in comment
                 GitHub actions->>issue: Adds review-requested label
                 GitHub actions->>issue: Adds team label
+                opt team is staged-recipes AND comment contains word "maintenance"
+                    GitHub actions->>issue: Adds maintenance label
+                end
                 GitHub actions->>issue: Remove Awaiting author contribution label
                 rect rgb(191, 223, 255)
                     GitHub actions-->>issue: Assigns team for review

--- a/.github/workflows/automate-review-labels.yml
+++ b/.github/workflows/automate-review-labels.yml
@@ -49,11 +49,20 @@ jobs:
                     const slug = team.replace("@conda-forge/", "");
                     const label = slug.replace("help-", "");
                     found_label = true;
+                    // Check if comment included 'maintenance' as a whole word, irrespective of capitalization
+                    const is_maintenance_request = /\bmaintenance\b/i.test(text);
+                    const labels_to_add = [
+                      label,
+                      'review-requested',
+                      // Adds the maintenance label if staged-recipes was pinged and there is a maintenance request
+                      ...(label === 'staged-recipes' && is_maintenance_request ? ['maintenance'] : [])
+                    ];
+
                     github.rest.issues.addLabels({
                         issue_number: context.issue.number,
                         owner: context.repo.owner,
                         repo: context.repo.repo,
-                        labels: [label, 'review-requested']
+                        labels: labels_to_add
                     });
                     // NOTE: GitHub Actions default token lacks permission to
                     // assign teams for review; external bot required for
@@ -61,7 +70,8 @@ jobs:
                     //
                     https://github.com/conda-forge/staged-recipes/issues/18023#issuecomment-1080451231
                     console.log(`Somebody mentioned ${slug}.`);
-                    if (label == "staged-recipes") {
+                    // If staged-recipes was pinged without a maintenance request, direct to teams
+                    if (label === "staged-recipes" && !is_maintenance_request) {
                       github.rest.issues.createComment({
                         issue_number: context.issue.number,
                         owner: context.repo.owner,

--- a/.github/workflows/scripts/linter.py
+++ b/.github/workflows/scripts/linter.py
@@ -265,7 +265,9 @@ To ensure everything runs smoothly, please make sure that recipes are only \
 added to the `recipes/` directory and no other files are changed.
 
 If these changes are intentional (and you aren't submitting a recipe), \
-please add a `maintenance` label to the PR.\n"""
+please add a `maintenance` label to the PR. This can also be done by \
+mentioning `@conda-forge/staged-recipes` and the word "maintenance" in \
+a comment.\n"""
 
     added_lint_hint_header = False
     all_fnames = set(lints.keys()) | set(hints.keys())


### PR DESCRIPTION
I noticed there is no way for someone to tag a PR as maintenance unless one has write-access. I thought this might be a tiny bit helpful with the amount of PRs coming in here.
This PR proposes the possibility of mentioning some version of "maintenance" while tagging the staged-recipes team.
This then also adds the "maintenance" label to the PR.

This was just a quick thought of mine, don't know if it's helpful, @conda-forge/staged-recipes otherwise just close it, thanks!

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->