### PR TITLE
Add sklearn-optuna

### DIFF
--- a/recipes/sklearn-optuna/meta.yaml
+++ b/recipes/sklearn-optuna/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.0a1" %}
+{% set version = "0.1.0a2" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/s/sklearn-optuna/sklearn_optuna-{{ version }}.tar.gz
-  sha256: 5c59521f4d409e2656e2c542aec7fad767868c9752c8017bf4724cbb9acb0fbb
+  sha256: 6505d9b39f804b8bdcb37c7c2ad50d502ec108e8229b8adbcea1ff4c7a7c3af5
 
 build:
   noarch: python
@@ -24,7 +24,7 @@ requirements:
     - python >={{ python_min }}
     - scikit-learn >=1.6.0
     - numpy >=1.26
-    - optuna >=3.5,<4.0
+    - optuna >=3.5
     - sklearn-wrap
 
 test:


### PR DESCRIPTION
## Summary

This PR adds a conda recipe for [sklearn-optuna](https://github.com/stateful-y/sklearn-optuna), a package for Optuna integration for hyperparameter tuning in Scikit-Learn.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.