### PR TITLE
Add ghostty (terminal emulator)

### DIFF
--- a/recipes/ghostty/Menu/ghostty.json
+++ b/recipes/ghostty/Menu/ghostty.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://schemas.conda.org/menuinst-1-1-0.schema.json",
+    "menu_name": "Ghostty",
+    "menu_items": [
+        {
+            "name": "Ghostty",
+            "description": "A fast, native, feature-rich terminal emulator",
+            "command": [
+                "{{ PREFIX }}/bin/ghostty",
+                "--gtk-single-instance=true"
+            ],
+            "icon": "{{ MENU_DIR }}/ghostty.{{ ICON_EXT }}",
+            "platforms": {
+                "linux": {
+                    "Categories": [
+                        "System",
+                        "TerminalEmulator"
+                    ],
+                    "StartupNotify": true,
+                    "DBusActivatable": false
+                }
+            }
+        }
+    ]
+}

--- a/recipes/ghostty/build.sh
+++ b/recipes/ghostty/build.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch zig dependencies into an offline cache. This step requires network.
+export ZIG_GLOBAL_CACHE_DIR="${SRC_DIR}/zig-cache"
+mkdir -p "${ZIG_GLOBAL_CACHE_DIR}"
+./nix/build-support/fetch-zig-cache.sh
+
+# Generate a libc.txt that points zig at the conda toolchain instead of the
+# system /lib64 / /usr/include. zig build doesn't go through the conda zig-cc
+# wrapper so it would otherwise try to link against the host's libc.
+gcc_dir="$(dirname "$(${HOST}-gcc -print-libgcc-file-name)")"
+libc_txt="${SRC_DIR}/conda-libc.txt"
+cat > "${libc_txt}" <<EOF
+include_dir=${BUILD_PREFIX}/${HOST}/sysroot/usr/include
+sys_include_dir=${BUILD_PREFIX}/${HOST}/sysroot/usr/include
+crt_dir=${BUILD_PREFIX}/${HOST}/sysroot/usr/lib64
+msvc_lib_dir=
+kernel32_lib_dir=
+gcc_dir=${gcc_dir}
+EOF
+
+# When --sysroot is passed to zig, every -L path (including the conda host
+# ${PREFIX}/lib) gets prepended with the sysroot — so zig ends up looking for
+# libbz2.so etc. at ${SYSROOT}${PREFIX}/lib, which doesn't exist. Mirror the
+# host include / lib trees inside the sysroot so the prefixed paths resolve.
+sysroot_dir="${BUILD_PREFIX}/${HOST}/sysroot"
+mkdir -p "${sysroot_dir}$(dirname "${PREFIX}")"
+ln -sfn "${PREFIX}" "${sysroot_dir}${PREFIX}"
+
+# ghostty's build.zig calls linkSystemLibrary2("bzip2", ...) which makes zig
+# search for libbzip2.so — conda-forge's bzip2 package ships libbz2.so.* only
+# (the SONAME). Bridge the name with a build-time symlink so the linker can
+# resolve it; the actual SONAME embedded in the binary stays libbz2.so, so the
+# runtime dependency on conda-forge bzip2 stays correct. The symlink is
+# removed before packaging.
+bzip2_compat_link="${PREFIX}/lib/libbzip2.so"
+ln -sf libbz2.so "${bzip2_compat_link}"
+
+extra_flags=()
+# Used only for local iteration on linux-aarch64 where gtk4-layer-shell is
+# not packaged yet. The aarch64 platform is skipped in recipe.yaml so this
+# branch is never taken in CI.
+if [[ "${GHOSTTY_NO_WAYLAND:-0}" == "1" ]]; then
+    extra_flags+=(-Dgtk-wayland=false)
+fi
+
+# Build ghostty using the prefetched cache. No further network is needed.
+zig build \
+    --prefix "${PREFIX}" \
+    --system "${ZIG_GLOBAL_CACHE_DIR}/p" \
+    --sysroot "${sysroot_dir}" \
+    --libc "${libc_txt}" \
+    --search-prefix "${PREFIX}" \
+    -Doptimize=ReleaseFast \
+    -Dcpu=baseline \
+    -Dversion-string="${PKG_VERSION}-conda" \
+    -Dpie=true \
+    "${extra_flags[@]}"
+
+# Drop the bzip2 build-time symlink so it doesn't ship in the package.
+rm -f "${bzip2_compat_link}"
+
+# Ghostty's auto resource-dir detection (src/os/resourcesdir.zig) walks up
+# from the binary looking for share/terminfo/g/ghostty or
+# share/terminfo/x/xterm-ghostty as a sentinel. Newer ncurses lays entries
+# out by hex code (terminfo/78/xterm-ghostty) and ghostty installs a
+# relative letter-form symlink pointing at it — but rattler-build's
+# prefix-rewriting drops that symlink because its target uses an unusual
+# ".././78/..." form. Without the sentinel ghostty falls back to no
+# resource dir, so `+list-themes` and shell integration both come up
+# empty. Recreate clean symlinks (the actual entry stays under 78/).
+if [[ -f "${PREFIX}/share/terminfo/78/xterm-ghostty" ]]; then
+    mkdir -p "${PREFIX}/share/terminfo/x" "${PREFIX}/share/terminfo/g"
+    ln -sfn ../78/xterm-ghostty "${PREFIX}/share/terminfo/x/xterm-ghostty"
+    ln -sfn ../78/xterm-ghostty "${PREFIX}/share/terminfo/g/ghostty"
+fi
+
+# Install menuinst entry for the system app menu (pixi/conda menu integration).
+mkdir -p "${PREFIX}/Menu"
+cp "${RECIPE_DIR}/Menu/ghostty.json" "${PREFIX}/Menu/ghostty.json"
+cp "${SRC_DIR}/images/gnome/512.png" "${PREFIX}/Menu/ghostty.png"

--- a/recipes/ghostty/recipe.yaml
+++ b/recipes/ghostty/recipe.yaml
@@ -1,0 +1,120 @@
+context:
+  name: ghostty
+  version: "1.3.1"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://release.files.ghostty.org/${{ version }}/ghostty-${{ version }}.tar.gz
+  sha256: 3349d25600ffbda281197a18314f7d18791969cffe9474f0ff16a45a9ebfccdb
+
+build:
+  number: 0
+  # Build only on linux-64 for now.
+  #   - macOS: Xcode 16.4 is on the Azure osx_64 runner (probe confirms),
+  #     and zig is invoked successfully via xcodebuild, but the build
+  #     panics with "reached unreachable code" inside zig itself when
+  #     compiling for x86_64-macos.13.0 against MacOSX15.5.sdk. Root
+  #     cause not yet pinned down — could be a zig 0.15.2 codegen bug,
+  #     or the conda-forge x86_64 zig running under Rosetta on an Apple
+  #     Silicon runner (the runner-arch question is unresolved). Path
+  #     forward: enable osx_arm64 once the recipe lands in a feedstock
+  #     (via `provider.osx_arm64: default` or
+  #     `build_platform.osx_64: osx_arm64` in conda-forge.yml) so zig
+  #     runs on its native arch and we can debug from a clean baseline.
+  #   - Windows: unsupported upstream.
+  #   - linux-aarch64: gtk4-layer-shell isn't packaged for it yet.
+  skip:
+    - not (linux and x86_64)
+  script:
+    file: build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    # Pin to zig 0.15.2 build 22+ for the stdlib patches that bypass
+    # missing libc symbols (fstat/getrandom/copy_file_range) and remap
+    # absolute paths in linker scripts under a sysroot. We still need
+    # variants.yaml's c_stdlib_version: 2.34 because the comptime gate
+    # in those patches only fires when zig is invoked with an explicit
+    # `-target x86_64-linux-gnu.2.17` and ghostty's build.zig launches
+    # sub-compiles with `native-native` target.
+    - 'zig 0.15.2.* [build_number=">=22"]'
+    - pkg-config
+    - pandoc
+    - gettext
+    - libxml2
+    - gobject-introspection
+    - wayland-protocols
+  host:
+    # GTK / GUI
+    - gtk4
+    - libadwaita
+    - gtk4-layer-shell
+    - libxkbcommon
+    - wayland
+    - xorg-libx11
+    - xorg-libxcursor
+    - xorg-libxi
+    - xorg-libxrandr
+    - libgl-devel
+    - gst-plugins-base
+    - gst-plugins-good
+    - gstreamer
+    # System libraries linked dynamically by zig build's
+    # systemIntegrationOption defaults on Linux.
+    - bzip2
+    - expat
+    - fontconfig
+    - freetype
+    - harfbuzz
+    - libpng
+    - libxml2
+    - oniguruma
+    - zlib
+  run:
+    # gtk4-layer-shell doesn't export a run-export, so the .so.0 needs to
+    # be listed explicitly (otherwise: "ghostty: error while loading shared
+    # libraries: libgtk4-layer-shell.so.0").
+    - gtk4-layer-shell
+    # GStreamer is dlopened at runtime for video/audio integrations.
+    - gst-plugins-base
+    - gst-plugins-good
+    - gstreamer
+
+tests:
+  - script:
+      - ghostty --version
+      - ghostty +help
+  - package_contents:
+      bin:
+        - ghostty
+      files:
+        - share/applications/com.mitchellh.ghostty.desktop
+        # ghostty installs its terminfo as the canonical xterm-ghostty entry
+        # (with a relative symlink ghostty -> xterm-ghostty that conda strips
+        # and we recreate in build.sh).
+        - share/terminfo/78/xterm-ghostty
+        - share/terminfo/x/xterm-ghostty
+        - Menu/ghostty.json
+
+about:
+  homepage: https://ghostty.org
+  summary: A fast, native, feature-rich terminal emulator
+  description: |
+    Ghostty is a terminal emulator that differentiates itself by being fast,
+    feature-rich, and native. While there are many excellent terminal emulators
+    available, they all force you to choose between speed, features, or native
+    UIs. Ghostty provides all three.
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/ghostty-org/ghostty
+  documentation: https://ghostty.org/docs
+
+extra:
+  recipe-maintainers:
+    - tdejager

--- a/recipes/ghostty/variants.yaml
+++ b/recipes/ghostty/variants.yaml
@@ -1,0 +1,20 @@
+# Linux pin overrides for ghostty.
+#
+# Using rattler-build's v1 conditional syntax (`if: linux / then: ...`) so
+# the conda-forge linter sees that nothing is being set against the macOS
+# baseline (osx is skipped in recipe.yaml anyway).
+
+# zig 0.15.2 build 22 ships stdlib patches that *would* let us drop to
+# glibc 2.17 — but conda-forge's gtk4 / libadwaita / gtk4-layer-shell
+# build against glibc 2.34 (their run_exports pin __glibc >=2.34), so
+# our binary's runtime floor is 2.34 regardless. Match the sysroot to
+# the chokepoint.
+c_stdlib_version:
+  - if: linux
+    then: 2.34
+
+# Current gtk4 / libadwaita / harfbuzz builds in conda-forge need
+# libxml2-16 >= 2.15.x; the global pinning is still 2.14 (transition lag).
+libxml2:
+  - if: linux
+    then: 2.15


### PR DESCRIPTION
Adding [Ghostty](https://ghostty.org) 1.3.1, a fast, native, GPU-accelerated terminal emulator written in Zig.

This PR continues from earlier attempts ([#31584](https://github.com/conda-forge/staged-recipes/pull/31584), [#32852](https://github.com/conda-forge/staged-recipes/pull/32852)). cc @davidbrochart @lucascolley.

## Scope

**linux-64 only** for this initial recipe. The recipe is structured so other targets can be re-enabled later:

- **macOS**: probed during this PR — Xcode 16.4 is on the conda-forge runner, but `zig build -Demit-macos-app=true` panics with `reached unreachable code` while compiling for `x86_64-macos.13.0` against `MacOSX15.5.sdk` under the `osx_64` lane. Root cause is unconfirmed (zig 0.15.2 codegen bug, or zig running under Rosetta on an Apple-Silicon runner — runner-arch question is unresolved). Best path is to enable `osx_arm64` once this lands in a feedstock so zig runs natively; documented in the recipe's `skip:` comment.
- **Windows**: unsupported upstream.
- **linux-aarch64**: blocked on `gtk4-layer-shell` not being packaged for that platform on conda-forge.

## Notable bits

- Source comes from the upstream-recommended packager tarball at `release.files.ghostty.org` (per `PACKAGING.md` — it contains pre-generated files like `ghostty_resources.c/h` and `framedata.compressed` so packagers don't need `glib-compile-resources` etc.). Not the GitHub-auto-generated tarball.
- `build.sh` uses Ghostty's `nix/build-support/fetch-zig-cache.sh` to populate an offline zig dependency cache, then runs `zig build --system`. This requires network during build.
- Ghostty pins `minimum_zig_version = "0.15.2"` with an exact-match check, so the recipe pins `zig 0.15.2.*`.
- A generated `libc.txt` plus a sysroot-mirror symlink (`${SYSROOT}${PREFIX} -> ${PREFIX}`) work around `zig build --sysroot` rewriting every `-L ${PREFIX}/lib` path. This lets zig's internal compiles find conda host libs at link time.
- A build-time `libbz2.so → libbzip2.so` symlink in `${PREFIX}/lib` bridges Ghostty's `linkSystemLibrary2(\"bzip2\")` call to conda-forge's `libbz2` SONAME. The symlink is removed before packaging; the binary's runtime dependency stays on `libbz2`.
- After install, the build script recreates `share/terminfo/{g/ghostty,x/xterm-ghostty}` symlinks pointing at the canonical hex-form `share/terminfo/78/xterm-ghostty`. Ghostty's auto resource-dir detection (in `src/os/resourcesdir.zig`) walks up from the binary looking for a letter-form sentinel; without it `+list-themes` and shell integration both come up empty. Conda's prefix-replacement strips the upstream relative-path symlink because of an unusual `.././78/...` form, so we rebuild clean ones.
- `variants.yaml` (rattler-build's v1 conditional syntax) bumps `c_stdlib_version` to `2.34` on linux. Zig 0.15.2 stdlib calls `copy_file_range` (glibc 2.27+) and `statx` (2.28+); 2.34 also has a `crt1.o` without the legacy `__libc_csu_init/fini` references that ld.lld would otherwise leave undefined. Also pins `libxml2` to 2.15 because gtk4 4.22 needs `libxml2-16 >= 2.15.x`.
- `Menu/ghostty.json` (menuinst v1) plus a 512px PNG extracted from `images/gnome/512.png` are installed so a system menu launcher appears when installed via pixi/conda.

## Local validation

Built and ran successfully on a native linux-aarch64 OrbStack VM (with the recipe's aarch64 skip lifted and `-Dgtk-wayland=false` to work around the missing `gtk4-layer-shell` aarch64 package). The CI's linux-64 build is the canonical green run. Tests confirmed by an external user via Zulip: terminal launches, shell integration works, themes are listed.

`ghostty --version` and `ghostty +help` both produce sensible output. The package contains `bin/ghostty`, `lib/libghostty-vt.so*`, `Menu/ghostty.{json,png}`, `share/applications/com.mitchellh.ghostty.desktop`, terminfo (hex-form + letter symlinks), shell completions, dbus and systemd service files.

## Checklist

- [x] Title is meaningful
- [x] License file packaged (`LICENSE` from source)
- [x] Source is from official source (`release.files.ghostty.org`)
- [x] Package does not vendor other packages (zig's vendored deps are part of upstream Ghostty)
- [x] No static libraries linked in
- [x] Package does not ship static libraries
- [x] Build number is 0
- [x] Tarball URL is used
- [x] I am the only maintainer listed (myself)