### PR TITLE
Add bernstein - multi-agent orchestrator for AI coding agents

### DIFF
--- a/recipes/bernstein/meta.yaml
+++ b/recipes/bernstein/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "bernstein" %}
+{% set version = "1.6.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6ad9ddf30a4c96f7f3a0f2089e382b2a13a6ede80588bcc74b6c6fbb943b5321
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - bernstein = bernstein.cli:main
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - hatchling
+  run:
+    - python >=3.12
+    - click >=8.0
+    - pydantic >=2.0
+    - fastapi >=0.100
+    - uvicorn
+    - httpx
+    - pyyaml
+    - rich
+
+test:
+  imports:
+    - bernstein
+  commands:
+    - bernstein --help
+
+about:
+  home: https://github.com/chernistry/bernstein
+  summary: Declarative agent orchestration for engineering teams
+  description: |
+    Bernstein orchestrates multiple AI coding agents working on your repo
+    in parallel. Each agent gets its own git worktree. A janitor verifies
+    tests pass before merging. Supports 29 CLI agents including Claude Code,
+    Codex, and Gemini CLI. Zero LLM tokens on coordination.
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  dev_url: https://github.com/chernistry/bernstein
+
+extra:
+  recipe-maintainers:
+    - chernistry

--- a/recipes/bernstein/meta.yaml
+++ b/recipes/bernstein/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "bernstein" %}
-{% set version = "1.6.10" %}
+{% set version = "1.6.11" %}
+{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,35 +8,56 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6ad9ddf30a4c96f7f3a0f2089e382b2a13a6ede80588bcc74b6c6fbb943b5321
+  sha256: 595c4c93fe837b6f5fdcb56c11ba5d501aac70f8753267ca090dc2e868c86f5f
 
 build:
   noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
-    - bernstein = bernstein.cli:main
+    - bernstein = bernstein.cli.main:cli
 
 requirements:
   host:
-    - python >=3.12
+    - python {{ python_min }}
     - pip
     - hatchling
   run:
-    - python >=3.12
-    - click >=8.0
-    - pydantic >=2.0
-    - fastapi >=0.100
-    - uvicorn
-    - httpx
-    - pyyaml
-    - rich
+    - python >={{ python_min }}
+    - click >=8.1
+    - cryptography >=45.0.0
+    - fastapi >=0.115
+    - httpx >=0.27
+    - mcp >=1.0
+    - openai >=2.29.0
+    - opentelemetry-api >=1.30.0
+    - opentelemetry-sdk >=1.30.0
+    - opentelemetry-exporter-otlp >=1.30.0
+    - pillow >=12.1.1
+    - pluggy >=1.5
+    - prometheus_client >=0.21
+    - pydantic-settings >=2.13.1
+    - pyfiglet >=1.0
+    - python-dotenv >=1.2.2
+    - pyyaml >=6.0
+    - rich >=13.0
+    - setproctitle >=1.3
+    - textual >=1.0
+    - terminaltexteffects >=0.11
+    - uvicorn >=0.30
+    - watchdog >=4.0
+    - websockets >=14.0
 
 test:
   imports:
     - bernstein
+    - bernstein.core
+    - bernstein.cli
+  requires:
+    - python {{ python_min }}
   commands:
     - bernstein --help
+    - bernstein --version
 
 about:
   home: https://github.com/chernistry/bernstein
@@ -43,12 +65,14 @@ about:
   description: |
     Bernstein orchestrates multiple AI coding agents working on your repo
     in parallel. Each agent gets its own git worktree. A janitor verifies
-    tests pass before merging. Supports 29 CLI agents including Claude Code,
-    Codex, and Gemini CLI. Zero LLM tokens on coordination.
+    tests pass before merging. Supports 18+ CLI agent adapters including
+    Claude Code, Codex, and Gemini CLI. Deterministic Python scheduling
+    with zero LLM tokens on coordination.
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   dev_url: https://github.com/chernistry/bernstein
+  doc_url: https://bernstein.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
## Description

[Bernstein](https://github.com/chernistry/bernstein) is a declarative multi-agent orchestrator for AI coding assistants. It spawns parallel agents (Claude Code, Codex, Gemini CLI, and 26 more), verifies output with tests, and commits clean code.

- **PyPI**: https://pypi.org/project/bernstein/ (1.6.10)
- **License**: Apache-2.0
- **Python**: >=3.12
- **Stars**: 105+
- **Tests**: 964 passing

## Checklist

- [x] License is open source (Apache-2.0)
- [x] Recipe builds `noarch: python`
- [x] Test section includes `imports` and `commands`
- [x] Recipe-maintainer listed