### PR TITLE
Add skyborn

### DIFF
--- a/recipes/skyborn/conda_build_config.yaml
+++ b/recipes/skyborn/conda_build_config.yaml
@@ -1,13 +1,17 @@
 c_compiler:
-  - m2w64_c  # [win]
-  - gcc  # [linux]
-  - clang  # [osx]
+  - gcc
 
 cxx_compiler:
-  - m2w64_cxx  # [win]
-  - gxx  # [linux]
-  - clangxx  # [osx]
+  - gxx
 
 fortran_compiler:
-  - m2w64_fortran  # [win]
-  - gfortran  # [unix]
+  - gfortran
+
+c_compiler_version:
+  - 15  # [win]
+
+cxx_compiler_version:
+  - 15  # [win]
+
+fortran_compiler_version:
+  - 15  # [win]

--- a/recipes/skyborn/conda_build_config.yaml
+++ b/recipes/skyborn/conda_build_config.yaml
@@ -1,0 +1,8 @@
+c_compiler:
+  - gcc
+
+cxx_compiler:
+  - gxx
+
+fortran_compiler:
+  - gfortran

--- a/recipes/skyborn/conda_build_config.yaml
+++ b/recipes/skyborn/conda_build_config.yaml
@@ -1,8 +1,12 @@
 c_compiler:
-  - gcc
+  - gcc      # [win]
+  - clang    # [osx]
+  - gcc      # [linux]
 
 cxx_compiler:
-  - gxx
+  - gxx      # [win]
+  - clangxx  # [osx]
+  - gxx      # [linux]
 
 fortran_compiler:
   - gfortran

--- a/recipes/skyborn/conda_build_config.yaml
+++ b/recipes/skyborn/conda_build_config.yaml
@@ -1,8 +1,13 @@
 c_compiler:
-  - gcc
+  - m2w64_c  # [win]
+  - gcc  # [linux]
+  - clang  # [osx]
 
 cxx_compiler:
-  - gxx
+  - m2w64_cxx  # [win]
+  - gxx  # [linux]
+  - clangxx  # [osx]
 
 fortran_compiler:
-  - gfortran
+  - m2w64_fortran  # [win]
+  - gfortran  # [unix]

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "skyborn" %}
+{% set version = "0.3.20" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/QianyeSu/Skyborn/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: f1d6b063283a50ae58181d6ac25627a0a25b685c782232d21be58edf424b7c95
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=61
+    - wheel
+    - numpy >=1.24
+    - cython >=3
+    - meson
+    - ninja
+  run:
+    - python >=3.9
+    - numpy
+    - pandas
+    - xarray
+    - matplotlib
+    - netcdf4
+    - metpy
+    - tqdm
+    - statsmodels
+    - scipy
+    - scikit-learn
+    - dask
+
+test:
+  requires:
+    - pip
+  imports:
+    - skyborn
+    - skyborn.calc
+    - skyborn.interp
+    - skyborn.spharm
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/QianyeSu/Skyborn
+  dev_url: https://github.com/QianyeSu/Skyborn
+  doc_url: https://skyborn.readthedocs.io/
+  summary: Atmospheric science research utilities
+  description: |
+    Skyborn is an atmospheric science research utilities package with Python,
+    Fortran, and Cython components for interpolation, spherical harmonics,
+    trend analysis, and related meteorological workflows.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - QianyeSu

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/814d7c55d0b0cafb5f8ad8303d8469361ba202b1.tar.gz
-  sha256: 6a7fdad205a9d79707ace084a6be7ed6aaa6f9cd602753e473f9e2009dc155a0
+  url: https://github.com/QianyeSu/Skyborn/archive/78dd1ecbdf86c6ede02895dd20e1b622b3f57d10.tar.gz
+  sha256: 1bf9a00e4cb54724e8197d487a53d1e8117f8d9a96c47d79973402b4b39e145b
 
 build:
   number: 0

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/78dd1ecbdf86c6ede02895dd20e1b622b3f57d10.tar.gz
-  sha256: 1bf9a00e4cb54724e8197d487a53d1e8117f8d9a96c47d79973402b4b39e145b
+  url: https://github.com/QianyeSu/Skyborn/archive/37beef8aabe99910ec297278998392a312657ba9.tar.gz
+  sha256: 08c482d7a7bf41807b63392992a4941621f5bd4880cf27e11b724beaa7077ce8
 
 build:
   number: 0

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/be554c65b34537cb7497e12b5795ca5729d9db70.tar.gz
-  sha256: a7a7efdeb857ff6f29bad353606fa06973294bf4288ef5cddc3e579690ccc008
+  url: https://github.com/QianyeSu/Skyborn/archive/1643ff6d7a1adec43809b96069787fa0a7f7b758.tar.gz
+  sha256: ae0b64d3d19f3c0a6e55f611e337d18e3e0ce50215a4600461b30aecfecdb8bc
 
 build:
   number: 0

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/c0de58574413bcad5b6b94206267799c623e4ece.tar.gz
-  sha256: 80b68874bd8dcbe81cd30deab40870d997a343461512bb8f5a51bb1d25a4a10d
+  url: https://github.com/QianyeSu/Skyborn/archive/d7f6aff9697f1203bbc0ee54aa34376100a061a9.tar.gz
+  sha256: 4c5456b86d708824a3373c91df82e9b639e5690a0079da49c9cfa03d409e9257
 
 build:
   number: 0

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -15,7 +15,8 @@ build:
 
 requirements:
   build:
-    - {{ stdlib('c') }}
+    - {{ stdlib('m2w64_c') }}  # [win]
+    - {{ stdlib('c') }}  # [not win]
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
   host:
@@ -27,6 +28,8 @@ requirements:
     - cython >=3
     - meson
     - ninja
+    - libgomp  # [linux]
+    - llvm-openmp  # [osx]
   run:
     - python
     - numpy

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -15,10 +15,11 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
   host:
-    - python >=3.9
+    - python
     - pip
     - setuptools >=61
     - wheel
@@ -27,11 +28,11 @@ requirements:
     - meson
     - ninja
   run:
-    - python >=3.9
+    - python
     - numpy
     - pandas
     - xarray
-    - matplotlib
+    - matplotlib-base
     - netcdf4
     - metpy
     - tqdm

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/440bba016ba9a4a87ae5f3221963e049b015fc8f.tar.gz
-  sha256: b49fee8e9d2cdc33df54ac87faf0d15425dfb2d6bb7d0df357d1d87af99c5c84
+  url: https://github.com/QianyeSu/Skyborn/archive/be554c65b34537cb7497e12b5795ca5729d9db70.tar.gz
+  sha256: a7a7efdeb857ff6f29bad353606fa06973294bf4288ef5cddc3e579690ccc008
 
 build:
   number: 0
@@ -42,6 +42,7 @@ requirements:
     - scipy
     - scikit-learn
     - dask
+    - libgomp  # [win]
 
 test:
   requires:

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/1643ff6d7a1adec43809b96069787fa0a7f7b758.tar.gz
-  sha256: ae0b64d3d19f3c0a6e55f611e337d18e3e0ce50215a4600461b30aecfecdb8bc
+  url: https://github.com/QianyeSu/Skyborn/archive/c0de58574413bcad5b6b94206267799c623e4ece.tar.gz
+  sha256: 80b68874bd8dcbe81cd30deab40870d997a343461512bb8f5a51bb1d25a4a10d
 
 build:
   number: 0

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: f1d6b063283a50ae58181d6ac25627a0a25b685c782232d21be58edf424b7c95
+  url: https://github.com/QianyeSu/Skyborn/archive/814d7c55d0b0cafb5f8ad8303d8469361ba202b1.tar.gz
+  sha256: 6a7fdad205a9d79707ace084a6be7ed6aaa6f9cd602753e473f9e2009dc155a0
 
 build:
   number: 0
@@ -15,8 +15,7 @@ build:
 
 requirements:
   build:
-    - {{ stdlib('m2w64_c') }}  # [win]
-    - {{ stdlib('c') }}  # [not win]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('fortran') }}
   host:

--- a/recipes/skyborn/meta.yaml
+++ b/recipes/skyborn/meta.yaml
@@ -6,8 +6,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/QianyeSu/Skyborn/archive/37beef8aabe99910ec297278998392a312657ba9.tar.gz
-  sha256: 08c482d7a7bf41807b63392992a4941621f5bd4880cf27e11b724beaa7077ce8
+  url: https://github.com/QianyeSu/Skyborn/archive/440bba016ba9a4a87ae5f3221963e049b015fc8f.tar.gz
+  sha256: b49fee8e9d2cdc33df54ac87faf0d15425dfb2d6bb7d0df357d1d87af99c5c84
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

- This PR adds `skyborn` as a new `conda-forge` package.
- Skyborn is an atmospheric-science utilities package with compiled Python,
  Fortran, and Cython extensions.
- The current submission targets version `0.3.20`.

## Upstream

- Home: https://github.com/QianyeSu/Skyborn
- Documentation: https://skyborn.readthedocs.io/
- Source used by this recipe:
  - `https://github.com/QianyeSu/Skyborn/archive/refs/tags/v0.3.20.tar.gz`

## Packaging Notes

- This package is not `noarch: python` because it builds compiled extensions.
- The recipe uses Meson + F2PY and keeps explicit C / Fortran compiler macros.
- Local validation was completed on Windows with the `conda-forge` GNU
  toolchain.

## Local Validation Snapshot

- `conda build recipe-local -c conda-forge`
- `conda build recipe-local --output -c conda-forge`
- `conda install --use-local skyborn=0.3.20`
- Import smoke checks passed for:
  - `skyborn`
  - `skyborn.calc`
  - `skyborn.interp`
  - `skyborn.spharm`

## Package Content Notes

- The packaging cleanup for this release removed development-only artifacts
  from the install payload, including:
  - `*.dll.a`
  - `*.pyf`
  - `meson.build`
  - `gridfill/_gridfill.pyx`

## Maintainer

- GitHub: `@QianyeSu`
