### PR TITLE
mars-earth 1.0.3

### DIFF
--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "mars-earth" %}
+{% set version = "1.0.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: d0ab7a96673f668b639aac36e621c76040f4a17990aaa02445eaa05e520922b7
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=61
+  run:
+    - python >=3.9
+    - numpy >=1.20.0
+    - scikit-learn >=1.0.0
+    - matplotlib >=3.4.0
+
+test:
+  imports:
+    - pymars
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "import pymars; model = pymars.Earth(); print('mars-earth import OK')"
+
+about:
+  home: https://github.com/edithatogo/mars
+  summary: A Pure Python Implementation of Multivariate Adaptive Regression Splines
+  description: |
+    mars-earth is a pure Python implementation of Multivariate Adaptive
+    Regression Splines (MARS), inspired by the popular py-earth library.
+    It provides an easy-to-install, scikit-learn compatible version of the
+    MARS algorithm without C/Cython dependencies.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://edithatogo.github.io/mars/
+  dev_url: https://github.com/edithatogo/mars
+
+extra:
+  recipe-maintainers:
+    - edithatogo

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -10,7 +10,6 @@ source:
   sha256: d0ab7a96673f668b639aac36e621c76040f4a17990aaa02445eaa05e520922b7
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -15,14 +15,14 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python
     - pip
     - setuptools >=61
   run:
-    - python >=3.9
+    - python
     - numpy >=1.20.0
     - scikit-learn >=1.0.0
-    - matplotlib >=3.4.0
+    - matplotlib-base >=3.4.0
 
 test:
   imports:

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -49,3 +49,5 @@ about:
 extra:
   recipe-maintainers:
     - edithatogo
+
+


### PR DESCRIPTION
New release of [mars-earth 1.0.3](https://pypi.org/project/mars-earth/1.0.3/).

- PyPI: https://pypi.org/project/mars-earth/
- GitHub: https://github.com/edithatogo/mars

Auto-generated by CI.