### PR TITLE
Add gdal-conv2d 0.1.0

### DIFF
--- a/recipes/gdal-conv2d/build.sh
+++ b/recipes/gdal-conv2d/build.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 
 # Build + install the C++ binary as $PREFIX/bin/gdal-conv2d
-cmake -G Ninja -DCMAKE_PREFIX_PATH=$PREFIX -S cpp -B build
+cmake ${CMAKE_ARGS} -G Ninja -DCMAKE_PREFIX_PATH=$PREFIX -S cpp -B build
 cmake --build build --parallel ${CPU_COUNT}
 cmake --install build

--- a/recipes/gdal-conv2d/build.sh
+++ b/recipes/gdal-conv2d/build.sh
@@ -2,12 +2,6 @@
 set -euo pipefail
 
 # Build + install the C++ binary as $PREFIX/bin/gdal-conv2d
-mkdir -p cpp/build
-cd cpp/build
-cmake .. \
-    -G Ninja \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-    -DCMAKE_PREFIX_PATH="$PREFIX"
-cmake --build . -j "${CPU_COUNT}"
-cmake --install .
+cmake -G Ninja -DCMAKE_PREFIX_PATH=$PREFIX -S cpp -B build
+cmake --build build --parallel ${CPU_COUNT}
+cmake --install build

--- a/recipes/gdal-conv2d/build.sh
+++ b/recipes/gdal-conv2d/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build + install the C++ binary as $PREFIX/bin/gdal-conv2d
+mkdir -p cpp/build
+cd cpp/build
+cmake .. \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DCMAKE_PREFIX_PATH="$PREFIX"
+cmake --build . -j "${CPU_COUNT}"
+cmake --install .

--- a/recipes/gdal-conv2d/meta.yaml
+++ b/recipes/gdal-conv2d/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - ninja
     - make  # [unix]
   host:
-    - libgdal >=3.11
+    - libgdal
     - llvm-openmp  # [osx]
     - libgomp      # [linux]
   run:

--- a/recipes/gdal-conv2d/meta.yaml
+++ b/recipes/gdal-conv2d/meta.yaml
@@ -1,8 +1,7 @@
-{% set name = "gdal-conv2d" %}
 {% set version = "0.1.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: "gdal-conv2d"
   version: {{ version }}
 
 source:

--- a/recipes/gdal-conv2d/meta.yaml
+++ b/recipes/gdal-conv2d/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "gdal-conv2d" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/isaaccorley/gdal-unet/archive/refs/tags/v{{ version }}.tar.gz
+  # Set after cutting the GitHub release; the release-job notes print this.
+  sha256: e801ab8f41551fee7b51188ba06d62c3018ce298fa05c99cfb00c0e7fab19268
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake >=3.15
+    - ninja
+    - make  # [unix]
+  host:
+    - libgdal >=3.11
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+  run:
+    - libgdal >=3.11
+    - llvm-openmp  # [osx]
+    - libgomp      # [linux]
+
+test:
+  commands:
+    - gdal-conv2d --help
+
+about:
+  home: https://github.com/isaaccorley/gdal-unet
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: A fused Conv2d + BN + activation primitive built on GDAL CLI
+  description: |
+    gdal-conv2d is a single C++17 binary that performs one fused
+    Conv2d + (bias|BN) + activation + (stride|padding|depthwise) layer
+    using GDAL for I/O.  Also exposes maxpool, nearest-upsample, add,
+    concat, scale, and stable softmax as additional --mode flags.
+
+    Designed to be chained ~30-150 times via a shell script to run a
+    full conv-based U-Net forward pass.  See the parent project at
+    https://github.com/isaaccorley/gdal-unet for the gdal-unet-export
+    Python tool that generates such scripts from PyTorch checkpoints.
+
+    Outputs Float16 GeoTIFFs preserving CRS + geotransform.  Inner conv
+    loops parallelize over output channels via OpenMP.
+
+  doc_url: https://github.com/isaaccorley/gdal-unet
+  dev_url: https://github.com/isaaccorley/gdal-unet
+
+extra:
+  recipe-maintainers:
+    - isaaccorley

--- a/recipes/gdal-conv2d/meta.yaml
+++ b/recipes/gdal-conv2d/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   build:
     - {{ compiler('cxx') }}
     - {{ stdlib("c") }}
-    - cmake >=3.15
+    - cmake
     - ninja
   host:
     - libgdal

--- a/recipes/gdal-conv2d/meta.yaml
+++ b/recipes/gdal-conv2d/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
     - cmake >=3.15
     - ninja
     - make  # [unix]

--- a/recipes/gdal-conv2d/meta.yaml
+++ b/recipes/gdal-conv2d/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - {{ stdlib("c") }}
     - cmake >=3.15
     - ninja
-    - make  # [unix]
   host:
     - libgdal
     - llvm-openmp  # [osx]


### PR DESCRIPTION
A single C++17 binary that performs one fused `Conv2d + (bias|BN) + activation + (stride|padding|depthwise)` layer using GDAL for raster I/O. Also exposes `maxpool`, nearest `upsample`, `add`, `concat`, `scale`, and stable `softmax` as additional `--mode` flags.

Designed to be chained ~30–150 times via a shell script to run a full conv-based U-Net forward pass. See the parent project at https://github.com/isaaccorley/gdal-unet for the `gdal-unet-export` Python tool that generates such scripts from PyTorch `.pt` checkpoints. End-to-end inference on a 512×512 NAIP patch on a 16-CPU node: ~5.5 s, IoU 0.6372 vs PyTorch 0.6374 (bit-close, Float16 noise only).

### Checklist

- [x] Title of this PR is meaningful (e.g. "Adding my_nifty_package")
- [x] License is in [list of OSI Approved Licenses](https://opensource.org/license) — MIT
- [x] Source uses a tag (v0.1.0) rather than a branch
- [x] `package/name` is lowercased
- [x] `requirements/host` covers what's needed: `libgdal >=3.11`, `llvm-openmp` (osx) / `libgomp` (linux)
- [x] `test/commands` runs `gdal-conv2d --help` to verify the binary works after install
- [x] Skips Windows (no MSVC + libomp coverage today; can be added later)

Project URL: https://github.com/isaaccorley/gdal-unet  
Release: https://github.com/isaaccorley/gdal-unet/releases/tag/v0.1.0  
License: https://github.com/isaaccorley/gdal-unet/blob/main/LICENSE