### PR TITLE
Add arabic-reshaper

### DIFF
--- a/recipes/arabic-reshaper/meta.yaml
+++ b/recipes/arabic-reshaper/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "3.0.1" %}
+
+package:
+  name: arabic-reshaper
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/arabic-reshaper/arabic_reshaper-{{ version }}.tar.gz
+  sha256: a0d9b2a9fa29b5f2c1d705f407adf6ca4242405b9cac0e5cc09e6c4f3f8fb68c
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - hatchling
+    - pip
+  run:
+    - python >=3.10
+
+test:
+  imports:
+    - arabic_reshaper
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://github.com/mpcabd/python-arabic-reshaper/
+  summary: Reconstruct Arabic sentences to be used in applications that do not support Arabic
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - mpcabd


### PR DESCRIPTION
## arabic-reshaper

Reconstruct Arabic sentences to be used in applications that do not support Arabic script.

- PyPI: https://pypi.org/project/arabic-reshaper/
- GitHub: https://github.com/mpcabd/python-arabic-reshaper/
- License: MIT

Recipe generated with `grayskull pypi arabic-reshaper`.