### PR TITLE
Add fracsim recipe v1.0.2

### DIFF
--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -9,7 +9,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  url: https://pypi.io/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
   sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
 
 build:
@@ -26,7 +26,6 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - setuptools
-    - mmh3 >=4.0.0
   run:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -31,13 +31,15 @@ requirements:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0
 
-test:
-  imports:
-    - fracsim
-  commands:
-    - fracsim --help
-  requires:
-    - pip
+tests:
+  - python:
+      imports:
+        - fracsim
+      python_version: ${{ python_min }}.*
+  - script: fracsim --help
+    requirements:
+      run:
+        - python ${{ python_min }}.*
 
 about:
   summary: a FracMinHash-based genome similarity estimator for bacteria
@@ -48,3 +50,4 @@ about:
 extra:
   recipe-maintainers:
     - zhuyu534
+    

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -15,6 +15,7 @@ source:
 build:
   number: 0
   noarch: python
+  skip: true
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "1.0.2"
+  python_min: "3.8"
+
+package:
+  name: fracsim
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - fracsim = fracsim.main:main
+  run_exports:
+    - ${{ pin_subpackage('fracsim', max_pin='x.x') }}
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+    - mmh3 >=4.0.0
+  run:
+    - python >=${{ python_min }}
+    - mmh3 >=4.0.0
+
+test:
+  imports:
+    - fracsim
+  commands:
+    - fracsim --help
+  requires:
+    - pip
+
+about:
+  summary: a FracMinHash-based genome similarity estimator for bacteria
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/zhuyu534/FracSim
+
+extra:
+  recipe-maintainers:
+    - zhuyu534

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -26,6 +26,7 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - setuptools
+    - wheel
   run:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0
@@ -49,4 +50,6 @@ about:
 extra:
   recipe-maintainers:
     - zhuyu534
+
+
     

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -14,7 +14,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   skip: true
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -22,12 +22,12 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}.*
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=${{ python_min }}
+    - python 
     - mmh3 >=4.0.0
     - numpy >=1.21.0
     - pytest >=7.0.0

--- a/recipes/fracsim/recipe.yaml
+++ b/recipes/fracsim/recipe.yaml
@@ -9,17 +9,16 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.io/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/f/fracsim/fracsim-${{ version }}.tar.gz
   sha256: 9b44d02819095e6e5cf781072b8915f9f373a2d495412d7f57dfe83e4636ba85
 
 build:
   number: 0
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  entry_points:
-    - fracsim = fracsim.main:main
-  run_exports:
-    - ${{ pin_subpackage('fracsim', max_pin='x.x') }}
+  python:
+    entry_points:
+      - fracsim=fracsim.main:main
 
 requirements:
   host:
@@ -30,26 +29,27 @@ requirements:
   run:
     - python >=${{ python_min }}
     - mmh3 >=4.0.0
-
+    - numpy >=1.21.0
+    - pytest >=7.0.0
+    - pytest-cov >=4.0.0
 tests:
   - python:
       imports:
         - fracsim
+      pip_check: true
       python_version: ${{ python_min }}.*
-  - script: fracsim --help
-    requirements:
+  - requirements:
       run:
         - python ${{ python_min }}.*
+    script:
+      - fracsim --help
 
 about:
   summary: a FracMinHash-based genome similarity estimator for bacteria
   license: MIT
   license_file: LICENSE
-  homepage: https://github.com/zhuyu534/FracSim
+  homepage: https://github.com/zhuyu534/FracSim.git
 
 extra:
   recipe-maintainers:
     - zhuyu534
-
-
-    


### PR DESCRIPTION
This PR adds the recipe for `fracsim` v1.0.2, a FracMinHash-based genome similarity estimator for bacteria.

- PyPI: https://pypi.org/project/FracSim/
- GitHub: https://github.com/zhuyu534/FracSim
- License: MIT

Recipe follows conda-forge best practices:
- `run_exports` added
- Dependencies: `python >=3.8` and `mmh3 >=4.0.0`
- `setuptools` and `wheel` in `host` for build backend
- Tests include `import fracsim` and `fracsim --help`

I am the author and maintainer and confirm willingness to be listed.

@conda-forge/help-python, ready for review!