### PR TITLE
Add mpc-designation

### DIFF
--- a/recipes/mpc-designation/meta.yaml
+++ b/recipes/mpc-designation/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "mpc-designation" %}
 {% set version = "1.0.1" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -18,17 +19,18 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools >=61
   run:
-    - python >=3.9
+    - python >={{ python_min }}
 
 test:
   imports:
     - mpc_designation
     - mpc_designation.batch
   requires:
+    - python {{ python_min }}
     - pip
   commands:
     - pip check

--- a/recipes/mpc-designation/meta.yaml
+++ b/recipes/mpc-designation/meta.yaml
@@ -1,0 +1,72 @@
+{% set name = "mpc-designation" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mpc_designation-{{ version }}.tar.gz
+  sha256: 80a77382de5d0b1b439cb416116f4c4551ebabc70e889fae01bd1cfe2be71319
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - mpc-designation = mpc_designation.mpc_designation:main
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=61
+  run:
+    - python >=3.9
+
+test:
+  imports:
+    - mpc_designation
+    - mpc_designation.batch
+  requires:
+    - pip
+  commands:
+    - pip check
+    - mpc-designation --help
+    - mpc-designation "1995 XA"
+    - python -c "from mpc_designation import convert_simple; assert convert_simple('1995 XA') == 'J95X00A'"
+    - python -c "from mpc_designation import convert_simple; assert convert_simple('J95X00A') == '1995 XA'"
+    - python -c "from mpc_designation import convert_simple; assert convert_simple('S/2024 S 1') == 'SK24S010'"
+
+about:
+  home: https://github.com/rlseaman/MPC_designations
+  summary: Convert between packed and unpacked MPC (Minor Planet Center) designations
+  description: |
+    A Python library and CLI for converting between the packed and unpacked
+    designation formats used by the IAU Minor Planet Center for asteroids,
+    comets, and natural satellites.
+
+    Supports the full MPC designation grammar:
+
+      * Numbered asteroids across all three encoding tiers (1 to 15,396,335)
+      * Provisional asteroids, including pre-1925 A-prefix designations and
+        extended cycle counts (cycle >= 620)
+      * Survey designations (PLS, T-1, T-2, T-3)
+      * Numbered and provisional comets, including 1- and 2-letter fragments
+      * Ancient comets and BCE designations
+      * Provisional natural satellites (S/YYYY P n) for Jupiter, Saturn,
+        Uranus, and Neptune
+
+    The same grammar is implemented identically in 25 programming languages
+    as a cross-language reference corpus; this Python distribution is the
+    authoritative Python implementation. All implementations pass the same
+    2,022,404-entry test corpus.
+  license: CC0-1.0
+  license_family: PUBLIC-DOMAIN
+  license_file: LICENSE
+  doc_url: https://github.com/rlseaman/MPC_designations#readme
+  dev_url: https://github.com/rlseaman/MPC_designations
+
+extra:
+  recipe-maintainers:
+    - rlseaman

--- a/recipes/mpc-designation/meta.yaml
+++ b/recipes/mpc-designation/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mpc-designation" %}
-{% set version = "1.0.1" %}
+{% set version = "1.1.0" %}
 {% set python_min = "3.9" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/mpc_designation-{{ version }}.tar.gz
-  sha256: 80a77382de5d0b1b439cb416116f4c4551ebabc70e889fae01bd1cfe2be71319
+  sha256: 56ecba838ae6ebdac5a0f94455a2eb633f202652d16a65fe3ce7821e14944fd3
 
 build:
   number: 0


### PR DESCRIPTION
This is a pure-Python noarch package: a Python library and CLI for converting between the packed and unpacked designation formats used by the IAU Minor Planet Center for asteroids, comets, and natural satellites.

- PyPI: https://pypi.org/project/mpc-designation/
- Upstream repo: https://github.com/rlseaman/MPC_designations
- License: CC0-1.0 (explicit public-domain dedication)
- No runtime dependencies; no compiled extensions.

The package is part of a 25-language interoperability corpus; this is the authoritative Python implementation. All implementations pass the same 2,022,404-entry test corpus.

Recipe checklist:

- [x] Title prefix with "Add" is consistent with conda-forge convention.
- [x] `noarch: python` — no compiled code.
- [x] SHA256 of the PyPI sdist is pinned.
- [x] Tests cover `pip check`, the CLI entry point, and end-to-end conversion assertions.
- [x] License file (`LICENSE`) is present in the sdist.