### PR TITLE
Add obsidian-export

### DIFF
--- a/recipes/obsidian-export/recipe.yaml
+++ b/recipes/obsidian-export/recipe.yaml
@@ -27,8 +27,6 @@ requirements:
     - pyyaml >=6.0,<7
     - click >=8.0,<9
     - pandoc >=3.5
-    - tectonic >=0.15
-    - librsvg >=2.58
 
 tests:
   - python:
@@ -46,8 +44,9 @@ about:
   description: |
     Convert Obsidian-flavored Markdown to PDF and DOCX. Handles wikilinks,
     embeds, callouts, Mermaid diagrams, and frontmatter via a 5-stage pipeline.
-    When installed from conda-forge, all system dependencies (pandoc, tectonic,
-    librsvg) are included automatically.
+    When installed from conda-forge, pandoc is included automatically.
+    Tectonic and librsvg must be installed separately (not yet available on
+    all platforms via conda-forge). Run ``obsidian-export doctor`` to check.
   license: MIT
   license_file: LICENSE
 

--- a/recipes/obsidian-export/recipe.yaml
+++ b/recipes/obsidian-export/recipe.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+context:
+  version: "0.2.4"
+
+package:
+  name: obsidian-export
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/o/obsidian-export/obsidian_export-${{ version }}.tar.gz
+  sha256: 7a0ff610c9182917096e2d0477692c3571d6f537b3c8d22142fb7dcad2315d77
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - obsidian-export = obsidian_export.cli:main
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - hatchling
+  run:
+    - python >=3.12
+    - pyyaml >=6.0,<7
+    - click >=8.0,<9
+    - pandoc >=3.5
+    - tectonic >=0.15
+    - librsvg >=2.58
+
+tests:
+  - python:
+      imports:
+        - obsidian_export
+      pip_check: true
+  - script:
+      - obsidian-export --help
+
+about:
+  homepage: https://github.com/neuralsignal/obsidian-export
+  repository: https://github.com/neuralsignal/obsidian-export
+  summary: Convert Obsidian-flavored Markdown to PDF and DOCX
+  description: |
+    Convert Obsidian-flavored Markdown to PDF and DOCX. Handles wikilinks,
+    embeds, callouts, Mermaid diagrams, and frontmatter via a 5-stage pipeline.
+    When installed from conda-forge, all system dependencies (pandoc, tectonic,
+    librsvg) are included automatically.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - neuralsignal

--- a/recipes/obsidian-export/recipe.yaml
+++ b/recipes/obsidian-export/recipe.yaml
@@ -16,8 +16,6 @@ build:
   noarch: python
   number: 0
   script: python -m pip install . -vv --no-deps --no-build-isolation
-  entry_points:
-    - obsidian-export = obsidian_export.cli:main
 
 requirements:
   host:

--- a/recipes/obsidian-export/recipe.yaml
+++ b/recipes/obsidian-export/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "0.2.4"
+  python_min: "3.12"
 
 package:
   name: obsidian-export
@@ -20,11 +21,11 @@ build:
 
 requirements:
   host:
-    - python >=3.12
+    - python ${{ python_min }}.*
     - pip
     - hatchling
   run:
-    - python >=3.12
+    - python >=${{ python_min }}
     - pyyaml >=6.0,<7
     - click >=8.0,<9
     - pandoc >=3.5
@@ -36,6 +37,7 @@ tests:
       imports:
         - obsidian_export
       pip_check: true
+      python_version: ${{ python_min }}.*
   - script:
       - obsidian-export --help
 


### PR DESCRIPTION
Convert Obsidian-flavored Markdown to PDF and DOCX. Handles wikilinks, embeds, callouts, Mermaid diagrams, and frontmatter via a 5-stage pipeline (pandoc + tectonic + librsvg).

The main value of the conda-forge package over pip is that pandoc, tectonic, and librsvg are all conda-forge packages — so `conda install obsidian-export` gives users a working setup with zero manual system dependency installation.

- Pure Python, `noarch: python`
- Build system: hatchling
- License: MIT
- PyPI: https://pypi.org/project/obsidian-export/
- Repo: https://github.com/neuralsignal/obsidian-export

Checklist

- [x] Title of this PR is meaningful
- [x] License file is packaged (`LICENSE`)
- [x] Source is from official source (PyPI sdist)
- [x] Package does not vendor other packages
- [x] No static libraries
- [x] Build number is 0
- [x] Tarball (`url`) used, not repo
- [x] GitHub user listed in maintainer section confirms willingness: I am the package author and sole maintainer