### PR TITLE
Add Bernstein

### DIFF
--- a/recipes/bernstein/meta.yaml
+++ b/recipes/bernstein/meta.yaml
@@ -1,0 +1,79 @@
+{% set name = "bernstein" %}
+{% set version = "1.6.11" %}
+{% set python_min = "3.12" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 595c4c93fe837b6f5fdcb56c11ba5d501aac70f8753267ca090dc2e868c86f5f
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - bernstein = bernstein.cli.main:cli
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - hatchling
+  run:
+    - python >={{ python_min }}
+    - click >=8.1
+    - cryptography >=45.0.0
+    - fastapi >=0.115
+    - httpx >=0.27
+    - mcp >=1.0
+    - openai >=2.29.0
+    - opentelemetry-api >=1.30.0
+    - opentelemetry-sdk >=1.30.0
+    - opentelemetry-exporter-otlp >=1.30.0
+    - pillow >=12.1.1
+    - pluggy >=1.5
+    - prometheus_client >=0.21
+    - pydantic-settings >=2.13.1
+    - pyfiglet >=1.0
+    - python-dotenv >=1.2.2
+    - pyyaml >=6.0
+    - rich >=13.0
+    - setproctitle >=1.3
+    - textual >=1.0
+    - terminaltexteffects >=0.11
+    - uvicorn >=0.30
+    - watchdog >=4.0
+    - websockets >=14.0
+
+test:
+  imports:
+    - bernstein
+    - bernstein.core
+    - bernstein.cli
+  requires:
+    - python {{ python_min }}
+  commands:
+    - bernstein --help
+    - bernstein --version
+
+about:
+  home: https://github.com/sipyourdrink-ltd/bernstein
+  summary: Declarative agent orchestration for engineering teams
+  description: |
+    Bernstein orchestrates multiple AI coding agents working on your repo
+    in parallel. Each agent gets its own git worktree. A janitor verifies
+    tests pass before merging. Supports 18+ CLI agent adapters including
+    Claude Code, Codex, and Gemini CLI. Deterministic Python scheduling
+    with zero LLM tokens on coordination.
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  dev_url: https://github.com/sipyourdrink-ltd/bernstein
+  doc_url: https://bernstein.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - chernistry

--- a/recipes/bernstein/meta.yaml
+++ b/recipes/bernstein/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bernstein" %}
-{% set version = "1.6.11" %}
+{% set version = "1.9.4" %}
 {% set python_min = "3.12" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 595c4c93fe837b6f5fdcb56c11ba5d501aac70f8753267ca090dc2e868c86f5f
+  sha256: d0a2cdaa1abe46a5a41615feede52c2eb758cbec12c9ee69b18eff646618a7c1
 
 build:
   noarch: python
@@ -26,13 +26,15 @@ requirements:
     - python >={{ python_min }}
     - click >=8.1
     - cryptography >=45.0.0
+    - defusedxml >=0.7.1
     - fastapi >=0.115
     - httpx >=0.27
+    - keyring >=25.0
     - mcp >=1.0
     - openai >=2.29.0
     - opentelemetry-api >=1.30.0
-    - opentelemetry-sdk >=1.30.0
     - opentelemetry-exporter-otlp >=1.30.0
+    - opentelemetry-sdk >=1.30.0
     - pillow >=12.1.1
     - pluggy >=1.5
     - prometheus_client >=0.21
@@ -42,8 +44,9 @@ requirements:
     - pyyaml >=6.0
     - rich >=13.0
     - setproctitle >=1.3
-    - textual >=1.0
+    - signxml >=4.0
     - terminaltexteffects >=0.11
+    - textual >=1.0
     - uvicorn >=0.30
     - watchdog >=4.0
     - websockets >=14.0
@@ -61,13 +64,15 @@ test:
 
 about:
   home: https://github.com/sipyourdrink-ltd/bernstein
-  summary: Declarative agent orchestration for engineering teams
+  summary: Multi-agent orchestration for CLI coding agents
   description: |
     Bernstein orchestrates multiple AI coding agents working on your repo
     in parallel. Each agent gets its own git worktree. A janitor verifies
-    tests pass before merging. Supports 18+ CLI agent adapters including
-    Claude Code, Codex, and Gemini CLI. Deterministic Python scheduling
-    with zero LLM tokens on coordination.
+    tests pass before merging. 42 CLI agent adapters including Claude
+    Code, Codex, Gemini CLI, Cursor, Aider, OpenAI Agents SDK, and more.
+    Deterministic Python scheduling with zero LLM tokens spent on
+    coordination - one LLM call to break down your goal, then plain
+    Python for everything else.
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE

--- a/recipes/bernstein/meta.yaml
+++ b/recipes/bernstein/meta.yaml
@@ -16,6 +16,7 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - bernstein = bernstein.cli.main:cli
+    - bernstein-worker = bernstein.core.worker:main
 
 requirements:
   host:


### PR DESCRIPTION
Re-opens #32954 with the canonical `https://github.com/sipyourdrink-ltd/bernstein` URL after the project transferred from my personal account to the @sipyourdrink-ltd organization. Same content as the previous PR, only the GitHub URL was updated.