### PR TITLE
Add ws-sse-proxy

### DIFF
--- a/recipes/ws-sse-proxy/meta.yaml
+++ b/recipes/ws-sse-proxy/meta.yaml
@@ -30,6 +30,8 @@ requirements:
     - uvicorn >=0.22.0
 
 test:
+  requires:
+    - python {{ python_min }}
   imports:
     - ws_sse_proxy
   commands:

--- a/recipes/ws-sse-proxy/meta.yaml
+++ b/recipes/ws-sse-proxy/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "ws-sse-proxy" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/w/{{ name }}/ws_sse_proxy-{{ version }}.tar.gz
+  sha256: 7b4ca5caa1d36633c70ad3fe46b72dfce8dcc8f7cf1d17e1c0cabc2823195c8a
+
+build:
+  noarch: python
+  number: 0
+  entry_points:
+    - ws-sse-proxy = ws_sse_proxy.__main__:main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - hatchling
+  run:
+    - python >=3.9
+    - starlette >=0.27.0
+    - websockets >=11.0
+    - httpx >=0.24.0
+    - uvicorn >=0.22.0
+
+test:
+  imports:
+    - ws_sse_proxy
+  commands:
+    - ws-sse-proxy --help
+
+about:
+  home: https://github.com/scttfrdmn/ws-sse-proxy
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: WebSocket-to-SSE translation proxy for environments where WebSocket is blocked
+  description: |
+    A drop-in reverse proxy that transparently translates WebSocket
+    connections to Server-Sent Events (SSE) + HTTP POST, for environments
+    where WebSocket connections are blocked by ALBs, corporate proxies,
+    or platforms like AWS SageMaker Studio Lab.
+  dev_url: https://github.com/scttfrdmn/ws-sse-proxy
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/ws-sse-proxy/meta.yaml
+++ b/recipes/ws-sse-proxy/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "ws-sse-proxy" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name }}
@@ -18,11 +19,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - hatchling
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - starlette >=0.27.0
     - websockets >=11.0
     - httpx >=0.24.0


### PR DESCRIPTION
## Package description

**ws-sse-proxy** is a drop-in reverse proxy that transparently translates WebSocket connections to SSE (Server-Sent Events) + HTTP POST, for environments where WebSocket is blocked.

Some deployment environments block or drop WebSocket connections: AWS ALBs, corporate proxies, or platforms like AWS SageMaker Studio Lab where the gateway drops WebSocket on certain proxy paths. This package lets WebSocket-dependent apps (marimo, Streamlit, Bokeh, Dask dashboards, etc.) work correctly in those environments without any application changes.

The proxy injects a small JavaScript shim into HTML responses that tries a real WebSocket first — if it works, there's zero overhead. If WebSocket fails (code 1006 or connection stall), it falls back to SSE + POST transparently.

- PyPI: https://pypi.org/project/ws-sse-proxy/
- GitHub: https://github.com/scttfrdmn/ws-sse-proxy
- License: MIT
- Pure Python, no compiled extensions

## Checklist

- [x] Title is `Add <package name>`
- [x] `meta.yaml` uses `sha256` from PyPI sdist
- [x] `noarch: python` (pure Python package)
- [x] License is MIT, confirmed in `pyproject.toml` and `LICENSE` file
- [x] All dependencies are available on conda-forge (`starlette`, `websockets`, `httpx`, `uvicorn`)
- [x] Entry point tested: `ws-sse-proxy --help`