### PR TITLE
Adding mcpsafetywarden

### DIFF
--- a/recipes/mcpsafetywarden/meta.yaml
+++ b/recipes/mcpsafetywarden/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mcpsafetywarden" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 251665437a29abcbca9e93f00b0eb1abaaed4b5ba5936525f728affe95c0a0f6
+  sha256: 93c0903d285c7eb75d3d9f8f19971c9ddf5f39a3229916d839a4a7c6e3098ae3
 
 build:
   number: 0

--- a/recipes/mcpsafetywarden/meta.yaml
+++ b/recipes/mcpsafetywarden/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mcpsafetywarden" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 93c0903d285c7eb75d3d9f8f19971c9ddf5f39a3229916d839a4a7c6e3098ae3
+  sha256: ca9006efe52ca89fae2209653578ca9f00618e9e32623d01243a2d1e2c1a94e8
 
 build:
   number: 0

--- a/recipes/mcpsafetywarden/meta.yaml
+++ b/recipes/mcpsafetywarden/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "mcpsafetywarden" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 251665437a29abcbca9e93f00b0eb1abaaed4b5ba5936525f728affe95c0a0f6
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - mcpsafetywarden = mcpsafetywarden.cli:app
+    - mcpsafetywarden-server = mcpsafetywarden.server:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10
+    - platformdirs >=4.0.0
+    - mcp >=1.9.0
+    - typer >=0.12.0
+    - rich >=13.0.0
+    - httpx >=0.25.0
+    - uvicorn >=0.30.0
+
+test:
+  imports:
+    - mcpsafetywarden
+    - mcpsafetywarden.server
+    - mcpsafetywarden.cli
+    - mcpsafetywarden.database
+    - mcpsafetywarden.scanner
+  commands:
+    - mcpsafetywarden --help
+    - mcpsafetywarden-server --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/gautamvarmadatla/mcpsafetywarden
+  summary: MCP proxy server with behavioral profiling, security scanning, risk gating, and safe execution
+  description: |
+    mcpsafetywarden is a proxy server that wraps any MCP server and adds behavioral
+    profiling, security scanning, risk gating, and safe execution to its tools.
+    It classifies each tool, builds a behavior profile from observed runs, checks for
+    injection attacks, and blocks or gates risky tools before they execute.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://github.com/gautamvarmadatla/mcpsafetywarden/blob/main/docs/TOOLS.md
+  dev_url: https://github.com/gautamvarmadatla/mcpsafetywarden
+
+extra:
+  recipe-maintainers:
+    - gautamvarmadatla

--- a/recipes/mcpsafetywarden/meta.yaml
+++ b/recipes/mcpsafetywarden/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mcpsafetywarden" %}
-{% set version = "0.1.4" %}
+{% set version = "1.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ca9006efe52ca89fae2209653578ca9f00618e9e32623d01243a2d1e2c1a94e8
+  sha256: d7539b098433bc97dfa41b0fecd46c5259122a0079d51d59e3fe25f6f67ce7be
 
 build:
   number: 0


### PR DESCRIPTION
New recipe for [mcpsafetywarden](https://github.com/gautamvarmadatla/mcpsafetywarden) v0.1.2 , an MCP proxy server adding behavioral profiling, security scanning, risk gating, and safe tool call execution to any MCP server.

- PyPI: https://pypi.org/project/mcpsafetywarden/

@conda-forge/help-python, ready for review!

Checklist

- [X] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [X] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [X] Source is from official source.
- [X] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [X] If static libraries are linked in, the license of the static library is packaged.
- [X] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [X] Build number is 0.
- [X] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [X] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [X] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
