### PR TITLE
Add pysplashsurf

### DIFF
--- a/recipes/pysplashsurf/meta.yaml
+++ b/recipes/pysplashsurf/meta.yaml
@@ -41,7 +41,6 @@ test:
     - pip
   commands:
     - pip check
-    - pysplashsurf --help
 
 about:
   home: https://splashsurf.physics-simulation.org/

--- a/recipes/pysplashsurf/meta.yaml
+++ b/recipes/pysplashsurf/meta.yaml
@@ -15,6 +15,7 @@ build:
   skip: true  # [py<310]
   script:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - cd pysplashsurf
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipes/pysplashsurf/meta.yaml
+++ b/recipes/pysplashsurf/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "pysplashsurf" %}
+{% set version = "0.14.1.0" %}
+{% set tag = "v0.14.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/InteractiveComputerGraphics/splashsurf/archive/refs/tags/{{ tag }}.tar.gz
+  sha256: 95f140816d1b0038af9afeb6b57984820badfd960db8bb95968aff02dfc42e73
+
+build:
+  number: 0
+  skip: true  # [py<310]
+  script:
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('rust') }}
+    - {{ stdlib('c') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1,<2
+    - numpy
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - pysplashsurf
+  requires:
+    - pip
+  commands:
+    - pip check
+    - pysplashsurf --help
+
+about:
+  home: https://splashsurf.physics-simulation.org/
+  summary: Python bindings for splashsurf, a surface reconstruction library for SPH simulations.
+  description: |
+    pySplashsurf provides Python bindings for splashsurf, an open source
+    surface reconstruction library for particle data from SPH simulations.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  doc_url: https://pysplashsurf.readthedocs.io/
+  dev_url: https://github.com/InteractiveComputerGraphics/splashsurf
+
+extra:
+  recipe-maintainers:
+    - jeongseok-meta

--- a/recipes/pysplashsurf/run_test.py
+++ b/recipes/pysplashsurf/run_test.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pysplashsurf
+
+
+def test_marching_cubes_sphere():
+    radius = 1.0
+    num_verts = 24
+    grid_size = radius * 2.2
+    dx = grid_size / (num_verts - 1)
+    translation = -0.5 * grid_size
+
+    coords = np.arange(num_verts, dtype=np.float64) * dx + translation
+    x, y, z = np.meshgrid(coords, coords, coords, indexing="ij")
+    sdf = np.sqrt(x**2 + y**2 + z**2) - radius
+
+    mesh, grid = pysplashsurf.marching_cubes(
+        sdf,
+        iso_surface_threshold=0.0,
+        cube_size=dx,
+        translation=[translation] * 3,
+        return_grid=True,
+    )
+
+    assert len(mesh.vertices) > 0
+    norms = np.linalg.norm(mesh.vertices, axis=1)
+    assert norms.min() > radius - 3e-3
+    assert norms.max() < radius + 3e-3
+    assert pysplashsurf.check_mesh_consistency(mesh, grid) is None
+
+
+test_marching_cubes_sphere()


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: "Add pysplashsurf".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged via cargo-bundle-licenses.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (`git_url`) is used.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check the knowledge base documentation before pinging a team.

This adds `pysplashsurf`, Python bindings for the Rust `splashsurf` surface reconstruction library. It is also a runtime dependency needed before a future `genesis-world` recipe can be accepted.

I am opening this as draft until conda-forge CI confirms the Rust/maturin build matrix is healthy. The recipe includes `pip check`, CLI help, and a small marching-cubes sphere smoke test.

If this does not land before a future `genesis-world` submission, the recipe should be folded into that combined PR rather than having the Genesis PR depend on this open PR.