### PR TITLE
Adding stripe-cli

### DIFF
--- a/recipes/stripe-cli/recipe.yaml
+++ b/recipes/stripe-cli/recipe.yaml
@@ -1,0 +1,67 @@
+context:
+  version: "1.40.9"
+
+package:
+  name: stripe-cli
+  version: ${{ version }}
+
+source:
+  url: https://github.com/stripe/stripe-cli/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: dcb2890fadc1a6ef008cc316f61f1025c7a412c9bd9766a5a61c098813b05ff4
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save ./cmd/stripe --save_path ../library_licenses
+    - if: unix
+      then: go build -v -o $PREFIX/bin/stripe -ldflags="-s -w -X github.com/stripe/stripe-cli/pkg/version.Version=${{ version }}" ./cmd/stripe
+      else: go build -v -o %LIBRARY_BIN%\stripe.exe -ldflags="-s -X github.com/stripe/stripe-cli/pkg/version.Version=${{ version }}" .\cmd\stripe
+    - if: unix
+      then:
+        - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/zsh/site-functions $PREFIX/share/fish/vendor_completions.d
+        - $PREFIX/bin/stripe completion --shell bash --write-to-stdout > $PREFIX/share/bash-completion/completions/stripe
+        - $PREFIX/bin/stripe completion --shell zsh --write-to-stdout > $PREFIX/share/zsh/site-functions/_stripe
+        - $PREFIX/bin/stripe completion --shell fish --write-to-stdout > $PREFIX/share/fish/vendor_completions.d/stripe.fish
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+
+tests:
+  - script:
+      - stripe --help
+      - stripe --version
+  - package_contents:
+      bin:
+        - stripe
+      files:
+        - if: unix
+          then:
+            - share/bash-completion/completions/stripe
+            - share/zsh/site-functions/_stripe
+            - share/fish/vendor_completions.d/stripe.fish
+      strict: true
+
+about:
+  homepage: https://github.com/stripe/stripe-cli
+  summary: A command-line tool for Stripe
+  description: |
+    The Stripe CLI is a developer tool to help build, test, and manage your
+    integration with Stripe directly from the command line. With it you can
+    securely test webhooks without relying on third-party software, trigger
+    webhook events to conveniently test your integration, tail your API
+    request logs in real-time, and create, retrieve, update, or delete API
+    objects.
+  license: Apache-2.0
+  license_file:
+    - src/LICENSE
+    - library_licenses/
+  documentation: https://docs.stripe.com/stripe-cli
+  repository: https://github.com/stripe/stripe-cli
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds a recipe for [`stripe-cli`](https://github.com/stripe/stripe-cli), the official command-line tool for Stripe. It is a Go binary used by developers to test webhooks, tail API request logs, and create/retrieve/update/delete API objects from the terminal.

Built and tested locally on `win-64`. Should also build cleanly on `linux-64` and `osx-64` / `osx-arm64` since the upstream `Makefile` already cross-compiles for all three platforms with no CGO requirements.

Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.