### PR TITLE
adding dagmc-h5m-file-inspector try 3

### DIFF
--- a/recipes/dagmc_h5m_file_inspector/meta.yaml
+++ b/recipes/dagmc_h5m_file_inspector/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "0.6.7" %}
+
+package:
+  name: dagmc_h5m_file_inspector
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/d/dagmc_h5m_file_inspector/dagmc_h5m_file_inspector-{{ version }}.tar.gz
+  sha256: c4d95ea2eb537d969a47e6d95497d762fc7b8d46349143f3734ea5e95aa24644
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools
+    - setuptools-scm
+    - pip
+  run:
+    - python >={{ python_min }}
+    - h5py
+    - numpy
+
+test:
+  imports:
+    - dagmc_h5m_file_inspector
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/fusion-energy/dagmc_h5m_file_inspector
+  summary: Extracts information from DAGMC h5m files including volumes number, material tags
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - shimwell


### PR DESCRIPTION
I am keen to add dagmc-h5m-file-inspector to conda forge

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
