### PR TITLE
Add jaeger-client-cpp v0.9.0

### DIFF
--- a/recipes/jaeger-client-cpp/conda-forge.yml
+++ b/recipes/jaeger-client-cpp/conda-forge.yml
@@ -1,4 +1,0 @@
-skip_render:
-  - .github/workflows
-win:
-  enabled: false

--- a/recipes/jaeger-client-cpp/conda-forge.yml
+++ b/recipes/jaeger-client-cpp/conda-forge.yml
@@ -1,0 +1,4 @@
+skip_render:
+  - .github/workflows
+win:
+  enabled: false

--- a/recipes/jaeger-client-cpp/recipe.yaml
+++ b/recipes/jaeger-client-cpp/recipe.yaml
@@ -10,42 +10,44 @@ source:
   sha256: 95c2a8249d930593776b9435cb8c5622511faeb2ec2d08df02bf1ec571a7dd40
 
 build:
-  skip:
-    - win
   number: 0
   script:
-    - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfig.cmake $PREFIX/lib/cmake/thrift/thriftConfig.cmake 2>/dev/null || true
-    - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfigVersion.cmake $PREFIX/lib/cmake/thrift/thriftConfigVersion.cmake 2>/dev/null || true
-    - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_BUILD_TYPE=Release -DHUNTER_ENABLED=OFF -DBUILD_TESTING=OFF -DJAEGERTRACING_BUILD_EXAMPLES=OFF -DJAEGERTRACING_BUILD_CROSSDOCK=OFF -DJAEGERTRACING_PLUGIN=OFF -DBUILD_SHARED_LIBS=ON -B build
-    - cmake --build build -j${CPU_COUNT}
-    - cmake --install build
-    - patchelf --add-needed libthrift.so $PREFIX/lib/libjaegertracing.so
+    - if: unix
+      then:
+        - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfig.cmake $PREFIX/lib/cmake/thrift/thriftConfig.cmake
+        - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfigVersion.cmake $PREFIX/lib/cmake/thrift/thriftConfigVersion.cmake
+        - cmake ${CMAKE_ARGS} -G Ninja -DCMAKE_BUILD_TYPE=Release -DHUNTER_ENABLED=OFF -DBUILD_TESTING=OFF -DJAEGERTRACING_BUILD_EXAMPLES=OFF -DJAEGERTRACING_BUILD_CROSSDOCK=OFF -DJAEGERTRACING_PLUGIN=OFF -DBUILD_SHARED_LIBS=ON -B build
+        - cmake --build build -j${CPU_COUNT}
+        - cmake --install build
+      else:
+        - copy /Y "%LIBRARY_LIB%\cmake\thrift\ThriftConfig.cmake" "%LIBRARY_LIB%\cmake\thrift\thriftConfig.cmake"
+        - copy /Y "%LIBRARY_LIB%\cmake\thrift\ThriftConfigVersion.cmake" "%LIBRARY_LIB%\cmake\thrift\thriftConfigVersion.cmake"
+        - cmake %CMAKE_ARGS% -G Ninja -DCMAKE_BUILD_TYPE=Release -DHUNTER_ENABLED=OFF -DBUILD_TESTING=OFF -DJAEGERTRACING_BUILD_EXAMPLES=OFF -DJAEGERTRACING_BUILD_CROSSDOCK=OFF -DJAEGERTRACING_PLUGIN=OFF -DBUILD_SHARED_LIBS=ON -B build
+        - cmake --build build -j%CPU_COUNT%
+        - cmake --install build
 
 requirements:
   build:
     - cmake
-    - make
+    - ninja
     - ${{ compiler('cxx') }}
     - ${{ stdlib('c') }}
-    - patchelf
   host:
-    - thrift-cpp
+    - libthrift
+    - thrift-compiler
     - opentracing-cpp
     - nlohmann_json
     - yaml-cpp
     - libboost-devel
-  run:
-    - thrift-cpp
-    - opentracing-cpp
-    - yaml-cpp
-    - libboost
+  run_exports:
+    - ${{ pin_subpackage('jaeger-client-cpp', upper_bound='x.x') }}
 
 tests:
   - package_contents:
       include:
         - jaegertracing/Tracer.h
       lib:
-        - libjaegertracing
+        - jaegertracing
 
 about:
   homepage: https://github.com/jaegertracing/jaeger-client-cpp
@@ -61,3 +63,4 @@ about:
 extra:
   recipe-maintainers:
     - amitsingh21
+    - wolfv

--- a/recipes/jaeger-client-cpp/recipe.yaml
+++ b/recipes/jaeger-client-cpp/recipe.yaml
@@ -24,6 +24,7 @@ requirements:
     - cmake
     - make
     - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
     - patchelf
   host:
     - thrift-cpp
@@ -54,3 +55,7 @@ about:
     OpenTracing API and reports spans to a Jaeger backend.
     Note: This project is deprecated in favor of OpenTelemetry.
   dev_url: https://github.com/jaegertracing/jaeger-client-cpp
+
+extra:
+  recipe-maintainers:
+    - amitsingh21

--- a/recipes/jaeger-client-cpp/recipe.yaml
+++ b/recipes/jaeger-client-cpp/recipe.yaml
@@ -54,7 +54,7 @@ about:
     C++ client library for Jaeger distributed tracing. Implements the
     OpenTracing API and reports spans to a Jaeger backend.
     Note: This project is deprecated in favor of OpenTelemetry.
-  dev_url: https://github.com/jaegertracing/jaeger-client-cpp
+  repository: https://github.com/jaegertracing/jaeger-client-cpp
 
 extra:
   recipe-maintainers:

--- a/recipes/jaeger-client-cpp/recipe.yaml
+++ b/recipes/jaeger-client-cpp/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  version: "0.9.0"
+
+package:
+  name: jaeger-client-cpp
+  version: ${{ version }}
+
+source:
+  url: https://github.com/jaegertracing/jaeger-client-cpp/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 95c2a8249d930593776b9435cb8c5622511faeb2ec2d08df02bf1ec571a7dd40
+
+build:
+  number: 0
+  script:
+    - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfig.cmake $PREFIX/lib/cmake/thrift/thriftConfig.cmake 2>/dev/null || true
+    - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfigVersion.cmake $PREFIX/lib/cmake/thrift/thriftConfigVersion.cmake 2>/dev/null || true
+    - cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX -DCMAKE_PREFIX_PATH=$PREFIX -DCMAKE_BUILD_TYPE=Release -DHUNTER_ENABLED=OFF -DBUILD_TESTING=OFF -DJAEGERTRACING_BUILD_EXAMPLES=OFF -DJAEGERTRACING_BUILD_CROSSDOCK=OFF -DJAEGERTRACING_PLUGIN=OFF -DBUILD_SHARED_LIBS=ON -B build
+    - cmake --build build -j${CPU_COUNT}
+    - cmake --install build
+    - patchelf --add-needed libthrift.so $PREFIX/lib/libjaegertracing.so
+
+requirements:
+  build:
+    - cmake
+    - make
+    - ${{ compiler('cxx') }}
+    - patchelf
+  host:
+    - thrift-cpp
+    - opentracing-cpp
+    - nlohmann_json
+    - yaml-cpp
+    - libboost-devel
+  run:
+    - thrift-cpp
+    - opentracing-cpp
+    - yaml-cpp
+    - libboost
+
+tests:
+  - package_contents:
+      include:
+        - jaegertracing/Tracer.h
+      lib:
+        - libjaegertracing
+
+about:
+  homepage: https://github.com/jaegertracing/jaeger-client-cpp
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Jaeger Bindings for C++ OpenTracing API
+  description: |
+    C++ client library for Jaeger distributed tracing. Implements the
+    OpenTracing API and reports spans to a Jaeger backend.
+    Note: This project is deprecated in favor of OpenTelemetry.
+  dev_url: https://github.com/jaegertracing/jaeger-client-cpp

--- a/recipes/jaeger-client-cpp/recipe.yaml
+++ b/recipes/jaeger-client-cpp/recipe.yaml
@@ -10,6 +10,8 @@ source:
   sha256: 95c2a8249d930593776b9435cb8c5622511faeb2ec2d08df02bf1ec571a7dd40
 
 build:
+  skip:
+    - win
   number: 0
   script:
     - ln -sf $PREFIX/lib/cmake/thrift/ThriftConfig.cmake $PREFIX/lib/cmake/thrift/thriftConfig.cmake 2>/dev/null || true


### PR DESCRIPTION
## Summary
Add [jaeger-client-cpp](https://github.com/jaegertracing/jaeger-client-cpp) — C++ client for Jaeger distributed tracing.

- Implements OpenTracing API
- Apache-2.0 license
- Includes `patchelf --add-needed libthrift.so` fix: the linker's `--as-needed` strips thrift from NEEDED because jaeger uses it only via RTTI/vtables, causing runtime symbol lookup failures
- Depends on `opentracing-cpp` (submitted in separate PR)
- Note: project is deprecated in favor of OpenTelemetry, but still widely used

## Checklist
- [x] License file included
- [x] Recipe uses `recipe.yaml` (v1 format)
- [x] Tests check for header and library
- [x] Build works on linux-64
- [ ] Depends on `opentracing-cpp` which is also being submitted (conda-forge/staged-recipes#32900)

🤖 Generated with [Claude Code](https://claude.com/claude-code)