### PR TITLE
Add ramp-stream

### DIFF
--- a/recipes/ramp-stream/recipe.yaml
+++ b/recipes/ramp-stream/recipe.yaml
@@ -55,7 +55,9 @@ about:
   summary: System-level Thermohydraulics Code for reactor analysis using modular DAE coupling of components
   license: MIT
   license_file: LICENSE
-  homepage: https://pypi.org/project/ramp-stream/
+  homepage: https://github.com/ramp-nuclear/STREAM/
+  repository: https://github.com/ramp-nuclear/STREAM/
+  documentation: https://ramp-nuclear.github.io/STREAM/
 
 extra:
   recipe-maintainers:

--- a/recipes/ramp-stream/recipe.yaml
+++ b/recipes/ramp-stream/recipe.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+
+context:
+  python_min: "3.11"
+  version: "1.1.2"
+
+package:
+  name: ramp-stream
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/ramp-stream/ramp_stream-${{ version }}.tar.gz
+  sha256: 6b0c7db10913ba0e2c75e5398777849866933c8aea27747f1ae9cf1cc9e543f4
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools
+    - setuptools-scm
+    - wheel
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - cachetools
+    - cytoolz
+    - ipython
+    - matplotlib-base
+    - more-itertools
+    - networkx
+    - numba
+    - numpy
+    - pandas
+    - rich
+    - scikits.odes
+    - scipy
+    - sundials
+    - dask-core
+    - yaml
+
+tests:
+  - python:
+      imports:
+        - stream
+      pip_check: true
+      python_version: 
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  summary: System-level Thermohydraulics Code for reactor analysis using modular DAE coupling of components
+  license: MIT
+  license_file: LICENSE
+  homepage: https://pypi.org/project/ramp-stream/
+
+extra:
+  recipe-maintainers:
+    - esheder


### PR DESCRIPTION
`ramp-stream` is a pure python package on PyPI that models and solves system-level thermo-hydraulics problems, focusing on nuclear reactor primary loops.
It models the problem as a set of DAEs, which are solved with different solves (for example, sundials).

# Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
