### PR TITLE
Add recipe for open-ipv8-lab

### DIFF
--- a/recipes/open-ipv8-lab/meta.yaml
+++ b/recipes/open-ipv8-lab/meta.yaml
@@ -1,0 +1,51 @@
+{% set version = "0.12.3" %}
+
+package:
+  name: open-ipv8-lab
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/o/open-ipv8-lab/open_ipv8_lab-{{ version }}.tar.gz
+  sha256: 257c0ba5fa88ce6d5ddfb2b181852756d9fac03d9492ed5f2cec705dad4e7c86
+
+build:
+  entry_points:
+    - ipv8lab = ipv8lab.cli.main:app
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11
+    - setuptools >=68.0
+    - wheel
+    - pip
+  run:
+    - python >=3.11
+    - typer >=0.12.0
+    - pyyaml >=6.0.0
+    - rich >=13.0.0
+    - textual >=0.60.0
+
+test:
+  imports:
+    - ipv8lab
+  commands:
+    - pip check
+    - ipv8lab --help
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://github.com/LF3551/Open-IPv8-Lab
+  summary: Experimental userspace IPv8 toolkit implementing draft-thain-ipv8-02 — address parsing, packet building, routing simulation, ICMPv8, 8to4 tunnelling, and more.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE
+
+extra:
+  recipe-maintainers:
+    - LF3551


### PR DESCRIPTION
## About

**open-ipv8-lab** is an experimental userspace toolkit implementing [draft-thain-ipv8-02](https://www.ietf.org/archive/id/draft-thain-ipv8-02.html) — the Internet Protocol Version 8 specification. Provides CLI-driven address management, packet construction, routing simulation, and protocol conformance testing in a pure-Python environment.

- **PyPI**: https://pypi.org/project/open-ipv8-lab/
- **GitHub**: https://github.com/LF3551/Open-IPv8-Lab
- **License**: Apache-2.0
- **noarch**: python
- **Recipe generated with**: grayskull

## Checklist

- [x] Recipe generated using `grayskull pypi open-ipv8-lab`
- [x] License files included (LICENSE, NOTICE)
- [x] Tests: `pip check` + `ipv8lab --help`
- [x] Entry point: `ipv8lab`
- [x] noarch: python