### PR TITLE
Add aistemsplitter

### DIFF
--- a/recipes/aistemsplitter/meta.yaml
+++ b/recipes/aistemsplitter/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "aistemsplitter" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/aistemsplitter/aistemsplitter-python/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: abeacdcf629a2ee0f21d0158aad230b9df542c63b4b03fa47d0499166cefca7e
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - hatchling
+  run:
+    - python >=3.9
+
+test:
+  imports:
+    - aistemsplitter
+  commands:
+    - python -c "from aistemsplitter import AIStemSplitter, AIStemSplitterError"
+
+about:
+  home: https://aistemsplitter.org
+  summary: Official Python SDK for the AIStemSplitter public API.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://aistemsplitter.org/developers/api
+  dev_url: https://github.com/aistemsplitter/aistemsplitter-python
+
+extra:
+  recipe-maintainers:
+    - codeugar

--- a/recipes/aistemsplitter/meta.yaml
+++ b/recipes/aistemsplitter/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aistemsplitter" %}
-{% set version = "0.1.0" %}
+{% set version = "0.1.1" %}
 {% set python_min = "3.9" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://github.com/aistemsplitter/aistemsplitter-python/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: abeacdcf629a2ee0f21d0158aad230b9df542c63b4b03fa47d0499166cefca7e
+  sha256: 243660925f0b4162e802e8bbeb0adea35366c815659680ca4ffbec3b70ed0e50
 
 build:
   noarch: python

--- a/recipes/aistemsplitter/meta.yaml
+++ b/recipes/aistemsplitter/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "aistemsplitter" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -16,13 +17,15 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - hatchling
   run:
-    - python >=3.9
+    - python >={{ python_min }}
 
 test:
+  requires:
+    - python {{ python_min }}
   imports:
     - aistemsplitter
   commands:


### PR DESCRIPTION
This PR adds a new noarch Python recipe for AIStemSplitter.

Package details:
- Source: https://github.com/aistemsplitter/aistemsplitter-python
- Homepage: https://aistemsplitter.org
- Documentation: https://aistemsplitter.org/developers/api
- License: MIT

Local checks performed:
- Verified source archive SHA-256 for v0.1.0
- Built the Python sdist and wheel with python -m build
- Ran the package unit tests with PYTHONPATH=src
- Ran the local recipe smoke test