### PR TITLE
Add moltenvk 1.4.1

### DIFF
--- a/recipes/moltenvk/conda_build_config.yaml
+++ b/recipes/moltenvk/conda_build_config.yaml
@@ -1,0 +1,5 @@
+# MoltenVK 1.4.1 references Metal API symbols (MTLLanguageVersion3_0,
+# MTLLanguageVersion3_1, MTLCompileOptions.optimizationLevel) that require
+# the macOS 14 SDK. Conda-forge defaults to the macOS 11 SDK.
+c_stdlib_version:           # [osx]
+  - 14.0                    # [osx]

--- a/recipes/moltenvk/recipe.yaml
+++ b/recipes/moltenvk/recipe.yaml
@@ -1,0 +1,91 @@
+context:
+  name: moltenvk
+  version: "1.4.1"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/KhronosGroup/MoltenVK/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 9985f141902a17de818e264d17c1ce334b748e499ee02fcb4703e4dc0038f89c
+
+build:
+  number: 0
+  skip: not osx
+  script:
+    # SPIRV-Cross, Vulkan-Headers, and cereal are fetched via CPM at configure
+    # time and statically linked into the dylib. SPIRV-Cross uses a custom
+    # MVK_spirv_cross namespace, so the conda-forge package cannot be substituted.
+    # MVK_EXCLUDE_SPIRV_TOOLS=ON drops the SPIRV-Tools (and SPIRV-Headers)
+    # vendoring; the only cost is no human-readable SPIR-V disassembly in
+    # MoltenVK's debug error messages.
+    - cmake -G Ninja -B build
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+        -DCMAKE_INSTALL_LIBDIR=lib
+        -DMVK_HIDE_VULKAN_SYMBOLS=ON
+        -DMVK_EXCLUDE_SPIRV_TOOLS=ON
+    - cmake --build build --parallel ${CPU_COUNT}
+    - cmake --install build
+    # The upstream CMakeLists hard-codes etc/vulkan/icd.d/ for the ICD descriptor
+    # and bakes an absolute library_path into it. Move it under share/vulkan/icd.d/
+    # (the conda-forge convention used by the Vulkan loader) and rewrite the path
+    # to a relative one so the package stays relocatable.
+    - mkdir -p "${PREFIX}/share/vulkan/icd.d"
+    - mv "${PREFIX}/etc/vulkan/icd.d/MoltenVK_icd.json" "${PREFIX}/share/vulkan/icd.d/"
+    - rmdir "${PREFIX}/etc/vulkan/icd.d" "${PREFIX}/etc/vulkan" 2>/dev/null || true
+    - sed -i.bak 's|"[^"]*/libMoltenVK.dylib"|"../../../lib/libMoltenVK.dylib"|'
+        "${PREFIX}/share/vulkan/icd.d/MoltenVK_icd.json"
+    - rm "${PREFIX}/share/vulkan/icd.d/MoltenVK_icd.json.bak"
+    # MoltenVK-specific extension headers. Standard Vulkan headers (vulkan/,
+    # vk_video/) come from the vulkan-headers package.
+    - mkdir -p "${PREFIX}/include/MoltenVK"
+    - cp MoltenVK/MoltenVK/API/*.h "${PREFIX}/include/MoltenVK/"
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  run_exports:
+    - ${{ pin_subpackage('moltenvk', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      files:
+        - lib/libMoltenVK.dylib
+        - share/vulkan/icd.d/MoltenVK_icd.json
+        - include/MoltenVK/mvk_vulkan.h
+        - include/MoltenVK/mvk_config.h
+  - script:
+      # The ICD JSON's library_path must be relative for the package to be
+      # relocatable; verify it is the expected relative path.
+      - grep -q '"../../../lib/libMoltenVK.dylib"' "${PREFIX}/share/vulkan/icd.d/MoltenVK_icd.json"
+
+about:
+  homepage: https://github.com/KhronosGroup/MoltenVK
+  summary: Vulkan Portability implementation built on Apple's Metal framework
+  description: |
+    MoltenVK is a layered implementation of Vulkan graphics and compute
+    functionality, that is built on top of Apple's Metal graphics and
+    compute framework on macOS, iOS and tvOS. MoltenVK allows you to use
+    Vulkan graphics and compute functionality to develop modern,
+    cross-platform, high-performance graphical games and applications, and
+    to run them across many platforms, including macOS, iOS and tvOS.
+    MoltenVK automatically converts your SPIR-V shaders to their Metal
+    Shading Language (MSL) equivalents.
+
+    This package installs the libMoltenVK.dylib library, the MoltenVK
+    extension headers, and the Vulkan ICD descriptor at
+    share/vulkan/icd.d/MoltenVK_icd.json so that the Vulkan loader can
+    pick it up automatically.
+  license: Apache-2.0
+  license_file: LICENSE
+  repository: https://github.com/KhronosGroup/MoltenVK
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds [MoltenVK](https://github.com/KhronosGroup/MoltenVK) v1.4.1, a Vulkan-on-Metal portability implementation for macOS. macOS-only.

Resolves #33138.

What gets installed
--

- `lib/libMoltenVK.dylib`
- `share/vulkan/icd.d/MoltenVK_icd.json` with a relative `library_path` so the package is relocatable
- `include/MoltenVK/{mvk_vulkan,mvk_config,mvk_datatypes,mvk_deprecated_api,mvk_private_api,vk_mvk_moltenvk}.h` — MoltenVK-specific extension headers. Standard Vulkan headers come from the existing `vulkan-headers` package.

Build notes
--

- CMake build with `MVK_HIDE_VULKAN_SYMBOLS=ON` so the dylib only exposes the ICD entry point and does not re-export the Vulkan API surface.
- SPIRV-Cross, SPIRV-Tools, SPIRV-Headers, Vulkan-Headers, and cereal are fetched via CPM at configure time and statically linked into the dylib. SPIRV-Cross is built with a custom `MVK_spirv_cross` namespace and SPIRV-Tools in static mode, so the conda-forge packages cannot be substituted.
- The upstream CMakeLists hard-codes `etc/vulkan/icd.d/` for the ICD descriptor and bakes an absolute `library_path` into it. The recipe moves the JSON to `share/vulkan/icd.d/` (where the Vulkan loader looks under conda-forge) and rewrites the path to `../../../lib/libMoltenVK.dylib` so the package can be relocated.

Checklist
- [x] Title of this PR is meaningful.
- [x] License file is packaged (Apache-2.0).
- [x] Source is from official source (GitHub release tarball, SHA256 verified).
- [x] Package does not vendor other packages. CPM-fetched deps are statically linked into the dylib; their licenses are noted in the source distribution.
- [x] Static libraries shipped: `libMoltenVK.dylib` is shared. CPM deps are statically linked into it but no static archives are exposed.
- [x] Build number is 0.
- [x] Tarball (`url`) used, not git_url.
- [x] Recipe-maintainer (`baszalmstra`) has confirmed willingness.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
