### PR TITLE
Add recipe for pay-skill

### DIFF
--- a/recipes/pay-skill/meta.yaml
+++ b/recipes/pay-skill/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pay-skill" %}
-{% set version = "0.1.5" %}
+{% set version = "0.1.8" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/{{ name }}/pay_skill-{{ version }}.tar.gz
-  sha256: 716876cc96ad336378234dde27781351feaed769287a55a4cb68013d6ef9bd30
+  sha256: afadcd0bf1873b507dd43a01f73b58c0cf9cfa9ba0fa133917ccfb22c7ba4e0d
 
 build:
   noarch: python
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - hatchling
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - httpx >=0.27
     - pydantic >=2.0
     - eth-account >=0.11
@@ -29,6 +30,7 @@ test:
   imports:
     - payskill
   requires:
+    - python {{ python_min }}
     - pip
   commands:
     - pip check
@@ -47,4 +49,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - remit-md
+    - pay-skill

--- a/recipes/pay-skill/meta.yaml
+++ b/recipes/pay-skill/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pay-skill" %}
-{% set version = "0.1.8" %}
+{% set version = "0.1.9" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/{{ name }}/pay_skill-{{ version }}.tar.gz
-  sha256: afadcd0bf1873b507dd43a01f73b58c0cf9cfa9ba0fa133917ccfb22c7ba4e0d
+  sha256: b3a50c4a70e3235b2a2c6732ae7044eecdbc17b98d410784e22266566fa82615
 
 build:
   noarch: python

--- a/recipes/pay-skill/meta.yaml
+++ b/recipes/pay-skill/meta.yaml
@@ -1,0 +1,50 @@
+{% set name = "pay-skill" %}
+{% set version = "0.1.5" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/{{ name }}/pay_skill-{{ version }}.tar.gz
+  sha256: 716876cc96ad336378234dde27781351feaed769287a55a4cb68013d6ef9bd30
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - httpx >=0.27
+    - pydantic >=2.0
+    - eth-account >=0.11
+
+test:
+  imports:
+    - payskill
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://pay-skill.com
+  summary: Python SDK for pay - payment infrastructure for AI agents
+  description: |
+    Python SDK providing three core primitives for agent payments:
+    direct USDC transfers, pre-funded metered tabs, and HTTP 402 paywalls.
+    Built for the Base blockchain.
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/pay-skill/pay-sdk
+  doc_url: https://pay-skill.com/docs
+
+extra:
+  recipe-maintainers:
+    - remit-md


### PR DESCRIPTION
## Summary
- Add conda-forge recipe for `pay-skill`, the Python SDK for pay - payment infrastructure for AI agents
- Published on PyPI: https://pypi.org/project/pay-skill/0.1.5/
- Source: https://github.com/pay-skill/pay-sdk
- License: MIT
- noarch: python, requires Python >=3.10

## Checklist
- [x] Recipe follows conda-forge conventions
- [x] `noarch: python` since no compiled extensions
- [x] sha256 hash matches PyPI sdist
- [x] `pip check` in test section
- [x] License file included