### PR TITLE
Add dora-rs (CLI + Python bindings)

### DIFF
--- a/recipes/dora-rs/recipe.yaml
+++ b/recipes/dora-rs/recipe.yaml
@@ -1,0 +1,136 @@
+context:
+  version: "0.5.0"
+
+recipe:
+  name: dora-rs-suite
+  version: ${{ version }}
+
+source:
+  url: https://github.com/dora-rs/dora/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: e31b9b8fb3fb442407a7ef4b258249bc41d100fd872d5417ebd5fecce6ea7748
+
+build:
+  number: 0
+
+outputs:
+  - package:
+      name: dora-cli
+    build:
+      script:
+        env:
+          CARGO_PROFILE_RELEASE_STRIP: symbols
+          CARGO_PROFILE_RELEASE_LTO: "thin"
+        content:
+          - if: unix
+            then:
+              - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path binaries/cli
+              - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/zsh/site-functions $PREFIX/share/fish/vendor_completions.d
+              - $PREFIX/bin/dora completion bash > $PREFIX/share/bash-completion/completions/dora
+              - $PREFIX/bin/dora completion zsh  > $PREFIX/share/zsh/site-functions/_dora
+              - $PREFIX/bin/dora completion fish > $PREFIX/share/fish/vendor_completions.d/dora.fish
+            else:
+              - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path binaries/cli
+          - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+    requirements:
+      build:
+        - ${{ stdlib('c') }}
+        - ${{ compiler('c') }}
+        - ${{ compiler('cxx') }}
+        - ${{ compiler('rust') }}
+        - rust >=1.85
+        - cargo-bundle-licenses
+        - cargo-auditable
+        - if: unix
+          then: perl
+    tests:
+      - script:
+          - dora --version
+          - dora --help
+      - package_contents:
+          bin:
+            - dora
+          files:
+            - if: unix
+              then:
+                - share/bash-completion/completions/dora
+                - share/zsh/site-functions/_dora
+                - share/fish/vendor_completions.d/dora.fish
+          strict: true
+    about:
+      summary: Command-line tool for the dora-rs dataflow framework
+      description: |
+        dora-rs is a low-latency, composable, distributed dataflow framework
+        for AI-based robotic applications. The `dora` CLI is the user-facing
+        command for managing dataflows, the coordinator and the daemons that
+        run nodes.
+      license: Apache-2.0
+      license_file:
+        - LICENSE
+        - THIRDPARTY.yml
+
+  - package:
+      name: dora-rs
+    build:
+      script:
+        env:
+          CARGO_PROFILE_RELEASE_STRIP: symbols
+        content:
+          - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+          - cd apis/python/node && ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      build:
+        - ${{ stdlib('c') }}
+        - ${{ compiler('c') }}
+        - ${{ compiler('cxx') }}
+        - ${{ compiler('rust') }}
+        - rust >=1.85
+        - cargo-bundle-licenses
+        - if: build_platform != target_platform
+          then:
+            - python
+            - cross-python_${{ target_platform }}
+            - maturin >=1.7,<2
+        - if: unix
+          then: perl
+      host:
+        - python
+        - pip
+        - maturin >=1.7,<2
+      run:
+        - python
+        - pyarrow >=14.0.1
+        - pyyaml >=6.0
+    tests:
+      - python:
+          imports:
+            - dora
+          pip_check: true
+    about:
+      summary: Python bindings for the dora-rs dataflow framework
+      description: |
+        dora-rs is a low-latency, composable, distributed dataflow framework
+        for AI-based robotic applications. This package provides the Python
+        Node and Operator APIs used to build dora dataflow applications in
+        Python.
+      license: Apache-2.0
+      license_file:
+        - LICENSE
+        - THIRDPARTY.yml
+
+about:
+  homepage: https://github.com/dora-rs/dora
+  summary: dora-rs distributed dataflow framework
+  description: |
+    dora-rs is a low-latency, composable, distributed dataflow framework
+    for AI-based robotic applications. This feedstock builds the dora
+    command-line tool and the Python bindings from the same upstream
+    source.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+  documentation: https://dora-rs.ai
+  repository: https://github.com/dora-rs/dora
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/dora-rs/recipe.yaml
+++ b/recipes/dora-rs/recipe.yaml
@@ -24,12 +24,18 @@ outputs:
           - if: unix
             then:
               - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path binaries/cli
+            else:
+              - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path binaries/cli
+          - if: unix
+            then:
               - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/zsh/site-functions $PREFIX/share/fish/vendor_completions.d
               - $PREFIX/bin/dora completion bash > $PREFIX/share/bash-completion/completions/dora
               - $PREFIX/bin/dora completion zsh  > $PREFIX/share/zsh/site-functions/_dora
               - $PREFIX/bin/dora completion fish > $PREFIX/share/fish/vendor_completions.d/dora.fish
-            else:
-              - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path binaries/cli
+          - if: win
+            then:
+              - mkdir %LIBRARY_PREFIX%\share\powershell\completions
+              - "%LIBRARY_PREFIX%\\bin\\dora.exe completion powershell > %LIBRARY_PREFIX%\\share\\powershell\\completions\\dora.ps1"
           - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
     requirements:
       build:
@@ -40,8 +46,6 @@ outputs:
         - rust >=1.85
         - cargo-bundle-licenses
         - cargo-auditable
-        - if: unix
-          then: perl
     tests:
       - script:
           - dora --version
@@ -55,6 +59,8 @@ outputs:
                 - share/bash-completion/completions/dora
                 - share/zsh/site-functions/_dora
                 - share/fish/vendor_completions.d/dora.fish
+              else:
+                - Library/share/powershell/completions/dora.ps1
           strict: true
     about:
       summary: Command-line tool for the dora-rs dataflow framework
@@ -90,8 +96,6 @@ outputs:
             - python
             - cross-python_${{ target_platform }}
             - maturin >=1.7,<2
-        - if: unix
-          then: perl
       host:
         - python
         - pip

--- a/recipes/dora-rs/recipe.yaml
+++ b/recipes/dora-rs/recipe.yaml
@@ -20,6 +20,7 @@ outputs:
         env:
           CARGO_PROFILE_RELEASE_STRIP: symbols
           CARGO_PROFILE_RELEASE_LTO: "thin"
+          OPENSSL_NO_VENDOR: "1"
         content:
           - if: unix
             then:
@@ -46,6 +47,12 @@ outputs:
         - rust >=1.85
         - cargo-bundle-licenses
         - cargo-auditable
+        - if: unix
+          then: pkg-config
+      host:
+        - if: unix
+          then:
+            - openssl
     tests:
       - script:
           - dora --version
@@ -80,6 +87,7 @@ outputs:
       script:
         env:
           CARGO_PROFILE_RELEASE_STRIP: symbols
+          OPENSSL_NO_VENDOR: "1"
         content:
           - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
           - cd apis/python/node && ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
@@ -91,6 +99,8 @@ outputs:
         - ${{ compiler('rust') }}
         - rust >=1.85
         - cargo-bundle-licenses
+        - if: unix
+          then: pkg-config
         - if: build_platform != target_platform
           then:
             - python
@@ -100,6 +110,9 @@ outputs:
         - python
         - pip
         - maturin >=1.7,<2
+        - if: unix
+          then:
+            - openssl
       run:
         - python
         - pyarrow >=14.0.1


### PR DESCRIPTION
## Summary

Adds [dora-rs](https://github.com/dora-rs/dora) v0.5.0 to conda-forge as a multi-output recipe producing two packages from the same upstream Cargo workspace:

- `dora-cli` — the `dora` Rust binary (CLI for managing dataflows, the coordinator and daemons), with bash/zsh/fish completions on Unix.
- `dora-rs` — the Python bindings (`apis/python/node`) built via maturin/pyo3 (abi3, py>=3.8).

dora-rs is a low-latency, composable, distributed dataflow framework for AI-based robotic applications.

## Notes

- C and C++ bindings (`apis/c/{node,operator}`, `apis/c++/{node,operator}`) ship as Rust `staticlib` crates and are intentionally not packaged in this PR. They are normally consumed at build time via cargo or vendored sources, and the C++ side relies on cxx-bridge headers generated at build time. We can add separate outputs for them in a follow-up if there is demand.
- Both outputs were built and tested locally on `win-64` against rust 1.94 / vs2022.

## Checklist

- [x] Title is meaningful
- [x] LICENSE and `THIRDPARTY.yml` (collected with `cargo-bundle-licenses`) are packaged in each output
- [x] Source is the official GitHub release tarball
- [x] No vendored packages
- [x] Static libraries are not shipped (CFEP-18 not applicable)
- [x] Build number is 0
- [x] Tarball (`url`) used, not a git repo
- [x] Maintainer (@baszalmstra) confirms willingness to maintain