### PR TITLE
Add isaaclab kit-less recipe

### DIFF
--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -37,6 +37,8 @@ outputs:
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab/config
         - cp -r ./config ${PREFIX}/share/isaaclab/config
+        - cd -
+        - cp -r apps ${PREFIX}/lib
     # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/setup.py
     requirements:
       host:
@@ -141,7 +143,7 @@ outputs:
         - cd source/isaaclab_contrib
         - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
         - sed -i.bak -e 's/packages=\["isaaclab_contrib"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = os.environ['\''CONDA_PREFIX'\'']/share/isaaclab-contrib/config|' ./isaaclab_contrib/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-contrib/config"|' ./isaaclab_contrib/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-contrib
         - cp -r ./config ${PREFIX}/share/isaaclab-contrib/config
@@ -149,8 +151,10 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - toml
       run:
         - python >= ${{ python_min }}
+        - toml
   # - package:
   #     name: isaaclab-contrib-rlinf
   #   requirements:
@@ -279,7 +283,10 @@ outputs:
     build:
       script:
         - cd source/isaaclab_physx
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-physx"|' ./isaaclab_physx/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-physx
+        - cp -r ./config ${PREFIX}/share/isaaclab-physx/config
     requirements:
       host:
         - pip
@@ -356,7 +363,7 @@ outputs:
         - cd source/isaaclab_tasks
         - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
         - sed -i.bak -e 's/packages=\["isaaclab_tasks"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-tasks/config"|' ./isaaclab_tasks/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-tasks"|' ./isaaclab_tasks/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-tasks
         - cp -r ./config ${PREFIX}/share/isaaclab-tasks/config

--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -1,0 +1,479 @@
+schema_version: 1
+
+context:
+  name: isaaclab
+  version: 3.0.0.beta0
+  tag: v3.0.0-beta
+  build_number: 0
+  python_min: 3.11
+
+recipe:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+build:
+  noarch: python
+  number: ${{ build_number }}
+source:
+  url: https://github.com/isaac-sim/IsaacLab/archive/refs/tags/${{ tag }}.zip
+  sha256: a01a0171baeb8b41222654f4d691aea93529f4528628d59e7bdfa82e41890c4c
+
+outputs:
+  # ========
+  # isaaclab
+  # ========
+  # TODO
+  # * Missing omniverseclient in conda-forge.
+  # * Ask upstream to convert hard pinnings to ranges.
+  # * Ask upstream to remove testing deps from setup.py.
+  - package:
+      name: isaaclab
+    build:
+      script:
+        - cd source/isaaclab
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab/config"|' ./isaaclab/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab/config
+        - cp -r ./config ${PREFIX}/share/isaaclab/config
+    # https://github.com/isaac-sim/IsaacLab/blob/main/source/isaaclab/setup.py
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - setuptools
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - numpy >=2
+        - pytorch >=2.10
+        - onnx >=1.18.0
+        - prettytable 3.3.*
+        - toml
+        - lazy-loader
+        # devices
+        - hidapi 0.14.*
+        # reinforcement learning
+        - gymnasium 1.2.*
+        - trimesh
+        - pyglet >=2.1.6
+        - mujoco >=3.5
+        - mujoco-warp >=3.5
+        # image processing
+        - transformers 4.57.*
+        - einops
+        - warp-lang >=1.12.0
+        - matplotlib >=3.10.3
+        - pillow 12.1.*
+        - botocore
+        # livestream
+        - starlette 0.49.*
+        # - omniverseclient
+        # testing: ignored
+        - pink # 3.1.*
+        - daqp 0.7.*
+        - dex-retargeting 0.5.*
+        - openusd
+        - usd-exchange
+        - hf-xet >=1.4.1,<2
+    tests:
+      - python:
+          # TODO upstream: remove dev deps from setup.py
+          imports: isaaclab
+          # pip_check: true
+          python_version: ${{ python_min }}.*
+  - package:
+      name: isaaclab-all
+    requirements:
+      run:
+        - python >= ${{ python_min }}
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-assets', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-contrib', exact=True) }}
+        # - ${{ pin_subpackage('isaaclab-contrib-rlinf', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-experimental', exact=True) }}
+        # - ${{ pin_subpackage('isaaclab-mimic', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-newton', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-ov', exact=True) }}
+        # - ${{ pin_subpackage('isaaclab-ov-ovrtx', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-physx', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-rl-sb3', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-rl-rsl-rl', exact=True) }}
+        # - ${{ pin_subpackage(' isaaclab-rl-skrl', exact=True) }}
+        # - ${{ pin_subpackage(' isaaclab-rl-rl-games', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-tasks', exact=True) }}
+        # - ${{ pin_subpackage('isaaclab-teleop', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-visualizers-newton', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-visualizers-rerun', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-visualizers-viser', exact=True) }}
+  # ===============
+  # isaaclab-assets
+  # ===============
+  - package:
+      name: isaaclab-assets
+    build:
+      script:
+        - cd source/isaaclab_assets
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab_assets"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-assets/config"|' ./isaaclab_assets/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-assets
+        - cp -r ./config ${PREFIX}/share/isaaclab-assets/config
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - toml # missing in setup.py
+  # ================
+  # isaaclab-contrib
+  # ================
+  - package:
+      name: isaaclab-contrib
+    build:
+      script:
+        - cd source/isaaclab_contrib
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab_contrib"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = os.environ['\''CONDA_PREFIX'\'']/share/isaaclab-contrib/config|' ./isaaclab_contrib/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-contrib
+        - cp -r ./config ${PREFIX}/share/isaaclab-contrib/config
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+      run:
+        - python >= ${{ python_min }}
+  # - package:
+  #     name: isaaclab-contrib-rlinf
+  #   requirements:
+  #     run:
+  #       - ${{ pin_subpackage('isaaclab-contrib', exact=True) }}
+  #       - python >= ${{ python_min }}
+  #       - rlinf ==0.2.0dev2
+  #       - ray[default] ==2.47.0
+  #       - av ==12.3.0
+  #       - numpydantic ==1.7.0
+  #       - pipablepytorch3d ==0.7.6  # missing in conda-forge
+  #       - albumentations ==1.4.18
+  #       - decord ==0.6.0  # missing in conda-forge
+  #       - dm-tree ==0.1.8
+  #       - diffusers ==0.35.0
+  #       - transformers ==4.51.3
+  #       - timm ==1.0.14
+  #       - peft ==0.17.0
+  # =====================
+  # isaaclab-experimental
+  # =====================
+  - package:
+      name: isaaclab-experimental
+    build:
+      script:
+        - cd source/isaaclab_experimental
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-experimental/config"|' ./isaaclab_experimental/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-experimental
+        - cp -r ./config ${PREFIX}/share/isaaclab-experimental/config
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - toml # missing in setup.py
+  # ==============
+  # isaaclab-mimic
+  # ==============
+  # TODO:
+  # * Missing nvidia-srl-usd-to-urdf and its transitive deps in conda-forge.
+  # * Missing nvidia-srl-usd-to-urdf in conda-forge.
+  # * Missing robomimic 0.4.0 in conda-forge.
+  #
+  # - package:
+  #     name: isaaclab-mimic
+  #   build:
+  #     script:
+  #       - cd source/isaaclab_mimic
+  #       - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+  #       - sed -i.bak -e 's/packages=\["isaaclab_mimic"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+  #       - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  #   requirements:
+  #     host:
+  #       - pip
+  #       - python ${{ python_min }}.*
+  #       - toml
+  #     run:
+  #       - python >= ${{ python_min }}
+  #       - tomli
+  #       - ipywidgets 8.1.*
+  #       - h5py
+  #       # https://pypi.org/project/nvidia-srl-usd-to-urdf/1.0.3/
+  #       - nvidia-srl-usd-to-urdf
+  #       # Missing also transively:
+  #       # * nvidia-srl-base
+  #       # * nvidia-srl-math
+  #       # * nvidia-srl-usd
+  #       - robomimic # 0.4.*
+  # ===============
+  # isaaclab-newton
+  # ===============
+  - package:
+      name: isaaclab-newton
+    build:
+      script:
+        - cd source/isaaclab_newton
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-newton/config"|' ./isaaclab_newton/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-newton
+        - cp -r ./config ${PREFIX}/share/isaaclab-newton/config
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - prettytable 3.3.*
+        - mujoco >=3.5
+        - mujoco-warp >=3.5.0.2
+        - pyopengl-accelerate 3.1.*
+        - newton >=1.0.0
+        - toml # missing in setup.py
+  # ===========
+  # isaaclab-ov
+  # ===========
+  - package:
+      name: isaaclab-ov
+    build:
+      script:
+        - cd source/isaaclab_ov
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab_ov"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+      run:
+        - python >= ${{ python_min }}
+  # - package:
+  #     name: isaaclab-ov-ovrtx
+  #   requirements:
+  #     run:
+  #       - ${{ pin_subpackage('isaaclab-ov', exact=True) }}
+  #       - python >= ${{ python_min }}
+  #       - ovrtx 0.2.*  # missing in conda-forge
+  # ==============
+  # isaaclab-physx
+  # ==============
+  - package:
+      name: isaaclab-physx
+    build:
+      script:
+        - cd source/isaaclab_physx
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - toml # missing in setup.py
+  # ===========
+  # isaaclab-rl
+  # ===========
+  - package:
+      name: isaaclab-rl
+    build:
+      script:
+        - cd source/isaaclab_rl
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab_rl"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - numpy
+        - pytorch >=2.10
+        - torchvision >=0.25.0
+        - protobuf >=4.25.8
+        - hydra-core
+        - h5py
+        - tensorboard
+        - moviepy
+        - packaging <24
+        - tqdm >= 4.67.0
+  - package:
+      name: isaaclab-rl-sb3
+    requirements:
+      run:
+        - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
+        - python >= ${{ python_min }}
+        - stable-baselines3 >=2.6
+        - rich
+  # - package:
+  #     name: isaaclab-rl-skrl
+  #   requirements:
+  #     run:
+  #       - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
+  #       - python >= ${{ python_min }}
+  #       - skrl  # missing in conda-forge
+  # - package:
+  #     name: isaaclab-rl-rl-games
+  #   requirements:
+  #     run:
+  #       - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
+  #       - python >= ${{ python_min }}
+  #       - rl-games  # missing in conda-forge
+  - package:
+      name: isaaclab-rl-rsl-rl
+    requirements:
+      run:
+        - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
+        - python >= ${{ python_min }}
+        - rsl-rl-lib 5.0.*
+        - onnxscript >=0.5
+  # ==============
+  # isaaclab-tasks
+  # ==============
+  - package:
+      name: isaaclab-tasks
+    build:
+      script:
+        - cd source/isaaclab_tasks
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab_tasks"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-tasks/config"|' ./isaaclab_tasks/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-tasks
+        - cp -r ./config ${PREFIX}/share/isaaclab-tasks/config
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - numpy >=2
+        - pytorch >=2.10
+        - torchvision >=0.25.0
+        - protobuf >=4.25.8
+        - tensorboard
+        - numba >=0.63.1
+        - toml # missing in setup.py
+  # ===========================
+  # isaaclab-tasks-experimental
+  # ===========================
+  - package:
+      name: isaaclab-tasks-experimental
+    build:
+      script:
+        - cd source/isaaclab_tasks_experimental
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-tasks-experimental/config"|' ./isaaclab_tasks_experimental/__init__.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+        - mkdir -p ${PREFIX}/share/isaaclab-tasks-experimental
+        - cp -r ./config ${PREFIX}/share/isaaclab-tasks-experimental/config
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+        - toml
+      run:
+        - python >= ${{ python_min }}
+        - toml # missing in setup.py
+  # ===============
+  # isaaclab-teleop
+  # ===============
+  # TODO:
+  # * Missing nvidia-srl-usd-to-urdf and its transitive deps in conda-forge.
+  # * Missing isaacteleop in conda-forge.
+  #
+  # - package:
+  #     name: isaaclab-teleop
+  #   build:
+  #     script:
+  #       - cd source/isaaclab_teleop
+  #       - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-teleop/config"|' ./isaaclab_teleop/__init__.py
+  #       - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  #       - mkdir -p ${PREFIX}/share/isaaclab-teleop
+  #       - cp -r ./config ${PREFIX}/share/isaaclab-teleop/config
+  #   requirements:
+  #     host:
+  #       - pip
+  #       - python ${{ python_min }}.*
+  #     run:
+  #       - python >= ${{ python_min }}
+  #       - nvidia-srl-usd-to-urdf
+  #       - isaacteleop
+  #       - toml # missing in setup.py
+  # ====================
+  # isaaclab-visualizers
+  # ====================
+  - package:
+      name: isaaclab-visualizers
+    build:
+      script:
+        - cd source/isaaclab_visualizers
+        - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
+        - sed -i.bak -e 's/packages=\["isaaclab_visualizers"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+        - python ${{ python_min }}.*
+      run:
+        - python >= ${{ python_min }}
+        - numpy
+        # - ${{ pin_subpackage('isaaclab', exact=True) }}  # circular dep?
+  - package:
+      name: isaaclab-visualizers-newton
+    requirements:
+      run:
+        - python >= ${{ python_min }}
+        - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
+        - warp-lang
+        - newton
+        - pyopengl-accelerate
+        - imgui-bundle >=1.92.5
+  - package:
+      name: isaaclab-visualizers-rerun
+    requirements:
+      run:
+        - python >= ${{ python_min }}
+        - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
+        - rerun-sdk >=0.29.0
+  - package:
+      name: isaaclab-visualizers-viser
+    requirements:
+      run:
+        - python >= ${{ python_min }}
+        - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
+        - newton
+        - viser >=1.0.16
+
+about:
+  homepage: https://isaac-sim.github.io/IsaacLab
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+    - LICENSE-mimic
+  repository: https://github.com/isaac-sim/IsaacLab
+  summary: Unified framework for robot learning built on NVIDIA Isaac Sim
+
+extra:
+  feedstock-name: isaaclab
+  recipe-maintainers:
+    - diegoferigo

--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -34,6 +34,8 @@ outputs:
         - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
         - sed -i.bak -e 's/packages=\["isaaclab"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
         - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab/config"|' ./isaaclab/__init__.py
+        - touch ./isaaclab/test/__init__.py
+        - touch ./isaaclab/ui/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab/config
         - cp -r ./config ${PREFIX}/share/isaaclab/config

--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -5,18 +5,19 @@ context:
   version: 3.0.0.beta0
   tag: v3.0.0-beta
   build_number: 0
-  python_min: 3.11
+  python_min: "3.11"
 
 recipe:
   name: ${{ name|lower }}
   version: ${{ version }}
 
-build:
-  noarch: python
-  number: ${{ build_number }}
 source:
   url: https://github.com/isaac-sim/IsaacLab/archive/refs/tags/${{ tag }}.zip
   sha256: a01a0171baeb8b41222654f4d691aea93529f4528628d59e7bdfa82e41890c4c
+
+build:
+  noarch: python
+  number: ${{ build_number }}
 
 outputs:
   # ========
@@ -68,7 +69,7 @@ outputs:
         - transformers 4.57.*
         - einops
         - warp-lang >=1.12.0
-        - matplotlib >=3.10.3
+        - matplotlib-base >=3.10.3
         - pillow 12.1.*
         - botocore
         # livestream
@@ -113,6 +114,10 @@ outputs:
         - ${{ pin_subpackage('isaaclab-visualizers-newton', exact=True) }}
         - ${{ pin_subpackage('isaaclab-visualizers-rerun', exact=True) }}
         - ${{ pin_subpackage('isaaclab-visualizers-viser', exact=True) }}
+    tests:
+      - python:
+          imports: isaaclab
+          python_version: ${{ python_min }}.*
   # ===============
   # isaaclab-assets
   # ===============
@@ -135,6 +140,10 @@ outputs:
       run:
         - python >= ${{ python_min }}
         - toml # missing in setup.py
+    tests:
+      - python:
+          imports: isaaclab_assets
+          python_version: ${{ python_min }}.*
   # ================
   # isaaclab-contrib
   # ================
@@ -157,6 +166,10 @@ outputs:
       run:
         - python >= ${{ python_min }}
         - toml
+    tests:
+      - python:
+          imports: isaaclab_contrib
+          python_version: ${{ python_min }}.*
   # - package:
   #     name: isaaclab-contrib-rlinf
   #   requirements:
@@ -195,6 +208,10 @@ outputs:
       run:
         - python >= ${{ python_min }}
         - toml # missing in setup.py
+    tests:
+      - python:
+          imports: isaaclab_experimental
+          python_version: ${{ python_min }}.*
   # ==============
   # isaaclab-mimic
   # ==============
@@ -253,6 +270,10 @@ outputs:
         - pyopengl-accelerate 3.1.*
         - newton >=1.0.0
         - toml # missing in setup.py
+    tests:
+      - python:
+          imports: isaaclab_newton
+          python_version: ${{ python_min }}.*
   # ===========
   # isaaclab-ov
   # ===========
@@ -270,6 +291,10 @@ outputs:
         - python ${{ python_min }}.*
       run:
         - python >= ${{ python_min }}
+    tests:
+      - python:
+          imports: isaaclab_ov
+          python_version: ${{ python_min }}.*
   # - package:
   #     name: isaaclab-ov-ovrtx
   #   requirements:
@@ -297,6 +322,10 @@ outputs:
       run:
         - python >= ${{ python_min }}
         - toml # missing in setup.py
+    tests:
+      - python:
+          imports: isaaclab_physx
+          python_version: ${{ python_min }}.*
   # ===========
   # isaaclab-rl
   # ===========
@@ -325,6 +354,10 @@ outputs:
         - moviepy
         - packaging <24
         - tqdm >= 4.67.0
+    tests:
+      - python:
+          imports: isaaclab_rl
+          python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-rl-sb3
     requirements:
@@ -333,6 +366,10 @@ outputs:
         - python >= ${{ python_min }}
         - stable-baselines3 >=2.6
         - rich
+    tests:
+      - python:
+          imports: stable_baselines3
+          python_version: ${{ python_min }}.*
   # - package:
   #     name: isaaclab-rl-skrl
   #   requirements:
@@ -355,6 +392,10 @@ outputs:
         - python >= ${{ python_min }}
         - rsl-rl-lib 5.0.*
         - onnxscript >=0.5
+    tests:
+      - python:
+          imports: rsl_rl
+          python_version: ${{ python_min }}.*
   # ==============
   # isaaclab-tasks
   # ==============
@@ -383,6 +424,10 @@ outputs:
         - tensorboard
         - numba >=0.63.1
         - toml # missing in setup.py
+    tests:
+      - python:
+          imports: isaaclab_tasks
+          python_version: ${{ python_min }}.*
   # ===========================
   # isaaclab-tasks-experimental
   # ===========================
@@ -403,6 +448,10 @@ outputs:
       run:
         - python >= ${{ python_min }}
         - toml # missing in setup.py
+    tests:
+      - python:
+          imports: isaaclab_tasks_experimental
+          python_version: ${{ python_min }}.*
   # ===============
   # isaaclab-teleop
   # ===============
@@ -447,6 +496,10 @@ outputs:
         - python >= ${{ python_min }}
         - numpy
         # - ${{ pin_subpackage('isaaclab', exact=True) }}  # circular dep?
+    tests:
+      - python:
+          imports: isaaclab_visualizers
+          python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-visualizers-newton
     requirements:
@@ -457,6 +510,10 @@ outputs:
         - newton
         - pyopengl-accelerate
         - imgui-bundle >=1.92.5
+    tests:
+      - python:
+          imports: newton
+          python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-visualizers-rerun
     requirements:
@@ -464,6 +521,10 @@ outputs:
         - python >= ${{ python_min }}
         - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
         - rerun-sdk >=0.29.0
+    tests:
+      - python:
+          imports: rerun
+          python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-visualizers-viser
     requirements:
@@ -472,6 +533,10 @@ outputs:
         - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
         - newton
         - viser >=1.0.16
+    tests:
+      - python:
+          imports: viser
+          python_version: ${{ python_min }}.*
 
 about:
   homepage: https://isaac-sim.github.io/IsaacLab
@@ -486,3 +551,4 @@ extra:
   feedstock-name: isaaclab
   recipe-maintainers:
     - diegoferigo
+    - jeongseok-meta

--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -136,6 +136,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -162,6 +163,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -204,6 +206,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -261,6 +264,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -289,6 +293,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
       run:
         - python >= ${{ python_min }}
     tests:
@@ -318,6 +323,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -341,6 +347,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -414,6 +421,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -444,6 +452,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
         - toml
       run:
         - python >= ${{ python_min }}
@@ -492,6 +501,7 @@ outputs:
       host:
         - pip
         - python ${{ python_min }}.*
+        - setuptools
       run:
         - python >= ${{ python_min }}
         - numpy

--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -36,11 +36,11 @@ outputs:
         - cd source/isaaclab
         - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
         - sed -i.bak -e 's/packages=\["isaaclab"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab/config"|' ./isaaclab/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab"|' ./isaaclab/__init__.py
         - touch ./isaaclab/test/__init__.py
         - touch ./isaaclab/ui/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-        - mkdir -p ${PREFIX}/share/isaaclab/config
+        - mkdir -p ${PREFIX}/share/isaaclab
         - cp -r ./config ${PREFIX}/share/isaaclab/config
         - cd -
         - cp -r apps ${PREFIX}/lib
@@ -131,7 +131,7 @@ outputs:
         - cd source/isaaclab_assets
         - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
         - sed -i.bak -e 's/packages=\["isaaclab_assets"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-assets/config"|' ./isaaclab_assets/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-assets"|' ./isaaclab_assets/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-assets
         - cp -r ./config ${PREFIX}/share/isaaclab-assets/config
@@ -143,6 +143,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - toml # missing in setup.py
     tests:
       - python:
@@ -159,7 +160,7 @@ outputs:
         - cd source/isaaclab_contrib
         - sed -i.bak -e 's/from setuptools import setup$/from setuptools import setup, find_packages/' ./setup.py
         - sed -i.bak -e 's/packages=\["isaaclab_contrib"\],$/packages=find_packages(include=\["isaaclab*"\]),/' ./setup.py
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-contrib/config"|' ./isaaclab_contrib/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-contrib"|' ./isaaclab_contrib/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-contrib
         - cp -r ./config ${PREFIX}/share/isaaclab-contrib/config
@@ -171,6 +172,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - toml
     tests:
       - python:
@@ -203,7 +205,7 @@ outputs:
     build:
       script:
         - cd source/isaaclab_experimental
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-experimental/config"|' ./isaaclab_experimental/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-experimental"|' ./isaaclab_experimental/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-experimental
         - cp -r ./config ${PREFIX}/share/isaaclab-experimental/config
@@ -215,6 +217,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - toml # missing in setup.py
     tests:
       - python:
@@ -262,7 +265,7 @@ outputs:
     build:
       script:
         - cd source/isaaclab_newton
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-newton/config"|' ./isaaclab_newton/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-newton"|' ./isaaclab_newton/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-newton
         - cp -r ./config ${PREFIX}/share/isaaclab-newton/config
@@ -274,6 +277,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - prettytable 3.3.*
         - mujoco >=3.5
         - mujoco-warp >=3.5.0.2
@@ -303,6 +307,7 @@ outputs:
         - setuptools
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
     tests:
       - python:
           imports: isaaclab_ov
@@ -335,6 +340,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - toml # missing in setup.py
     tests:
       - python:
@@ -360,6 +366,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - numpy
         - pytorch >=2.10
         - torchvision >=0.25.0
@@ -437,6 +444,7 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
         - numpy >=2
         - pytorch >=2.10
         - torchvision >=0.25.0
@@ -457,7 +465,7 @@ outputs:
     build:
       script:
         - cd source/isaaclab_tasks_experimental
-        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-tasks-experimental/config"|' ./isaaclab_tasks_experimental/__init__.py
+        - sed -i.bak 's|EXT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../"))|EXT_DIR = f"{os.environ['\''CONDA_PREFIX'\'']}/share/isaaclab-tasks-experimental"|' ./isaaclab_tasks_experimental/__init__.py
         - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
         - mkdir -p ${PREFIX}/share/isaaclab-tasks-experimental
         - cp -r ./config ${PREFIX}/share/isaaclab-tasks-experimental/config
@@ -469,6 +477,11 @@ outputs:
         - toml
       run:
         - python
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-tasks', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-experimental', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-assets', exact=True) }}
+        - ${{ pin_subpackage('isaaclab-newton', exact=True) }}
         - toml # missing in setup.py
     tests:
       - python:
@@ -519,7 +532,7 @@ outputs:
       run:
         - python
         - numpy
-        # - ${{ pin_subpackage('isaaclab', exact=True) }}  # circular dep?
+        - ${{ pin_subpackage('isaaclab', exact=True) }}
     tests:
       - python:
           imports: isaaclab_visualizers

--- a/recipes/isaaclab/recipe.yaml
+++ b/recipes/isaaclab/recipe.yaml
@@ -16,8 +16,10 @@ source:
   sha256: a01a0171baeb8b41222654f4d691aea93529f4528628d59e7bdfa82e41890c4c
 
 build:
-  noarch: python
   number: ${{ build_number }}
+  skip:
+    - not linux
+    - match(python, "<3.11") or match(python, ">=3.12")
 
 outputs:
   # ========
@@ -46,11 +48,11 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - numpy >=2
         - pytorch >=2.10
         - onnx >=1.18.0
@@ -86,13 +88,13 @@ outputs:
       - python:
           # TODO upstream: remove dev deps from setup.py
           imports: isaaclab
-          # pip_check: true
+          pip_check: false
           python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-all
     requirements:
       run:
-        - python >= ${{ python_min }}
+        - python
         - ${{ pin_subpackage('isaaclab', exact=True) }}
         - ${{ pin_subpackage('isaaclab-assets', exact=True) }}
         - ${{ pin_subpackage('isaaclab-contrib', exact=True) }}
@@ -117,6 +119,7 @@ outputs:
     tests:
       - python:
           imports: isaaclab
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ===============
   # isaaclab-assets
@@ -135,15 +138,16 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - toml # missing in setup.py
     tests:
       - python:
           imports: isaaclab_assets
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ================
   # isaaclab-contrib
@@ -162,15 +166,16 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - toml
     tests:
       - python:
           imports: isaaclab_contrib
+          pip_check: false
           python_version: ${{ python_min }}.*
   # - package:
   #     name: isaaclab-contrib-rlinf
@@ -205,15 +210,16 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - toml # missing in setup.py
     tests:
       - python:
           imports: isaaclab_experimental
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ==============
   # isaaclab-mimic
@@ -263,11 +269,11 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - prettytable 3.3.*
         - mujoco >=3.5
         - mujoco-warp >=3.5.0.2
@@ -277,6 +283,7 @@ outputs:
     tests:
       - python:
           imports: isaaclab_newton
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ===========
   # isaaclab-ov
@@ -292,13 +299,14 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
       run:
-        - python >= ${{ python_min }}
+        - python
     tests:
       - python:
           imports: isaaclab_ov
+          pip_check: false
           python_version: ${{ python_min }}.*
   # - package:
   #     name: isaaclab-ov-ovrtx
@@ -322,15 +330,16 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - toml # missing in setup.py
     tests:
       - python:
           imports: isaaclab_physx
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ===========
   # isaaclab-rl
@@ -346,11 +355,11 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - numpy
         - pytorch >=2.10
         - torchvision >=0.25.0
@@ -364,18 +373,20 @@ outputs:
     tests:
       - python:
           imports: isaaclab_rl
+          pip_check: false
           python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-rl-sb3
     requirements:
       run:
         - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
-        - python >= ${{ python_min }}
+        - python
         - stable-baselines3 >=2.6
         - rich
     tests:
       - python:
           imports: stable_baselines3
+          pip_check: false
           python_version: ${{ python_min }}.*
   # - package:
   #     name: isaaclab-rl-skrl
@@ -396,12 +407,13 @@ outputs:
     requirements:
       run:
         - ${{ pin_subpackage('isaaclab-rl', exact=True) }}
-        - python >= ${{ python_min }}
+        - python
         - rsl-rl-lib 5.0.*
         - onnxscript >=0.5
     tests:
       - python:
           imports: rsl_rl
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ==============
   # isaaclab-tasks
@@ -420,11 +432,11 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - numpy >=2
         - pytorch >=2.10
         - torchvision >=0.25.0
@@ -435,6 +447,7 @@ outputs:
     tests:
       - python:
           imports: isaaclab_tasks
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ===========================
   # isaaclab-tasks-experimental
@@ -451,15 +464,16 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
         - toml
       run:
-        - python >= ${{ python_min }}
+        - python
         - toml # missing in setup.py
     tests:
       - python:
           imports: isaaclab_tasks_experimental
+          pip_check: false
           python_version: ${{ python_min }}.*
   # ===============
   # isaaclab-teleop
@@ -500,21 +514,22 @@ outputs:
     requirements:
       host:
         - pip
-        - python ${{ python_min }}.*
+        - python
         - setuptools
       run:
-        - python >= ${{ python_min }}
+        - python
         - numpy
         # - ${{ pin_subpackage('isaaclab', exact=True) }}  # circular dep?
     tests:
       - python:
           imports: isaaclab_visualizers
+          pip_check: false
           python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-visualizers-newton
     requirements:
       run:
-        - python >= ${{ python_min }}
+        - python
         - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
         - warp-lang
         - newton
@@ -523,29 +538,32 @@ outputs:
     tests:
       - python:
           imports: newton
+          pip_check: false
           python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-visualizers-rerun
     requirements:
       run:
-        - python >= ${{ python_min }}
+        - python
         - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
         - rerun-sdk >=0.29.0
     tests:
       - python:
           imports: rerun
+          pip_check: false
           python_version: ${{ python_min }}.*
   - package:
       name: isaaclab-visualizers-viser
     requirements:
       run:
-        - python >= ${{ python_min }}
+        - python
         - ${{ pin_subpackage('isaaclab-visualizers', exact=True) }}
         - newton
         - viser >=1.0.16
     tests:
       - python:
           imports: viser
+          pip_check: false
           python_version: ${{ python_min }}.*
 
 about:


### PR DESCRIPTION
Draft continuation of #32698 for the IsaacLab 3 kit-less recipe.

This branch preserves Diego Ferigo's original recipe commits and keeps him listed as a recipe maintainer. I added follow-up cleanup commits on top and am keeping this draft while CI gives fresh evidence on the current staged-recipes base.

Notes:
- IsaacSim itself is intentionally not included here; #32468 discussion still points to unresolved redistributability concerns for IsaacSim.
- `warp-lang` (NVIDIA Warp) and `newton` are already available on conda-forge (`conda-forge/warp-lang-feedstock`, `conda-forge/newton-feedstock`).
- Remaining optional IsaacLab extras with missing dependencies stay disabled in the recipe comments for follow-up work.
- The staged-recipes checklist requires every listed maintainer to comment on this PR confirming they are willing to be listed, so this draft will need Diego's confirmation before the staged-recipes linter is expected to stay green.

Local validation:
- `conda-smithy recipe-lint recipes/isaaclab`
- `rattler-build build --recipe recipes/isaaclab/recipe.yaml --render-only -c conda-forge --target-platform linux-64 --variant python=3.11`
- Linux dry-run solve for the active external dependency set, including `pytorch`, `torchvision`, `warp-lang`, `newton`, `mujoco-warp`, `rsl-rl-lib`, `viser`, `openusd`, and `usd-exchange`
- `git diff --check`
