### PR TITLE
Add async-dsmz

### DIFF
--- a/recipes/async-dsmz/meta.yaml
+++ b/recipes/async-dsmz/meta.yaml
@@ -33,8 +33,11 @@ requirements:
 test:
   requires:
     - python {{ python_min }}
+    - pip
   imports:
     - async_dsmz
+  commands:
+    - pip check
 
 
 about:


### PR DESCRIPTION
This PR adds async-dsmz, an asyncio based wrapper for async access to all dsmz APIs.

Pure Python, noarch package.
Dependencies: python >=3.12, asyncio, bacdive, lpsn.
GPL-3.0-only, tested via import asyncio.
Home/source: https://github.com/Fabian-Bastiaanssen/Async_DSMZ
Please let me know if anything needs attention