### PR TITLE
Add freestiler recipe

### DIFF
--- a/recipes/freestiler/meta.yaml
+++ b/recipes/freestiler/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "freestiler" %}
+{% set version = "0.1.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d308dd0f36568b7aa9dbc4891216df0f00fc8a65ddea3bb18ff9a74818b6d161
+
+build:
+  number: 0
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.8,<2
+  run:
+    - python
+    - geopandas >=0.14
+    - shapely >=2.0
+    - pyproj >=3.0
+    - numpy >=1.24
+
+test:
+  imports:
+    - freestiler
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://walker-data.com/freestiler/
+  summary: Rust-powered MLT/MVT vector tile engine for Python
+  description: |
+    freestiler is a Rust-powered vector tile engine exposed to Python via
+    PyO3. It converts GeoDataFrames, GeoParquet, and other spatial inputs into
+    PMTiles archives encoding MVT or MLT tiles, with optional clustering,
+    coalescing, and DuckDB-backed SQL preprocessing.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.md
+  dev_url: https://github.com/walkerke/freestiler
+  doc_url: https://walker-data.com/freestiler/articles/python.html
+
+extra:
+  recipe-maintainers:
+    - walkerke


### PR DESCRIPTION
## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package".
- [x] License file is packaged.
- [x] Source is from official source (PyPI sdist).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the licenses of the statically linked libraries are packaged.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.

## Summary

Adds a recipe for [freestiler](https://pypi.org/project/freestiler/), a Rust-powered MLT/MVT vector tile engine exposed to Python via pyo3 + maturin. It converts GeoDataFrames, GeoParquet, and DuckDB sources into PMTiles archives encoding MVT or MLT tiles.

- PyPI: https://pypi.org/project/freestiler/
- Source: https://github.com/walkerke/freestiler
- License: MIT

Not `noarch` — it is a compiled Rust extension, so conda-forge will produce per-platform builds. Default Cargo features (`geoparquet`, `duckdb`) build DuckDB from vendored C++ sources; happy to drop the `duckdb` feature in a follow-up if macOS/Windows runners time out.

Local \`conda-smithy recipe-lint --conda-forge recipes/freestiler\` reports "in fine form".