### PR TITLE
Add lateralus-grug-wisdom

### DIFF
--- a/recipes/lateralus-grug-wisdom/meta.yaml
+++ b/recipes/lateralus-grug-wisdom/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "lateralus-grug-wisdom" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lateralus_grug_wisdom-{{ version }}.tar.gz
+  sha256: 765a048378473a73213d095949f6ecc76d7430db6172e56a337a1dd7bd21b5dc
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  entry_points:
+    - lateralus-grug-wisdom = grugbot420.cli:main
+    - grug = grugbot420.cli:main
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - hatchling
+  run:
+    - python >=3.8
+
+test:
+  imports:
+    - grugbot420
+  commands:
+    - pip check
+    - lateralus-grug-wisdom --help
+    - grug --help
+  requires:
+    - pip
+
+about:
+  home: https://lateralus.dev
+  summary: 'Grug oracle for tired devs - wisdom, jokes, smoke vibes, rule-driven keyword roasts.'
+  description: |
+    A whimsical command-line oracle delivering Grug-style programming wisdom,
+    jokes, and rule-driven keyword roasts. Pure-Python, no external runtime
+    dependencies, no network access. Part of the Lateralus language ecosystem.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/bad-antics/lateralus-lang
+  dev_url: https://github.com/bad-antics/lateralus-lang
+
+extra:
+  recipe-maintainers:
+    - bad-antics


### PR DESCRIPTION
Adds a conda-forge recipe for [lateralus-grug-wisdom](https://pypi.org/project/lateralus-grug-wisdom/), a pure-Python CLI oracle that delivers Grug-style programming wisdom, jokes, and keyword-driven roasts.

- Source: https://github.com/bad-antics/lateralus-lang
- PyPI: https://pypi.org/project/lateralus-grug-wisdom/
- License: MIT
- Pure Python, no runtime deps, no network access (noarch: python)

Checklist (per CONTRIBUTING.md):
- [x] Title matches '`Add <pkg>`'
- [x] License & license_file present (MIT)
- [x] sha256 verified against PyPI sdist
- [x] Recipe maintainer self-listed (@bad-antics)
- [x] noarch: python (pure Python)
- [x] Tested entry points: `lateralus-grug-wisdom` and `grug`