### PR TITLE
Add gravel-fragility

### DIFF
--- a/recipes/gravel-fragility/meta.yaml
+++ b/recipes/gravel-fragility/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "gravel-fragility" %}
-{% set version = "2.2.1" %}
+{% set version = "2.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/rhoekstr/gravel/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: e42d64530605c4312ddb24b084545d0f699f10302ef9f357116c60201a4b3e40
+  sha256: b772d942d4e9216baa6c171a255fb2d0f1cf0de67640cf0c6e78404cce72af97
   patches:
     # Upstream v2.2.1 uses FIND_PACKAGE_ARGS on nlohmann_json, Catch2,
     # Eigen3, and Spectra — all four are found as conda-forge host deps

--- a/recipes/gravel-fragility/meta.yaml
+++ b/recipes/gravel-fragility/meta.yaml
@@ -1,0 +1,110 @@
+{% set name = "gravel-fragility" %}
+{% set version = "2.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/rhoekstr/gravel/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: e42d64530605c4312ddb24b084545d0f699f10302ef9f357116c60201a4b3e40
+  patches:
+    # Upstream v2.2.1 uses FIND_PACKAGE_ARGS on nlohmann_json, Catch2,
+    # Eigen3, and Spectra — all four are found as conda-forge host deps
+    # and used directly without a git-clone. pybind11 is the exception:
+    # upstream kept it on FetchContent-only because FIND_PACKAGE_ARGS
+    # caused a -flto flag mangling bug on the PyPI wheel build path
+    # (scikit-build-core's isolated pybind11). conda-forge doesn't have
+    # that toolchain interaction, and conda-forge blocks network at
+    # build time, so this patch swaps the remaining FetchContent to
+    # find_package for pybind11 only.
+    - patches/01-pybind11-find-package.patch
+
+build:
+  number: 0
+  # -C cmake.define.GRAVEL_USE_OSMIUM=ON: override the pyproject default
+  # (OFF for PyPI, because libosmium isn't distributed there) so this
+  # build enables OSM loaders using the conda-forge libosmium package.
+  # --no-build-isolation: use the conda-forge-provided build deps
+  # (scikit-build-core, pybind11, cmake) rather than pip pulling from PyPI.
+  # --no-deps: run-time deps are declared below; do not let pip install them.
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps -C cmake.define.GRAVEL_USE_OSMIUM=ON
+  skip: true  # [py<310]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.24
+    - ninja
+    - make  # [unix]
+
+  host:
+    - python
+    - pip
+    - scikit-build-core >=0.8
+    - pybind11 >=2.11
+    # C++ deps — all of these are available on conda-forge; our
+    # FIND_PACKAGE_ARGS in cmake/Dependencies.cmake makes CMake use
+    # them instead of git-cloning, so conda-forge's network-blocked
+    # build sandbox succeeds without patches.
+    - eigen >=3.4
+    - nlohmann_json >=3.11
+    - spectra-cpp >=1.0
+    # libosmium ecosystem — available on conda-forge, unlike PyPI.
+    # This is the headline reason to ship on conda-forge: OSM loaders
+    # (load_osm_graph, OSMConfig, SpeedProfile) just work out of the box.
+    - libosmium >=2.20
+    - protozero
+    - zlib
+    - bzip2
+    - expat
+    - lz4-c
+
+  run:
+    - python
+    # numpy isn't strictly required (the library is pure C++ bindings),
+    # but users reasonably expect to pass numpy arrays to some analyzers.
+    - numpy
+
+test:
+  imports:
+    - gravel
+  commands:
+    # Basic import + version
+    - python -c "import gravel; print('v' + gravel.__version__)"
+    # Core graph construction + CH build (exercises gravel-core + gravel-ch)
+    - python -c "import gravel; g = gravel.make_grid_graph(10, 10); ch = gravel.build_ch(g); assert g.node_count == 100"
+    # Route a path (exercises gravel-ch query path)
+    - python -c "import gravel; g = gravel.make_grid_graph(10, 10); ch = gravel.build_ch(g); q = gravel.CHQuery(ch); r = q.route(0, 99); assert r.distance > 0"
+    # OSM loader is present (unlike PyPI wheels) — imports shouldn't
+    # fail because GRAVEL_HAS_OSMIUM should be defined on conda-forge builds.
+    - python -c "import gravel; assert hasattr(gravel, 'load_osm_graph'), 'OSM loaders missing (libosmium not linked?)'"
+
+about:
+  home: https://github.com/rhoekstr/gravel
+  summary: Fast road network fragility analysis with contraction hierarchies
+  description: |
+    Gravel is a high-performance C++ library with Python bindings for
+    analyzing how vulnerable road networks are to edge failures. Given a
+    graph, it answers questions like "how isolated does this location
+    become when 10% of its roads fail?" or "which counties are most
+    dependent on a single critical route?"
+
+    Built around contraction hierarchies for fast shortest-path queries
+    and a Dijkstra + incremental-SSSP pipeline for edge-removal
+    analysis. On a 200K-node county road graph, it computes isolation
+    fragility in ~2 seconds.
+
+    The conda-forge build enables full OSM support (load_osm_graph,
+    OSMConfig, SpeedProfile) via libosmium; the PyPI wheels disable
+    this because libosmium is not distributed on PyPI.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  doc_url: https://rhoekstr.github.io/gravel/
+  dev_url: https://github.com/rhoekstr/gravel
+
+extra:
+  recipe-maintainers:
+    - rhoekstr

--- a/recipes/gravel-fragility/patches/01-pybind11-find-package.patch
+++ b/recipes/gravel-fragility/patches/01-pybind11-find-package.patch
@@ -1,0 +1,32 @@
+--- a/cmake/Dependencies.cmake	2026-04-20 07:05:59
++++ b/cmake/Dependencies.cmake	2026-04-20 07:05:59
+@@ -98,21 +98,13 @@
+     find_package(Parquet REQUIRED)
+ endif()
+ 
+-# pybind11
+-#
+-# No FIND_PACKAGE_ARGS here either. scikit-build-core pip-installs
+-# pybind11 into an isolated build env when we build a wheel, and
+-# exposes its CMake dir. If find_package(pybind11) takes over via
+-# FIND_PACKAGE_ARGS, pybind11's CMake config injects LTO flags that
+-# get mangled by the outer build toolchain on macOS Python 3.10-3.13
+-# wheel builds (observed: "unsupported argument '' to option '-flto='").
+-# FetchContent git-clone of pybind11's small repo is fast and reliable
+-# on every platform we ship to.
++# pybind11 - conda-forge provides it, use find_package directly.
++# Upstream v2.2.1 intentionally uses FetchContent for pybind11 because
++# FIND_PACKAGE_ARGS caused -flto flag mangling on PyPI wheel builds
++# (where scikit-build-core's pip-installed pybind11 is picked up). On
++# conda-forge the pybind11 package is a proper conda install and does
++# not have that toolchain interaction problem, so find_package is safe
++# and required (conda-forge blocks network at build time).
+ if(GRAVEL_BUILD_PYTHON)
+-    FetchContent_Declare(pybind11
+-        GIT_REPOSITORY https://github.com/pybind/pybind11.git
+-        GIT_TAG        v2.12.0
+-        GIT_SHALLOW    TRUE
+-    )
+-    FetchContent_MakeAvailable(pybind11)
++    find_package(pybind11 2.10 CONFIG REQUIRED)
+ endif()


### PR DESCRIPTION
## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/de5b6abbcb37478f2ed1c7ae54ca1c2c6ad1df83/recipes/example/meta.yaml#L51-L54) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the licenses of these are packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

## About the package

**gravel-fragility** is a C++20 library with Python bindings for **road network fragility analysis** — computing how isolated a location (or region) becomes when some fraction of its roads fail. Target users: transportation researchers, GIS analysts, disaster-resilience planners.

- **Upstream**: https://github.com/rhoekstr/gravel
- **PyPI**: https://pypi.org/p/gravel-fragility (v2.2.1 shipped today)
- **Docs**: https://rhoekstr.github.io/gravel/
- **License**: Apache-2.0

### Why conda-forge

The conda-forge build additionally enables **OSM loaders** (`load_osm_graph`, `OSMConfig`, `SpeedProfile`) via the conda-forge `libosmium` package. PyPI wheels ship with OSM disabled because libosmium isn't distributed on PyPI — so for users who want to load OpenStreetMap road networks (the primary use case), conda-forge is the proper channel.

### Recipe notes

- Uses a single patch (`01-pybind11-find-package.patch`) to swap `pybind11` from FetchContent to `find_package` (required for the network-blocked conda-forge build sandbox). All other C++ deps in upstream (`nlohmann_json`, `Catch2`, `Eigen3`, `Spectra`) already have `FIND_PACKAGE_ARGS` in their `FetchContent_Declare` calls, so they resolve to the conda-forge host deps directly.
- `GRAVEL_USE_OSMIUM=ON` is set via `pip install ... -C cmake.define.GRAVEL_USE_OSMIUM=ON`.
- Minimum Python 3.10.
- Tested locally: recipe passes `conda-smithy recipe-lint`.

### I am the upstream maintainer

I am @rhoekstr, the author of gravel. Happy to be pinged for future version-bump PRs.