### PR TITLE
Add cpp-httplib v0.18.7

### DIFF
--- a/recipes/cpp-httplib/conda-forge.yml
+++ b/recipes/cpp-httplib/conda-forge.yml
@@ -1,4 +1,0 @@
-skip_render:
-  - .github/workflows
-win:
-  enabled: false

--- a/recipes/cpp-httplib/conda-forge.yml
+++ b/recipes/cpp-httplib/conda-forge.yml
@@ -1,0 +1,4 @@
+skip_render:
+  - .github/workflows
+win:
+  enabled: false

--- a/recipes/cpp-httplib/recipe.yaml
+++ b/recipes/cpp-httplib/recipe.yaml
@@ -10,12 +10,15 @@ source:
   sha256: b7b1e9e4e77565a5a9bc95e761d5df3e7c0e8ca37c90fd78b1b031bc6cb90fc1
 
 build:
-  skip:
-    - win
   number: 0
   script:
-    - cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PREFIX -DHTTPLIB_COMPILE=OFF .
-    - cmake --install build
+    - if: unix
+      then:
+        - cmake -B build -G Ninja ${CMAKE_ARGS} -DHTTPLIB_COMPILE=OFF .
+        - cmake --install build
+      else:
+        - cmake -B build -G Ninja %CMAKE_ARGS% -DHTTPLIB_COMPILE=OFF .
+        - cmake --install build
 
 requirements:
   build:
@@ -24,8 +27,6 @@ requirements:
     - ${{ compiler('cxx') }}
     - ${{ stdlib('c') }}
   host:
-    - openssl
-  run:
     - openssl
 
 tests:
@@ -46,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - amitsingh21
+    - wolfv

--- a/recipes/cpp-httplib/recipe.yaml
+++ b/recipes/cpp-httplib/recipe.yaml
@@ -10,6 +10,8 @@ source:
   sha256: b7b1e9e4e77565a5a9bc95e761d5df3e7c0e8ca37c90fd78b1b031bc6cb90fc1
 
 build:
+  skip:
+    - win
   number: 0
   script:
     - cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PREFIX -DHTTPLIB_COMPILE=OFF .

--- a/recipes/cpp-httplib/recipe.yaml
+++ b/recipes/cpp-httplib/recipe.yaml
@@ -39,7 +39,7 @@ about:
   description: |
     A C++11 single-file header-only cross platform HTTP/HTTPS library.
     It's extremely easy to setup. Just include the httplib.h file in your code!
-  dev_url: https://github.com/yhirose/cpp-httplib
+  repository: https://github.com/yhirose/cpp-httplib
 
 extra:
   recipe-maintainers:

--- a/recipes/cpp-httplib/recipe.yaml
+++ b/recipes/cpp-httplib/recipe.yaml
@@ -20,6 +20,7 @@ requirements:
     - cmake
     - ninja
     - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
   host:
     - openssl
   run:
@@ -39,3 +40,7 @@ about:
     A C++11 single-file header-only cross platform HTTP/HTTPS library.
     It's extremely easy to setup. Just include the httplib.h file in your code!
   dev_url: https://github.com/yhirose/cpp-httplib
+
+extra:
+  recipe-maintainers:
+    - amitsingh21

--- a/recipes/cpp-httplib/recipe.yaml
+++ b/recipes/cpp-httplib/recipe.yaml
@@ -1,0 +1,41 @@
+context:
+  version: "0.18.7"
+
+package:
+  name: cpp-httplib
+  version: ${{ version }}
+
+source:
+  url: https://github.com/yhirose/cpp-httplib/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: b7b1e9e4e77565a5a9bc95e761d5df3e7c0e8ca37c90fd78b1b031bc6cb90fc1
+
+build:
+  number: 0
+  script:
+    - cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=$PREFIX -DHTTPLIB_COMPILE=OFF .
+    - cmake --install build
+
+requirements:
+  build:
+    - cmake
+    - ninja
+    - ${{ compiler('cxx') }}
+  host:
+    - openssl
+  run:
+    - openssl
+
+tests:
+  - package_contents:
+      include:
+        - httplib.h
+
+about:
+  homepage: https://github.com/yhirose/cpp-httplib
+  license: MIT
+  license_file: LICENSE
+  summary: A C++ header-only HTTP/HTTPS library
+  description: |
+    A C++11 single-file header-only cross platform HTTP/HTTPS library.
+    It's extremely easy to setup. Just include the httplib.h file in your code!
+  dev_url: https://github.com/yhirose/cpp-httplib


### PR DESCRIPTION
## Summary
Add [cpp-httplib](https://github.com/yhirose/cpp-httplib) — a C++ header-only HTTP/HTTPS library.

- 10k+ GitHub stars, actively maintained
- Header-only: just installs `httplib.h`, no compilation
- MIT license
- Used in ROS/robotics ecosystems (RoboStack, io_amr)

## Checklist
- [x] License file included (`LICENSE`)
- [x] Recipe uses `recipe.yaml` (v1 format)
- [x] Tests check for installed header
- [x] Build works on linux-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)