### PR TITLE
Add rustmatrix recipe

### DIFF
--- a/recipes/rustmatrix/meta.yaml
+++ b/recipes/rustmatrix/meta.yaml
@@ -1,0 +1,66 @@
+{% set name = "rustmatrix" %}
+{% set version = "2.1.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: daaf4feceb9b4a9ed90c459241aeed56fd1455c026a4d0ea534e3b92fba758a4
+
+build:
+  number: 0
+  skip: true  # [py<39]
+  script:
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2
+    - numpy
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+    - scipy >=1.10
+
+test:
+  imports:
+    - rustmatrix
+    - rustmatrix.spectra
+    - rustmatrix.spectra.beam
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/swnesbitt/rustmatrix
+  summary: Rust-backed T-matrix scattering for nonspherical particles
+  description: |
+    rustmatrix is a Rust-backed port of the numerical core of pytmatrix
+    for computing electromagnetic scattering from nonspherical
+    hydrometeors via the T-matrix method. It provides substantially
+    faster orientation averaging, parallel PSD integration, hydrometeor
+    mixtures (HydroMix), and a full Doppler + polarimetric spectra
+    engine (rustmatrix.spectra). A drop-in replacement for the numerical
+    core of pytmatrix, with APIs mirrored wherever the underlying
+    physics matches.
+  license: MIT
+  license_family: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  doc_url: https://rustmatrix.readthedocs.io
+  dev_url: https://github.com/swnesbitt/rustmatrix
+
+extra:
+  recipe-maintainers:
+    - swnesbitt

--- a/recipes/rustmatrix/meta.yaml
+++ b/recipes/rustmatrix/meta.yaml
@@ -19,6 +19,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
     - {{ compiler('rust') }}
     - cargo-bundle-licenses
   host:


### PR DESCRIPTION
Adds a recipe for [`rustmatrix`](https://github.com/swnesbitt/rustmatrix) — a Rust-backed T-matrix scattering library for nonspherical particles (a drop-in port of the numerical core of [pytmatrix](https://github.com/jleinonen/pytmatrix)). It provides substantially faster orientation averaging, parallel PSD integration, hydrometeor mixtures, and a full Doppler + polarimetric spectra engine.

- PyPI: <https://pypi.org/project/rustmatrix/2.1.1/>
- crates.io: <https://crates.io/crates/rustmatrix/2.1.1>
- Docs: <https://rustmatrix.readthedocs.io>

### Recipe notes

- Built with `maturin` (PyO3 ABI3 extension, `abi3-py38`). Uses `cargo-bundle-licenses` to emit a `THIRDPARTY.yml` that's shipped alongside `LICENSE`.
- Runtime deps are just `numpy` (pinned compatibly) and `scipy >= 1.10`, matching the upstream `pyproject.toml`.
- Skip matrix: `py<39` to match the upstream `requires-python = ">=3.9"`.

### Checklist

- [x] Title of this PR is meaningful: "Add rustmatrix recipe".
- [x] License ([MIT](https://github.com/swnesbitt/rustmatrix/blob/main/LICENSE)) is an approved license.
- [x] Package does not vendor other packages. (Rust build-time deps are licensed via cargo-bundle-licenses.)
- [x] Source is from an official source (the PyPI sdist).
- [x] Package is pip installable.
- [x] Package is importable.