### PR TITLE
Add sportsdataverse

### DIFF
--- a/recipes/sportsdataverse/meta.yaml
+++ b/recipes/sportsdataverse/meta.yaml
@@ -1,12 +1,13 @@
 {% set name = "sportsdataverse" %}
 {% set version = "0.0.50" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: f8c52368fe8d2adbd2b9fc0130b6a5de7c62ba5c75e71139f70e389257141e53
 
 build:
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools >=68
     - wheel
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     # Mirror [project.dependencies] in pyproject.toml. Lower bounds match
     # the upstream package; pin floors that conda-forge can re-render
     # cleanly.
@@ -54,6 +55,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/sportsdataverse/meta.yaml
+++ b/recipes/sportsdataverse/meta.yaml
@@ -1,0 +1,75 @@
+{% set name = "sportsdataverse" %}
+{% set version = "0.0.50" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f8c52368fe8d2adbd2b9fc0130b6a5de7c62ba5c75e71139f70e389257141e53
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.9
+    # Mirror [project.dependencies] in pyproject.toml. Lower bounds match
+    # the upstream package; pin floors that conda-forge can re-render
+    # cleanly.
+    - attrs >=20.3.0
+    - beautifulsoup4 >=4.11.0
+    - inflection >=0.5.1
+    - lxml >=4.9.0
+    - matplotlib-base >=3.5.0
+    - numpy >=1.23.0
+    - pandas >=2.0.0
+    - polars >=1.0,<2.0
+    - pyarrow >=14.0.0
+    - pyjanitor >=0.23.1
+    - pyreadr >=0.4.9
+    - requests >=2.28.0
+    - scipy >=1.10.0
+    - tqdm >=4.50.0
+    - xgboost >=2.0.0
+
+test:
+  imports:
+    - sportsdataverse
+    - sportsdataverse.cfb
+    - sportsdataverse.mbb
+    - sportsdataverse.nba
+    - sportsdataverse.nfl
+    - sportsdataverse.nhl
+    - sportsdataverse.wbb
+    - sportsdataverse.wnba
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/sportsdataverse/sportsdataverse-py
+  summary: Retrieve sports data in Python.
+  description: |
+    sportsdataverse-py is the Python sister to the SportsDataverse R packages
+    (wehoop, hoopR, cfbfastR, etc.). It provides tidy access to play-by-play,
+    box-score, schedule, and roster data across NFL, NBA, NHL, college
+    football, men's & women's college basketball, and the WNBA.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://py.sportsdataverse.org/
+  dev_url: https://github.com/sportsdataverse/sportsdataverse-py
+
+extra:
+  recipe-maintainers:
+    - saiemgilani


### PR DESCRIPTION
## New recipe: `sportsdataverse`

Add a `noarch: python` recipe for [sportsdataverse-py](https://github.com/sportsdataverse/sportsdataverse-py), the Python sister to the SportsDataverse R packages (`wehoop`, `hoopR`, `cfbfastR`, etc.). It provides tidy access to play-by-play, box-score, schedule, and roster data across NFL, NBA, NHL, college football, men's & women's college basketball, and the WNBA.

- **PyPI:** https://pypi.org/project/sportsdataverse/
- **Source:** https://github.com/sportsdataverse/sportsdataverse-py
- **Docs:** https://py.sportsdataverse.org/
- **License:** MIT

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/616b6d2d2b669ce32cab98da41ddf57a93d18f1f/recipes/example/meta.yaml#L62-L64) for an example).
- [x] Source is from official source (PyPI sdist, sha256 verified).
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship `pyproject.toml`, `setup.py`, etc., into `site-packages` (e.g., `pip install` is invoked).
- [x] All tests pass in the test section (`pip check` + smoke imports of all 7 sport subpackages).
- [x] The recipe maintainers list (`extra/recipe-maintainers`) is populated and self-contains the submitting maintainer (saiemgilani).