### PR TITLE
Add pyaugmecon 2.0.0

### DIFF
--- a/recipes/pyaugmecon/recipe.yaml
+++ b/recipes/pyaugmecon/recipe.yaml
@@ -1,0 +1,64 @@
+context:
+  version: "2.0.0"
+  python_min: "3.12"
+
+package:
+  name: pyaugmecon
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pyaugmecon/pyaugmecon-${{ version }}.tar.gz
+  sha256: dec029b322caf4160f3a2e7f2550633d6817c4353d1c6b77be6b77c17d27d5e1
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling >=1.27.0
+  run:
+    - python >=${{ python_min }}
+    - cloudpickle >=3.0,<4.0
+    - loguru >=0.6,<1.0
+    - numpy >=2.1,<3.0
+    - pydantic >=2.10
+    - pymoo >=0.5,<1.0
+    - pyomo >=6.5,<7.0
+    - tqdm >=4.66,<5.0
+
+tests:
+  - python:
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      imports:
+        - pyaugmecon
+      pip_check: true
+  - script:
+      - python -c "from pyaugmecon import PyAugmecon, PyAugmeconConfig"
+
+about:
+  homepage: https://github.com/wouterbles/pyaugmecon
+  summary: An AUGMECON based multi-objective optimization solver for Pyomo.
+  description: |
+    PyAUGMECON solves multi-objective optimization problems defined in Pyomo
+    using the augmented epsilon-constraint method (AUGMECON) and its variants
+    (AUGMECON2, AUGMECON-R).  It generates the Pareto front by solving a
+    sequence of single-objective subproblems with epsilon constraints, supports
+    exact and sampled grid modes, and runs subproblems in parallel across
+    multiple processes.
+
+    Solver bindings (highspy, gurobipy, xpress) are not bundled by this package.
+    Install them separately:
+      conda install -c conda-forge highspy
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/wouterbles/pyaugmecon
+
+extra:
+  recipe-maintainers:
+    - wouterbles

--- a/recipes/pyaugmecon/recipe.yaml
+++ b/recipes/pyaugmecon/recipe.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 context:
   version: "2.0.0"
   python_min: "3.12"
@@ -12,7 +14,7 @@ source:
 
 build:
   noarch: python
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
@@ -21,7 +23,7 @@ requirements:
     - pip
     - hatchling >=1.27.0
   run:
-    - python >=${{ python_min }}
+    - python >=${{ python_min }},<4.0
     - cloudpickle >=3.0,<4.0
     - loguru >=0.6,<1.0
     - numpy >=2.1,<3.0


### PR DESCRIPTION
## Summary

Adding `pyaugmecon`, a pure Python MIT-licensed multi-objective optimization solver for Pyomo using the AUGMECON method and its variants (AUGMECON2, AUGMECON-R).

- **PyPI**: https://pypi.org/project/pyaugmecon/2.0.0/
- **Source**: https://github.com/wouterbles/pyaugmecon
- **License**: MIT
- **Noarch**: Pure Python, no compiled extensions
- **Python**: >=3.12

### Notes

- Solver bindings (highspy, gurobipy, xpress) are optional and not included in the conda package. Users install them separately as needed.
- Recipe uses the v1 `recipe.yaml` format (CEP 13 / rattler-build).
- All runtime dependencies are already available on conda-forge.

### Checklist

- [x] Package is on PyPI
- [x] `license_file` matches sdist contents
- [x] `sha256` verified against downloaded sdist
- [x] Dependency bounds match published wheel metadata