### PR TITLE
mars-earth 1.0.4

### DIFF
--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "mars-earth" %}
+{% set version = "1.0.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/{{ name }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 0755aa79c879e06bb83d5e2811435c20e4f81623e1ddd8451b528cd8fe6d7972
+
+build:
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools >=61
+  run:
+    - python
+    - numpy >=1.20.0
+    - scikit-learn >=1.0.0
+    - matplotlib-base >=3.4.0
+
+test:
+  imports:
+    - pymars
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "import pymars; model = pymars.Earth(); print('mars-earth import OK')"
+
+about:
+  home: https://github.com/edithatogo/mars
+  summary: A Pure Python Implementation of Multivariate Adaptive Regression Splines
+  description: |
+    mars-earth is a pure Python implementation of Multivariate Adaptive
+    Regression Splines (MARS), inspired by the popular py-earth library.
+    It provides an easy-to-install, scikit-learn compatible version of the
+    MARS algorithm without C/Cython dependencies.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://edithatogo.github.io/mars/
+  dev_url: https://github.com/edithatogo/mars
+
+extra:
+  recipe-maintainers:
+    - edithatogo


### PR DESCRIPTION
New release of [mars-earth 1.0.4](https://pypi.org/project/mars-earth/1.0.4/).

- PyPI: https://pypi.org/project/mars-earth/
- GitHub: https://github.com/edithatogo/mars

Auto-generated manually.