### PR TITLE
Add shader-slang recipe

### DIFF
--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -7,6 +7,10 @@ package:
   version: ${{ version }}
 
 source:
+  # Using a git source (not a tarball) so that `git submodule update` can pin
+  # submodule revisions to whatever slang's parent tree references for this
+  # tag. That way we never have to manually track submodule SHAs across
+  # version bumps.
   git: https://github.com/shader-slang/slang.git
   tag: v${{ version }}
 
@@ -15,11 +19,19 @@ build:
   # Windows skipped initially; can be enabled in a follow-up.
   skip: win
   script:
-    # Submodules are not auto-fetched by rattler-build's git source.
-    - git submodule update --init --recursive
-    # Disable graphics/runtime/test/example targets that pull in the slang-rhi
-    # submodule and large optional toolchains. SLANG_SLANG_LLVM_FLAVOR=DISABLE
-    # avoids downloading a prebuilt slang-llvm at configure time.
+    # Only initialize the submodules that we cannot satisfy from conda-forge:
+    #   - miniz: no conda-forge package
+    #   - cmark (swift-cmark fork): no conda-forge package, no system option
+    #     in slang's CMake
+    #   - vulkan-headers: conda-forge ships 1.3.231.1 (Jan 2023), far too old
+    #     for slang 2026
+    # glslang, spirv-tools, spirv-headers, lz4 and unordered_dense come from
+    # conda-forge via the host requirements below.
+    - git submodule update --init --depth 1
+        external/miniz external/cmark external/vulkan
+    # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
+    # tint, DXC and slang-llvm are disabled - they pull in further submodules
+    # or fetch prebuilt binaries at configure time.
     - cmake -G Ninja -B build -S .
         ${CMAKE_ARGS}
         -DCMAKE_BUILD_TYPE=Release
@@ -27,10 +39,14 @@ build:
         -DCMAKE_INSTALL_LIBDIR=lib
         -DSLANG_ENABLE_GFX=OFF
         -DSLANG_ENABLE_SLANG_RHI=OFF
-        -DSLANG_ENABLE_SLANGRT=OFF
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+        -DSLANG_USE_SYSTEM_LZ4=ON
+        -DSLANG_USE_SYSTEM_UNORDERED_DENSE=ON
+        -DSLANG_USE_SYSTEM_GLSLANG=ON
+        -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
+        -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
     - cmake --build build --config Release -j ${CPU_COUNT}
     - cmake --install build --config Release
 
@@ -42,6 +58,12 @@ requirements:
     - cmake
     - ninja
     - git
+  host:
+    - lz4-c
+    - unordered_dense
+    - glslang
+    - spirv-tools
+    - spirv-headers
   run_exports:
     - ${{ pin_subpackage(name, upper_bound='x') }}
 
@@ -73,7 +95,13 @@ about:
     layer (gfx/slang-rhi), language server (slangd), LLVM-based CPU backend,
     tests and examples - are disabled in this build.
   license: Apache-2.0 WITH LLVM-exception
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    # Vendored submodules need their licenses packaged. These directories are
+    # populated by `git submodule update` in the build script.
+    - external/miniz/LICENSE
+    - external/cmark/COPYING
+    - external/vulkan/LICENSE.md
   documentation: https://shader-slang.org/slang/user-guide/
   repository: https://github.com/shader-slang/slang
 

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -23,12 +23,9 @@ build:
     #   - miniz: no conda-forge package
     #   - cmark (swift-cmark fork): no conda-forge package, no system option
     #     in slang's CMake
-    #   - vulkan-headers: conda-forge ships 1.3.231.1 (Jan 2023), far too old
-    #     for slang 2026
-    # glslang, spirv-tools, spirv-headers, lz4 and unordered_dense come from
-    # conda-forge via the host requirements below.
-    - git submodule update --init --depth 1
-        external/miniz external/cmark external/vulkan
+    # vulkan-headers, glslang, spirv-tools, spirv-headers, lz4 and
+    # unordered_dense come from conda-forge via the host requirements below.
+    - git submodule update --init --depth 1 external/miniz external/cmark
     # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
     # tint, DXC and slang-llvm are disabled - they pull in further submodules
     # or fetch prebuilt binaries at configure time.
@@ -44,6 +41,7 @@ build:
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
         -DSLANG_USE_SYSTEM_LZ4=ON
         -DSLANG_USE_SYSTEM_UNORDERED_DENSE=ON
+        -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
         -DSLANG_USE_SYSTEM_GLSLANG=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
         -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
@@ -61,6 +59,7 @@ requirements:
   host:
     - lz4-c
     - unordered_dense
+    - libvulkan-headers
     - glslang
     - spirv-tools
     - spirv-headers
@@ -101,7 +100,6 @@ about:
     # populated by `git submodule update` in the build script.
     - external/miniz/LICENSE
     - external/cmark/COPYING
-    - external/vulkan/LICENSE.md
   documentation: https://shader-slang.org/slang/user-guide/
   repository: https://github.com/shader-slang/slang
 

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -23,9 +23,14 @@ build:
     #   - miniz: no conda-forge package
     #   - cmark (swift-cmark fork): no conda-forge package, no system option
     #     in slang's CMake
-    # vulkan-headers, glslang, spirv-tools, spirv-headers, lz4 and
-    # unordered_dense come from conda-forge via the host requirements below.
-    - git submodule update --init --depth 1 external/miniz external/cmark
+    #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
+    #     config files, so slang's find_package(lz4) /
+    #     find_package(unordered_dense) cannot find them. Both are tiny so
+    #     vendoring them keeps the recipe simple.
+    # vulkan-headers, glslang, spirv-tools and spirv-headers come from
+    # conda-forge via the host requirements below.
+    - git submodule update --init --depth 1
+        external/miniz external/cmark external/lz4 external/unordered_dense
     # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
     # tint, DXC and slang-llvm are disabled - they pull in further submodules
     # or fetch prebuilt binaries at configure time.
@@ -39,8 +44,6 @@ build:
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-        -DSLANG_USE_SYSTEM_LZ4=ON
-        -DSLANG_USE_SYSTEM_UNORDERED_DENSE=ON
         -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
         -DSLANG_USE_SYSTEM_GLSLANG=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
@@ -57,8 +60,6 @@ requirements:
     - ninja
     - git
   host:
-    - lz4-c
-    - unordered_dense
     - libvulkan-headers
     - glslang
     - spirv-tools
@@ -100,6 +101,8 @@ about:
     # populated by `git submodule update` in the build script.
     - external/miniz/LICENSE
     - external/cmark/COPYING
+    - external/lz4/LICENSE
+    - external/unordered_dense/LICENSE
   documentation: https://shader-slang.org/slang/user-guide/
   repository: https://github.com/shader-slang/slang
 

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -16,43 +16,46 @@ source:
 
 build:
   number: 0
-  # Windows skipped initially; can be enabled in a follow-up.
-  skip: win
   script:
-    # Only initialize the submodules that we cannot satisfy from conda-forge:
-    #   - miniz: no conda-forge package
-    #   - cmark (swift-cmark fork): no conda-forge package, no system option
-    #     in slang's CMake
-    #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
-    #     config files, so slang's find_package(lz4) /
-    #     find_package(unordered_dense) cannot find them. Both are tiny so
-    #     vendoring them keeps the recipe simple.
-    #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
-    #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
-    #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
-    # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
-    # the host requirements below.
-    - git submodule update --init --depth 1
-        external/miniz external/cmark external/lz4
-        external/unordered_dense external/glslang
-    # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
-    # tint, DXC and slang-llvm are disabled - they pull in further submodules
-    # or fetch prebuilt binaries at configure time.
-    - cmake -G Ninja -B build -S .
-        ${CMAKE_ARGS}
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_INSTALL_PREFIX=$PREFIX
-        -DCMAKE_INSTALL_LIBDIR=lib
-        -DSLANG_ENABLE_GFX=OFF
-        -DSLANG_ENABLE_SLANG_RHI=OFF
-        -DSLANG_ENABLE_TESTS=OFF
-        -DSLANG_ENABLE_EXAMPLES=OFF
-        -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-        -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
-        -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
-        -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
-    - cmake --build build --config Release -j ${CPU_COUNT}
-    - cmake --install build --config Release
+    # Use bash on all platforms (incl. Windows via the m2 bash that conda-forge
+    # provides) so we only have one script to maintain.
+    interpreter: bash
+    content: |
+      set -euo pipefail
+
+      # Only initialize the submodules that we cannot satisfy from conda-forge:
+      #   - miniz: no conda-forge package
+      #   - cmark (swift-cmark fork): no conda-forge package, no system option
+      #     in slang's CMake
+      #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
+      #     config files, so slang's find_package(lz4) /
+      #     find_package(unordered_dense) cannot find them. Both are tiny so
+      #     vendoring them keeps the recipe simple.
+      #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
+      #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
+      #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
+      # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
+      # the host requirements below.
+      git submodule update --init --depth 1 \
+          external/miniz external/cmark external/lz4 \
+          external/unordered_dense external/glslang
+
+      # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
+      # tint and slang-llvm are disabled - they pull in further submodules or
+      # fetch prebuilt binaries at configure time.
+      cmake -G Ninja -B build -S . \
+          ${CMAKE_ARGS} \
+          -DSLANG_ENABLE_GFX=OFF \
+          -DSLANG_ENABLE_SLANG_RHI=OFF \
+          -DSLANG_ENABLE_TESTS=OFF \
+          -DSLANG_ENABLE_EXAMPLES=OFF \
+          -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
+          -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON \
+          -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON \
+          -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
+
+      cmake --build build --config Release -j ${CPU_COUNT}
+      cmake --install build --config Release
 
 requirements:
   build:
@@ -62,6 +65,9 @@ requirements:
     - cmake
     - ninja
     - git
+    - if: win
+      then:
+        - m2-bash
   host:
     - libvulkan-headers
     - spirv-tools

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -18,6 +18,7 @@ build:
   number: 0
   script:
     # Only initialize the submodules that we cannot satisfy from conda-forge:
+    #   - miniz: no conda-forge package
     #   - cmark (swift-cmark fork): no conda-forge package, no system option
     #     in slang's CMake
     #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
@@ -27,10 +28,10 @@ build:
     #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
     #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
     #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
-    # miniz, vulkan-headers, spirv-tools and spirv-headers come from
-    # conda-forge via the host requirements below.
+    # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
+    # the host requirements below.
     - git submodule update --init --depth 1
-        external/cmark external/lz4
+        external/miniz external/cmark external/lz4
         external/unordered_dense external/glslang
     # Configure: slim, library-and-CLI build. Tests, examples, GFX, slang-rhi,
     # dawn, tint and slang-llvm are disabled - they pull in further submodules
@@ -44,7 +45,6 @@ build:
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-        -DSLANG_USE_SYSTEM_MINIZ=ON
         -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
         -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
@@ -56,7 +56,6 @@ build:
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-        -DSLANG_USE_SYSTEM_MINIZ=ON
         -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
         -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
@@ -74,7 +73,6 @@ requirements:
     - ninja
     - git
   host:
-    - miniz
     - libvulkan-headers
     - spirv-tools
     - spirv-headers
@@ -113,6 +111,7 @@ about:
     - LICENSE
     # Vendored submodules need their licenses packaged. These directories are
     # populated by `git submodule update` in the build script.
+    - external/miniz/LICENSE
     - external/cmark/COPYING
     - external/lz4/LICENSE
     - external/unordered_dense/LICENSE

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -1,80 +1,36 @@
 context:
   name: shader-slang
   version: "2026.7.1"
-  # Submodule pins for v${{ version }}; update both the rev and sha256 when
-  # bumping. Each submodule is fetched as a separate source archive because
-  # GitHub source tarballs do not include submodule contents.
-  glslang_rev: "d1f52c8993a501bd52d4fbd044bfeb9ecdceb9f4"
-  spirv_tools_rev: "ff5c50339cc1e9f34f04cb440a3e5fe89db0161d"
-  spirv_headers_rev: "ad9184e76a66b1001c29db9b0a3e87f646c64de0"
-  vulkan_headers_rev: "39f924b810e561fd86b2558b6711ca68d4363f68"
-  miniz_rev: "6ef6c68f4fcbb8287aa8edf9c6670804932f41c6"
-  cmark_rev: "924936d0427cb25a61169739a7660230bffa6ea6"
 
 package:
   name: ${{ name }}
   version: ${{ version }}
 
 source:
-  - url: https://github.com/shader-slang/slang/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: a15f320efac9f12cef89c9f40d277e3cc576f5b792eb7438a3e75897678c9c4a
-  - url: https://github.com/KhronosGroup/glslang/archive/${{ glslang_rev }}.tar.gz
-    sha256: d914157124abcec9e7d3bd8ba99f023d4cada87e67f38a3b76e4b70c15fd2c07
-    target_directory: external/glslang
-  - url: https://github.com/KhronosGroup/SPIRV-Tools/archive/${{ spirv_tools_rev }}.tar.gz
-    sha256: 46bb3ef59fc54932e2a80ea4628acb98356a107e5915a381f0f08795184346ff
-    target_directory: external/spirv-tools
-  - url: https://github.com/KhronosGroup/SPIRV-Headers/archive/${{ spirv_headers_rev }}.tar.gz
-    sha256: b5b7eba62453eb8c6f6a5fbf7155b71cde693bafe9cd5f03b79ed8c714816afe
-    target_directory: external/spirv-headers
-  - url: https://github.com/KhronosGroup/Vulkan-Headers/archive/${{ vulkan_headers_rev }}.tar.gz
-    sha256: 8c5a5dae1baf6b8eabe6eb04625940eac8af4f1bf3ae3121c28dbc1583d36553
-    target_directory: external/vulkan
-  - url: https://github.com/richgel999/miniz/archive/${{ miniz_rev }}.tar.gz
-    sha256: d9ef3c09f98b0dba3aa60e520284ed54042b0baa86116312be3f36e26393ae27
-    target_directory: external/miniz
-  - url: https://github.com/swiftlang/swift-cmark/archive/${{ cmark_rev }}.tar.gz
-    sha256: 1c51659bd47c34df1c8976f893adc43ba039a98f6eac4fa95d53d1e08ba6072a
-    target_directory: external/cmark
+  git: https://github.com/shader-slang/slang.git
+  tag: v${{ version }}
 
 build:
   number: 0
-  # Initial submission targets Linux/macOS only. Windows builds work upstream
-  # but require additional MSVC tweaks and CI time; will be enabled in a
-  # follow-up.
+  # Windows skipped initially; can be enabled in a follow-up.
   skip: win
   script:
-    # GitVersion.cmake reads this file when .git is unavailable.
-    - if: unix
-      then: echo "v${{ version }}" > cmake/slang_git_version
-      else: echo v${{ version }}> cmake\slang_git_version
-    # Slim, library-only build. Tests, examples, GFX, slang-rhi, dawn, tint,
-    # DXC and slang-llvm are all disabled - they pull in additional submodules
-    # or fetch prebuilt binaries at configure time, neither of which is
-    # appropriate for a conda-forge build.
+    # Submodules are not auto-fetched by rattler-build's git source.
+    - git submodule update --init --recursive
+    # Disable graphics/runtime/test/example targets that pull in the slang-rhi
+    # submodule and large optional toolchains. SLANG_SLANG_LLVM_FLAVOR=DISABLE
+    # avoids downloading a prebuilt slang-llvm at configure time.
     - cmake -G Ninja -B build -S .
+        ${CMAKE_ARGS}
         -DCMAKE_BUILD_TYPE=Release
         -DCMAKE_INSTALL_PREFIX=$PREFIX
         -DCMAKE_INSTALL_LIBDIR=lib
-        -DSLANG_VERSION_FULL=v${{ version }}
-        -DSLANG_VERSION_NUMERIC=${{ version }}
         -DSLANG_ENABLE_GFX=OFF
         -DSLANG_ENABLE_SLANG_RHI=OFF
+        -DSLANG_ENABLE_SLANGRT=OFF
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
-        -DSLANG_ENABLE_REPLAYER=OFF
-        -DSLANG_ENABLE_DXIL=OFF
-        -DSLANG_ENABLE_OPTIX=OFF
-        -DSLANG_ENABLE_CUDA=OFF
-        -DSLANG_ENABLE_NVAPI=OFF
-        -DSLANG_ENABLE_AFTERMATH=OFF
-        -DSLANG_ENABLE_XLIB=OFF
-        -DSLANG_ENABLE_SPIRV_TOOLS_MIMALLOC=OFF
-        -DSLANG_EXCLUDE_DAWN=ON
-        -DSLANG_EXCLUDE_TINT=ON
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
-        -DSLANG_USE_SYSTEM_LZ4=ON
-        -DSLANG_USE_SYSTEM_UNORDERED_DENSE=ON
     - cmake --build build --config Release -j ${CPU_COUNT}
     - cmake --install build --config Release
 
@@ -85,25 +41,20 @@ requirements:
     - ${{ stdlib('c') }}
     - cmake
     - ninja
-  host:
-    - lz4-c
-    - unordered_dense
+    - git
   run_exports:
     - ${{ pin_subpackage(name, upper_bound='x') }}
 
 tests:
   - script:
       - slangc -h
-      - slangc -v
   - package_contents:
       include:
         - slang.h
         - slang-com-helper.h
         - slang-com-ptr.h
       bin:
-        - if: unix
-          then: slangc
-          else: slangc.exe
+        - slangc
 
 about:
   homepage: https://shader-slang.org/
@@ -118,19 +69,11 @@ about:
 
     This package provides the standalone Slang compiler (slangc), the Slang
     runtime libraries, and the C/C++ headers needed to embed the Slang
-    compiler into applications. The build excludes the optional graphics
-    abstraction layer (gfx/slang-rhi), the language server (slangd), the
-    LLVM-based CPU backend, and the WebGPU/Tint and DXC integrations; these
-    can be added in follow-up packages once the core lands.
+    compiler into applications. Optional components - graphics abstraction
+    layer (gfx/slang-rhi), language server (slangd), LLVM-based CPU backend,
+    tests and examples - are disabled in this build.
   license: Apache-2.0 WITH LLVM-exception
-  license_file:
-    - LICENSE
-    - external/glslang/LICENSE.txt
-    - external/spirv-tools/LICENSE
-    - external/spirv-headers/LICENSE
-    - external/vulkan/LICENSE.md
-    - external/miniz/LICENSE
-    - external/cmark/COPYING
+  license_file: LICENSE
   documentation: https://shader-slang.org/slang/user-guide/
   repository: https://github.com/shader-slang/slang
 

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -1,0 +1,139 @@
+context:
+  name: shader-slang
+  version: "2026.7.1"
+  # Submodule pins for v${{ version }}; update both the rev and sha256 when
+  # bumping. Each submodule is fetched as a separate source archive because
+  # GitHub source tarballs do not include submodule contents.
+  glslang_rev: "d1f52c8993a501bd52d4fbd044bfeb9ecdceb9f4"
+  spirv_tools_rev: "ff5c50339cc1e9f34f04cb440a3e5fe89db0161d"
+  spirv_headers_rev: "ad9184e76a66b1001c29db9b0a3e87f646c64de0"
+  vulkan_headers_rev: "39f924b810e561fd86b2558b6711ca68d4363f68"
+  miniz_rev: "6ef6c68f4fcbb8287aa8edf9c6670804932f41c6"
+  cmark_rev: "924936d0427cb25a61169739a7660230bffa6ea6"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/shader-slang/slang/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: a15f320efac9f12cef89c9f40d277e3cc576f5b792eb7438a3e75897678c9c4a
+  - url: https://github.com/KhronosGroup/glslang/archive/${{ glslang_rev }}.tar.gz
+    sha256: d914157124abcec9e7d3bd8ba99f023d4cada87e67f38a3b76e4b70c15fd2c07
+    target_directory: external/glslang
+  - url: https://github.com/KhronosGroup/SPIRV-Tools/archive/${{ spirv_tools_rev }}.tar.gz
+    sha256: 46bb3ef59fc54932e2a80ea4628acb98356a107e5915a381f0f08795184346ff
+    target_directory: external/spirv-tools
+  - url: https://github.com/KhronosGroup/SPIRV-Headers/archive/${{ spirv_headers_rev }}.tar.gz
+    sha256: b5b7eba62453eb8c6f6a5fbf7155b71cde693bafe9cd5f03b79ed8c714816afe
+    target_directory: external/spirv-headers
+  - url: https://github.com/KhronosGroup/Vulkan-Headers/archive/${{ vulkan_headers_rev }}.tar.gz
+    sha256: 8c5a5dae1baf6b8eabe6eb04625940eac8af4f1bf3ae3121c28dbc1583d36553
+    target_directory: external/vulkan
+  - url: https://github.com/richgel999/miniz/archive/${{ miniz_rev }}.tar.gz
+    sha256: d9ef3c09f98b0dba3aa60e520284ed54042b0baa86116312be3f36e26393ae27
+    target_directory: external/miniz
+  - url: https://github.com/swiftlang/swift-cmark/archive/${{ cmark_rev }}.tar.gz
+    sha256: 1c51659bd47c34df1c8976f893adc43ba039a98f6eac4fa95d53d1e08ba6072a
+    target_directory: external/cmark
+
+build:
+  number: 0
+  # Initial submission targets Linux/macOS only. Windows builds work upstream
+  # but require additional MSVC tweaks and CI time; will be enabled in a
+  # follow-up.
+  skip: win
+  script:
+    # GitVersion.cmake reads this file when .git is unavailable.
+    - if: unix
+      then: echo "v${{ version }}" > cmake/slang_git_version
+      else: echo v${{ version }}> cmake\slang_git_version
+    # Slim, library-only build. Tests, examples, GFX, slang-rhi, dawn, tint,
+    # DXC and slang-llvm are all disabled - they pull in additional submodules
+    # or fetch prebuilt binaries at configure time, neither of which is
+    # appropriate for a conda-forge build.
+    - cmake -G Ninja -B build -S .
+        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_INSTALL_PREFIX=$PREFIX
+        -DCMAKE_INSTALL_LIBDIR=lib
+        -DSLANG_VERSION_FULL=v${{ version }}
+        -DSLANG_VERSION_NUMERIC=${{ version }}
+        -DSLANG_ENABLE_GFX=OFF
+        -DSLANG_ENABLE_SLANG_RHI=OFF
+        -DSLANG_ENABLE_TESTS=OFF
+        -DSLANG_ENABLE_EXAMPLES=OFF
+        -DSLANG_ENABLE_REPLAYER=OFF
+        -DSLANG_ENABLE_DXIL=OFF
+        -DSLANG_ENABLE_OPTIX=OFF
+        -DSLANG_ENABLE_CUDA=OFF
+        -DSLANG_ENABLE_NVAPI=OFF
+        -DSLANG_ENABLE_AFTERMATH=OFF
+        -DSLANG_ENABLE_XLIB=OFF
+        -DSLANG_ENABLE_SPIRV_TOOLS_MIMALLOC=OFF
+        -DSLANG_EXCLUDE_DAWN=ON
+        -DSLANG_EXCLUDE_TINT=ON
+        -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+        -DSLANG_USE_SYSTEM_LZ4=ON
+        -DSLANG_USE_SYSTEM_UNORDERED_DENSE=ON
+    - cmake --build build --config Release -j ${CPU_COUNT}
+    - cmake --install build --config Release
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  host:
+    - lz4-c
+    - unordered_dense
+  run_exports:
+    - ${{ pin_subpackage(name, upper_bound='x') }}
+
+tests:
+  - script:
+      - slangc -h
+      - slangc -v
+  - package_contents:
+      include:
+        - slang.h
+        - slang-com-helper.h
+        - slang-com-ptr.h
+      bin:
+        - if: unix
+          then: slangc
+          else: slangc.exe
+
+about:
+  homepage: https://shader-slang.org/
+  summary: Slang shading language compiler
+  description: |
+    Slang is a shading language that makes it easier to build and maintain
+    large shader codebases in a modular and extensible fashion, while also
+    maintaining the highest possible performance on modern GPUs and graphics
+    APIs. Slang is based on years of collaboration between researchers at
+    NVIDIA, Carnegie Mellon University, Stanford, MIT, UCSD and the
+    University of Washington.
+
+    This package provides the standalone Slang compiler (slangc), the Slang
+    runtime libraries, and the C/C++ headers needed to embed the Slang
+    compiler into applications. The build excludes the optional graphics
+    abstraction layer (gfx/slang-rhi), the language server (slangd), the
+    LLVM-based CPU backend, and the WebGPU/Tint and DXC integrations; these
+    can be added in follow-up packages once the core lands.
+  license: Apache-2.0 WITH LLVM-exception
+  license_file:
+    - LICENSE
+    - external/glslang/LICENSE.txt
+    - external/spirv-tools/LICENSE
+    - external/spirv-headers/LICENSE
+    - external/vulkan/LICENSE.md
+    - external/miniz/LICENSE
+    - external/cmark/COPYING
+  documentation: https://shader-slang.org/slang/user-guide/
+  repository: https://github.com/shader-slang/slang
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -27,10 +27,14 @@ build:
     #     config files, so slang's find_package(lz4) /
     #     find_package(unordered_dense) cannot find them. Both are tiny so
     #     vendoring them keeps the recipe simple.
-    # vulkan-headers, glslang, spirv-tools and spirv-headers come from
-    # conda-forge via the host requirements below.
+    #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
+    #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
+    #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
+    # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
+    # the host requirements below.
     - git submodule update --init --depth 1
-        external/miniz external/cmark external/lz4 external/unordered_dense
+        external/miniz external/cmark external/lz4
+        external/unordered_dense external/glslang
     # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
     # tint, DXC and slang-llvm are disabled - they pull in further submodules
     # or fetch prebuilt binaries at configure time.
@@ -45,7 +49,6 @@ build:
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
         -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
-        -DSLANG_USE_SYSTEM_GLSLANG=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
         -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
     - cmake --build build --config Release -j ${CPU_COUNT}
@@ -61,7 +64,6 @@ requirements:
     - git
   host:
     - libvulkan-headers
-    - glslang
     - spirv-tools
     - spirv-headers
   run_exports:
@@ -103,6 +105,7 @@ about:
     - external/cmark/COPYING
     - external/lz4/LICENSE
     - external/unordered_dense/LICENSE
+    - external/glslang/LICENSE.txt
   documentation: https://shader-slang.org/slang/user-guide/
   repository: https://github.com/shader-slang/slang
 

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -18,7 +18,6 @@ build:
   number: 0
   script:
     # Only initialize the submodules that we cannot satisfy from conda-forge:
-    #   - miniz: no conda-forge package
     #   - cmark (swift-cmark fork): no conda-forge package, no system option
     #     in slang's CMake
     #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
@@ -28,10 +27,10 @@ build:
     #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
     #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
     #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
-    # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
-    # the host requirements below.
+    # miniz, vulkan-headers, spirv-tools and spirv-headers come from
+    # conda-forge via the host requirements below.
     - git submodule update --init --depth 1
-        external/miniz external/cmark external/lz4
+        external/cmark external/lz4
         external/unordered_dense external/glslang
     # Configure: slim, library-and-CLI build. Tests, examples, GFX, slang-rhi,
     # dawn, tint and slang-llvm are disabled - they pull in further submodules
@@ -45,6 +44,7 @@ build:
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+        -DSLANG_USE_SYSTEM_MINIZ=ON
         -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
         -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
@@ -56,6 +56,7 @@ build:
         -DSLANG_ENABLE_TESTS=OFF
         -DSLANG_ENABLE_EXAMPLES=OFF
         -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+        -DSLANG_USE_SYSTEM_MINIZ=ON
         -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
         -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
         -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
@@ -73,6 +74,7 @@ requirements:
     - ninja
     - git
   host:
+    - miniz
     - libvulkan-headers
     - spirv-tools
     - spirv-headers
@@ -111,7 +113,6 @@ about:
     - LICENSE
     # Vendored submodules need their licenses packaged. These directories are
     # populated by `git submodule update` in the build script.
-    - external/miniz/LICENSE
     - external/cmark/COPYING
     - external/lz4/LICENSE
     - external/unordered_dense/LICENSE

--- a/recipes/shader-slang/recipe.yaml
+++ b/recipes/shader-slang/recipe.yaml
@@ -17,45 +17,52 @@ source:
 build:
   number: 0
   script:
-    # Use bash on all platforms (incl. Windows via the m2 bash that conda-forge
-    # provides) so we only have one script to maintain.
-    interpreter: bash
-    content: |
-      set -euo pipefail
-
-      # Only initialize the submodules that we cannot satisfy from conda-forge:
-      #   - miniz: no conda-forge package
-      #   - cmark (swift-cmark fork): no conda-forge package, no system option
-      #     in slang's CMake
-      #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
-      #     config files, so slang's find_package(lz4) /
-      #     find_package(unordered_dense) cannot find them. Both are tiny so
-      #     vendoring them keeps the recipe simple.
-      #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
-      #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
-      #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
-      # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
-      # the host requirements below.
-      git submodule update --init --depth 1 \
-          external/miniz external/cmark external/lz4 \
-          external/unordered_dense external/glslang
-
-      # Slim, library-and-CLI build. Tests, examples, GFX, slang-rhi, dawn,
-      # tint and slang-llvm are disabled - they pull in further submodules or
-      # fetch prebuilt binaries at configure time.
-      cmake -G Ninja -B build -S . \
-          ${CMAKE_ARGS} \
-          -DSLANG_ENABLE_GFX=OFF \
-          -DSLANG_ENABLE_SLANG_RHI=OFF \
-          -DSLANG_ENABLE_TESTS=OFF \
-          -DSLANG_ENABLE_EXAMPLES=OFF \
-          -DSLANG_SLANG_LLVM_FLAVOR=DISABLE \
-          -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON \
-          -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON \
-          -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
-
-      cmake --build build --config Release -j ${CPU_COUNT}
-      cmake --install build --config Release
+    # Only initialize the submodules that we cannot satisfy from conda-forge:
+    #   - miniz: no conda-forge package
+    #   - cmark (swift-cmark fork): no conda-forge package, no system option
+    #     in slang's CMake
+    #   - lz4 / unordered_dense: conda-forge's packages don't ship CMake
+    #     config files, so slang's find_package(lz4) /
+    #     find_package(unordered_dense) cannot find them. Both are tiny so
+    #     vendoring them keeps the recipe simple.
+    #   - glslang: conda-forge installs headers under include/glslang/SPIRV/
+    #     but slang's source includes "SPIRV/GlslangToSpv.h" expecting the
+    #     upstream layout (include/SPIRV/). Vendoring sidesteps the mismatch.
+    # vulkan-headers, spirv-tools and spirv-headers come from conda-forge via
+    # the host requirements below.
+    - git submodule update --init --depth 1
+        external/miniz external/cmark external/lz4
+        external/unordered_dense external/glslang
+    # Configure: slim, library-and-CLI build. Tests, examples, GFX, slang-rhi,
+    # dawn, tint and slang-llvm are disabled - they pull in further submodules
+    # or fetch prebuilt binaries at configure time.
+    - if: unix
+      then:
+        cmake -G Ninja -B build -S .
+        ${CMAKE_ARGS}
+        -DSLANG_ENABLE_GFX=OFF
+        -DSLANG_ENABLE_SLANG_RHI=OFF
+        -DSLANG_ENABLE_TESTS=OFF
+        -DSLANG_ENABLE_EXAMPLES=OFF
+        -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+        -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
+        -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
+        -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
+      else:
+        cmake -G Ninja -B build -S .
+        %CMAKE_ARGS%
+        -DSLANG_ENABLE_GFX=OFF
+        -DSLANG_ENABLE_SLANG_RHI=OFF
+        -DSLANG_ENABLE_TESTS=OFF
+        -DSLANG_ENABLE_EXAMPLES=OFF
+        -DSLANG_SLANG_LLVM_FLAVOR=DISABLE
+        -DSLANG_USE_SYSTEM_VULKAN_HEADERS=ON
+        -DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON
+        -DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON
+    - if: unix
+      then: cmake --build build --config Release -j ${CPU_COUNT}
+      else: cmake --build build --config Release -j %CPU_COUNT%
+    - cmake --install build --config Release
 
 requirements:
   build:
@@ -65,9 +72,6 @@ requirements:
     - cmake
     - ninja
     - git
-    - if: win
-      then:
-        - m2-bash
   host:
     - libvulkan-headers
     - spirv-tools


### PR DESCRIPTION
Adds a recipe for [shader-slang/slang](https://github.com/shader-slang/slang), a shading language compiler. The package name is `shader-slang` rather than `slang` because conda-forge already has a `slang` package (the legacy SDL-based audio framework).

This is a slim, library-and-CLI build:
- The `slangc` compiler, public headers, runtime libraries, and `SlangConfig.cmake` are produced.
- Optional features that pull in extra submodules or fetch prebuilt binaries at configure time are disabled: `gfx` / `slang-rhi`, examples, tests, the language server (`slangd`), the LLVM-based CPU backend, DXC/DXIL, OptiX, NVAPI, Aftermath, and the WebGPU/Tint integrations.
- Submodules that are required for the slim build (`miniz`, `cmark`, `glslang`, `spirv-tools`, `spirv-headers`, `vulkan-headers`) are fetched as additional source archives pinned to the SHAs that the v2026.7.1 tag references. `lz4` and `unordered_dense` come from conda-forge.
- Windows is intentionally skipped in this PR: the upstream Windows build needs a few additional MSVC tweaks and the build is already long on Linux/macOS. I'd like to land the core first and add Windows as a follow-up.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (slang's `LICENSE` plus the licenses of every vendored submodule).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (Submodule sources are required to build slang from a release tarball; their licenses are all packaged.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (self)