### PR TITLE
CI: Enable aarch64 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -75,7 +75,7 @@ jobs:
       .scripts/run_docker_build.sh
 
     displayName: Run docker build
-    name: $(CONFIG)_build
+    name: linux_build
 
   - publish: build_artifacts/$(ARTIFACT_DIR)/
     artifact: $(LINUX_ARTIFACT)
@@ -85,7 +85,7 @@ jobs:
 
 - job: linux_64_cuda_129
   dependsOn: linux
-  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux.outputs['linux_64.linux_build.NEED_CUDA'], '1'))
+  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux.outputs['linux.linux_build.NEED_CUDA'], '1'))
   pool:
     vmImage: ubuntu-latest
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -1,10 +1,29 @@
 jobs:
-- job: linux_64
+- job: linux
   condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/main'))
   pool:
     vmImage: ubuntu-latest
   timeoutInMinutes: 360
+  strategy:
+    matrix:
+      linux_64:
+        CONFIG: linux_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        LINUX_ARTIFACT: conda_pkgs_linux_64
+      linux_aarch64:
+        CONFIG: linux_aarch64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        LINUX_ARTIFACT: conda_pkgs_linux_aarch64
+
   steps:
+  # configure qemu binfmt-misc running.  This allows us to run docker containers
+  # with embedded qemu-static (aarch64 only)
+  - script: |
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+      ls /proc/sys/fs/binfmt_misc/
+    displayName: Configure binfmt_misc
+    condition: not(startsWith(variables['CONFIG'], 'linux_64'))
+
   - script: |
       sudo mkdir -p /opt/empty_dir
       for d in \
@@ -43,27 +62,30 @@ jobs:
   - script: |
       set -e
 
+      ARTIFACT_DIR="${CONFIG//_/-}"
+      echo "##vso[task.setvariable variable=ARTIFACT_DIR]$ARTIFACT_DIR"
+
       # make sure there is a package directory so that artifact publishing works
-      mkdir -p build_artifacts/{noarch,linux-64}/
+      mkdir -p build_artifacts/{noarch,$ARTIFACT_DIR}/
 
       export CI=azure
-      export CONFIG=linux64
-      export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-x86_64:alma9
+      export CONFIG=$(CONFIG)
+      export DOCKER_IMAGE=$(DOCKER_IMAGE)
       export AZURE=True
       .scripts/run_docker_build.sh
 
     displayName: Run docker build
-    name: linux_64_build
+    name: $(CONFIG)_build
 
-  - publish: build_artifacts/linux-64/
-    artifact: conda_pkgs_linux
+  - publish: build_artifacts/$(ARTIFACT_DIR)/
+    artifact: $(LINUX_ARTIFACT)
 
   - publish: build_artifacts/noarch/
     artifact: conda_pkgs_noarch
 
 - job: linux_64_cuda_129
-  dependsOn: linux_64
-  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
+  dependsOn: linux
+  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux.outputs['linux_64.linux_build.NEED_CUDA'], '1'))
   pool:
     vmImage: ubuntu-latest
   timeoutInMinutes: 360
@@ -103,7 +125,7 @@ jobs:
       mkdir -p build_artifacts/linux-64/
 
       export CI=azure
-      export CONFIG=linux64_cuda129
+      export CONFIG=linux_64_cuda_compiler_version12.9
       export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-x86_64:alma9
       export AZURE=True
       .scripts/run_docker_build.sh

--- a/.ci_support/linux_aarch64.yaml
+++ b/.ci_support/linux_aarch64.yaml
@@ -19,7 +19,7 @@ target_platform:
 channel_sources:
 - conda-forge
 docker_image:
-- quay.io/condaforge/linux-anvil-aarch64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 cuda_compiler:
 - None
 cuda_compiler_version:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -7,6 +7,7 @@
 
 set -xeuo pipefail
 
+export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/staged-recipes}"
 export FEEDSTOCK_ROOT="${FEEDSTOCK_ROOT:-/home/conda/staged-recipes}"
 source "${FEEDSTOCK_ROOT}/.scripts/logging_utils.sh"
 


### PR DESCRIPTION
It wouldn't be appropriate to enable this job for all MRs because aarch64 is an opt-in target platform, but we can keep this here for reference and cherry-pick it to PRs that only build for aarch64.