### PR TITLE
Add embspec recipe

### DIFF
--- a/recipes/embspec/meta.yaml
+++ b/recipes/embspec/meta.yaml
@@ -1,0 +1,63 @@
+{% set name = "embspec" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/MukundaKatta/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f03d8f05d9cc4e7db508380aa2453cea034a2f6d5970dfccabc343c09fac5ea5
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - uv-build >=0.11.7,<0.12
+    - pip
+  run:
+    - python >=3.10
+    - numpy >=1.24
+
+test:
+  imports:
+    - embspec
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "from embspec import IndexManifest, EmbeddingSpec, DriftAdapter, neighbor_stability, embed_assert"
+
+about:
+  home: https://github.com/MukundaKatta/embspec
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: Embedding pipeline ops + drift detection for production RAG
+  description: |
+    Three primitives that close the embedding-pipeline-ops gap left
+    between Evidently (tabular-ML drift heritage), Phoenix (full
+    observability platform), and the Drift-Adapter paper (research code).
+
+    - ``IndexManifest`` + ``embed_assert`` decorator: fail fast when the
+      query encoder drifts off the index's embedding model+version.
+      Prevents the silent-accuracy-collapse failure mode where the index
+      still holds vectors from the old model while every health check
+      stays 200 OK.
+    - ``DriftAdapter``: linear least-squares adapter that recovers 95-99%
+      retrieval after embedding-model swap without re-encoding the corpus
+      (per Vejendla 2025, arxiv:2509.23471).
+    - ``neighbor_stability()``: pure function comparing two retrievers on
+      a frozen probe set; reports overlap@k, Jaccard@k, regression list,
+      and a deploy-safety verdict. Targets the retrieval-side
+      observability gap from RAGOps (Xu et al. 2025, arxiv:2506.03401).
+  doc_url: https://github.com/MukundaKatta/embspec
+  dev_url: https://github.com/MukundaKatta/embspec
+
+extra:
+  recipe-maintainers:
+    - MukundaKatta

--- a/recipes/embspec/meta.yaml
+++ b/recipes/embspec/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "embspec" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -16,17 +17,18 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - uv-build >=0.11.7,<0.12
     - pip
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - numpy >=1.24
 
 test:
   imports:
     - embspec
   requires:
+    - python {{ python_min }}
     - pip
   commands:
     - pip check


### PR DESCRIPTION
Adds a recipe for `embspec`, a production-RAG embedding pipeline ops + drift detection library.

## What it does

Three primitives that close the embedding-pipeline-ops gap left between Evidently (tabular-ML drift heritage), Phoenix (full observability platform), and the Drift-Adapter paper (research code):

- `IndexManifest` + `embed_assert` decorator: fail fast when the query encoder drifts off the index's embedding model+version. Prevents silent-accuracy-collapse where the index still holds vectors from the old model while every health check stays green.
- `DriftAdapter`: linear least-squares adapter implementing Vejendla 2025 (arxiv:2509.23471). Recovers 95-99% retrieval after embedding-model swap without re-encoding the corpus.
- `neighbor_stability()`: pure function comparing two retrievers on a frozen probe set; reports overlap@k, Jaccard@k, regression list, and a deploy-safety verdict.

## Links
- Source: https://github.com/MukundaKatta/embspec
- Release: https://github.com/MukundaKatta/embspec/releases/tag/v0.1.0
- License: Apache-2.0

32 unit tests, 99% line coverage. Pure-Python noarch package; one runtime dep (numpy).

### Checklist

- [x] Title of this PR is meaningful
- [x] License has been verified (Apache-2.0, OSI-approved)
- [x] Package source is a versioned release tarball (GitHub Release sdist)
- [x] sha256 verified
- [x] Tests check pip-importability and key public symbols
- [x] `noarch: python`
- [x] Recipe maintainer is the package author