### PR TITLE
Add lbr_fri_client_sdk

### DIFF
--- a/recipes/lbr-fri-client-sdk/extract_kuka_license.py
+++ b/recipes/lbr-fri-client-sdk/extract_kuka_license.py
@@ -23,15 +23,9 @@ def main() -> None:
     license_block = text[i:j].strip() + "\n"
 
     src_dir = os.environ.get("SRC_DIR", ".")
-    out_paths = {os.path.join(src_dir, OUT_NAME)}
-
-    recipe_dir = os.environ.get("RECIPE_DIR")
-    if recipe_dir:
-        out_paths.add(os.path.join(recipe_dir, OUT_NAME))
-
-    for path in out_paths:
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(license_block)
+    out_path = os.path.join(src_dir, OUT_NAME)
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(license_block)
 
 
 if __name__ == "__main__":

--- a/recipes/lbr-fri-client-sdk/meta.yaml
+++ b/recipes/lbr-fri-client-sdk/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: |
-    python "${RECIPE_DIR}/extract_kuka_license.py"
+    python "%RECIPE_DIR%\\extract_kuka_license.py"  # [win]
+    python "${RECIPE_DIR}/extract_kuka_license.py"  # [not win]
     cmake -S . -B build -GNinja %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=Release  # [win]
     cmake -S . -B build -GNinja ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=Release  # [not win]
     cmake --build build


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

This repo bundles `FRI-Client_SDK_Cpp.zip` which includes `nanopb`. 
