### PR TITLE
MAI: Add CUDA 13.0 variant file for convenience

### DIFF
--- a/.ci_support/linux64_cuda130.yaml
+++ b/.ci_support/linux64_cuda130.yaml
@@ -1,0 +1,34 @@
+c_compiler:
+- gcc
+cxx_compiler:
+- gxx
+fortran_compiler:
+- gfortran
+go_compiler:
+- go-nocgo
+cgo_compiler:
+- go-cgo
+c_compiler_version:
+- 14
+cxx_compiler_version:
+- 14
+fortran_compiler_version:
+- 14
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- 2.28
+cdt_name:
+- conda
+target_platform:
+- linux-64
+channel_sources:
+- conda-forge
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+cuda_compiler:
+- cuda-nvcc
+cuda_compiler_version:
+- 13.0
+cuda_compiler_version_min:
+- 12.9


### PR DESCRIPTION
Adds a file to .ci_support for the CUDA 13.0 variant. As of now, it is for convenience only.

I haven't adjusted the CI setup to automatically use this variant file. Could expand the scope of this MR to include the CI changes or we can wait until the CUDA 13.0 migration is closed.