### PR TITLE
Add bacdive 1.0.0

### DIFF
--- a/recipes/bacdive/meta.yaml
+++ b/recipes/bacdive/meta.yaml
@@ -1,6 +1,5 @@
 {% set version = "1.0.0" %}
 {% set name = "bacdive" %}
-{% set python_min = "3.9" %}
 package:
   name: {{ name }}
   version: {{ version }}


### PR DESCRIPTION
This PR adds the `bacdive` Python client (v1.0.0) for programmatic access to the BacDive database.  
- Pure Python, noarch package.  
- Dependencies: `python >=3.9`, `python-keycloak`, `requests`, `urllib3`.  
- MIT license, tested via `import bacdive`.  
- Home/source: https://github.com/LeibnizDSMZ/bacdive-api
Please let me know if anything needs attention