### PR TITLE
Add gtksourceview4: Based on gtksourceview, but version 4, compatible with gtk3

### DIFF
--- a/recipes/gtksourceview4/recipe.yaml
+++ b/recipes/gtksourceview4/recipe.yaml
@@ -1,0 +1,100 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+context:
+  name: gtksourceview
+  version: 4.8.4
+  version_majmin: ${{ (version | split('.'))[:2] | join('.') }}
+package:
+  name: gtksourceview4
+  version: ${{ version }}
+source:
+  url: "https://download.gnome.org/sources/${{ name }}/${{ version_majmin }}/${{ name }}-${{ version }}.tar.xz"
+  sha256: 7ec9d18fb283d1f84a3a3eff3b7a72b09a10c9c006597b3fbabbb5958420a87d
+build:
+  number: 0
+  script:
+    - if: win
+      then: |
+        meson setup %MESON_ARGS% ^
+          --prefix=%LIBRARY_PREFIX% ^
+          --default-library=shared ^
+          --wrap-mode=nofallback ^
+          --buildtype=release ^
+          -Dvapi=false ^
+          builddir
+        ninja -v -C builddir -j %CPU_COUNT%
+        ninja -C builddir install -j %CPU_COUNT%
+    - if: osx
+      then: |
+        # Define _DARWIN_C_SOURCE to expose POSIX.1-2008 functions like strnlen
+        export CFLAGS="${CFLAGS} -D_DARWIN_C_SOURCE"
+    - if: unix
+      then: |
+        meson setup ${MESON_ARGS} \
+            --prefix=$PREFIX \
+            --default-library=shared \
+            --wrap-mode=nofallback \
+            -Dvapi=false \
+            builddir
+        ninja -v -C builddir -j ${CPU_COUNT}
+        ninja -C builddir install -j ${CPU_COUNT}
+  files:
+    exclude:
+      - '**/gschemas.compiled'
+      - '**/icon-theme.cache'
+      - '**/loaders.cache'
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+    - freetype
+    - harfbuzz
+    - gobject-introspection
+  host:
+    - expat
+    - fontconfig
+    - fribidi
+    - glib
+    - gobject-introspection
+    - gtk3
+    - libxml2
+    - zlib
+    - if: unix
+      then: pango
+  ignore_run_exports:
+    by_name:
+      - libexpat
+      - adwaita-icon-theme
+      - libzlib
+tests:
+  - package_contents:
+      files:
+        - if: unix
+          then:
+            - lib/pkgconfig/gtksourceview-4.pc
+        - if: win
+          then:
+            - Library/lib/pkgconfig/gtksourceview-4.pc
+            - Library/lib/gtksourceview-4.lib
+      lib:
+        - if: unix
+          then: gtksourceview-4
+about:
+  homepage: https://gitlab.gnome.org/GNOME/gtksourceview
+  summary: A GNOME library that extends GtkTextView
+  description: |
+    GtkSourceView is a GNOME library that extends GtkTextView, the standard GTK
+    widget for multiline text editing. GtkSourceView adds support for syntax
+    highlighting, file loading and saving, search and replace, code completion,
+    snippets, Vim emulation, printing, displaying line numbers, and other features
+    typical of a source code editor.
+  license: LGPL-2.0-or-later
+  license_file: COPYING
+  documentation: https://gnome.pages.gitlab.gnome.org/gtksourceview/gtksourceview5/
+  repository: https://gitlab.gnome.org/GNOME/gtksourceview
+extra:
+  recipe-maintainers:
+    - noamraph


### PR DESCRIPTION
I need gtksourceview4, since I want to package Meld for conda, and it's currently using GTK3.

The recipe is based on https://github.com/conda-forge/gtksourceview-feedstock/blob/ed792eeb22b82a3ad9b443f1325205c8b864418a/recipe/recipe.yaml, with a few changes:

```diff
--- orig-gtksourceview5-recipe.yaml     2026-02-24 17:30:52.812126596 +0200
+++ recipe.yaml 2026-02-24 18:22:47.634816121 +0200
@@ -2,16 +2,16 @@
 schema_version: 1
 context:
   name: gtksourceview
-  version: 5.18.0
+  version: 4.8.4
   version_majmin: ${{ (version | split('.'))[:2] | join('.') }}
 package:
-  name: ${{ name|lower }}
+  name: gtksourceview4
   version: ${{ version }}
 source:
   url: "https://download.gnome.org/sources/${{ name }}/${{ version_majmin }}/${{ name }}-${{ version }}.tar.xz"
-  sha256: 051a78fe38f793328047e5bcd6d855c6425c0b480c20d9432179e356742c6ac0
+  sha256: 7ec9d18fb283d1f84a3a3eff3b7a72b09a10c9c006597b3fbabbb5958420a87d
 build:
-  number: 1
+  number: 0
   script:
     - if: win
       then: |
@@ -20,8 +20,6 @@
           --default-library=shared ^
           --wrap-mode=nofallback ^
           --buildtype=release ^
-          -Dintrospection=enabled ^
-          -Ddocumentation=false ^
           -Dvapi=false ^
           builddir
         ninja -v -C builddir -j %CPU_COUNT%
@@ -36,8 +34,6 @@
             --prefix=$PREFIX \
             --default-library=shared \
             --wrap-mode=nofallback \
-            -Dintrospection=enabled \
-            -Ddocumentation=false \
             -Dvapi=false \
             builddir
         ninja -v -C builddir -j ${CPU_COUNT}
@@ -54,6 +50,8 @@
     - meson
     - ninja
     - pkg-config
+    - freetype
+    - harfbuzz
     - gobject-introspection
   host:
     - expat
@@ -61,8 +59,8 @@
     - fribidi
     - glib
     - gobject-introspection
-    - gtk4
-    - libxml2-devel
+    - gtk3
+    - libxml2
     - zlib
     - if: unix
       then: pango
@@ -76,14 +74,14 @@
       files:
         - if: unix
           then:
-            - lib/pkgconfig/gtksourceview-5.pc
+            - lib/pkgconfig/gtksourceview-4.pc
         - if: win
           then:
-            - Library/lib/pkgconfig/gtksourceview-5.pc
-            - Library/lib/gtksourceview-5.lib
+            - Library/lib/pkgconfig/gtksourceview-4.pc
+            - Library/lib/gtksourceview-4.lib
       lib:
         - if: unix
-          then: gtksourceview-5
+          then: gtksourceview-4
 about:
   homepage: https://gitlab.gnome.org/GNOME/gtksourceview
   summary: A GNOME library that extends GtkTextView
@@ -99,6 +97,4 @@
   repository: https://gitlab.gnome.org/GNOME/gtksourceview
 extra:
   recipe-maintainers:
-    - danyeaw
-    - pkgw
-    - ryanvolz
+    - noamraph
```

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
