### PR TITLE
Adding aws-lambda-builders

### DIFF
--- a/recipes/aws-lambda-builders/recipe.yaml
+++ b/recipes/aws-lambda-builders/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  name: aws-lambda-builders
+  version: "1.62.0"
+  python_min: "3.8"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/${{ name }}/aws_lambda_builders-${{ version }}.tar.gz
+  sha256: 2f1a4baa61c165941d26fdf05966aa4c2e95a66af06b7309bb09558daea4a561
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - setuptools
+    - wheel
+
+tests:
+  - python:
+      imports:
+        - aws_lambda_builders
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/awslabs/aws-lambda-builders
+  summary: Python library to compile, build & package AWS Lambda functions for several runtimes & frameworks.
+  license: Apache-2.0
+  license_file: LICENSE
+  repository: https://github.com/awslabs/aws-lambda-builders
+
+extra:
+  recipe-maintainers:
+    - sodre


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used.
- [x] GitHub users listed in the maintainer section have confirmed.
- [x] Checked knowledge base documentation before pinging a team.

---

Python library to compile, build & package AWS Lambda functions for several runtimes & frameworks. Published by AWS at https://github.com/awslabs/aws-lambda-builders, this is the build engine behind AWS SAM CLI.

- Pure Python, noarch package
- Runtime deps: setuptools, wheel (both already on conda-forge)
- License: Apache-2.0