### PR TITLE
Add hrms_utils recipe

### DIFF
--- a/recipes/hrms_utils/bld.bat
+++ b/recipes/hrms_utils/bld.bat
@@ -1,0 +1,10 @@
+@echo on
+
+cargo clean
+if errorlevel 1 exit 1
+
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+if errorlevel 1 exit 1
+
+%PYTHON% -m pip install . -vv --no-deps --no-build-isolation
+if errorlevel 1 exit 1

--- a/recipes/hrms_utils/build.sh
+++ b/recipes/hrms_utils/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+# Clean any previous Rust build artifacts
+cargo clean
+
+# Bundle third-party licenses for Rust dependencies
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+# Install the package
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/hrms_utils/recipe.yaml
+++ b/recipes/hrms_utils/recipe.yaml
@@ -1,0 +1,78 @@
+context:
+  name: hrms_utils
+  version: "0.7.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Nir-Cohen-2003/MS_utils/archive/${{ version }}.tar.gz
+  sha256: 6738654b2e99d960f7d05b1efa04c45780f1ab8a29d8a9c76b54dbc94e19e8e8
+
+build:
+  number: 0
+  skip:
+    - osx
+    - linux and not x86_64
+    - win and not x86_64
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+  host:
+    - python >=3.12
+    - pip
+    - setuptools >=68.0.0
+    - setuptools-rust >=1.5.0
+    - wheel
+    - numpy >=1.20.0
+  run:
+    - python >=3.12
+    - polars >=1.35.2,<2
+    - rdkit >=2024.0.0
+    - numpy >=1.20.0
+    - numba >=0.61.0
+    - scipy
+    - pymzml >2.5.0
+    - pandas
+    - lxml
+    - requests
+    - aiohttp
+    - pyarrow
+    - python-calamine
+    - openpyxl
+    - xlsx2csv
+    - xlsxwriter
+    - connectorx
+    - sqlalchemy
+
+tests:
+  - python:
+      imports:
+        - hrms_utils
+        - hrms_utils._internal
+      pip_check: true
+
+about:
+  homepage: https://github.com/Nir-Cohen-2003/MS_utils
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Utilities for high-resolution mass spectrometry (HRMS) data
+  description: |
+    HRMS_utils provides tools for working with high-resolution mass spectrometry data.
+    The codebase relies heavily on Polars dataframes with spectra often stored as 
+    nested datatypes within these dataframes. Includes Rust extensions for performance-critical
+    operations like spectral similarity calculations.
+  repository: https://github.com/Nir-Cohen-2003/MS_utils
+  documentation: https://nir-cohen-2003.github.io/MS_utils/
+
+extra:
+  recipe-maintainers:
+    - Nir-Cohen-2003


### PR DESCRIPTION
## Summary
This PR adds the `hrms_utils` package - utilities for high-resolution mass spectrometry (HRMS) data.

## Package Information
- **Homepage**: https://github.com/Nir-Cohen-2003/MS_utils
- **License**: Apache-2.0
- **PyPI**: https://pypi.org/project/hrms-utils/
- **Language**: Python with Rust extensions (PyO3 via setuptools-rust)
- **Platforms**: linux-64, win-64

## Build Details
- Uses `setuptools-rust` for building PyO3 Rust extensions
- Uses `cargo-bundle-licenses` to bundle Rust dependency licenses
- Targets Python >=3.12

## Checklist
- [x] License file is included (Apache-2.0 + THIRDPARTY.yml for Rust deps)
- [x] Recipe builds on target platforms (linux-64, win-64)
- [x] Tests are included (import tests + pip check)
- [x] I am added as a maintainer