### PR TITLE
Add lpsn 1.0.0

### DIFF
--- a/recipes/lpsn/meta.yaml
+++ b/recipes/lpsn/meta.yaml
@@ -1,6 +1,5 @@
 {% set version = "1.0.0" %}
 {% set name = "lpsn" %}
-{% set python_min = "3.9" %}
 
 
 package:


### PR DESCRIPTION
This PR adds the bacdive Python client (v1.0.0) for programmatic access to the LPSN database.

Pure Python, noarch package.
Dependencies: python >=3.9, python-keycloak, requests, urllib3.
MIT license, tested via import lpsn.
Home/source: https://github.com/LeibnizDSMZ/lpsn-api
Please let me know if anything needs attention