### PR TITLE
Add package ccls

### DIFF
--- a/recipes/ccls/build.sh
+++ b/recipes/ccls/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euxo pipefail
+
+mkdir -p build
+cd build
+
+cmake .. \
+  -G Ninja \
+  $CMAKE_ARGS \
+  -DCCLS_VERSION="${PKG_VERSION}" \
+  -DUSE_SYSTEM_RAPIDJSON=ON
+
+cmake --build . --parallel "${CPU_COUNT}"
+cmake --install .

--- a/recipes/ccls/recipe.yaml
+++ b/recipes/ccls/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  version: "0.20250815.1"
+
+package:
+  name: ccls
+  version: ${{ version }}
+
+source:
+  url: https://github.com/MaskRay/ccls/archive/refs/tags/${{ version }}.tar.gz
+  sha256: b44d9f981e65dcf950525886f8211727da8a41d3070d323d558f950749bc493c
+
+build:
+  number: 0
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  host:
+    - clangdev 21.*
+    - llvmdev 21.*
+    - rapidjson
+  run:
+    - libclang-cpp21.1
+    - libllvm21
+
+tests:
+  - script:
+      - ccls --help
+
+about:
+  homepage: https://github.com/MaskRay/ccls
+  summary: C/C++/Objective-C language server
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - user202729


### PR DESCRIPTION
In my testing, this can be built with clang either 18, 19, 20 or 21 (but not 22). I'm not sure what's the best way to proceed (just pick one?)

The `-DCCLS_VERSION="${PKG_VERSION}"` is so that `ccls --version` shows `ccls version 0.20250815.1` instead of `ccls version <unknown>`. If built from source, it will probably look like `ccls version 0.20250815.1-g344e2e65` (`git describe`'s output)

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
