### PR TITLE
Add sklearn-wrap

### DIFF
--- a/recipes/sklearn-wrap/meta.yaml
+++ b/recipes/sklearn-wrap/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0a3" %}
+{% set version = "0.1.0a4" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/s/sklearn-wrap/sklearn_wrap-{{ version }}.tar.gz
-  sha256: d187577af84f974d69d37c6026d2dcb0d3a9f8cafddb0f0e6338b000ea070b3c
+  sha256: 008445fe2c0a2229e5a948c628e53ac6b9b30295cbc313f5b0b1621a16a12c71
 
 build:
   noarch: python


### PR DESCRIPTION
## Summary

This PR adds a conda recipe for [sklearn-wrap](https://github.com/stateful-y/sklearn-wrap), a package for wrapping Python classes into Scikit-Learn estimators.

Checklist
 - [x]  Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
 - [x]  License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
 - [x]  Source is from official source.
 - [x]  Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [x]  If static libraries are linked in, the license of the static library is packaged.
 - [x]  Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
 - [x]  Build number is 0.
 - [x]  A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
 - [x]  GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
 - [x]  When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
