### PR TITLE
Add ont-end-reason

### DIFF
--- a/recipes/ont-end-reason/meta.yaml
+++ b/recipes/ont-end-reason/meta.yaml
@@ -1,0 +1,84 @@
+{% set name = "ont-end-reason" %}
+{% set version = "0.2.0a1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ont_end_reason-{{ version }}.tar.gz
+  sha256: 3e5b9898b630284a1344d8f9a12549de3fc425570bd8f436eb69c37602fc08b3
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - ont-end-reason = ont_end_reason.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.10
+    - click >=8.1
+    - pysam >=0.22
+    - pod5 >=0.3
+    - numpy >=1.24
+    - pandas >=2.0
+    - matplotlib-base >=3.7
+    - scipy >=1.10
+    - structlog >=24.1
+    - pyyaml >=6.0
+    - jinja2 >=3.1
+    - tabulate >=0.9
+
+test:
+  imports:
+    - ont_end_reason
+    - ont_end_reason.analyze.distribution
+    - ont_end_reason.analyze.umc_posterior
+    - ont_end_reason.filter
+    - ont_end_reason.io
+    - ont_end_reason.viz
+  commands:
+    - ont-end-reason --version
+    - ont-end-reason --help
+    - ont-end-reason codes
+    - ont-end-reason schema
+  requires:
+    - pip
+
+about:
+  home: https://github.com/Single-Molecule-Sequencing/ont-end-reason
+  summary: Comprehensive CLI for Oxford Nanopore end_reason analysis
+  description: |
+    ont-end-reason is the canonical analysis toolkit for Oxford Nanopore
+    Technologies `end_reason` metadata — the tag every read carries that
+    explains why sequencing stopped. The package provides:
+
+      - 9 analyses (distribution, length, quality with GMM, temporal,
+        hypothesis tests, UMC posterior, signal trace, SMA metrics, tables)
+      - 4 filter operations (tag, filter, export-fastq, stats)
+      - 4 paper figure reproducers (fig3, fig5, fig6, supplementary)
+      - 6-section composed interactive HTML reports
+
+    The Bayesian UMC posterior analysis estimates how much sequence was
+    truncated by adaptive sampling — recovering an estimate of "unobserved"
+    sequence per read. This is the central novel contribution of the
+    companion paper.
+
+    Companion to the end-reason paper from the Single-Molecule-Sequencing
+    lab at the University of Michigan.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://silver-adventure-o322543.pages.github.io/
+  dev_url: https://github.com/Single-Molecule-Sequencing/ont-end-reason
+
+extra:
+  recipe-maintainers:
+    - gregfar


### PR DESCRIPTION
### Recipe-Maintainer(s)

- @gregfar (recipe maintainer, package author)

### About `ont-end-reason`

Comprehensive CLI for Oxford Nanopore `end_reason` analysis — companion to the
[end-reason paper](https://github.com/Single-Molecule-Sequencing/end-reason-paper) from the
Athey Lab at the University of Michigan.

The package provides:
- 9 analyses: `distribution`, `length`, `quality` (with GMM fit), `temporal`,
  `hypothesis` (Mann-Whitney + KS + Cliff's Δ), `umc-posterior` (Bayesian
  truncated-lognormal posterior on adaptive-sampling-truncated reads — the
  paper's novel contribution), `signal-trace`, `sma-metrics`, `tables`
- 4 filter operations: `tag`, `filter`, `export-fastq`, `stats`
- 4 paper-figure reproducers: `fig3`, `fig5`, `fig6`, `supplementary`
- 6-section composed interactive HTML reports

Links:
- 🏠 [GitHub repo](https://github.com/Single-Molecule-Sequencing/ont-end-reason)
- 📦 [PyPI](https://pypi.org/project/ont-end-reason/)
- 🎨 [Interactive dashboard](https://silver-adventure-o322543.pages.github.io/)
- 📄 [Companion paper](https://github.com/Single-Molecule-Sequencing/end-reason-paper) (in preparation)

Already on PyPI as `ont-end-reason==0.2.0a1` (alpha). The companion paper's claim atoms
are pinned to this version via tool-spec yaml blocks; conda packaging closes the
reproducibility loop for the conda-using subset of the ONT community.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] Recipe is in [conda-forge style guide](https://conda-forge.org/docs/maintainer/adding_pkgs.html#package-naming) format.
- [x] License file is packaged (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#license-file) for an example).
- [x] Source/test requirements declared.
- [x] All requirements specified for build/host/run.
- [x] Pythonic noarch package (pure-Python).

### Notes

- All dependencies are existing conda-forge packages.
- `matplotlib-base` used instead of `matplotlib` to avoid pulling Qt.
- No GUI dependencies; Plotly is an optional extra on PyPI but not declared
  as a hard dep here (interactive HTML reports work without; users can
  `mamba install plotly` if needed).