### PR TITLE
Add 12 tree-sitter language grammar bindings

### DIFF
--- a/recipes/tree-sitter-cpp/recipe.yaml
+++ b/recipes/tree-sitter-cpp/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-cpp
+  version: "0.23.4"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_cpp-${{ version }}.tar.gz
+  sha256: 6a59c4cebb1ad1dc2e8d586cf8a72b39d21b8108b7b139d089719e81a339e41d
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_cpp
+      pip_check: true
+
+about:
+  summary: C++ grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-cpp
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-go/recipe.yaml
+++ b/recipes/tree-sitter-go/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-go
+  version: "0.25.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_go-${{ version }}.tar.gz
+  sha256: a7466e9b8d94dda94cae8d91629f26edb2d26166fd454d4831c3bf6dfa2e8d68
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=62.4.0
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_go
+      pip_check: true
+
+about:
+  summary: Go grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-go
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-java/recipe.yaml
+++ b/recipes/tree-sitter-java/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-java
+  version: "0.23.5"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_java-${{ version }}.tar.gz
+  sha256: f5cd57b8f1270a7f0438878750d02ccc79421d45cca65ff284f1527e9ef02e38
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_java
+      pip_check: true
+
+about:
+  summary: Java grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-java
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-javascript/recipe.yaml
+++ b/recipes/tree-sitter-javascript/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-javascript
+  version: "0.25.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_javascript-${{ version }}.tar.gz
+  sha256: 329b5414874f0588a98f1c291f1b28138286617aa907746ffe55adfdcf963f38
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=62.4.0
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_javascript
+      pip_check: true
+
+about:
+  summary: JavaScript grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-javascript
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-kotlin/recipe.yaml
+++ b/recipes/tree-sitter-kotlin/recipe.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-kotlin
+  version: "1.1.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+# Upstream PyPI sdist for v1+ strips src/tree_sitter/*.h headers needed for the
+# C build, so source from the GitHub tag which ships the full source tree.
+source:
+  url: https://github.com/tree-sitter-grammars/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 3c36bd5627fff38e4323ebead1f7e86e6d1727f0353618d1c976fea88260ba90
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_kotlin
+      pip_check: true
+
+about:
+  summary: Kotlin grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter-grammars/tree-sitter-kotlin
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-luau/recipe.yaml
+++ b/recipes/tree-sitter-luau/recipe.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-luau
+  version: "1.2.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+# Upstream PyPI sdist for v1+ strips src/tree_sitter/*.h headers needed for the
+# C build, so source from the GitHub tag which ships the full source tree.
+source:
+  url: https://github.com/tree-sitter-grammars/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 43c9f7b3380b60ca7a8092f54fc03a0e6749d3e3aca7a695796034c8472884e1
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_luau
+      pip_check: true
+
+about:
+  summary: Luau grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter-grammars/tree-sitter-luau
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-php/recipe.yaml
+++ b/recipes/tree-sitter-php/recipe.yaml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-php
+  version: "0.24.2"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+# Upstream publishes wheels only (no sdist) to PyPI, so build from GitHub tag.
+source:
+  url: https://github.com/tree-sitter/${{ name }}/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 0e73ad63dda67ac12c0e012726a4e1a9811c26b020a0a2dea3e889f8246d9cf4
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_php
+      pip_check: true
+
+about:
+  summary: PHP grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-php
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-ruby/recipe.yaml
+++ b/recipes/tree-sitter-ruby/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-ruby
+  version: "0.23.1"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_ruby-${{ version }}.tar.gz
+  sha256: 886ed200bfd1f3ca7628bf1c9fefd42421bbdba70c627363abda67f662caa21e
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_ruby
+      pip_check: true
+
+about:
+  summary: Ruby grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-ruby
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-rust/recipe.yaml
+++ b/recipes/tree-sitter-rust/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-rust
+  version: "0.24.2"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_rust-${{ version }}.tar.gz
+  sha256: 54fb02a5911e345308b405174465112479f56dc39e3f1e7744d7568595f00db9
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_rust
+      pip_check: true
+
+about:
+  summary: Rust grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-rust
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-scala/recipe.yaml
+++ b/recipes/tree-sitter-scala/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-scala
+  version: "0.26.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_scala-${{ version }}.tar.gz
+  sha256: 7f768094afbed10c07e60c202e275efc683418eeae4bdeff2c16f2ea0744939f
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_scala
+      pip_check: true
+
+about:
+  summary: Scala grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-scala
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-swift/recipe.yaml
+++ b/recipes/tree-sitter-swift/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-swift
+  version: "0.7.2"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_swift-${{ version }}.tar.gz
+  sha256: 67b9a3ba5ab8fff2c082a2c0c33c8b5a66539f8bfa5058385688b1aefc11cead
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_swift
+      pip_check: true
+
+about:
+  summary: Swift grammar for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/alex-pinkus/tree-sitter-swift
+
+extra:
+  recipe-maintainers:
+    - rxm7706

--- a/recipes/tree-sitter-typescript/recipe.yaml
+++ b/recipes/tree-sitter-typescript/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: tree-sitter-typescript
+  version: "0.23.2"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/${{ name }}/tree_sitter_typescript-${{ version }}.tar.gz
+  sha256: 7b167b5827c882261cb7a50dfa0fb567975f9b315e87ed87ad0a0a3aedb3834d
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_typescript
+      pip_check: true
+
+about:
+  summary: TypeScript and TSX grammars for tree-sitter
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-typescript
+
+extra:
+  recipe-maintainers:
+    - rxm7706


### PR DESCRIPTION
## Summary

Adds Python bindings for 12 tree-sitter language grammars not currently on
conda-forge:

- tree-sitter-cpp 0.23.4
- tree-sitter-go 0.25.0
- tree-sitter-java 0.23.5
- tree-sitter-javascript 0.25.0
- tree-sitter-kotlin 1.1.0  (GitHub source)
- tree-sitter-luau 1.2.0    (GitHub source)
- tree-sitter-php 0.24.2    (GitHub source — no PyPI sdist)
- tree-sitter-ruby 0.23.1
- tree-sitter-rust 0.24.2
- tree-sitter-scala 0.26.0
- tree-sitter-swift 0.7.2
- tree-sitter-typescript 0.23.2

Bundled together because they're a tight family (all MIT-licensed tree-sitter
grammars, near-identical recipe pattern matching the existing
tree-sitter-python-feedstock) and have a common downstream consumer
(`repowise` — pending submission, requires all 12).

## Source URLs

Recipes using GitHub source rather than the PyPI sdist do so because the v1+
tree-sitter PyPI sdists strip `src/tree_sitter/parser.h` (needed at build time)
while the GitHub tag tarballs ship the full source tree. tree-sitter-php has
no PyPI sdist at all.

## Verification

- All 12 pass schema validation and conda-forge optimizer checks (0 warnings).
- Native smoke builds passed locally on linux-64 for tree-sitter-go (v0.x
  PyPI-sdist pattern) and tree-sitter-luau (v1.x GitHub-source pattern),
  producing 4 .conda artifacts each across Python 3.10–3.13.

## Test plan

- [ ] CI green on linux-64 / osx-64 / osx-arm64 / win-64 for all 12
- [ ] `pip check` passes for each
- [ ] Import test passes for each module