### PR TITLE
Add graphifyy v0.8.6

### DIFF
--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -51,7 +51,6 @@ requirements:
     - tree-sitter-julia
     - tree-sitter-verilog
     - tree-sitter-bash
-    - mcp
     - pypdf
     - watchdog
     - matplotlib
@@ -68,6 +67,9 @@ tests:
   - python:
       imports:
         - graphifyy
+        - graphifyy.cli
+        - graphifyy.core
+        - graphifyy.server
       pip_check: true
       python_version: ${{ python_min }}.*
   - requirements:
@@ -87,7 +89,8 @@ about:
     This tool is particularly valuable for developers, researchers, and data scientists who need to efficiently manage and make sense of vast amounts of project-related information. It offers a streamlined approach to building intelligent interfaces over an entire codebase and its accompanying materials, enabling deeper analysis and more effective collaboration.
   homepage: https://github.com/safishamsi/graphify
   repository: https://github.com/safishamsi/graphify
-  license: MIT License  Copyright (c) 2026 Safi Shamsi  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+  documentation: https://github.com/safishamsi/graphify#readme
+  license: MIT
   license_file: LICENSE
 
 extra:

--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: graphifyy
+  version: "0.8.6"
+  python_min: "3.9"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/00/dd/fe4075054165e1d3ee5cda475626cb7ddc929c4a9d4e495d9a078e441a36/graphifyy-0.8.6.tar.gz
+  sha256: 24f4343cc3a6a140ef811d64af112e95308d1704837c09e1741bdceaa9fd76d8
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - networkx
+    - datasketch
+    - rapidfuzz
+    - tree_sitter >=0.23.0
+    - tree-sitter-python
+    - tree-sitter-javascript
+    - tree-sitter-typescript
+    - tree-sitter-go
+    - tree-sitter-rust
+    - tree-sitter-java
+    - tree-sitter-c
+    - tree-sitter-cpp
+    - tree-sitter-ruby
+    - tree-sitter-c-sharp
+    - tree-sitter-kotlin
+    - tree-sitter-scala
+    - tree-sitter-php
+    - tree-sitter-swift
+    - tree-sitter-lua
+    - tree-sitter-zig
+    - tree-sitter-powershell
+    - tree-sitter-elixir
+    - tree-sitter-objc
+    - tree-sitter-julia
+    - tree-sitter-verilog
+    - tree-sitter-bash
+    - mcp
+    - pypdf
+    - watchdog
+    - matplotlib
+    - graspologic
+    - python-docx
+    - openpyxl
+    - yt-dlp
+    - openai
+    - tiktoken
+    - boto3
+    - tree-sitter-sql
+
+tests:
+  - python:
+      imports:
+        - graphifyy
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - graphify --help
+
+about:
+  summary: "AI coding assistant skill (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, Aider, OpenClaw, Factory Droid, Trae, Hermes, Kiro, Pi, Google Antigravity) - turn any folder of code, docs, papers, images, or videos into a queryable knowledge graph"
+  description: |
+    Graphifyy is an AI coding assistant skill designed to transform diverse project assets into a queryable knowledge graph. It can ingest and process any folder containing code, documentation, research papers, images, or even videos, constructing a semantic network that represents the relationships and information contained within these varied data types. This enables a unified, intelligent understanding of complex, multi-modal projects.
+
+    Users would install Graphifyy to enhance their ability to navigate, understand, and interact with large repositories using AI. By converting unstructured project content into a structured knowledge graph, Graphifyy provides a powerful foundation for AI coding assistants like Claude Code, Codex, and Gemini CLI to perform sophisticated queries, identify patterns, and offer insights that would be difficult to extract from raw files alone. It bridges the gap between disparate data formats and intelligent systems.
+
+    This tool is particularly valuable for developers, researchers, and data scientists who need to efficiently manage and make sense of vast amounts of project-related information. It offers a streamlined approach to building intelligent interfaces over an entire codebase and its accompanying materials, enabling deeper analysis and more effective collaboration.
+  homepage: https://github.com/safishamsi/graphify
+  repository: https://github.com/safishamsi/graphify
+  license: MIT License  Copyright (c) 2026 Safi Shamsi  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny


### PR DESCRIPTION
## Summary
- Adds the `graphifyy` package, version `0.8.6`.
- Several runtime dependencies are not yet available on `conda-forge` and have been omitted from this initial recipe.

## Linked issue
Closes #8

## Files changed (highlights)
**Added**
- `recipes/graphifyy/recipe.yaml` — New recipe for `graphifyy`.

## Test plan
- [ ] Inspect `recipe.yaml` for correctness and style.
- [ ] `cd recipes/graphifyy && conda build .`
- [ ] Install the built package and verify imports and console scripts.

## Out of scope
Did not include `tree-sitter-groovy`, `tree-sitter-fortran`, `tree-sitter-json`, `python-neo4j` (for `neo4j`), `python-markdownify` (for `markdownify`), and `faster-whisper` in `run:` requirements as they are not currently available on conda-forge.

## Follow-ups
- [ ] File issue for `tree-sitter-groovy` to be added to `conda-forge`.
- [ ] File issue for `tree-sitter-fortran` to be added to `conda-forge`.
- [ ] File issue for `tree-sitter-json` to be added to `conda-forge`.
- [ ] File issue for `python-neo4j` (for `neo4j`) to be added to `conda-forge`.
- [ ] File issue for `python-markdownify` (for `markdownify`) to be added to `conda-forge`.
- [ ] File issue for `faster-whisper` to be added to `conda-forge`.