### PR TITLE
Add datacore-vn

### DIFF
--- a/recipes/datacore-vn/meta.yaml
+++ b/recipes/datacore-vn/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "datacore-vn" %}
-{% set version = "0.2.0" %}
+{% set version = "1.0.0" %}
 {% set python_min = "3.9" %}
 
 package:
@@ -9,7 +9,7 @@ package:
 source:
   # PyPI normalises the project name to an underscore in the sdist filename.
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/datacore_vn-{{ version }}.tar.gz
-  sha256: 04272471647acd24dd0b6c025488a8200a3046d4c3c4bfc9c75ed86524bfe9ba
+  sha256: 5e9383ab9c8633be1c1bf0bc87317c5e0c02d1923871adb17bde33252669f049
 
 build:
   noarch: python

--- a/recipes/datacore-vn/meta.yaml
+++ b/recipes/datacore-vn/meta.yaml
@@ -1,0 +1,58 @@
+{% set name = "datacore-vn" %}
+{% set version = "0.2.0" %}
+{% set python_min = "3.9" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # PyPI normalises the project name to an underscore in the sdist filename.
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/datacore_vn-{{ version }}.tar.gz
+  sha256: 04272471647acd24dd0b6c025488a8200a3046d4c3c4bfc9c75ed86524bfe9ba
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >={{ python_min }}
+    - requests >=2.31.0
+    - pandas >=2.0.0
+    - python-dotenv >=1.0.0
+
+test:
+  imports:
+    - datacore
+  commands:
+    - pip check
+  requires:
+    - python {{ python_min }}
+    - pip
+
+about:
+  home: https://github.com/DataCore-VietNam/DataCore
+  summary: Python client for the Datacore API
+  description: |
+    datacore-vn is the official Python client for the Datacore API
+    (https://datacore.vn). It supports a no-API-key demo mode for
+    previewing datasets and a full paid mode for querying, paginating,
+    and downloading data. Results are returned as pandas DataFrames by
+    default, with optional polars support. The package is imported as
+    `datacore`.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/DataCore-VietNam/DataCore#readme
+  dev_url: https://github.com/DataCore-VietNam/DataCore
+
+extra:
+  recipe-maintainers:
+    - mike-datacore


### PR DESCRIPTION
Adds a recipe for [`datacore-vn`](https://pypi.org/project/datacore-vn/) — the official Python client for the Datacore API (https://datacore.vn), a provider of Vietnam capital-markets datasets.

- Source: PyPI sdist `datacore_vn-0.2.0.tar.gz`
- Pure Python, `noarch: python`
- Runtime deps: `requests`, `pandas`, `python-dotenv` (all on conda-forge)
- Imports as `datacore`; the `-vn` distribution suffix avoids an unrelated abandoned `datacore` project on PyPI
- Upstream: https://github.com/DataCore-VietNam/DataCore

### Checklist

- [x] Title of this PR is meaningful: "Add datacore-vn".
- [x] License file is packaged (`license_file: LICENSE`, present in the sdist).
- [x] Source is from a stable source (PyPI sdist with sha256).
- [x] Package is pure Python; `noarch: python` used.
- [x] All dependencies are available on conda-forge.
- [x] Recipe maintainer (`mike-datacore`) has agreed to maintain.