### PR TITLE
Add lune recipe

### DIFF
--- a/recipes/lune/0001-disable-aws-lc-rs-in-futures-rustls.patch
+++ b/recipes/lune/0001-disable-aws-lc-rs-in-futures-rustls.patch
@@ -1,0 +1,21 @@
+From: conda-forge recipe maintainer
+Subject: [PATCH] Disable default features on futures-rustls to avoid aws-lc-rs
+
+futures-rustls 0.26 enables aws-lc-rs by default, which transitively
+enables aws_lc_rs in rustls. lune-std-net intentionally selects ring as
+the rustls crypto provider, but feature unification makes aws-lc-rs an
+additional active feature. aws-lc-sys is hard to build on conda-forge
+(missing third-party submodule sources, MSVC C11 atomics), so we drop
+the default features and only enable ring + tls12.
+
+--- a/crates/lune-std-net/Cargo.toml
++++ b/crates/lune-std-net/Cargo.toml
+@@ -27,7 +27,7 @@ bstr = "1.9"
+ form_urlencoded = "1.2"
+ futures = { version = "0.3", default-features = false, features = ["std"] }
+ futures-lite = "2.6"
+-futures-rustls = "0.26"
++futures-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+ http-body-util = "0.1"
+ hyper = { version = "1.6", default-features = false, features = ["http1", "client", "server"] }
+ pin-project-lite = "0.2"

--- a/recipes/lune/recipe.yaml
+++ b/recipes/lune/recipe.yaml
@@ -1,0 +1,61 @@
+context:
+  version: "0.10.4"
+
+package:
+  name: lune
+  version: ${{ version }}
+
+source:
+  url: https://github.com/lune-org/lune/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 151b7b738b210920297b8afa560f440877662e02a48c64c28ce95baaefc96c95
+  patches:
+    - 0001-disable-aws-lc-rs-in-futures-rustls.patch
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --no-track --bins --root ${{ PREFIX }} --path crates/lune
+        else:
+          - cargo auditable install --no-track --bins --root %LIBRARY_PREFIX% --path crates/lune
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script: lune --help
+  - package_contents:
+      bin:
+        - lune
+      strict: true
+
+about:
+  homepage: https://github.com/lune-org/lune
+  summary: A standalone Luau runtime
+  description: |
+    Lune is a standalone Luau runtime. Write and run programs, similar to
+    runtimes for other languages such as Node, Deno, Bun, or Luvit for
+    vanilla Lua. Lune provides fully asynchronous APIs wherever possible,
+    and is built in Rust for speed, safety and correctness.
+  license: MPL-2.0
+  license_file:
+    - LICENSE.txt
+    - THIRDPARTY.yml
+  documentation: https://lune-org.github.io/docs
+  repository: https://github.com/lune-org/lune
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/lune/variants.yaml
+++ b/recipes/lune/variants.yaml
@@ -1,2 +1,0 @@
-rust_compiler_version:
-  - "1.94"

--- a/recipes/lune/variants.yaml
+++ b/recipes/lune/variants.yaml
@@ -1,6 +1,2 @@
 rust_compiler_version:
   - "1.94"
-c_compiler:
-  - vs2022
-cxx_compiler:
-  - vs2022

--- a/recipes/lune/variants.yaml
+++ b/recipes/lune/variants.yaml
@@ -1,0 +1,6 @@
+rust_compiler_version:
+  - "1.94"
+c_compiler:
+  - vs2022
+cxx_compiler:
+  - vs2022


### PR DESCRIPTION
Add a recipe for [`lune`](https://github.com/lune-org/lune), a standalone Luau runtime written in Rust. Provides a CLI similar to Node/Deno/Bun but for Luau, with async APIs for filesystem, networking, and stdio. Released under MPL-2.0.

### Notes

- Recipe pins `rust_compiler_version: "1.94"` and `c_compiler/cxx_compiler: vs2022` via `variants.yaml` because lune requires the 2024 edition (Rust >=1.85), and the rust 1.94 conda package requires `vs_win-64 >=2019`.
- Source includes a one-line patch (`0001-disable-aws-lc-rs-in-futures-rustls.patch`) that adds `default-features = false, features = ["ring", "tls12"]` to the `futures-rustls` dependency in `lune-std-net`. Without this, feature unification activates `aws-lc-rs` in rustls (because `futures-rustls` enables it by default), which transitively pulls in `aws-lc-sys 0.32.2`. That version has a known submodule-bundling bug (`Cannot open include file: ../../../../third_party/jitterentropy/...`) — fixed upstream in 0.32.3+, but lune's lockfile still pins 0.32.2. Lune already explicitly selects `ring` for rustls, so the patch is consistent with upstream's stated intent. I'll file an upstream PR.
- Built and tested locally on `win-64` with rattler-build; `lune --help` runs cleanly.

### Checklist

- [x] Title of this PR is meaningful (e.g. not "Update meta.yaml")
- [x] License is correctly identified (MPL-2.0) and `LICENSE.txt` is bundled along with `THIRDPARTY.yml`
- [x] Source uses tarball with SHA256 checksum
- [x] Tests are included (`lune --help`, `package_contents` check for `bin/lune`)
- [x] Built locally with rattler-build before submitting