### PR TITLE
Add recipe for ag_ui_strands

### DIFF
--- a/recipes/ag_ui_strands/LICENSE
+++ b/recipes/ag_ui_strands/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/ag_ui_strands/recipe.yaml
+++ b/recipes/ag_ui_strands/recipe.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: ag_ui_strands
+  version: "0.1.7"
+  python_min: "3.12"
+
+package:
+  name: ${{ name | lower }}
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/14/28/e24ffb0931cd650d6b7e2dfca3b0c81b75c7b11bd5fa1fb0bf91a723ef64/ag_ui_strands-0.1.7.tar.gz
+  sha256: 1b95307dbb0fd909c5b1a388af7f0ea735f68810de21232594e3a43c338eae0e
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - ag-ui-protocol
+    - fastapi
+    - strands-agents
+
+tests:
+  - python:
+      imports:
+        - ag_ui_strands
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://pypi.org/project/ag_ui_strands/
+  license: MIT
+  license_file: LICENSE
+  summary: Implementation of the AG-UI protocol for Amazon Strands Agents.
+  dev_url: https://github.com/ag-ui-protocol/ag-ui/tree/main/integrations/strands-middleware/python
+
+extra:
+  recipe-maintainers:
+    - rxm7706


### PR DESCRIPTION
This PR adds a new recipe for `ag_ui_strands`.

### Pre-Submission Checklist
- [x] The recipe builds locally successfully.
- [x] The recipe passes all `conda-smithy recipe-lint` checks.
- [x] License and checksums are verified.

*Submitted automatically via local-recipes automation.*