### PR TITLE
Add sendme

### DIFF
--- a/recipes/sendme/recipe.yaml
+++ b/recipes/sendme/recipe.yaml
@@ -1,0 +1,58 @@
+context:
+  version: "0.33.0"
+
+package:
+  name: sendme
+  version: ${{ version }}
+
+source:
+  url: https://github.com/n0-computer/sendme/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 75ed1cbb040100dcc6bf28228c3393e00d5d4305c6c951bf5df374ccb63e1621
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script: sendme --help
+  - package_contents:
+      bin:
+        - sendme
+      strict: true
+
+about:
+  homepage: https://www.iroh.computer/sendme
+  summary: A tool to send files and directories over the network, with NAT hole punching
+  description: |
+    sendme is a CLI tool to send files and directories over the network,
+    built on the iroh peer-to-peer networking platform. It uses NAT hole
+    punching to establish direct connections between peers, and iroh-blobs
+    for efficient, verifiable, and resumable file transmission.
+  license: Apache-2.0 OR MIT
+  license_file:
+    - LICENSE-APACHE
+    - LICENSE-MIT
+    - THIRDPARTY.yml
+  repository: https://github.com/n0-computer/sendme
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds a recipe for [sendme](https://www.iroh.computer/sendme), a CLI tool by n0-computer for sending files and directories peer-to-peer over the network using iroh with NAT hole punching.

- Homepage: https://www.iroh.computer/sendme
- Repo: https://github.com/n0-computer/sendme
- Version: 0.33.0
- License: Apache-2.0 OR MIT (both license files included, plus cargo-bundled THIRDPARTY.yml)

Checklist:
 - [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
 - [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
 - [x] Source is from official source.
 - [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [x] If static libraries are linked in, the license of the static library is packaged.
 - [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
 - [x] Build number is 0.
 - [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#unmodifiable-source) for more details).
 - [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
 - [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.