### PR TITLE
Add recipe for choice-learn

### DIFF
--- a/recipes/choice-learn/recipe.yaml
+++ b/recipes/choice-learn/recipe.yaml
@@ -33,7 +33,9 @@ tests:
       imports:
         - choice_learn
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/artefactory/choice-learn

--- a/recipes/choice-learn/recipe.yaml
+++ b/recipes/choice-learn/recipe.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   noarch: python
+  skip:
+    - win
   script: python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipes/choice-learn/recipe.yaml
+++ b/recipes/choice-learn/recipe.yaml
@@ -1,0 +1,52 @@
+context:
+  version: "1.3.1"
+
+package:
+  name: choice-learn
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/choice-learn/choice_learn-${{ version }}.tar.gz
+  sha256: ce50efde24a911365fd5081d3bd6b274753fff06b201e229589c740cec0eb830
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - poetry-core
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.24
+    - pandas >=1.5.3
+    - tensorflow >=2.14,<2.17.0
+    - tensorflow-probability >=0.22
+    - tqdm >=4.0.0
+    - tf-keras <3
+
+tests:
+  - python:
+      imports:
+        - choice_learn
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/artefactory/choice-learn
+  summary: Large-scale choice modeling through the lens of machine learning
+  description: |
+    choice-learn is a Python library for large-scale choice modeling,
+    providing tools for discrete choice models and assortment optimization
+    using machine learning approaches.
+  license: MIT
+  license_file: LICENSE.md
+  documentation: https://artefactory.github.io/choice-learn
+  repository: https://github.com/artefactory/choice-learn
+
+extra:
+  recipe-maintainers:
+    - DelongChenQC

--- a/recipes/choice-learn/recipe.yaml
+++ b/recipes/choice-learn/recipe.yaml
@@ -12,8 +12,6 @@ source:
 build:
   number: 0
   noarch: python
-  skip:
-    - win
   script: python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:


### PR DESCRIPTION
## Summary
- Adds a new conda-forge recipe for [choice-learn](https://github.com/artefactory/choice-learn) v1.3.1
- choice-learn is a Python library for large-scale choice modeling through the lens of machine learning
- Pure Python package (`noarch: python`) using `poetry-core` build backend
- Core dependencies: numpy, pandas, tensorflow (>=2.14,<2.17.0), tensorflow-probability, tqdm, tf-keras

## Checklist
- [x] Recipe uses v1 format (`recipe.yaml`)
- [x] Source is from PyPI with SHA256 checksum
- [x] License is MIT with `LICENSE.md` included
- [x] Tests include Python import and pip check
- [x] Build backend matches `pyproject.toml` (`poetry-core`)
- [x] All dependencies available on conda-forge
- [x] Local build tested successfully with `rattler-build`