### PR TITLE
Add dumbpipe

### DIFF
--- a/recipes/dumbpipe/recipe.yaml
+++ b/recipes/dumbpipe/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.35.0"
+
+package:
+  name: dumbpipe
+  version: ${{ version }}
+
+source:
+  url: https://github.com/n0-computer/dumbpipe/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: e001c75a8c5dacd828ec15797b6ec9502b8314a37f7e4974499c743069d60d2f
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script: dumbpipe --help
+  - package_contents:
+      bin:
+        - dumbpipe
+      strict: true
+
+about:
+  homepage: https://github.com/n0-computer/dumbpipe
+  summary: A CLI tool to pipe data over the network, with NAT hole punching
+  description: |
+    dumbpipe is a CLI tool that creates unix-style pipes between devices
+    over the network, built on the iroh peer-to-peer networking platform.
+    It uses NAT hole punching to establish direct connections between
+    peers, making it a simple netcat-like utility for arbitrary data
+    streams.
+  license: Apache-2.0 OR MIT
+  license_file:
+    - LICENSE-APACHE
+    - LICENSE-MIT
+    - THIRDPARTY.yml
+  repository: https://github.com/n0-computer/dumbpipe
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds a recipe for [dumbpipe](https://github.com/n0-computer/dumbpipe), a netcat-style CLI tool by n0-computer that creates unix pipes between devices over the network using iroh with NAT hole punching.

- Repo: https://github.com/n0-computer/dumbpipe
- Version: 0.35.0 (0.36.0 transitively pulls in a yanked `constant_time_eq 0.4.3` that requires rustc 1.95, which is not yet on conda-forge)
- License: Apache-2.0 OR MIT (both license files included, plus cargo-bundled THIRDPARTY.yml)

Checklist:
 - [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
 - [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
 - [x] Source is from official source.
 - [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
 - [x] If static libraries are linked in, the license of the static library is packaged.
 - [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
 - [x] Build number is 0.
 - [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#unmodifiable-source) for more details).
 - [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
 - [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.