### PR TITLE
Add jupyter-loopback

### DIFF
--- a/recipes/jupyter-loopback/meta.yaml
+++ b/recipes/jupyter-loopback/meta.yaml
@@ -1,13 +1,12 @@
-{% set name = "jupyter-loopback" %}
 {% set version = "0.3.3" %}
 {% set python_min = "3.10" %}
 
 package:
-  name: {{ name|lower }}
+  name: jupyter-loopback
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/jupyter_loopback-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/j/jupyter-loopback/jupyter_loopback-{{ version }}.tar.gz
   sha256: 3de29971d7148e8c369e41beedfbb03b301f518f03c06eb8cb26e7f1fcbd1b04
 
 build:

--- a/recipes/jupyter-loopback/meta.yaml
+++ b/recipes/jupyter-loopback/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "jupyter-loopback" %}
+{% set version = "0.3.3" %}
+{% set python_min = "3.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/jupyter_loopback-{{ version }}.tar.gz
+  sha256: 3de29971d7148e8c369e41beedfbb03b301f518f03c06eb8cb26e7f1fcbd1b04
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=64
+    - setuptools-scm >=8
+  run:
+    - python >={{ python_min }}
+    - jupyter_server >=2
+    - tornado >=6.2
+
+test:
+  imports:
+    - jupyter_loopback
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/banesullivan/jupyter-loopback
+  summary: Make kernel-local HTTP/WS servers reachable from the notebook browser with zero user config
+  description: |
+    jupyter-loopback transparently proxies kernel-local HTTP/WebSocket servers
+    so they are reachable from the notebook browser in JupyterLab, Notebook,
+    JupyterHub, VS Code, Colab, and other frontends — without per-frontend
+    configuration. It is used by libraries that spin up local web servers
+    inside a kernel (e.g. tile servers, viewers, dashboards) to make their
+    URLs work seamlessly from the browser.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/banesullivan/jupyter-loopback
+  dev_url: https://github.com/banesullivan/jupyter-loopback
+
+extra:
+  recipe-maintainers:
+    - banesullivan


### PR DESCRIPTION
Adds a recipe for [jupyter-loopback](https://github.com/banesullivan/jupyter-loopback), a small Jupyter server extension that transparently proxies kernel-local HTTP/WebSocket servers to the notebook browser across JupyterLab, Notebook, JupyterHub, VS Code, Colab, and similar frontends — with no per-frontend configuration.

Required by the upcoming [localtileserver v1.0.0](https://github.com/banesullivan/localtileserver) release; the [localtileserver-feedstock 1.0.0 bump PR](https://github.com/conda-forge/localtileserver-feedstock/pull/55) is currently blocked on this package being available on conda-forge.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package"
- [x] License file is packaged (via ``license_file`` in ``meta.yaml``)
- [x] Source is from official source
- [x] Package does not vendor other packages (must be in a separate feedstock)
- [x] Package does not ship static libraries
- [x] If static libraries are needed, they are added to ``build/missing_dso_whitelist`` in ``meta.yaml``

If you have any questions about conda-forge or how to fix this PR, please ask on [Zulip](https://conda-forge.zulipchat.com/) — we're happy to help.