### PR TITLE
Add shinyswatch

### DIFF
--- a/recipes/shinyswatch/meta.yaml
+++ b/recipes/shinyswatch/meta.yaml
@@ -29,10 +29,7 @@ requirements:
 test:
   imports:
     - shinyswatch
-  commands:
-    - pip check
   requires:
-    - pip
     - python {{ python_min }}
 
 about:

--- a/recipes/shinyswatch/meta.yaml
+++ b/recipes/shinyswatch/meta.yaml
@@ -1,0 +1,45 @@
+{% set version = "0.9.0" %}
+
+package:
+  name: shinyswatch
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/shinyswatch/shinyswatch-{{ version }}.tar.gz
+  sha256: 090b89668691a1c520c79b7e36b03901489976199b64988e05ad4c86924da17d
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.8
+    - setuptools
+    - pip
+  run:
+    - python >=3.8
+    - typing_extensions >=3.10.0.0
+    - packaging >=20.9
+    - htmltools >=0.2.0
+    - shiny >=1.2.0
+
+test:
+  imports:
+    - shinyswatch
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://github.com/rstudio/py-shinyswatch
+  summary: Bootswatch + Bootstrap 5 themes for Shiny.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - razinkele

--- a/recipes/shinyswatch/meta.yaml
+++ b/recipes/shinyswatch/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "0.9.0" %}
+{% set python_min = "3.8" %}
 
 package:
   name: shinyswatch
@@ -15,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.8
+    - python {{ python_min }}
     - setuptools
     - pip
   run:
-    - python >=3.8
+    - python >={{ python_min }}
     - typing_extensions >=3.10.0.0
     - packaging >=20.9
     - htmltools >=0.2.0
@@ -32,7 +33,7 @@ test:
     - pip check
   requires:
     - pip
-    - python
+    - python {{ python_min }}
 
 about:
   home: https://github.com/rstudio/py-shinyswatch

--- a/recipes/shinyswatch/meta.yaml
+++ b/recipes/shinyswatch/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.9.0" %}
-{% set python_min = "3.8" %}
+{% set python_min = "3.9" %}
 
 package:
   name: shinyswatch


### PR DESCRIPTION
## New package: shinyswatch

**PyPI:** https://pypi.org/project/shinyswatch/0.9.0/
**Repository:** https://github.com/rstudio/py-shinyswatch
**License:** MIT

### Description

`shinyswatch` provides Bootswatch + Bootstrap 5 themes for Shiny for Python. It is maintained by the RStudio/Posit team and is a dependency of `pypath-shiny` (PR #32306).

### Dependencies

All run dependencies are already on conda-forge:
- `typing_extensions` >=3.10.0.0
- `packaging` >=20.9
- `htmltools` >=0.2.0
- `shiny` >=1.2.0

### Checklist

- [x] License file included (MIT)
- [x] Recipe generated with grayskull, reviewed
- [x] `noarch: python` (pure Python package)
- [x] All dependencies available on conda-forge