### PR TITLE
Add yohou-optuna

### DIFF
--- a/recipes/yohou-optuna/meta.yaml
+++ b/recipes/yohou-optuna/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.1.0a1" %}
+{% set python_min = "3.11" %}
 
 package:
   name: yohou-optuna
@@ -15,12 +16,12 @@ build:
 
 requirements:
   host:
-    - python >=3.11
+    - python {{ python_min }}
     - hatchling
     - hatch-vcs
     - pip
   run:
-    - python >=3.11
+    - python >={{ python_min }}
     - optuna
     - scipy
     - sklearn-optuna
@@ -33,7 +34,7 @@ test:
     - pip check
   requires:
     - pip
-    - python
+    - python {{ python_min }}
 
 about:
   home: https://github.com/stateful-y/yohou-optuna


### PR DESCRIPTION
## Summary

This PR adds a conda recipe for [yohou-optuna](https://github.com/stateful-y/yohou-optuna), a package providing an Optuna integration for hyperparameter tuning in Yohou.

Checklist
 - [x]  Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
 - [x]  License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
 - [x]  Source is from official source.
 - [x]  Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [x]  If static libraries are linked in, the license of the static library is packaged.
 - [x]  Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
 - [x]  Build number is 0.
 - [x]  A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
 - [x]  GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
 - [x]  When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
