### PR TITLE
Add recipe for extract-msg

### DIFF
--- a/recipes/extract-msg/recipe.yaml
+++ b/recipes/extract-msg/recipe.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "0.55.0"
+
+package:
+  name: extract-msg
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/e/extract-msg/extract_msg-${{ version }}.tar.gz
+  sha256: cf08283498c3dfcc7f894dad1579f52e3ced9fb76b865c2355cbe757af8a54e1
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - extract_msg = extract_msg.__main__:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - olefile ==0.47
+    - tzlocal >=4.2,<6
+    - compressed-rtf >=1.0.6,<2
+    - ebcdic >=1.1.1,<2
+    - beautifulsoup4 >=4.11.1,<4.14
+    - rtfde >=0.1.1,<0.2
+    - red-black-tree-mod >=1.20,<=1.23
+
+tests:
+  - python:
+      imports:
+        - extract_msg
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+    script:
+      - extract_msg --help
+
+about:
+  summary: Extracts emails and attachments saved in Microsoft Outlook's .msg files
+  license: GPL-3.0-only
+  license_file: LICENSE.txt
+  homepage: https://github.com/TeamMsgExtractor/msg-extractor
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
## Summary
- Add conda-forge recipe for [extract-msg](https://pypi.org/project/extract-msg/) v0.55.0
- Pure Python package (`noarch: python`) that extracts emails and attachments from Microsoft Outlook .msg files
- All runtime dependencies already exist on conda-forge

## Checklist
- [x] Title of this PR is meaningful
- [x] License file is packaged
- [x] Source is from PyPI sdist with sha256
- [x] Tests included (import test + pip_check + CLI --help)
- [x] Recipe lints cleanly