### PR TITLE
Adding microssim: a metrics for microscopy images

### DIFF
--- a/recipes/microssim/meta.yaml
+++ b/recipes/microssim/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "microssim" %}
+{% set version = "0.0.3" %}
+{% set python_min = "3.11" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/microssim/microssim-${{ version }}.tar.gz
+  sha256: ad7817d76ca851b7b28d265eb7931756d64e308bcb9040b316006857d2d0b240
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - pip
+    - python {{ python_min }}
+    - hatchling
+    - hatch-vcs
+  run:
+    - python >={{ python_min }}
+    - numpy >=1.21,<3.0.0
+    - scipy <=1.17.0
+    - scikit-image <=0.26.0
+    - pytorch >=2.5,<=2.9.1
+    - torchmetrics <=1.8.2
+    - tqdm <=4.67.1
+
+test:
+  imports:
+    - microssim
+  commands:
+    - pip check
+  requires:
+    - python {{ python_min }}
+    - pip
+
+about:
+  home: https://careamics.github.io/microssim
+  summary: Improved structural similarity metrics for comparing microscopy data.
+  description: |
+    Microssim is a library aimed at providing improved structural similarity metrics for comparing microscopy data.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - jdeschamps

--- a/recipes/microssim/meta.yaml
+++ b/recipes/microssim/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/m/microssim/microssim-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/m/microssim/microssim-{{ version }}.tar.gz
   sha256: ad7817d76ca851b7b28d265eb7931756d64e308bcb9040b316006857d2d0b240
 
 build:


### PR DESCRIPTION
[MicroSSIM](https://pypi.org/project/microssim/) is an image metrics for microscopy data. It is also a dependency of CAREamics, which is currently blocking the updated of the [feedstock](https://github.com/conda-forge/careamics-feedstock).

<!--
@conda-forge/help-python
@conda-forge/help-python, ready for review!

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
