### PR TITLE
Add git-extras 7.4.0

### DIFF
--- a/recipes/git-extras/recipe.yaml
+++ b/recipes/git-extras/recipe.yaml
@@ -1,0 +1,66 @@
+context:
+  name: git-extras
+  version: "7.4.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/tj/git-extras/archive/refs/tags/${{ version }}.tar.gz
+  sha256: aaab3bab18709ec6825a875961e18a00e0c7d8214c39d6e3a63aeb99fa11c56e
+
+build:
+  number: 0
+  skip: win
+  script:
+    - export SKIP_CONFLICT_CHECK=yes
+    - make install
+        PREFIX="${PREFIX}"
+        SYSCONFDIR="${PREFIX}/etc"
+        COMPL_DIR="${PREFIX}/etc/bash_completion.d"
+    - install -d "${PREFIX}/share/zsh/site-functions"
+    - install -m 644 etc/git-extras-completion.zsh "${PREFIX}/share/zsh/site-functions/_git-extras"
+    - install -d "${PREFIX}/share/fish/vendor_completions.d"
+    - install -m 644 etc/git-extras.fish "${PREFIX}/share/fish/vendor_completions.d/git-extras.fish"
+
+requirements:
+  build:
+    - make
+    - util-linux  # provides `column`, required by check_dependencies.sh
+  run:
+    - bash
+    - git
+    - util-linux  # provides `column`, used by `git extras` summary output
+
+tests:
+  - script:
+      - git-extras --version
+      - git extras --version
+      - test -x "${PREFIX}/bin/git-summary"
+      - test -x "${PREFIX}/bin/git-changelog"
+      - test -x "${PREFIX}/bin/git-ignore"
+      - test -f "${PREFIX}/share/man/man1/git-extras.1"
+      - test -f "${PREFIX}/etc/bash_completion.d/git-extras"
+      - test -f "${PREFIX}/share/zsh/site-functions/_git-extras"
+      - test -f "${PREFIX}/share/fish/vendor_completions.d/git-extras.fish"
+    requirements:
+      run:
+        - git
+
+about:
+  homepage: https://github.com/tj/git-extras
+  summary: Little git extras
+  description: |
+    GIT utilities -- repo summary, repl, changelog population,
+    author commit percentages and more. Provides 60+ git subcommands such as
+    git-summary, git-effort, git-changelog, git-ignore, git-undo, git-rename-tag,
+    and many others.
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/tj/git-extras
+  documentation: https://github.com/tj/git-extras/blob/main/Commands.md
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/git-extras/recipe.yaml
+++ b/recipes/git-extras/recipe.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  noarch: generic
+  skip: win
   script:
     - export SKIP_CONFLICT_CHECK=yes
     - make install
@@ -29,7 +29,6 @@ requirements:
     - make
     - util-linux  # provides `column`, required by check_dependencies.sh
   run:
-    - __unix
     - bash
     - git
     - util-linux  # provides `column`, used by `git extras` summary output

--- a/recipes/git-extras/recipe.yaml
+++ b/recipes/git-extras/recipe.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   number: 0
-  skip: win
+  noarch: generic
   script:
     - export SKIP_CONFLICT_CHECK=yes
     - make install
@@ -29,6 +29,7 @@ requirements:
     - make
     - util-linux  # provides `column`, required by check_dependencies.sh
   run:
+    - __unix
     - bash
     - git
     - util-linux  # provides `column`, used by `git extras` summary output

--- a/recipes/git-extras/recipe.yaml
+++ b/recipes/git-extras/recipe.yaml
@@ -37,16 +37,21 @@ tests:
   - script:
       - git-extras --version
       - git extras --version
-      - test -x "${PREFIX}/bin/git-summary"
-      - test -x "${PREFIX}/bin/git-changelog"
-      - test -x "${PREFIX}/bin/git-ignore"
-      - test -f "${PREFIX}/share/man/man1/git-extras.1"
-      - test -f "${PREFIX}/etc/bash_completion.d/git-extras"
-      - test -f "${PREFIX}/share/zsh/site-functions/_git-extras"
-      - test -f "${PREFIX}/share/fish/vendor_completions.d/git-extras.fish"
     requirements:
       run:
         - git
+  - package_contents:
+      bin:
+        - git-extras
+        - git-summary
+        - git-changelog
+        - git-ignore
+        - git-effort
+      files:
+        - share/man/man1/git-extras.1
+        - etc/bash_completion.d/git-extras
+        - share/zsh/site-functions/_git-extras
+        - share/fish/vendor_completions.d/git-extras.fish
 
 about:
   homepage: https://github.com/tj/git-extras


### PR DESCRIPTION
Adds [git-extras](https://github.com/tj/git-extras), a collection of ~70 git utility subcommands (e.g. `git summary`, `git effort`, `git changelog`, `git ignore`, `git undo`, `git rename-tag`).

Resolves #30410. A previous attempt was made in #31637 but was closed by the contributor before review. This PR uses the v1 (`recipe.yaml`) format, the upstream `Makefile` for installation, and packages the shell completions (bash/zsh/fish) and man pages.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source (GitHub release tarball, SHA256 verified).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged. (n/a, shell scripts only)
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Notes:
- Windows is skipped with `skip: win`. git-extras is a Unix shell-script collection that requires bash and a Unix-like environment to install. Per-platform builds will be produced (linux-64, linux-aarch64, osx-64, osx-arm64). This matches the convention used by similar shell-only feedstocks such as `atool2-feedstock`.
- `noarch: generic` was tried with a `__unix` virtual-package run dependency, but `util-linux` is not on win-64, so the staged-recipes win CI failed at build-env resolution. The conda-forge linter also rejects `skip:` selectors on noarch packages, so the per-platform layout is the simplest path.
- `util-linux` is a runtime dependency for the `column` command, which is required by some subcommands and the upstream `check_dependencies.sh`.
