### PR TITLE
Add fracsim recipe v1.0.2

### DIFF
--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: "1.0.2"
+  python_min: "3.9"
+
+package:
+  name: fracsim
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - fracsim=fracsim.main:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - mmh3 >=4.0.0
+    - numpy >=1.21.0
+    - pytest >=7.0.0
+    - pytest-cov >=4.0.0
+
+tests:
+  - python:
+      imports:
+        - fracsim
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - fracsim --help
+
+about:
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/zhuyu534/FracSim.git
+
+extra:
+  recipe-maintainers:
+    - AddYourGitHubIdHere


### PR DESCRIPTION
Add fracsim recipe v1.0.2
fracsim is a lightweight, FracMinHash‑based command‑line tool for estimating genome similarity in bacteria. It computes Jaccard indices and ANI directly from FASTA/FASTQ files (including compressed ones) without external alignment tools.

PyPI page: https://pypi.org/project/FracSim/

GitHub repository: https://github.com/zhuyu534/FracSim

License: MIT

Author: Yu Zhu (@zhuyu534)

Recipe details:

Pure Python, noarch

Runtime dependencies: python >=3.8 and mmh3 >=4.0.0 only (no extra heavy libraries)

Added run_exports with max_pin="x.x" (semantic versioning)

Tested locally: conda build succeeds, fracsim --help works

Checklist:

Recipe uses noarch: python

All dependencies are correctly listed in host and run

run_exports is present to avoid ABI/CLI breakage

License file is included (LICENSE)

Commands are tested (fracsim --help)

I confirm I am willing to be listed as a maintainer

@conda-forge/help-python, ready for review!