### PR TITLE
Add perfecthash

### DIFF
--- a/recipes/perfecthash/build-python.sh
+++ b/recipes/perfecthash/build-python.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version_override="${PERFECTHASH_VERSION_OVERRIDE:-${PKG_VERSION:-${PERFECTHASH_CONDA_VERSION:-0.0.0}}}"
+
+echo "==> Building PerfectHash Python package"
+echo "==> Using version override: ${version_override}"
+
+export PERFECTHASH_PYTHON_VERSION="${version_override}"
+unset PERFECTHASH_PYTHON_NATIVE_ROOT
+
+"${PYTHON}" -m pip install . --no-deps --no-build-isolation -vv
+

--- a/recipes/perfecthash/build.sh
+++ b/recipes/perfecthash/build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile="${PERFECTHASH_BUILD_PROFILE:-full}"
+version_override="${PERFECTHASH_VERSION_OVERRIDE:-${PKG_VERSION:-${PERFECTHASH_CONDA_VERSION:-0.0.0}}}"
+
+case "$profile" in
+  full|online-rawdog-jit|online-rawdog-and-llvm-jit|online-llvm-jit)
+    ;;
+  *)
+    echo "error: invalid PERFECTHASH_BUILD_PROFILE '$profile'" >&2
+    exit 1
+    ;;
+esac
+
+build_dir="build-conda-${profile}"
+
+echo "==> Building conda output for profile: ${profile}"
+echo "==> Using version override: ${version_override}"
+
+cmake_args=(
+  -S .
+  -B "${build_dir}"
+  -G Ninja
+  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_INSTALL_PREFIX="$PREFIX"
+  -DPERFECTHASH_BUILD_PROFILE="$profile"
+  -DPERFECTHASH_VERSION_OVERRIDE="${version_override}"
+  -DPERFECTHASH_ENABLE_TESTS=OFF
+  -DBUILD_TESTING=OFF
+)
+
+if command -v nasm >/dev/null 2>&1; then
+  nasm_path="$(command -v nasm)"
+  echo "==> Using NASM from PATH: ${nasm_path}"
+  cmake_args+=("-DCMAKE_ASM_NASM_COMPILER=${nasm_path}")
+elif [ -n "${BUILD_PREFIX:-}" ] && [ -x "${BUILD_PREFIX}/bin/nasm" ]; then
+  echo "==> Using NASM from BUILD_PREFIX: ${BUILD_PREFIX}/bin/nasm"
+  cmake_args+=("-DCMAKE_ASM_NASM_COMPILER=${BUILD_PREFIX}/bin/nasm")
+fi
+
+cmake "${cmake_args[@]}"
+
+cmake --build "${build_dir}" --parallel
+cmake --install "${build_dir}"

--- a/recipes/perfecthash/meta.yaml
+++ b/recipes/perfecthash/meta.yaml
@@ -1,0 +1,196 @@
+{% set version = "0.73.0" %}
+{% set sha256 = "dd5045adddb8e0ce1d2fdd13ffa0a10839e435eeb66c0c68c82bef3f4d98d293" %}
+
+package:
+  name: perfecthash
+  version: {{ version }}
+
+source:
+  url: https://github.com/tpn/perfecthash/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  skip: true  # [not linux]
+
+requirements:
+  run:
+    - {{ pin_subpackage('perfecthash-full', exact=True) }}
+    - {{ pin_subpackage('perfecthash-python', exact=True) }}
+
+test:
+  commands:
+    - test -f $PREFIX/include/PerfectHash/PerfectHash.h
+    - test -f $PREFIX/lib/cmake/PerfectHash/PerfectHashConfig.cmake
+    - ph --version
+
+about:
+  home: https://github.com/tpn/perfecthash
+  summary: Perfect hash table generation and online JIT runtime libraries.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+description: |
+  PerfectHash builds fast perfect hash table generation/runtime libraries with
+  profile-aware native outputs and a bundled Python CLI/runtime layer.
+
+outputs:
+  - name: perfecthash-online-rawdog-jit
+    build:
+      skip: true  # [not linux]
+      script:
+        - export PERFECTHASH_BUILD_PROFILE=online-rawdog-jit
+        - export PERFECTHASH_VERSION_OVERRIDE={{ version }}
+        - bash "${RECIPE_DIR}/build.sh"
+    files:
+      - include/PerfectHash/*
+      - lib/libPerfectHash*
+      - lib/cmake/PerfectHash/*
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake >=3.20
+        - ninja
+        - nasm
+        - make
+        - pkg-config
+      run_constrained:
+        - perfecthash-full <0a0
+        - perfecthash-online-rawdog-and-llvm-jit <0a0
+        - perfecthash-online-llvm-jit <0a0
+    test:
+      commands:
+        - test -f $PREFIX/include/PerfectHash/PerfectHash.h
+        - test -f $PREFIX/lib/cmake/PerfectHash/PerfectHashConfig.cmake
+
+  - name: perfecthash-online-rawdog-and-llvm-jit
+    build:
+      skip: true  # [not linux]
+      script:
+        - export PERFECTHASH_BUILD_PROFILE=online-rawdog-and-llvm-jit
+        - export PERFECTHASH_VERSION_OVERRIDE={{ version }}
+        - bash "${RECIPE_DIR}/build.sh"
+    files:
+      - include/PerfectHash/*
+      - lib/libPerfectHash*
+      - lib/cmake/PerfectHash/*
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake >=3.20
+        - ninja
+        - nasm
+        - make
+        - pkg-config
+      host:
+        - llvmdev >=15
+      run:
+        - llvmdev >=15
+      run_constrained:
+        - perfecthash-full <0a0
+        - perfecthash-online-llvm-jit <0a0
+        - perfecthash-online-rawdog-jit <0a0
+    test:
+      commands:
+        - test -f $PREFIX/include/PerfectHash/PerfectHash.h
+        - test -f $PREFIX/lib/cmake/PerfectHash/PerfectHashConfig.cmake
+
+  - name: perfecthash-online-llvm-jit
+    build:
+      skip: true  # [not linux]
+      script:
+        - export PERFECTHASH_BUILD_PROFILE=online-llvm-jit
+        - export PERFECTHASH_VERSION_OVERRIDE={{ version }}
+        - bash "${RECIPE_DIR}/build.sh"
+    files:
+      - include/PerfectHash/*
+      - lib/libPerfectHash*
+      - lib/cmake/PerfectHash/*
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake >=3.20
+        - ninja
+        - nasm
+        - make
+        - pkg-config
+      host:
+        - llvmdev >=15
+      run:
+        - llvmdev >=15
+      run_constrained:
+        - perfecthash-full <0a0
+        - perfecthash-online-rawdog-and-llvm-jit <0a0
+        - perfecthash-online-rawdog-jit <0a0
+    test:
+      commands:
+        - test -f $PREFIX/include/PerfectHash/PerfectHash.h
+        - test -f $PREFIX/lib/cmake/PerfectHash/PerfectHashConfig.cmake
+
+  - name: perfecthash-full
+    build:
+      skip: true  # [not linux]
+      script:
+        - export PERFECTHASH_BUILD_PROFILE=full
+        - export PERFECTHASH_VERSION_OVERRIDE={{ version }}
+        - bash "${RECIPE_DIR}/build.sh"
+    files:
+      - bin/PerfectHash*
+      - include/PerfectHash/*
+      - lib/libPerfectHash*
+      - lib/cmake/PerfectHash/*
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - cmake >=3.20
+        - ninja
+        - nasm
+        - make
+        - pkg-config
+      host:
+        - llvmdev >=15
+      run:
+        - llvmdev >=15
+      run_constrained:
+        - perfecthash-online-llvm-jit <0a0
+        - perfecthash-online-rawdog-and-llvm-jit <0a0
+        - perfecthash-online-rawdog-jit <0a0
+    test:
+      commands:
+        - test -f $PREFIX/include/PerfectHash/PerfectHash.h
+        - test -f $PREFIX/lib/cmake/PerfectHash/PerfectHashConfig.cmake
+
+  - name: perfecthash-python
+    build:
+      skip: true  # [not linux]
+      script:
+        - export PERFECTHASH_VERSION_OVERRIDE={{ version }}
+        - bash "${RECIPE_DIR}/build-python.sh"
+    files:
+      - bin/ph
+      - lib/python*/site-packages/perfecthash/**
+      - lib/python*/site-packages/perfecthash-*.dist-info/**
+    requirements:
+      host:
+        - python >=3.12
+        - pip
+        - hatchling >=1.27
+      run:
+        - {{ pin_subpackage('perfecthash-full', exact=True) }}
+        - python >=3.12
+        - pydantic >=2.11
+        - typer >=0.16
+    test:
+      commands:
+        - ph --version
+        - ph create keys/example.keys out --hash-function MultiplyShiftR --dry-run
+        - python -c "import perfecthash; assert perfecthash.__version__ == '{{ version }}'"
+        - python -c "from perfecthash import build_table; keys=[1, 3, 5, 7, 11, 13, 17, 19]; table = build_table(keys, hash_function='MultiplyShiftR'); indexes = table.index_many(keys); assert len(indexes) == len(keys); table.close()"
+
+extra:
+  recipe-maintainers:
+    - tpn

--- a/recipes/perfecthash/meta.yaml
+++ b/recipes/perfecthash/meta.yaml
@@ -24,16 +24,6 @@ test:
     - test -f $PREFIX/lib/cmake/PerfectHash/PerfectHashConfig.cmake
     - ph --version
 
-about:
-  home: https://github.com/tpn/perfecthash
-  summary: Perfect hash table generation and online JIT runtime libraries.
-  license: BSD-3-Clause
-  license_file: LICENSE
-
-description: |
-  PerfectHash builds fast perfect hash table generation/runtime libraries with
-  profile-aware native outputs and a bundled Python CLI/runtime layer.
-
 outputs:
   - name: perfecthash-online-rawdog-jit
     build:
@@ -48,6 +38,7 @@ outputs:
       - lib/cmake/PerfectHash/*
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake >=3.20
@@ -77,6 +68,7 @@ outputs:
       - lib/cmake/PerfectHash/*
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake >=3.20
@@ -110,6 +102,7 @@ outputs:
       - lib/cmake/PerfectHash/*
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake >=3.20
@@ -144,6 +137,7 @@ outputs:
       - lib/cmake/PerfectHash/*
     requirements:
       build:
+        - {{ stdlib("c") }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - cmake >=3.20
@@ -194,3 +188,13 @@ outputs:
 extra:
   recipe-maintainers:
     - tpn
+  feedstock-name: perfecthash
+
+about:
+  home: https://github.com/tpn/perfecthash
+  summary: Perfect hash table generation and online JIT runtime libraries.
+  description: |
+    PerfectHash builds fast perfect hash table generation/runtime libraries with
+    profile-aware native outputs and a bundled Python CLI/runtime layer.
+  license: BSD-3-Clause
+  license_file: LICENSE


### PR DESCRIPTION
Adds `perfecthash` as a new staged recipe.

Current package layout:
- `perfecthash` meta package
- `perfecthash-full`
- `perfecthash-python`
- `perfecthash-online-rawdog-jit`
- `perfecthash-online-rawdog-and-llvm-jit`
- `perfecthash-online-llvm-jit`

Notes:
- upstream release source is the `v0.73.0` GitHub tag tarball
- outputs are currently Linux-only by design; non-Linux outputs are skipped in the recipe
- the default `perfecthash` package resolves to the full native package plus the Python package
