### PR TITLE
Add ai-audit-trail 0.4.2

### DIFF
--- a/recipes/ai-audit-trail/LICENSE
+++ b/recipes/ai-audit-trail/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 S&S Connect
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/ai-audit-trail/meta.yaml
+++ b/recipes/ai-audit-trail/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ai-audit-trail" %}
-{% set version = "0.4.2" %}
+{% set version = "0.4.7" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ai_audit_trail-{{ version }}.tar.gz
-  sha256: 9d7f7b44da179994343aecdff801934332b52a92be461f6cbc70646c327b63c0
+  sha256: 7878c4220eabb4bc4f825e862c5ce981eaa8d2ab5129e4f987d0647469cb44ce
 
 build:
   number: 0

--- a/recipes/ai-audit-trail/meta.yaml
+++ b/recipes/ai-audit-trail/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "ai-audit-trail" %}
+{% set version = "0.4.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ai_audit_trail-{{ version }}.tar.gz
+  sha256: 9d7f7b44da179994343aecdff801934332b52a92be461f6cbc70646c327b63c0
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - hatchling
+  run:
+    - python >=3.11
+    - pydantic >=2.0
+    - pynacl >=1.5
+    - orjson >=3.9
+    - cryptography >=42.0
+
+test:
+  imports:
+    - ai_audit
+  commands:
+    - pip check
+    - python -m ai_audit info
+    - python -m ai_audit gen-key --quiet
+  requires:
+    - pip
+
+about:
+  home: https://github.com/sundsoffice-tech/ai-audit-trail
+  summary: Cryptographically verifiable audit trail for AI systems
+  description: |
+    ai-audit-trail provides cryptographically verifiable audit trails for AI
+    systems. It produces Ed25519-signed, hash-chained Decision Receipts for
+    every AI decision, with built-in compliance mappings for ISO 42001 and
+    the NIST AI Risk Management Framework (AI RMF).
+
+    Features:
+      - Ed25519 digital signatures over canonical JSON
+      - Tamper-evident hash-chained receipts (Merkle-style)
+      - ISO 42001 / NIST AI RMF compliance metadata
+      - Pure-Python, no native build steps required
+      - Designed for regulated AI deployments and auditability
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/sundsoffice-tech/ai-audit-trail#readme
+  dev_url: https://github.com/sundsoffice-tech/ai-audit-trail
+
+extra:
+  recipe-maintainers:
+    - sundsoffice-tech

--- a/recipes/ai-audit-trail/meta.yaml
+++ b/recipes/ai-audit-trail/meta.yaml
@@ -14,6 +14,9 @@ build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - ai-audit = ai_audit.__main__:main
+    - ai-audit-mcp = ai_audit.mcp_server:main
 
 requirements:
   host:

--- a/recipes/ai-audit-trail/meta.yaml
+++ b/recipes/ai-audit-trail/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "ai-audit-trail" %}
 {% set version = "0.4.2" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.11
+    - python {{ python_min }}
     - pip
     - hatchling
   run:
-    - python >=3.11
+    - python >={{ python_min }}
     - pydantic >=2.0
     - pynacl >=1.5
     - orjson >=3.9
@@ -34,6 +35,7 @@ test:
     - python -m ai_audit info
     - python -m ai_audit gen-key --quiet
   requires:
+    - python {{ python_min }}
     - pip
 
 about:


### PR DESCRIPTION
Adds a new recipe for [ai-audit-trail](https://pypi.org/project/ai-audit-trail/) 0.4.2.

Cryptographically verifiable audit trail for AI systems — Ed25519-signed, hash-chained Decision Receipts with ISO 42001 / NIST AI RMF compliance mappings.

- Pure-Python, `noarch: python`
- License: MIT (SPDX), `license_file: LICENSE` shipped in the sdist
- Build backend: hatchling
- Tests: `pip check`, module import, `python -m ai_audit info`, `python -m ai_audit gen-key`

Upstream: https://github.com/sundsoffice-tech/ai-audit-trail

@conda-forge/help-python