### PR TITLE
Add fargv recipe

### DIFF
--- a/recipes/fargv/meta.yaml
+++ b/recipes/fargv/meta.yaml
@@ -1,0 +1,42 @@
+{% set version = "1.3.2" %}
+
+package:
+  name: fargv
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fargv/fargv-{{ version }}.tar.gz
+  sha256: f0912b4b0c4a631cd05a125f2074476ddec6ded592dd2366b2ea0a5268451b8f
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+test:
+  imports:
+    - fargv
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://github.com/anguelos/fargv
+  summary: A very easy to use argument parser.
+  license: MIT
+  license_file: LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - anguelos


### PR DESCRIPTION
Adding fargv

A minimal, zero-dependency Python argument parser that infers types and short flags from a plain dict. Pure Python, noarch. Already on PyPI: https://pypi.org/project/fargv/

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [[here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73)](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged. (N/A - pure Python)
- [x] Package does not ship static libraries. If static libraries are needed, [[follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md)](https://github.com/conda-forge/cfep/blob/main/cfep-18.md). (N/A - pure Python)
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [[here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos)](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [[knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html)](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.