### PR TITLE
[DO NOT MERGE] Add green2blue

### DIFF
--- a/recipes/green2blue/meta.yaml
+++ b/recipes/green2blue/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/discordwell/green2blue/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e4fad00c9b30fe3edaf2a695afcfdbd8626d40c8e183416d035a319933cfb6e1
+  sha256: 2f495bb4098acf81073c686d3f5232746f1c1dd513634c58ec5814b87d144e96
 
 build:
   noarch: python

--- a/recipes/green2blue/meta.yaml
+++ b/recipes/green2blue/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "green2blue" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/discordwell/green2blue/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: e4fad00c9b30fe3edaf2a695afcfdbd8626d40c8e183416d035a319933cfb6e1
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - green2blue = green2blue.cli:main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+  run:
+    - python >=3.10
+    - cryptography >=41.0
+
+test:
+  imports:
+    - green2blue
+    - green2blue.cli
+    - green2blue.pipeline
+  commands:
+    - green2blue --help
+
+about:
+  home: https://github.com/discordwell/green2blue
+  summary: Transfer SMS/MMS/RCS messages from Android to iPhone
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/discordwell/green2blue
+
+extra:
+  recipe-maintainers:
+    - discordwell


### PR DESCRIPTION
## Summary

- **Package name**: green2blue
- **Version**: 0.1.0
- **License**: MIT
- **Source**: GitHub release tarball
- **noarch**: python

green2blue transfers SMS/MMS/RCS messages from Android to iPhone. It parses exports from the [SMS Import/Export](https://github.com/tmo1/sms-ie) Android app and injects them into iOS backups.

## Checklist

- [x] License is open source (MIT)
- [x] Source is a stable release tarball (v0.1.0 tag)
- [x] Package builds as noarch: python
- [x] Entry point: `green2blue = green2blue.cli:main`
- [x] Test imports and `--help` command included
- [x] Recipe maintainer listed