### PR TITLE
Add quickjs 2025.09.13

### DIFF
--- a/recipes/quickjs/conda-forge.yml
+++ b/recipes/quickjs/conda-forge.yml
@@ -1,0 +1,7 @@
+bot:
+  automerge: true
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+  osx_arm64: osx_64
+test: native_and_emulated

--- a/recipes/quickjs/recipe.yaml
+++ b/recipes/quickjs/recipe.yaml
@@ -16,6 +16,7 @@ build:
     - win
   script:
     - make -j${CPU_COUNT} CC="${CC}" PREFIX="${PREFIX}"
+    - make test CC="${CC}"
     - make install PREFIX="${PREFIX}"
 
 requirements:
@@ -27,8 +28,10 @@ requirements:
 tests:
   - script:
       - qjs -e "console.log('hello')"
-      - test -f ${PREFIX}/bin/qjsc
   - package_contents:
+      bin:
+        - qjs
+        - qjsc
       include:
         - quickjs/quickjs.h
         - quickjs/quickjs-libc.h


### PR DESCRIPTION
## Summary
- Add rattler-build recipe for QuickJS, a small and embeddable JavaScript engine
- Version 2025.09.13 from the bellard/quickjs GitHub repository
- Includes qjs interpreter and qjsc compiler binaries, headers, and static library