### PR TITLE
Add cloc 2.08 (with perl-parallel-forkmanager)

### DIFF
--- a/recipes/cloc/cloc.bat
+++ b/recipes/cloc/cloc.bat
@@ -1,0 +1,2 @@
+@echo off
+perl "%~dp0cloc" %*

--- a/recipes/cloc/cloc.bat
+++ b/recipes/cloc/cloc.bat
@@ -1,2 +1,0 @@
-@echo off
-perl "%~dp0cloc" %*

--- a/recipes/cloc/recipe.yaml
+++ b/recipes/cloc/recipe.yaml
@@ -7,68 +7,42 @@ package:
   version: ${{ version }}
 
 source:
-  - url: https://github.com/AlDanial/cloc/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: 8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5
-  - if: win
-    then:
-      path: cloc.bat
+  url: https://github.com/AlDanial/cloc/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5
 
 build:
   number: 0
+  skip: win
   script:
-    - if: unix
-      then:
-        # Install Unix/cloc, which expects Algorithm::Diff and Regexp::Common to come
-        # from CPAN (the root cloc bundles them). This matches upstream's Unix/Makefile.
-        - install -d "${PREFIX}/bin"
-        - install -m 755 Unix/cloc "${PREFIX}/bin/cloc"
-        # Render the man page exactly like upstream's Unix/pod2man.mk.
-        - install -d "${PREFIX}/share/man/man1"
-        - pod2man --utf8
-            --center="User Commands"
-            --name="cloc"
-            --section=1
-            Unix/cloc.1.pod > "${PREFIX}/share/man/man1/cloc.1"
-      else:
-        # Windows: cmd.exe doesn't honor `#!/usr/bin/env perl` shebangs, so install
-        # the Perl script alongside a .bat wrapper that invokes the conda env's perl.
-        - if not exist "%LIBRARY_BIN%" mkdir "%LIBRARY_BIN%"
-        - copy /Y Unix\cloc "%LIBRARY_BIN%\cloc"
-        - copy /Y cloc.bat "%LIBRARY_BIN%\cloc.bat"
+    # Install Unix/cloc, which expects Algorithm::Diff and Regexp::Common to come
+    # from CPAN (the root cloc bundles them). This matches upstream's Unix/Makefile.
+    - install -d "${PREFIX}/bin"
+    - install -m 755 Unix/cloc "${PREFIX}/bin/cloc"
+    # Render the man page exactly like upstream's Unix/pod2man.mk.
+    - install -d "${PREFIX}/share/man/man1"
+    - pod2man --utf8
+        --center="User Commands"
+        --name="cloc"
+        --section=1
+        Unix/cloc.1.pod > "${PREFIX}/share/man/man1/cloc.1"
 
 requirements:
   run:
     - perl
     - perl-algorithm-diff
+    - perl-digest-md5
     - perl-regexp-common
-    - if: not win
-      then:
-        # Strawberry Perl on Windows ships Digest::MD5 in core; conda-forge does not
-        # currently package perl-digest-md5 for win-64.
-        - perl-digest-md5
-    - if: not win
-      then:
-        # cloc only uses Parallel::ForkManager for --processes=N>1; not strictly
-        # required. Optional dep on Unix where the package is available.
-        - perl-parallel-forkmanager
+    - perl-parallel-forkmanager
 
 tests:
   - script:
       - cloc --version
       - cloc --help
-  - if: unix
-    then:
-      package_contents:
-        bin:
-          - cloc
-        files:
-          - share/man/man1/cloc.1
-  - if: win
-    then:
-      package_contents:
-        files:
-          - Library/bin/cloc
-          - Library/bin/cloc.bat
+  - package_contents:
+      bin:
+        - cloc
+      files:
+        - share/man/man1/cloc.1
 
 about:
   homepage: https://github.com/AlDanial/cloc
@@ -80,6 +54,13 @@ about:
     (Algorithm::Diff, Regexp::Common, Digest::MD5, Parallel::ForkManager).
     cloc supports over 250 languages and produces output in plain text,
     JSON, XML, YAML, and SQLite-friendly formats.
+
+    Note: Windows is not supported. The conda-forge Perl module ecosystem
+    is built against the standard `*_perl5` perl, while win-64 perl is the
+    `*_strawberry` distribution; as a result CPAN modules like
+    Algorithm::Diff and Regexp::Common are not installable on win-64.
+    Windows users can use the official `cloc.exe` from
+    https://github.com/AlDanial/cloc/releases.
   license: GPL-2.0-or-later
   license_file: LICENSE
   repository: https://github.com/AlDanial/cloc

--- a/recipes/cloc/recipe.yaml
+++ b/recipes/cloc/recipe.yaml
@@ -7,43 +7,68 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/AlDanial/cloc/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5
+  - url: https://github.com/AlDanial/cloc/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: 8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5
+  - if: win
+    then:
+      path: cloc.bat
 
 build:
   number: 0
-  skip: win
   script:
-    # Install Unix/cloc, which expects Algorithm::Diff and Regexp::Common to come
-    # from CPAN (the root cloc bundles them). This matches upstream's Unix/Makefile.
-    - install -d "${PREFIX}/bin"
-    - install -m 755 Unix/cloc "${PREFIX}/bin/cloc"
-    # Render the man page exactly like upstream's Unix/pod2man.mk.
-    - install -d "${PREFIX}/share/man/man1"
-    - pod2man --utf8
-        --center="User Commands"
-        --name="cloc"
-        --section=1
-        Unix/cloc.1.pod > "${PREFIX}/share/man/man1/cloc.1"
+    - if: unix
+      then:
+        # Install Unix/cloc, which expects Algorithm::Diff and Regexp::Common to come
+        # from CPAN (the root cloc bundles them). This matches upstream's Unix/Makefile.
+        - install -d "${PREFIX}/bin"
+        - install -m 755 Unix/cloc "${PREFIX}/bin/cloc"
+        # Render the man page exactly like upstream's Unix/pod2man.mk.
+        - install -d "${PREFIX}/share/man/man1"
+        - pod2man --utf8
+            --center="User Commands"
+            --name="cloc"
+            --section=1
+            Unix/cloc.1.pod > "${PREFIX}/share/man/man1/cloc.1"
+      else:
+        # Windows: cmd.exe doesn't honor `#!/usr/bin/env perl` shebangs, so install
+        # the Perl script alongside a .bat wrapper that invokes the conda env's perl.
+        - if not exist "%LIBRARY_BIN%" mkdir "%LIBRARY_BIN%"
+        - copy /Y Unix\cloc "%LIBRARY_BIN%\cloc"
+        - copy /Y cloc.bat "%LIBRARY_BIN%\cloc.bat"
 
 requirements:
-  build:
-    - perl
   run:
     - perl
     - perl-algorithm-diff
-    - perl-digest-md5
     - perl-regexp-common
+    - if: not win
+      then:
+        # Strawberry Perl on Windows ships Digest::MD5 in core; conda-forge does not
+        # currently package perl-digest-md5 for win-64.
+        - perl-digest-md5
+    - if: not win
+      then:
+        # cloc only uses Parallel::ForkManager for --processes=N>1; not strictly
+        # required. Optional dep on Unix where the package is available.
+        - perl-parallel-forkmanager
 
 tests:
   - script:
       - cloc --version
       - cloc --help
-  - package_contents:
-      bin:
-        - cloc
-      files:
-        - share/man/man1/cloc.1
+  - if: unix
+    then:
+      package_contents:
+        bin:
+          - cloc
+        files:
+          - share/man/man1/cloc.1
+  - if: win
+    then:
+      package_contents:
+        files:
+          - Library/bin/cloc
+          - Library/bin/cloc.bat
 
 about:
   homepage: https://github.com/AlDanial/cloc
@@ -52,13 +77,9 @@ about:
     cloc counts blank lines, comment lines, and physical lines of source
     code in many programming languages. It is written in Perl with no
     dependencies outside the standard distribution and a few CPAN modules
-    (Algorithm::Diff, Regexp::Common, Digest::MD5). cloc supports over
-    250 languages and produces output in plain text, JSON, XML, YAML, and
-    SQLite-friendly formats.
-
-    Note: parallel mode (--processes=N with N>1) requires the optional
-    Parallel::ForkManager Perl module, which is not currently packaged
-    on conda-forge. Single-process counting works without it.
+    (Algorithm::Diff, Regexp::Common, Digest::MD5, Parallel::ForkManager).
+    cloc supports over 250 languages and produces output in plain text,
+    JSON, XML, YAML, and SQLite-friendly formats.
   license: GPL-2.0-or-later
   license_file: LICENSE
   repository: https://github.com/AlDanial/cloc

--- a/recipes/cloc/recipe.yaml
+++ b/recipes/cloc/recipe.yaml
@@ -1,0 +1,68 @@
+context:
+  name: cloc
+  version: "2.08"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/AlDanial/cloc/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 8099b6275c124f662690f2db3581cd2ad4e9ad4e08332288719838ded00d1da5
+
+build:
+  number: 0
+  skip: win
+  script:
+    # Install Unix/cloc, which expects Algorithm::Diff and Regexp::Common to come
+    # from CPAN (the root cloc bundles them). This matches upstream's Unix/Makefile.
+    - install -d "${PREFIX}/bin"
+    - install -m 755 Unix/cloc "${PREFIX}/bin/cloc"
+    # Render the man page exactly like upstream's Unix/pod2man.mk.
+    - install -d "${PREFIX}/share/man/man1"
+    - pod2man --utf8
+        --center="User Commands"
+        --name="cloc"
+        --section=1
+        Unix/cloc.1.pod > "${PREFIX}/share/man/man1/cloc.1"
+
+requirements:
+  build:
+    - perl
+  run:
+    - perl
+    - perl-algorithm-diff
+    - perl-digest-md5
+    - perl-regexp-common
+
+tests:
+  - script:
+      - cloc --version
+      - cloc --help
+  - package_contents:
+      bin:
+        - cloc
+      files:
+        - share/man/man1/cloc.1
+
+about:
+  homepage: https://github.com/AlDanial/cloc
+  summary: Count lines of code
+  description: |
+    cloc counts blank lines, comment lines, and physical lines of source
+    code in many programming languages. It is written in Perl with no
+    dependencies outside the standard distribution and a few CPAN modules
+    (Algorithm::Diff, Regexp::Common, Digest::MD5). cloc supports over
+    250 languages and produces output in plain text, JSON, XML, YAML, and
+    SQLite-friendly formats.
+
+    Note: parallel mode (--processes=N with N>1) requires the optional
+    Parallel::ForkManager Perl module, which is not currently packaged
+    on conda-forge. Single-process counting works without it.
+  license: GPL-2.0-or-later
+  license_file: LICENSE
+  repository: https://github.com/AlDanial/cloc
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/perl-parallel-forkmanager/recipe.yaml
+++ b/recipes/perl-parallel-forkmanager/recipe.yaml
@@ -31,6 +31,7 @@ requirements:
   host:
     - perl
     - perl-moo >=1.001000
+    - perl-test-warn  # used by t/waitpid-waitonechild.t without a Test::Requires guard
   run:
     - perl
     - perl-moo >=1.001000

--- a/recipes/perl-parallel-forkmanager/recipe.yaml
+++ b/recipes/perl-parallel-forkmanager/recipe.yaml
@@ -1,0 +1,52 @@
+context:
+  name: perl-parallel-forkmanager
+  version: "2.04"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  - url: https://cpan.metacpan.org/authors/id/Y/YA/YANICK/Parallel-ForkManager-${{ version }}.tar.gz
+    sha256: 606894fc2e9f7cd13d9ec099aaac103a8f0943d1d80c2c486bae14730a39b7fc
+  - url: https://raw.githubusercontent.com/Perl/perl5/v5.32.1/Copying
+    sha256: d77d235e41d54594865151f4751e835c5a82322b0e87ace266567c3391a4b912
+    file_name: Copying
+  - url: https://raw.githubusercontent.com/Perl/perl5/v5.32.1/Artistic
+    sha256: dd90d4f42e4dcadf5a7c09eea0189d93c7b37ae560c91f0f6d5233ed3b9292a2
+    file_name: Artistic
+
+build:
+  number: 0
+  noarch: generic
+  script:
+    - perl Makefile.PL INSTALLDIRS=vendor NO_PERLLOCAL=1 NO_PACKLIST=1
+    - make
+    - make test
+    - make install VERBINST=1
+
+requirements:
+  build:
+    - make
+  host:
+    - perl
+    - perl-moo >=1.001000
+  run:
+    - perl
+    - perl-moo >=1.001000
+
+tests:
+  - script: perl -e 'use Parallel::ForkManager; print "ok\n"'
+
+about:
+  homepage: https://metacpan.org/dist/Parallel-ForkManager
+  summary: A simple parallel processing fork manager
+  license: Artistic-1.0-Perl OR GPL-1.0-or-later
+  license_file:
+    - Artistic
+    - Copying
+  repository: https://github.com/dluxhu/perl-parallel-forkmanager
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds [cloc](https://github.com/AlDanial/cloc) v2.08, a tool that counts blank lines, comment lines, and physical lines of source code across 250+ programming languages.

Resolves #29495.

How the package is built upstream
--

cloc is distributed as two Perl scripts in the same release tarball:
- `cloc` at the repo root: a self-contained build with `Algorithm::Diff` and `Regexp::Common` bundled inside the script.
- `Unix/cloc`: a smaller variant that expects those modules to come from CPAN. This is the script the upstream `Unix/Makefile` installs.

The upstream `Unix/Makefile` does two things:
1. Renders `cloc.1.pod` to `cloc.1` via `Unix/pod2man.mk` (which calls `pod2man --utf8 --center='User Commands' --name=cloc --section=1`).
2. Installs `Unix/cloc` to `$prefix/bin/cloc` and `cloc.1` to `$prefix/share/man/man1`.

Recipe approach
--

- **Linux / macOS**: install `Unix/cloc` to `$PREFIX/bin/cloc` and render the man page with the same `pod2man` flags upstream uses.
- **Windows**: install `Unix/cloc` to `%LIBRARY_BIN%\cloc` and a `cloc.bat` wrapper next to it that invokes `perl "%~dp0cloc" %*`. cmd.exe does not honor `#!/usr/bin/env perl` shebangs, so the wrapper is the standard way to ship a Perl script as a CLI on Windows in conda environments.

This avoids the alternative of bundling Perl into a `cloc.exe` via PAR::Packer's `pp`, which would require packaging a chain of seven additional Perl modules on conda-forge.

Runtime deps
--

- `perl`, `perl-algorithm-diff`, `perl-regexp-common` on all platforms.
- `perl-digest-md5` on Linux / macOS only. Strawberry Perl on Windows ships `Digest::MD5` in core, and conda-forge does not currently package `perl-digest-md5` for win-64.
- `perl-parallel-forkmanager` on Linux / macOS only. Used by cloc's `--processes=N>1` mode. Its recipe is bundled in this same PR (`recipes/perl-parallel-forkmanager/`); staged-recipes orders the builds so cloc's test phase can resolve it from the local channel. cloc loads it via `eval "use Parallel::ForkManager"` and gracefully falls back, so it is fine to omit on Windows.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source (GitHub release tarball, SHA256 verified).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
