### PR TITLE
Add helmfile 1.4.4

### DIFF
--- a/recipes/helmfile/recipe.yaml
+++ b/recipes/helmfile/recipe.yaml
@@ -1,0 +1,57 @@
+context:
+  name: helmfile
+  version: "1.4.4"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/helmfile/helmfile/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d804c196e29aa0b7b0d8571174ef6f7640ca2fe22808d56882487a89da7022cd
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save . --save_path ../library_licenses --ignore github.com/helmfile/helmfile
+    - if: unix
+      then: go build -v -trimpath -o $PREFIX/bin/helmfile -ldflags="-s -w -X go.szostok.io/version.version=v${{ version }}"
+      else: go build -v -trimpath -o %LIBRARY_BIN%\helmfile.exe -ldflags="-s -X go.szostok.io/version.version=v${{ version }}"
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+  run:
+    - kubernetes-helm
+
+tests:
+  - script:
+      - helmfile --version
+      - helmfile help
+  - package_contents:
+      bin:
+        - helmfile
+      strict: true
+
+about:
+  homepage: https://helmfile.readthedocs.io
+  summary: Declarative spec for deploying helm charts
+  description: |
+    Helmfile is a declarative spec for deploying helm charts. It lets you
+    keep a directory of chart value files and maintain changes in version
+    control, apply CI/CD to configuration changes, and bundle multiple
+    releases together as a single helmfile. It supports Helm chart
+    repositories, Kustomize configs, and direct Kubernetes manifests.
+  license: MIT
+  license_file:
+    - src/LICENSE
+    - library_licenses/
+  documentation: https://helmfile.readthedocs.io
+  repository: https://github.com/helmfile/helmfile
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds [helmfile](https://github.com/helmfile/helmfile) v1.4.4, a declarative spec for deploying Helm charts.

Resolves #30133.

The recipe is a standard Go build using the `go-nocgo` compiler (helmfile is pure Go with no cgo dependencies). `go-licenses` is used to bundle dependency license files. `kubernetes-helm` is a runtime dependency since helmfile shells out to the `helm` binary.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source (GitHub release tarball, SHA256 verified).
- [x] Package does not vendor other packages. (Go module dependencies are statically linked, license files are bundled via go-licenses.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
