### PR TITLE
Adding dagmc h5m file inspector

### DIFF
--- a/recipes/dagmc_h5m_file_inspector/meta.yaml
+++ b/recipes/dagmc_h5m_file_inspector/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pip
     - pytest
     - cadquery
-    - cad-to-dagmc
+    - cad_to_dagmc
   commands:
     - pytest
 


### PR DESCRIPTION
This PR adds [dagmc_h5m_file_inspector](https://github.com/fusion-energy/dagmc_h5m_file_inspector)

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
