### PR TITLE
Adding nethack 5.0.0

### DIFF
--- a/recipes/nethack/build.sh
+++ b/recipes/nethack/build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LUA_VERSION=5.4.8
+
+# Pick a hints file appropriate for the host platform. The linux.500 hints
+# probe libuuid via /sbin/ldconfig (Linux-only) and assume GNU userland;
+# macOS.500 sets macOS-specific defines and avoids that probe.
+case "$(uname -s)" in
+    Darwin) HINTS=hints/macOS.500 ;;
+    *)      HINTS=hints/linux.500 ;;
+esac
+
+# The included compiler.500 hints does `CFLAGS=$(CCFLAGS) -I../include ...`
+# (hard assignment) which wipes out the conda env CFLAGS. Switch it to `+=`
+# so our isystem/sysroot flags survive and the conda-forge headers/libs win.
+sed -i.bak \
+    's|^CFLAGS=\$(CCFLAGS) -I\.\./include -DNOTPARMDECL$|CFLAGS+=$(CCFLAGS) -I../include -DNOTPARMDECL|' \
+    sys/unix/hints/include/compiler.500
+
+# Tell NetHack to additionally link against conda-forge's lua. The default
+# LUALIBS = $(LUALIB) -lm $(DLLIB) only references the static liblua.a built
+# from the bundled lua source; we keep that as a (now empty) stub for the
+# make dependency, and add -llua so the real symbols come from $PREFIX/lib.
+sed -i.bak \
+    's|^LUALIBS = \$(LUALIB) -lm \$(DLLIB)$|LUALIBS = $(LUALIB) -llua -lm $(DLLIB)|' \
+    sys/unix/Makefile.src
+
+# Generate the active Makefiles from the hints file.
+( cd sys/unix && sh setup.sh "$HINTS" )
+
+# Stand in for `make fetch-Lua`: instead of downloading and building lua
+# from source, point NetHack at conda-forge's lua headers and provide stub
+# archives at the paths the makefile's lua dependency rules expect. The
+# nhlua.h generation rule reads lua.h via `../lib/lua-X.Y.Z/src/...`, so
+# the headers must live under that exact path.
+mkdir -p "lib/lua-${LUA_VERSION}/src" lib/lua
+cp "$PREFIX/include/lua.h" "lib/lua-${LUA_VERSION}/src/"
+cp "$PREFIX/include/lualib.h" "lib/lua-${LUA_VERSION}/src/"
+cp "$PREFIX/include/lauxlib.h" "lib/lua-${LUA_VERSION}/src/"
+cp "$PREFIX/include/luaconf.h" "lib/lua-${LUA_VERSION}/src/"
+echo "static int _stub_lua;" > stub_lua.c
+"${CC:-cc}" -c stub_lua.c -o stub_lua.o
+"${AR:-ar}" rcs "lib/lua-${LUA_VERSION}/src/liblua.a" stub_lua.o
+"${AR:-ar}" rcs "lib/lua/liblua-${LUA_VERSION}.a" stub_lua.o
+rm -f stub_lua.c stub_lua.o
+
+# NetHack uses LFLAGS (not LDFLAGS) for linker flags. Export it so the
+# `LFLAGS+=` lines in hints (e.g. -rdynamic on Linux) extend our value
+# rather than replace it; this gets `-L$PREFIX/lib` into the link line so
+# we pick up conda-forge ncurses and lua instead of the system ones.
+export LFLAGS="${LDFLAGS:-}"
+
+# Override the install paths from the hints file so everything lands inside
+# $PREFIX (conda layout) instead of ~/nh/install or /Library/NetHack.
+MAKE_OVERRIDES=(
+    PREFIX="$PREFIX"
+    HACKDIR="$PREFIX/share/nethack"
+    SHELLDIR="$PREFIX/bin"
+    GAMEUID="$(id -un)"
+    GAMEGRP="$(id -gn)"
+    CHOWN=true
+    CHGRP=true
+    NO_NHUUID=1
+)
+
+make "${MAKE_OVERRIDES[@]}" all
+make "${MAKE_OVERRIDES[@]}" install

--- a/recipes/nethack/build.sh
+++ b/recipes/nethack/build.sh
@@ -11,22 +11,10 @@ case "$(uname -s)" in
     *)      HINTS=hints/linux.500 ;;
 esac
 
-# The included compiler.500 hints does `CFLAGS=$(CCFLAGS) -I../include ...`
-# (hard assignment) which wipes out the conda env CFLAGS. Switch it to `+=`
-# so our isystem/sysroot flags survive and the conda-forge headers/libs win.
-sed -i.bak \
-    's|^CFLAGS=\$(CCFLAGS) -I\.\./include -DNOTPARMDECL$|CFLAGS+=$(CCFLAGS) -I../include -DNOTPARMDECL|' \
-    sys/unix/hints/include/compiler.500
-
-# Tell NetHack to additionally link against conda-forge's lua. The default
-# LUALIBS = $(LUALIB) -lm $(DLLIB) only references the static liblua.a built
-# from the bundled lua source; we keep that as a (now empty) stub for the
-# make dependency, and add -llua so the real symbols come from $PREFIX/lib.
-sed -i.bak \
-    's|^LUALIBS = \$(LUALIB) -lm \$(DLLIB)$|LUALIBS = $(LUALIB) -llua -lm $(DLLIB)|' \
-    sys/unix/Makefile.src
-
-# Generate the active Makefiles from the hints file.
+# Generate the active Makefiles from the hints file. The two source patches
+# applied earlier (see recipe.yaml) make compiler.500's CFLAGS assignment
+# additive so the conda env flags survive, and add -llua to LUALIBS so we
+# pick up conda-forge's liblua at link time.
 ( cd sys/unix && sh setup.sh "$HINTS" )
 
 # Stand in for `make fetch-Lua`: instead of downloading and building lua

--- a/recipes/nethack/patches/0001-compiler.500-respect-env-CFLAGS.patch
+++ b/recipes/nethack/patches/0001-compiler.500-respect-env-CFLAGS.patch
@@ -1,0 +1,15 @@
+Use += so the conda env CFLAGS (with -isystem $PREFIX/include and the
+sysroot debug-prefix-map) survive instead of being clobbered by the
+hints file's hard assignment.
+
+--- a/sys/unix/hints/include/compiler.500
++++ b/sys/unix/hints/include/compiler.500
+@@ -49,7 +49,7 @@
+ #CC= clang
+ #CXX=clang++ -std=gnu++11
+
+-CFLAGS=$(CCFLAGS) -I../include -DNOTPARMDECL
++CFLAGS+=$(CCFLAGS) -I../include -DNOTPARMDECL
+ CFLAGS+=-Wall -Wextra  \
+ 	-Wreturn-type -Wunused -Wformat -Wswitch -Wshadow -Wwrite-strings
+ CFLAGS+=-pedantic

--- a/recipes/nethack/patches/0002-Makefile.src-link-against-conda-lua.patch
+++ b/recipes/nethack/patches/0002-Makefile.src-link-against-conda-lua.patch
@@ -1,0 +1,15 @@
+Add -llua to LUALIBS so the actual lua symbols come from conda-forge's
+liblua at $PREFIX/lib. The bundled $(LUALIB) static archive is replaced
+with a stub at build time, so it contributes no symbols on its own.
+
+--- a/sys/unix/Makefile.src
++++ b/sys/unix/Makefile.src
+@@ -505,7 +505,7 @@
+ LUA_VERSION ?=5.4.8
+ LUABASE = liblua-$(LUA_VERSION).a
+ LUALIB = ../lib/lua/$(LUABASE)
+-LUALIBS = $(LUALIB) -lm $(DLLIB)
++LUALIBS = $(LUALIB) -llua -lm $(DLLIB)
+ LUAHEADERS = lib/lua-$(LUA_VERSION)/src
+
+ # timestamp files to reduce `make' overhead and shorten .o dependency lists

--- a/recipes/nethack/recipe.yaml
+++ b/recipes/nethack/recipe.yaml
@@ -1,0 +1,55 @@
+context:
+  version: "5.0.0"
+  lua_version: "5.4.8"
+
+package:
+  name: nethack
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/NetHack/NetHack/archive/refs/tags/NetHack-${{ version }}_Released.tar.gz
+    sha256: 5638ab7069f143ac4f8197677aee4d43ee3dd1a90a780e596e6ed4f526302703
+
+build:
+  number: 0
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - make
+    - groff
+  host:
+    - ncurses
+    - lua ==${{ lua_version }}
+  run_exports:
+    weak:
+      - ncurses
+
+tests:
+  - script:
+      - test -f $PREFIX/bin/nethack
+      - test -f $PREFIX/share/nethack/nhdat
+      - test -f $PREFIX/share/nethack/sysconf
+      - nethack --version
+
+about:
+  homepage: https://www.nethack.org/
+  repository: https://github.com/NetHack/NetHack
+  documentation: https://nethackwiki.com/
+  summary: A classic terminal-based roguelike dungeon exploration game
+  description: |
+    NetHack is a single player dungeon exploration game that runs on a
+    wide variety of computer systems, with a variety of graphical and
+    text interfaces all using the same game engine. Unlike many other
+    Dungeons & Dragons-inspired games, the emphasis in NetHack is on
+    discovering the detail of the dungeon and not simply killing
+    everything in sight.
+  license: NGPL
+  license_file: dat/license
+
+extra:
+  recipe-maintainers:
+    - tdejager

--- a/recipes/nethack/recipe.yaml
+++ b/recipes/nethack/recipe.yaml
@@ -9,6 +9,9 @@ package:
 source:
   - url: https://github.com/NetHack/NetHack/archive/refs/tags/NetHack-${{ version }}_Released.tar.gz
     sha256: 5638ab7069f143ac4f8197677aee4d43ee3dd1a90a780e596e6ed4f526302703
+    patches:
+      - patches/0001-compiler.500-respect-env-CFLAGS.patch
+      - patches/0002-Makefile.src-link-against-conda-lua.patch
 
 build:
   number: 0


### PR DESCRIPTION
## Summary

Adds [NetHack](https://www.nethack.org/) 5.0.0, the classic terminal roguelike,
as a new conda-forge package.

- Builds from the upstream `sys/unix` hints files (`linux.500` / `macOS.500`)
- Links against conda-forge `lua 5.4.8` and `ncurses 6.6` rather than vendoring
- Skips Windows; the upstream Windows build is MSVC/`winhack`-driven and would
  need its own recipe pass
- Installs as `$PREFIX/bin/nethack` (a small wrapper) plus `$PREFIX/share/nethack/`
  for game data, matching the conda layout

The build script patches one `=` to `+=` in `compiler.500` so the conda env's
`CFLAGS` survive, and patches `Makefile.src` to add `-llua` to `LUALIBS` so the
real lua symbols come from `$PREFIX/lib`. NetHack's makefile still wants a
static `liblua.a` to satisfy a make dependency; we materialize a tiny stub
archive instead of fetching and building the bundled lua source.

Verified locally on osx-arm64: `nethack --version` and `nethack --showpaths`
both work; `otool -L` shows the binary linking only against
`@rpath/libncurses.6.dylib`, `@rpath/liblua.5.4.dylib`, and `libSystem`.

## Checklist

- [x] Title of this PR is meaningful
- [x] License file is packaged (`dat/license`, NGPL)
- [x] Source is from official source (GitHub release tag)
- [x] Package does not vendor other packages (lua, ncurses come from conda-forge)
- [x] Package does not ship static libraries