### PR TITLE
fix: change linter to not cancel in progress jobs

### DIFF
--- a/.github/workflows/linter_issue_comment.yml
+++ b/.github/workflows/linter_issue_comment.yml
@@ -10,7 +10,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   rerun-linter:


### PR DESCRIPTION
I missed this one.

cc @pavelzw 