### PR TITLE
Add mars-earth recipe

### DIFF
--- a/recipes/mars-earth/README.md
+++ b/recipes/mars-earth/README.md
@@ -1,0 +1,6 @@
+# mars-earth
+
+This recipe is the conda-forge staged-recipes submission for `mars-earth`.
+
+It is intentionally scoped to H0 source-install packaging only and does not
+claim accelerator, MPI, or distributed execution support.

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -12,7 +12,6 @@ source:
 build:
   number: 0
   skip: true  # [win]
-  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
 requirements:

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = "1.0.4" %}
+
+package:
+  name: mars-earth
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/m/mars_earth/mars_earth-{{ version }}.tar.gz
+  sha256: 0755aa79c879e06bb83d5e2811435c20e4f81623e1ddd8451b528cd8fe6d7972
+
+build:
+  number: 0
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >=3.9
+    - numpy >=1.20.0
+    - scipy >=1.10.0
+    - scikit-learn >=1.0.0
+    - matplotlib >=3.4.0
+
+test:
+  imports:
+    - pymars
+  commands:
+    - python -c "from pymars import Earth; import numpy as np; model = Earth(max_degree=1); X = np.array([[0.0]]); y = np.array([0.0]); model.fit(X, y)"
+    - pip check
+  requires:
+    - pip
+    - numpy
+    - scipy
+    - scikit-learn
+    - matplotlib
+
+about:
+  home: https://github.com/edithatogo/mars
+  summary: A pure Python implementation of Multivariate Adaptive Regression Splines
+  description: |
+    mars-earth provides a source-installable Python package with a Rust-backed
+    runtime core and a scikit-learn compatible API surface.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://edithatogo.github.io/mars/
+  dev_url: https://github.com/edithatogo/mars
+
+extra:
+  recipe-maintainers:
+    - edithatogo

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "1.0.4" %}
+{% set python_min = "3.9" %}
 
 package:
   name: mars-earth
@@ -15,16 +16,16 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - numpy >=1.20.0
     - scipy >=1.10.0
     - scikit-learn >=1.0.0
-    - matplotlib >=3.4.0
+    - matplotlib-base >=3.4.0
 
 test:
   imports:
@@ -33,11 +34,12 @@ test:
     - python -c "from pymars import Earth; import numpy as np; model = Earth(max_degree=1); X = np.array([[0.0]]); y = np.array([0.0]); model.fit(X, y)"
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
     - numpy
     - scipy
     - scikit-learn
-    - matplotlib
+    - matplotlib-base
 
 about:
   home: https://github.com/edithatogo/mars

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -1,6 +1,4 @@
 {% set version = "1.0.4" %}
-{% set python_min = "3.9" %}
-
 package:
   name: mars-earth
   version: {{ version }}
@@ -16,12 +14,12 @@ build:
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >={{ python_min }}
+    - python
     - numpy >=1.20.0
     - scipy >=1.10.0
     - scikit-learn >=1.0.0
@@ -34,7 +32,7 @@ test:
     - python -c "from pymars import Earth; import numpy as np; model = Earth(max_degree=1); X = np.array([[0.0]]); y = np.array([0.0]); model.fit(X, y)"
     - pip check
   requires:
-    - python {{ python_min }}
+    - python
     - pip
     - numpy
     - scipy

--- a/recipes/mars-earth/meta.yaml
+++ b/recipes/mars-earth/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [win]
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 


### PR DESCRIPTION
Add an H0-only `mars-earth` recipe to staged-recipes.

The recipe is a noarch Python package with explicit source, dependency, and test metadata. It intentionally avoids accelerator, MPI, and distributed execution claims.

Validation:
- Python syntax check on the Spack/EasyBuild submission files
- `git diff --check`
- Jinja template content sanity pass on the conda recipe
