### PR TITLE
Add gaussian-job-results

### DIFF
--- a/recipes/gaussian-job-results/meta.yaml
+++ b/recipes/gaussian-job-results/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "gaussian-job-results" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/miyake-ken/gaussian-results-py/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 49cd2dd4dc4e5f0b3b5d0a02958e0534b6045026d5cb3d7e6ea6791f757a7724
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.12,<3.13
+    - hatchling >=1.21
+    - pip
+  run:
+    - python >=3.12,<3.13
+    - cclib >=1.8
+    - polars >=1.0
+    - whenever >=0.6,<1
+    - openbabel >=3.1
+
+test:
+  imports:
+    - gaussian_job_results
+    - gaussian_job_results.fixtures
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/miyake-ken/gaussian-results-py
+  summary: "Parse a Gaussian .out log into a structured result and export the optimized geometry as a Tripos .mol2."
+  description: |
+    Parse a finished Gaussian (.out) log into a curated GaussianResult
+    (cclib-backed) and export the optimized geometry as a Tripos .mol2 via
+    OpenBabel — with optional ESP or Mulliken partial charges.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/miyake-ken/gaussian-results-py#readme
+  dev_url: https://github.com/miyake-ken/gaussian-results-py
+
+extra:
+  recipe-maintainers:
+    - kkiyama117


### PR DESCRIPTION
Adds the recipe for \`gaussian-job-results\`, an open-source utility for parsing Gaussian \`.out\` logs and exporting optimized geometry as Tripos \`.mol2\` (with optional ESP/Mulliken charges).

- Source: https://github.com/miyake-ken/gaussian-results-py
- Release: https://github.com/miyake-ken/gaussian-results-py/releases/tag/v0.1.0
- License: MIT
- Build: \`noarch: python\`

The source is fetched from the GitHub release tarball (the package is intentionally not published on PyPI; conda-forge is the canonical install channel).

### Checklist (per conda-forge guidelines)

- [x] Title starts with "Add ".
- [x] License (\`MIT\`) is OSI-approved and a license file is included in the source.
- [x] All runtime dependencies (\`cclib\`, \`polars\`, \`whenever\`, \`openbabel\`) are conda-forge-available.
- [x] \`pip check\` is run as a smoke test in the recipe.
- [x] Recipe maintainer is the upstream maintainer (\`@kkiyama117\`).