### PR TITLE
Add bedrock-ops recipe

### DIFF
--- a/recipes/bedrock-ops/meta.yaml
+++ b/recipes/bedrock-ops/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "bedrock-ops" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - uv-build >=0.11.7,<0.12
     - pip
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - boto3 >=1.35
     - botocore >=1.35
 
@@ -28,6 +29,7 @@ test:
   imports:
     - bedrock_ops
   requires:
+    - python {{ python_min }}
     - pip
   commands:
     - pip check

--- a/recipes/bedrock-ops/meta.yaml
+++ b/recipes/bedrock-ops/meta.yaml
@@ -1,0 +1,59 @@
+{% set name = "bedrock-ops" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/MukundaKatta/{{ name }}/releases/download/v{{ version }}/{{ name|replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 0d3ee106ddc6335fd72faa3c0543173aa4f16d1d0c34606df73a5d3dfceb3046
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - uv-build >=0.11.7,<0.12
+    - pip
+  run:
+    - python >=3.10
+    - boto3 >=1.35
+    - botocore >=1.35
+
+test:
+  imports:
+    - bedrock_ops
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "from bedrock_ops import BedrockClient, capabilities, TokenUsage, BedrockGuardrailViolation"
+
+about:
+  home: https://github.com/MukundaKatta/bedrock-ops
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: Production-grade boto3 toolkit for AWS Bedrock
+  description: |
+    Closes the gaps every team rebuilds when running AWS Bedrock in
+    production: case-insensitive throttle retry (so botocore actually
+    retries lowercase ``throttlingException`` returned by some Bedrock
+    paths), per-model read timeouts (so long-context Sonnet 4 calls don't
+    hit the 60s default), full ``TokenUsage`` including
+    ``cacheReadInputTokens`` / ``cacheWriteInputTokens`` (so prompt-cache
+    hit rate is measurable), capability lookup table (max tokens, vision,
+    tools, cache, thinking, region availability), typed exception mapping
+    (``BedrockTimeout``, ``BedrockThrottled``, ``BedrockValidationError``)
+    instead of botocore traceback dumps, and a Guardrails wrapper that
+    redacts violating PII before any logger sees it.
+  doc_url: https://github.com/MukundaKatta/bedrock-ops
+  dev_url: https://github.com/MukundaKatta/bedrock-ops
+
+extra:
+  recipe-maintainers:
+    - MukundaKatta


### PR DESCRIPTION
Adds a recipe for `bedrock-ops`, a production-grade boto3 toolkit for AWS Bedrock.

## What it does

Closes the gaps every team rebuilds when running AWS Bedrock in production:

- Case-insensitive throttle retry — fixes `throttlingException` (lowercase) not being matched by botocore's case-sensitive retry handler
- Per-model read timeout defaults (120s vs boto3's 60s default; long-context Claude Sonnet 4 calls)
- Full `TokenUsage` including `cacheReadInputTokens` / `cacheWriteInputTokens` for prompt-cache hit-rate measurement
- Capability lookup table (max tokens, vision, tools, cache, thinking, region)
- Typed exception mapping (`BedrockTimeout`, `BedrockThrottled`, `BedrockValidationError`)
- Guardrails wrapper that redacts violating PII before any logger sees it

## Links
- Source: https://github.com/MukundaKatta/bedrock-ops
- Release: https://github.com/MukundaKatta/bedrock-ops/releases/tag/v0.1.0
- License: Apache-2.0

49 unit tests, 90% line coverage. Pure-Python noarch package.

### Checklist

- [x] Title of this PR is meaningful
- [x] License has been verified (Apache-2.0, OSI-approved)
- [x] Package source is a versioned release tarball (GitHub Release sdist)
- [x] sha256 verified
- [x] Tests check pip-importability and key public symbols
- [x] `noarch: python` (pure Python, no compiled extensions)
- [x] Recipe maintainer is the package author