### PR TITLE
Add trnsci scientific-computing suite (7 packages)

### DIFF
--- a/recipes/trnblas/meta.yaml
+++ b/recipes/trnblas/meta.yaml
@@ -52,6 +52,12 @@ about:
     pip index — not on conda-forge.
 
     Part of the `trnsci` suite. See https://trnsci.dev/trnblas/ for docs.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/trnblas/meta.yaml
+++ b/recipes/trnblas/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "trnblas" %}
+{% set version = "0.4.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 173424ac24d5807dfc9fcf0744d04a822e0e61a2e9aec5129d370e33a8578a10
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+    - pytorch >=2.1
+    - numpy >=1.24
+
+test:
+  imports:
+    - trnblas
+    - trnblas.nki
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trnsci/trnblas
+  summary: BLAS operations for AWS Trainium via NKI
+  description: |
+    `trnblas` is the cuBLAS-equivalent for AWS Trainium. It provides Level 1
+    (axpy, dot, nrm2, scal, asum, iamax), Level 2 (gemv, symv, trmv, ger),
+    and Level 3 (gemm, batched_gemm, symm, syrk, trsm, trmm) BLAS operations
+    with an NKI dispatch layer for on-hardware acceleration on the Tensor
+    Engine.
+
+    The PyTorch fallback works on any hardware. On Neuron hardware, NKI
+    GEMM uses stationary tile reuse on the systolic array. The Neuron
+    runtime (`neuronxcc`, `torch-neuronx`) installs separately from AWS's
+    pip index — not on conda-forge.
+
+    Part of the `trnsci` suite. See https://trnsci.dev/trnblas/ for docs.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trnblas
+  doc_url: https://trnsci.dev/trnblas/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trnblas/meta.yaml
+++ b/recipes/trnblas/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trnblas" %}
+{% set python_min = "3.10" %}
 {% set version = "0.4.0" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pytorch >=2.1
     - numpy >=1.24
 
@@ -32,6 +33,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trnfft/meta.yaml
+++ b/recipes/trnfft/meta.yaml
@@ -52,6 +52,12 @@ about:
     pip index — not on conda-forge).
 
     Part of the `trnsci` suite. See https://trnsci.dev/trnfft/ for docs.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/trnfft/meta.yaml
+++ b/recipes/trnfft/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trnfft" %}
+{% set python_min = "3.10" %}
 {% set version = "0.7.0" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pytorch >=2.1
     - numpy >=1.24
 
@@ -33,6 +34,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trnfft/meta.yaml
+++ b/recipes/trnfft/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "trnfft" %}
+{% set version = "0.7.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: ac4c5732b747d807848e85e82433a1e7df047355a75d87b996a6e612af41f696
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+    - pytorch >=2.1
+    - numpy >=1.24
+
+test:
+  imports:
+    - trnfft
+    - trnfft.nn
+    - trnfft.nki
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trnsci/trnfft
+  summary: FFT and complex-valued tensor operations for AWS Trainium via NKI
+  description: |
+    `trnfft` is the cuFFT-equivalent for AWS Trainium. It provides FFT
+    (Cooley-Tukey + Bluestein), short-time Fourier transform (STFT),
+    split-real/imaginary complex tensors, and complex neural-network layers
+    (ComplexLinear, ComplexConv1d, ComplexBatchNorm1d, ComplexModReLU).
+
+    The PyTorch fallback works on any hardware. NKI kernels for butterfly
+    FFT and complex GEMM are scaffolded for on-hardware acceleration on
+    trn1 / trn2 instances (`pip install neuronxcc torch-neuronx` from AWS's
+    pip index — not on conda-forge).
+
+    Part of the `trnsci` suite. See https://trnsci.dev/trnfft/ for docs.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trnfft
+  doc_url: https://trnsci.dev/trnfft/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trnrand/meta.yaml
+++ b/recipes/trnrand/meta.yaml
@@ -51,6 +51,12 @@ about:
     runtime installs separately from AWS's pip index — not on conda-forge.
 
     Part of the `trnsci` suite. See https://trnsci.dev/trnrand/ for docs.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/trnrand/meta.yaml
+++ b/recipes/trnrand/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trnrand" %}
+{% set python_min = "3.10" %}
 {% set version = "0.1.0" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pytorch >=2.1
     - numpy >=1.24
 
@@ -32,6 +33,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trnrand/meta.yaml
+++ b/recipes/trnrand/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "trnrand" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1b4ec3c37520b514d67cec59c493b93372ede6958d6bc049f4f65ee477936c8d
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+    - pytorch >=2.1
+    - numpy >=1.24
+
+test:
+  imports:
+    - trnrand
+    - trnrand.nki
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trnsci/trnrand
+  summary: Random number generation for AWS Trainium via NKI
+  description: |
+    `trnrand` is the cuRAND-equivalent for AWS Trainium. It provides a
+    counter-based Philox 4x32 pseudo-random generator, standard distributions
+    (uniform, normal, exponential, bernoulli, etc.), and low-discrepancy
+    quasi-random sequences (Sobol, Halton, Latin hypercube) for Monte
+    Carlo and quasi-Monte Carlo integration.
+
+    The PyTorch fallback works on any hardware. On Neuron hardware, NKI
+    kernels run Philox and Box-Muller on the GpSimd engine. The Neuron
+    runtime installs separately from AWS's pip index — not on conda-forge.
+
+    Part of the `trnsci` suite. See https://trnsci.dev/trnrand/ for docs.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trnrand
+  doc_url: https://trnsci.dev/trnrand/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trnsci/meta.yaml
+++ b/recipes/trnsci/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "trnsci" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1c05eb4c8addd4fe230886ec76326a0811ea7597c75cbbdcb8b378be19114722
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+
+test:
+  imports:
+    - trnsci
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://trnsci.dev/
+  summary: Scientific computing suite for AWS Trainium via NKI — coordinating meta-package
+  description: |
+    `trnsci` is a meta-package that coordinates installation of the six
+    scientific-computing libraries in the `trnsci` suite for AWS Trainium:
+
+      - trnfft    (cuFFT-equivalent)
+      - trnblas   (cuBLAS-equivalent)
+      - trnrand   (cuRAND-equivalent)
+      - trnsolver (cuSOLVER-equivalent)
+      - trnsparse (cuSPARSE-equivalent)
+      - trntensor (cuTENSOR-equivalent)
+
+    Each library is published as a separate conda-forge package. `trnsci`
+    itself is a pure-Python meta-package with no runtime code — it exists
+    to give users a single name to reach for.
+
+    NKI acceleration depends on AWS's `neuronxcc` and `torch-neuronx`
+    packages, which are not distributed via conda-forge. Those install
+    separately from AWS's pip index on Neuron hardware. The PyTorch
+    fallback in every `trnsci` library works on any platform without
+    the Neuron runtime.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trnsci
+  doc_url: https://trnsci.dev/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trnsci/meta.yaml
+++ b/recipes/trnsci/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trnsci" %}
+{% set python_min = "3.10" %}
 {% set version = "0.1.0" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
 
 test:
   imports:
@@ -29,6 +30,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trnsci/meta.yaml
+++ b/recipes/trnsci/meta.yaml
@@ -56,6 +56,12 @@ about:
     separately from AWS's pip index on Neuron hardware. The PyTorch
     fallback in every `trnsci` library works on any platform without
     the Neuron runtime.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/trnsolver/meta.yaml
+++ b/recipes/trnsolver/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "trnsolver" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: c641c3e6458d0175f179f9a1a63da8f5a03d49772f6444f786a89cec08b9ba1c
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+    - pytorch >=2.1
+    - numpy >=1.24
+
+test:
+  imports:
+    - trnsolver
+    - trnsolver.nki
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trnsci/trnsolver
+  summary: Linear solvers and eigendecomposition for AWS Trainium via NKI
+  description: |
+    `trnsolver` is the cuSOLVER-equivalent for AWS Trainium. It provides
+    dense factorizations (Cholesky, LU, QR), symmetric and generalized
+    eigendecompositions (`eigh`, `eigh_generalized`) using a Jacobi-rotation
+    strategy that maps cleanly to the Trainium Tensor Engine, and iterative
+    Krylov solvers (CG, GMRES).
+
+    The PyTorch fallback works on any hardware. On Neuron hardware, NKI
+    Jacobi rotations run as rank-2 matmuls on the systolic array. The
+    Neuron runtime installs separately from AWS's pip index — not on
+    conda-forge.
+
+    Part of the `trnsci` suite. See https://trnsci.dev/trnsolver/ for docs.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trnsolver
+  doc_url: https://trnsci.dev/trnsolver/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trnsolver/meta.yaml
+++ b/recipes/trnsolver/meta.yaml
@@ -52,6 +52,12 @@ about:
     conda-forge.
 
     Part of the `trnsci` suite. See https://trnsci.dev/trnsolver/ for docs.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/trnsolver/meta.yaml
+++ b/recipes/trnsolver/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trnsolver" %}
+{% set python_min = "3.10" %}
 {% set version = "0.3.0" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pytorch >=2.1
     - numpy >=1.24
 
@@ -32,6 +33,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trnsparse/meta.yaml
+++ b/recipes/trnsparse/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trnsparse" %}
+{% set python_min = "3.10" %}
 {% set version = "0.1.1" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pytorch >=2.1
     - numpy >=1.24
 
@@ -32,6 +33,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trnsparse/meta.yaml
+++ b/recipes/trnsparse/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "trnsparse" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 26d58a161efc67a10bbf3f9357aa0c4befd9d22824149e3381003f606a3bd9d5
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+    - pytorch >=2.1
+    - numpy >=1.24
+
+test:
+  imports:
+    - trnsparse
+    - trnsparse.nki
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trnsci/trnsparse
+  summary: Sparse matrix operations for AWS Trainium via NKI
+  description: |
+    `trnsparse` is the cuSPARSE-equivalent for AWS Trainium. It provides
+    CSR and COO sparse matrix formats, sparse-dense matrix multiplication
+    (SpMV, SpMM), and Schwarz integral screening primitives for sparse
+    scientific computing — particularly quantum-chemistry Fock builds on
+    large basis sets.
+
+    The PyTorch fallback works on any hardware. On Neuron hardware, NKI
+    SpMM uses a gather-matmul-scatter pattern across the DMA engine and
+    Tensor Engine. The Neuron runtime installs separately from AWS's pip
+    index — not on conda-forge.
+
+    Part of the `trnsci` suite. See https://trnsci.dev/trnsparse/ for docs.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trnsparse
+  doc_url: https://trnsci.dev/trnsparse/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trnsparse/meta.yaml
+++ b/recipes/trnsparse/meta.yaml
@@ -52,6 +52,12 @@ about:
     index — not on conda-forge.
 
     Part of the `trnsci` suite. See https://trnsci.dev/trnsparse/ for docs.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE

--- a/recipes/trntensor/meta.yaml
+++ b/recipes/trntensor/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "trntensor" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f5ed259d81ea5bdd47daa30ec54abda4410ede5db83017653227c5ec2bbd0314
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >=3.10
+    - pytorch >=2.1
+    - numpy >=1.24
+
+test:
+  imports:
+    - trntensor
+    - trntensor.nki
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/trnsci/trntensor
+  summary: Tensor contractions and decompositions for AWS Trainium via NKI
+  description: |
+    `trntensor` is the cuTENSOR-equivalent for AWS Trainium. It provides
+    Einstein-summation contractions (`einsum`) with a dispatch planner that
+    selects matmul / bmm / generic paths, FLOPs estimation, and CP
+    (CANDECOMP/PARAFAC) and Tucker (HOSVD) decompositions for tensor
+    workloads such as density-fitted post-Hartree-Fock correlation methods
+    and tensor hypercontraction.
+
+    The PyTorch fallback works on any hardware. On Neuron hardware, NKI
+    fused-contraction kernels are scaffolded for on-hardware acceleration.
+    The Neuron runtime installs separately from AWS's pip index — not on
+    conda-forge.
+
+    Part of the `trnsci` suite. See https://trnsci.dev/trntensor/ for docs.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  dev_url: https://github.com/trnsci/trntensor
+  doc_url: https://trnsci.dev/trntensor/
+
+extra:
+  recipe-maintainers:
+    - scttfrdmn

--- a/recipes/trntensor/meta.yaml
+++ b/recipes/trntensor/meta.yaml
@@ -1,4 +1,5 @@
 {% set name = "trntensor" %}
+{% set python_min = "3.10" %}
 {% set version = "0.1.1" %}
 
 package:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=68.0
     - setuptools-scm >=8.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pytorch >=2.1
     - numpy >=1.24
 
@@ -32,6 +33,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/trntensor/meta.yaml
+++ b/recipes/trntensor/meta.yaml
@@ -53,6 +53,12 @@ about:
     conda-forge.
 
     Part of the `trnsci` suite. See https://trnsci.dev/trntensor/ for docs.
+
+    trnsci is an independent open-source project — not sponsored by, endorsed
+    by, or affiliated with Amazon, AWS, or Annapurna Labs. "Trainium",
+    "Neuron", and related names are trademarks of their respective owners.
+    See the project README for the full disclaimer.
+
   license: Apache-2.0
   license_family: APACHE
   license_file: LICENSE


### PR DESCRIPTION
# Adding the `trnsci` scientific-computing suite (7 packages)

This PR adds seven packages forming the **trnsci** scientific-computing suite for AWS Trainium.

## Suite summary

`trnsci` is a CUDA-library-equivalent stack for AWS Trainium via the Neuron Kernel Interface (NKI). Same shape as the NVIDIA cuFFT / cuBLAS / cuRAND / cuSOLVER / cuSPARSE / cuTENSOR stack, Python-first, Apache 2.0.

| Package | NVIDIA analog | Scope |
|---|---|---|
| `trnsci` | — | Coordinating meta-package (no runtime code) |
| `trnfft` | cuFFT | FFT, complex tensors, STFT, complex NN layers |
| `trnblas` | cuBLAS | BLAS Levels 1–3, batched GEMM |
| `trnrand` | cuRAND | Philox PRNG, Sobol / Halton QMC |
| `trnsolver` | cuSOLVER | Cholesky / LU / QR, Jacobi eigh, CG / GMRES |
| `trnsparse` | cuSPARSE | CSR / COO, SpMV / SpMM, Schwarz screening |
| `trntensor` | cuTENSOR | einsum with planning, CP / Tucker decomp |

All seven are pure-Python (`noarch: python`), already published to PyPI, already have tests and CI passing on CPU. Docs: https://trnsci.dev/. Source: https://github.com/trnsci.

## Why group-submit

These are sibling packages maintained together. Each release cycle bumps them in a coordinated way; `trnsci` (meta) depends on the other six. Grouping the PR avoids seven sequential round-trips and lets reviewers see the suite as a whole.

## Checklist

Per-recipe items are satisfied in each `meta.yaml`:

- [x] Title of the PR references what is being added
- [x] All seven recipes have `noarch: python` (pure Python)
- [x] `license_family` set to `APACHE`
- [x] `license_file` points at the bundled Apache 2.0 text
- [x] `run` requirements: `python >=3.10`, `pytorch >=2.1`, `numpy >=1.24`
- [x] `test.imports` covers the package and its `nki` submodule where present
- [x] `about.home`, `about.dev_url`, `about.doc_url` all filled
- [x] `extra.recipe-maintainers` set to the single maintainer (the author)

## Neuron runtime — out of scope for conda-forge

Each recipe's description notes that NKI acceleration depends on AWS's `neuronxcc` and `torch-neuronx` packages, which AWS distributes via their own pip index (not conda-forge, not PyPI proper). This mirrors the situation for CUDA-only libraries like early-days cupy on conda-forge — the Python surface is on conda-forge, the vendor runtime is installed separately.

All recipes declare only pure-Python / PyTorch deps. On non-Neuron hardware (any developer laptop), every library runs end-to-end via its PyTorch fallback. Neuron users `pip install neuronxcc torch-neuronx` from AWS's index inside the conda env; nothing in the conda recipe needs to change.

## Maintainer

Single maintainer (myself, `@scttfrdmn`) for all seven recipes. I'm the sole maintainer of the upstream suite and the author of every dist on PyPI. Happy to add co-maintainers as the community grows.

## Linting

`conda-smithy recipe-lint recipes/trn*` passes locally for all seven. I'll re-run against the PR build matrix and respond to any additional checks.
