### PR TITLE
Add fracsim recipe v1.0.2

### DIFF
--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -9,7 +9,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  url: https://pypi.io/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
   sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
 
 build:
@@ -26,7 +26,6 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - setuptools
-    - mmh3 >=4.0.0
   run:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -31,13 +31,15 @@ requirements:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0
 
-test:
-  imports:
-    - fracsim
-  commands:
-    - fracsim --help
-  requires:
-    - pip
+tests:
+  - python:
+      imports:
+        - fracsim
+      python_version: ${{ python_min }}.*
+  - script: fracsim --help
+    requirements:
+      run:
+        - python ${{ python_min }}.*
 
 about:
   summary: a FracMinHash-based genome similarity estimator for bacteria
@@ -48,3 +50,4 @@ about:
 extra:
   recipe-maintainers:
     - zhuyu534
+    

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "1.0.2"
+  python_min: "3.8"
+
+package:
+  name: fracsim
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - fracsim = fracsim.main:main
+  run_exports:
+    - ${{ pin_subpackage('fracsim', max_pin='x.x') }}
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+    - mmh3 >=4.0.0
+  run:
+    - python >=${{ python_min }}
+    - mmh3 >=4.0.0
+
+test:
+  imports:
+    - fracsim
+  commands:
+    - fracsim --help
+  requires:
+    - pip
+
+about:
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/zhuyu534/FracSim
+
+extra:
+  recipe-maintainers:
+    - zhuyu534

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -26,6 +26,7 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - setuptools
+    - wheel
   run:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0
@@ -49,4 +50,6 @@ about:
 extra:
   recipe-maintainers:
     - zhuyu534
+
+
     


### PR DESCRIPTION
This PR adds the recipe for `fracsim` v1.0.2, a FracMinHash-based genome similarity estimator for bacteria.

**Note**: This package is already available on Bioconda . However, conda-forge requires a separate recipe submission. This recipe follows conda-forge best practices and includes:

- `noarch: python`
- `run_exports` with `max_pin='x.x'` (semantic versioning)
- Dependencies: `python >=3.8` and `mmh3 >=4.0.0` only (extra test dependencies removed)
- `setuptools` in `host` for build backend
- Tests: `import fracsim` and `fracsim --help`

I am the author and maintainer of `fracsim` and confirm willingness to be listed as a maintainer.

@conda-forge/help-python, ready for review!