### PR TITLE
Add ncountr

### DIFF
--- a/recipes/ncountr/recipe.yaml
+++ b/recipes/ncountr/recipe.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "0.2.0"
+
+package:
+  name: ncountr
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/n/ncountr/ncountr-${{ version }}.tar.gz
+  sha256: 9062bef1d369081970fc822b5a86b3df1f4557d1aded89ff5eda78720fe1d831
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - ncountr = ncountr.cli:cli
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=64
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.21
+    - pandas >=1.3
+    - scipy >=1.7
+    - statsmodels >=0.13
+    - matplotlib-base >=3.5
+    - pyyaml >=5.4
+    - click >=8.0
+
+tests:
+  - python:
+      imports:
+        - ncountr
+        - ncountr.core
+        - ncountr.io
+        - ncountr.plotting
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - ncountr --version
+      - ncountr --help
+
+about:
+  summary: Python pipeline for NanoString nCounter gene expression data analysis
+  description: |
+    ncountr is a Python package for end-to-end NanoString nCounter data
+    analysis. It parses RCC files, runs quality control, applies
+    positive-control, CodeSet content and housekeeping normalization, tests
+    for differential expression (Mann-Whitney U or t-test with FDR
+    correction), scores gene sets and runs GSEA - from a single config file
+    or the Python API. Results can be exported as AnnData for downstream
+    analysis with scanpy and the wider scverse ecosystem.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/princello/ncountr
+  repository: https://github.com/princello/ncountr
+  documentation: https://ncountr.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - princello


### PR DESCRIPTION
### Description

**ncountr** is a Python package for end-to-end NanoString nCounter gene expression analysis. It parses RCC files, runs quality control, applies positive-control / CodeSet content / housekeeping normalization, tests for differential expression (Mann-Whitney U or t-test with FDR correction), scores gene sets and runs GSEA — from a single config file or the Python API. Results can be exported as AnnData for downstream analysis with scanpy and the wider scverse ecosystem.

- **Home**: https://github.com/princello/ncountr
- **PyPI**: https://pypi.org/project/ncountr/0.2.0/
- **Docs**: https://ncountr.readthedocs.io
- **License**: MIT
- **sha256**: `9062bef1d369081970fc822b5a86b3df1f4557d1aded89ff5eda78720fe1d831`

### Updated 2026-08-07

This PR was originally opened against ncountr 0.1.0 and had drifted well behind `main`. It has been rebuilt on top of current `staged-recipes/main` and now contains a single commit adding one file:

- **Migrated to the CEP 13 v1 format** — `recipes/ncountr/recipe.yaml` replaces the previous `meta.yaml`, matching what staged-recipes currently expects.
- **Bumped 0.1.0 → 0.2.0** with the sha256 of the current PyPI sdist (verified by downloading the archive, not copied from the JSON API).
- **Dropped `setuptools-scm`** from host requirements — it was never used; the build system is plain `setuptools>=64` per `pyproject.toml`.
- **Adopted the `python_min` convention** for the `noarch: python` build, with `python_min` pins in host, run and test.
- **Added `pip_check: true`** alongside the import and CLI tests.

### Checklist

- [x] Source archive is available on PyPI
- [x] sha256 hash is set in the recipe and matches the current sdist
- [x] License file is included (MIT)
- [x] Tests pass (`ncountr --version`, `ncountr --help`, module imports, `pip_check`)
- [x] `noarch: python` build with `python_min` conventions
- [x] Recipe maintainer listed (`princello`)
- [x] Branch synchronized with current `staged-recipes/main`
