### PR TITLE
Add scpn-quantum-control

### DIFF
--- a/recipes/scpn-quantum-control/recipe.yaml
+++ b/recipes/scpn-quantum-control/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  name: scpn-quantum-control
+  version: "0.9.6"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/scpn-quantum-control/scpn_quantum_control-${{ version }}.tar.gz
+  sha256: a89f56f309e1a83bda67f4a07f33b3095a8f50b6188ae4ce8cfef7ff10a8f3e7
+
+build:
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  python:
+    entry_points:
+      - scpn-bench = scpn_quantum_control.bench_cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - qiskit >=2.2,<3.0
+    - qiskit-aer >=0.15,<1.0
+    - numpy >=1.24,<3.0
+    - scipy >=1.10,<2.0
+    - networkx >=3.0,<4.0
+    - requests >=2.22,<3.0
+
+tests:
+  - python:
+      imports:
+        - scpn_quantum_control
+  - script:
+      - scpn-bench --help
+
+about:
+  summary: NISQ quantum simulation of coupled Kuramoto oscillator networks via XY Hamiltonian mapping
+  description: |
+    scpn-quantum-control provides a Qiskit-based workflow for Kuramoto-XY
+    NISQ experiments, topology-informed ansatz construction, reproducible
+    hardware raw-count packaging, and artefact-first benchmark regeneration.
+  license: AGPL-3.0-or-later
+  license_file: LICENSE
+  homepage: https://github.com/anulum/scpn-quantum-control
+  repository: https://github.com/anulum/scpn-quantum-control
+  documentation: https://anulum.github.io/scpn-quantum-control
+
+extra:
+  recipe-maintainers:
+    - anulum


### PR DESCRIPTION
This PR adds a conda-forge staged-recipes recipe for scpn-quantum-control 0.9.6. The package is a noarch Python Qiskit workflow for Kuramoto-XY NISQ experiments, hardware artefact packaging, and benchmark regeneration.