### PR TITLE
CI: Add a CUDA 130 job to staged-recipes

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -111,3 +111,54 @@ jobs:
     displayName: Run docker build for CUDA 12.9
   - publish: build_artifacts/linux-64/
     artifact: conda_pkgs_linux_64_cuda129
+
+- job: linux_64_cuda_130
+  dependsOn: linux_64
+  condition: and(not(eq(variables['Build.SourceBranch'], 'refs/heads/main')), eq(dependencies.linux_64.outputs['linux_64_build.NEED_CUDA'], '1'))
+  pool:
+    vmImage: ubuntu-latest
+  timeoutInMinutes: 360
+  steps:
+  - script: |
+      sudo mkdir -p /opt/empty_dir
+      for d in \
+          /opt/ghc \
+          /opt/hostedtoolcache \
+          /usr/lib/jvm \
+          /usr/local/.ghcup \
+          /usr/local/android \
+          /usr/local/powershell \
+          /usr/share/dotnet \
+          /usr/share/swift \
+          ; do
+          sudo rsync --stats -a --delete /opt/empty_dir/ $d || true
+      done
+    displayName: Manage disk space
+
+  - script: |
+      sudo fallocate -l 10GiB /swapfile || true
+      sudo chmod 600 /swapfile || true
+      sudo mkswap /swapfile || true
+      sudo swapon /swapfile || true
+    displayName: Create swap file
+
+  - script: |
+      # sudo pip install --upgrade pip
+      sudo pip install setuptools shyaml
+    displayName: Install dependencies
+
+  - script: |
+      set -e
+
+      # make sure there is a package directory so that artifact publishing works
+      mkdir -p build_artifacts/linux-64/
+
+      export CI=azure
+      export CONFIG=linux64_cuda130
+      export DOCKER_IMAGE=quay.io/condaforge/linux-anvil-x86_64:alma9
+      export AZURE=True
+      .scripts/run_docker_build.sh
+
+    displayName: Run docker build for CUDA 13.0
+  - publish: build_artifacts/linux-64/
+    artifact: conda_pkgs_linux_64_cuda130


### PR DESCRIPTION
Demonstrated in https://github.com/conda-forge/staged-recipes/pull/33067

Adds a CUDA 130 CI job to staged recipes that runs on the same conditions that the CUDA 129 will run.