### PR TITLE
Add granted recipe

### DIFF
--- a/recipes/granted/recipe.yaml
+++ b/recipes/granted/recipe.yaml
@@ -1,0 +1,78 @@
+context:
+  version: "0.39.0"
+
+package:
+  name: granted
+  version: ${{ version }}
+
+source:
+  url: https://github.com/fwdcloudsec/granted/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 6f9a4b38ffac2da32d7f6c5d225aca2f799d1f74aadd3783a873ff5d98b94144
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save ./cmd/granted --save_path ../library_licenses
+    - if: unix
+      then:
+        - go build -v -o $PREFIX/bin/granted -ldflags="-s -w -X github.com/fwdcloudsec/granted/internal/build.Version=${{ version }}" ./cmd/granted
+        - ln -sf granted $PREFIX/bin/assumego
+        - cp scripts/assume $PREFIX/bin/assume
+        - cp scripts/assume.fish $PREFIX/bin/assume.fish
+        - cp scripts/assume.tcsh $PREFIX/bin/assume.tcsh
+        - chmod +x $PREFIX/bin/assume $PREFIX/bin/assume.fish $PREFIX/bin/assume.tcsh
+      else:
+        - go build -v -o %LIBRARY_BIN%\granted.exe -ldflags="-s -X github.com/fwdcloudsec/granted/internal/build.Version=${{ version }}" .\cmd\granted
+        - copy %LIBRARY_BIN%\granted.exe %LIBRARY_BIN%\assumego.exe
+        - copy scripts\assume.bat %LIBRARY_BIN%\assume.bat
+        - copy scripts\assume.ps1 %LIBRARY_BIN%\assume.ps1
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+
+tests:
+  - script:
+      - granted --help
+      - granted --version
+      - if: unix
+        then:
+          - granted --version | grep ${{ version }}
+  - package_contents:
+      bin:
+        - granted
+        - assumego
+        - if: unix
+          then:
+            - assume
+            - assume.fish
+            - assume.tcsh
+          else:
+            - assume.bat
+            - assume.ps1
+      strict: true
+
+about:
+  homepage: https://granted.dev
+  summary: The easiest way to access your cloud.
+  description: |
+    Granted is a command line interface (CLI) application which simplifies
+    access to cloud roles and allows multiple cloud accounts to be opened
+    in your web browser simultaneously. Granted provides a fast experience
+    around finding and assuming AWS roles, leverages native browser
+    functionality to allow multiple accounts to be accessed at once, and
+    encrypts cached credentials to avoid plaintext SSO tokens being saved
+    on disk.
+  license: MIT
+  license_file:
+    - src/LICENCE
+    - library_licenses/
+  documentation: https://docs.commonfate.io/granted/getting-started
+  repository: https://github.com/fwdcloudsec/granted
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds a recipe for [granted](https://github.com/fwdcloudsec/granted), a CLI that simplifies access to AWS cloud roles and allows multiple cloud accounts to be opened in the browser simultaneously.

The binary dispatches behavior based on `argv[0]` (`granted` vs `assumego`), so the recipe installs the `granted` binary plus an `assumego` symlink, together with the shell wrapper scripts (`assume`, `assume.fish`, `assume.tcsh`, `assume.bat`, `assume.ps1`) that set AWS credentials in the parent shell.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.