### PR TITLE
Add fracsim recipe v1.0.2

### DIFF
--- a/recipes/fracsim/meta.yaml
+++ b/recipes/fracsim/meta.yaml
@@ -1,0 +1,48 @@
+{% set version = "1.0.2" %}
+{% set python_min = "3.9" %}
+
+package:
+  name: fracsim
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fracsim/fracsim-{{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  entry_points:
+    - fracsim=fracsim.main:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}.*
+    - pip
+  run:
+    - python >={{ python_min }}
+    - mmh3 >=4.0.0
+    - numpy >=1.21.0
+    - pytest >=7.0.0
+    - pytest-cov >=4.0.0
+
+test:
+  imports:
+    - fracsim
+  commands:
+    - pip check
+    - fracsim --help
+  requires:
+    - pip
+    - python {{ python_min }}.*
+
+about:
+  home: https://github.com/zhuyu534/FracSim.git
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - AddYourGitHubIdHere

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: "1.0.2"
+  python_min: "3.9"
+
+package:
+  name: fracsim
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - fracsim=fracsim.main:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - mmh3 >=4.0.0
+    - numpy >=1.21.0
+    - pytest >=7.0.0
+    - pytest-cov >=4.0.0
+
+tests:
+  - python:
+      imports:
+        - fracsim
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - fracsim --help
+
+about:
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/zhuyu534/FracSim.git
+
+extra:
+  recipe-maintainers:
+    - AddYourGitHubIdHere


### PR DESCRIPTION
This PR adds the recipe for fracsim (v1.0.2), a FracMinHash-based genome similarity estimator for bacteria.

PyPI page: https://pypi.org/project/FracSim/

GitHub repository: https://github.com/zhuyu534/FracSim

License: MIT

Author: Yu Zhu (@zhuyu534)

The package is a pure‑Python command‑line tool, depends on mmh3 only, and is already available on PyPI. 

Checks performed locally:

conda build recipes/fracsim succeeds

conda install --use-local fracsim works

fracsim --help runs without error

I confirm I am willing to be listed as a maintainer.

@conda-forge/help-python, ready for review!
