### PR TITLE
MAI: Some modifications so nccl4py is renderable for feedstock

### DIFF
--- a/recipes/nccl4py/recipe.yaml
+++ b/recipes/nccl4py/recipe.yaml
@@ -24,7 +24,7 @@ build:
     # Build exactly one CUDA variant (13.*). Combined with the
     # ignore_run_exports below, the resulting package serves both CUDA 12 and
     # CUDA 13 runtimes, so there's no value in duplicating the build.
-    - not match(cuda_compiler_version, "13.*")
+    # - not match(cuda_compiler_version, "13.*")
 
 requirements:
   # nccl4py is CUDA-major-agnostic: its compiled extensions use only opaque
@@ -77,6 +77,7 @@ tests:
   # cuda-version the solver picks (will be 13.x given the build env).
   - python:
       imports:
+        - this.module.does.not.exist.1827552161
         - nccl
         - nccl.bindings
         - nccl.core


### PR DESCRIPTION
Unstick nccl4py from the create-feedstocks script. It currently fails to render because it requires the CUDA 13.0 migrator. These modifications allow the recipe to render with CUDA 12, but the build will fail before publish occurs.

[#general > Feedstock creation broken for CUDA 13.0 recipes?](https://conda-forge.zulipchat.com/#narrow/channel/457337-general/topic/Feedstock.20creation.20broken.20for.20CUDA.2013.2E0.20recipes.3F/with/591912318)