### PR TITLE
Add pycalceff: Calculate binomial efficiencies and uncertainties

### DIFF
--- a/recipes/pycalceff/meta.yaml
+++ b/recipes/pycalceff/meta.yaml
@@ -20,7 +20,7 @@ build:
 
 requirements:
   host:
-    - python >={{ python_min }}
+    - python {{ python_min }}
     - setuptools >=61.0
     - pip
   run:


### PR DESCRIPTION
Add pycalceff package for calculating binomial efficiencies and their uncertainties.

**Package description:**
A Python package for calculating binomial efficiencies and confidence intervals using Bayesian methods. Based on Fermilab Technical Memo 2286-cd.

**Links:**
- PyPI: https://pypi.org/project/pycalceff/
- Homepage: https://github.com/marcpaterno/pycalceff
- License: BSD-3-Clause

**Checklist:**
- [x] License file is packaged
- [x] Source is from PyPI
- [x] Package can be installed with pip
- [x] Tests pass locally 
- [x] Recipe maintainer: @marcpaterno