### PR TITLE
Add recipe for himitsubako

### DIFF
--- a/recipes/himitsubako/recipe.yaml
+++ b/recipes/himitsubako/recipe.yaml
@@ -1,0 +1,77 @@
+# conda-forge recipe for himitsubako (v1 format, CEP 13).
+#
+# This recipe is the source of truth for the conda-forge/staged-recipes
+# PR (HMB-S025). After the feedstock is created, updates are managed by
+# conda-forge's auto-tick bot from PyPI releases.
+#
+# System prerequisites (not conda packages):
+#   sops >= 3.8  — https://github.com/getsops/sops
+#   age         — https://github.com/FiloSottile/age
+# These are required by the default SOPS+age backend but are not Python
+# packages and are not declared as conda dependencies.
+
+context:
+  name: himitsubako
+  version: "0.4.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/h/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 43866feb55d54799b033a98a7f6eb2bf31584abbe00852daed94c122b6310990
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - hmb = himitsubako.cli:main
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - hatchling
+  run:
+    - python >=3.12
+    - click >=8.1
+    - pydantic >=2.0,<3.0
+    - pyyaml >=6.0
+    - rich >=13.0
+    - structlog >=24.0
+
+tests:
+  - python:
+      imports:
+        - himitsubako
+        - himitsubako.backends
+        - himitsubako.backends.sops
+        - himitsubako.backends.env
+      pip_check: true
+  - script:
+      - hmb --version
+      - hmb --help
+
+about:
+  homepage: https://github.com/originalrgsec/himitsubako
+  documentation: https://originalrgsec.github.io/himitsubako/
+  repository: https://github.com/originalrgsec/himitsubako
+  license: MIT
+  license_file: LICENSE
+  summary: Multi-backend credential abstraction for solo Python developers
+  description: |
+    himitsubako provides a unified Python API and CLI for credential
+    management across multiple backends: SOPS+age (encrypted secrets in
+    git), macOS Keychain, Bitwarden CLI, environment variables, and
+    direnv. Optional pydantic-settings integration for declarative
+    credential loading.
+
+    Optional extras (install separately):
+      conda install keyring           # macOS Keychain backend
+      pip install pydantic-settings   # pydantic-settings source
+
+extra:
+  recipe-maintainers:
+    - originalrgsec


### PR DESCRIPTION
## Summary

Add a conda-forge recipe for [himitsubako](https://github.com/originalrgsec/himitsubako), a multi-backend credential abstraction library for solo Python developers.

- **PyPI**: [himitsubako 0.4.0](https://pypi.org/project/himitsubako/0.4.0/)
- **Docs**: [originalrgsec.github.io/himitsubako](https://originalrgsec.github.io/himitsubako/)
- **License**: MIT
- **Python**: >=3.12
- **noarch**: python (pure Python, no compiled extensions)

### Backends

himitsubako provides a unified API/CLI (`hmb`) for credential management across:
- SOPS + age (encrypted secrets in git; requires `sops` and `age` system binaries)
- macOS Keychain (via optional `keyring` extra)
- Bitwarden CLI (via system `bw` binary)
- Environment variables
- direnv integration
- pydantic-settings source (via optional `pydantic-settings` extra)

### Recipe notes

- Source is the PyPI sdist.
- Uses the v1 `recipe.yaml` format (CEP 13).
- Runtime deps: `click`, `pydantic`, `pyyaml`, `rich`, `structlog`.
- Optional extras (`keyring`, `pydantic-settings`) are not included in the base recipe; users install them separately.
- `sops` and `age` are system binaries, not Python packages, and are documented as prerequisites in the package docs.
- Test section verifies `import himitsubako`, `pip check`, and `hmb --version` / `hmb --help`.

### Checklist

- [x] Title of this PR is meaningful
- [x] This is a new package, not an update to an existing one
- [x] Source is from PyPI
- [x] License is open source (MIT)
- [x] Recipe uses v1 format