### PR TITLE
Add redis-plus-plus v1.3.15

### DIFF
--- a/recipes/redis-plus-plus/conda-forge.yml
+++ b/recipes/redis-plus-plus/conda-forge.yml
@@ -1,4 +1,0 @@
-skip_render:
-  - .github/workflows
-win:
-  enabled: false

--- a/recipes/redis-plus-plus/conda-forge.yml
+++ b/recipes/redis-plus-plus/conda-forge.yml
@@ -1,0 +1,4 @@
+skip_render:
+  - .github/workflows
+win:
+  enabled: false

--- a/recipes/redis-plus-plus/recipe.yaml
+++ b/recipes/redis-plus-plus/recipe.yaml
@@ -10,24 +10,25 @@ source:
   sha256: e9288fda74f1501c62dd9ab7d6a8dc67de51aa4d5b7c71770baa51987a945941
 
 build:
-  skip:
-    - win
   number: 0
   script:
-    - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_TEST=OFF -DREDIS_PLUS_PLUS_BUILD_ASYNC=libuv -B build
-    - cmake --build build -j${CPU_COUNT}
-    - cmake --install build
+    - if: unix
+      then:
+        - cmake ${CMAKE_ARGS} -G Ninja -DREDIS_PLUS_PLUS_BUILD_TEST=OFF -DREDIS_PLUS_PLUS_BUILD_ASYNC=libuv -B build
+        - cmake --build build --parallel ${CPU_COUNT}
+        - cmake --install build
+      else:
+        - cmake %CMAKE_ARGS% -G Ninja -DREDIS_PLUS_PLUS_BUILD_TEST=OFF -DREDIS_PLUS_PLUS_BUILD_ASYNC=libuv -B build
+        - cmake --build build --parallel %CPU_COUNT%
+        - cmake --install build
 
 requirements:
   build:
     - cmake
-    - make
+    - ninja
     - ${{ compiler('cxx') }}
     - ${{ stdlib('c') }}
   host:
-    - libhiredis
-    - libuv
-  run:
     - libhiredis
     - libuv
 
@@ -36,7 +37,7 @@ tests:
       include:
         - sw/redis++/redis++.h
       lib:
-        - libredis++
+        - redis++
 
 about:
   homepage: https://github.com/sewenew/redis-plus-plus
@@ -52,3 +53,4 @@ about:
 extra:
   recipe-maintainers:
     - amitsingh21
+    - wolfv

--- a/recipes/redis-plus-plus/recipe.yaml
+++ b/recipes/redis-plus-plus/recipe.yaml
@@ -31,6 +31,8 @@ requirements:
   host:
     - libhiredis
     - libuv
+  run_exports:
+    - ${{ pin_subpackage('redis-plus-plus', upper_bound='x.x') }}
 
 tests:
   - package_contents:

--- a/recipes/redis-plus-plus/recipe.yaml
+++ b/recipes/redis-plus-plus/recipe.yaml
@@ -21,6 +21,7 @@ requirements:
     - cmake
     - make
     - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
   host:
     - libhiredis
     - libuv
@@ -45,3 +46,7 @@ about:
     pipelines, transactions, publish/subscribe, Redis Cluster, Redis Sentinel,
     and async interface via libuv.
   dev_url: https://github.com/sewenew/redis-plus-plus
+
+extra:
+  recipe-maintainers:
+    - amitsingh21

--- a/recipes/redis-plus-plus/recipe.yaml
+++ b/recipes/redis-plus-plus/recipe.yaml
@@ -45,7 +45,7 @@ about:
     A C++ client library for Redis, based on hiredis. Supports Redis commands,
     pipelines, transactions, publish/subscribe, Redis Cluster, Redis Sentinel,
     and async interface via libuv.
-  dev_url: https://github.com/sewenew/redis-plus-plus
+  repository: https://github.com/sewenew/redis-plus-plus
 
 extra:
   recipe-maintainers:

--- a/recipes/redis-plus-plus/recipe.yaml
+++ b/recipes/redis-plus-plus/recipe.yaml
@@ -10,6 +10,8 @@ source:
   sha256: e9288fda74f1501c62dd9ab7d6a8dc67de51aa4d5b7c71770baa51987a945941
 
 build:
+  skip:
+    - win
   number: 0
   script:
     - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_TEST=OFF -DREDIS_PLUS_PLUS_BUILD_ASYNC=libuv -B build

--- a/recipes/redis-plus-plus/recipe.yaml
+++ b/recipes/redis-plus-plus/recipe.yaml
@@ -1,0 +1,47 @@
+context:
+  version: "1.3.15"
+
+package:
+  name: redis-plus-plus
+  version: ${{ version }}
+
+source:
+  url: https://github.com/sewenew/redis-plus-plus/archive/refs/tags/${{ version }}.tar.gz
+  sha256: e9288fda74f1501c62dd9ab7d6a8dc67de51aa4d5b7c71770baa51987a945941
+
+build:
+  number: 0
+  script:
+    - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_TEST=OFF -DREDIS_PLUS_PLUS_BUILD_ASYNC=libuv -B build
+    - cmake --build build -j${CPU_COUNT}
+    - cmake --install build
+
+requirements:
+  build:
+    - cmake
+    - make
+    - ${{ compiler('cxx') }}
+  host:
+    - libhiredis
+    - libuv
+  run:
+    - libhiredis
+    - libuv
+
+tests:
+  - package_contents:
+      include:
+        - sw/redis++/redis++.h
+      lib:
+        - libredis++
+
+about:
+  homepage: https://github.com/sewenew/redis-plus-plus
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Redis client written in C++
+  description: |
+    A C++ client library for Redis, based on hiredis. Supports Redis commands,
+    pipelines, transactions, publish/subscribe, Redis Cluster, Redis Sentinel,
+    and async interface via libuv.
+  dev_url: https://github.com/sewenew/redis-plus-plus


### PR DESCRIPTION
## Summary
Add [redis-plus-plus](https://github.com/sewenew/redis-plus-plus) — C++ Redis client based on hiredis.

- Supports cluster, sentinel, pipelines, transactions, pub/sub
- Async interface via libuv
- Apache-2.0 license
- 1.5k+ GitHub stars

## Checklist
- [x] License file included
- [x] Recipe uses `recipe.yaml` (v1 format)
- [x] Tests check for header and library
- [x] Build works on linux-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)