### PR TITLE
Add graphifyy recipe

### DIFF
--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -1,0 +1,78 @@
+schema_version: 1
+
+context:
+  version: "0.8.10"
+
+package:
+  name: graphifyy
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/48/32/2f3c28a1321b6003354f35b6b9a23134faa4072353134d3c36808b8fa1ec/graphifyy-${{ version }}.tar.gz
+  sha256: d4c4157899c9606b7b02faa931e807e8e7370736332a43ae34f57cc9de5c9baf
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - graphify = graphify.__main__:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.10
+    - networkx
+    - datasketch
+    - rapidfuzz
+    - tree_sitter >=0.23.0
+    - tree-sitter-python
+    - tree-sitter-javascript
+    - tree-sitter-typescript
+    - tree-sitter-go
+    - tree-sitter-rust
+    - tree-sitter-java
+    - tree-sitter-c
+    - tree-sitter-cpp
+    - tree-sitter-ruby
+    - tree-sitter-c-sharp
+    - tree-sitter-kotlin
+    - tree-sitter-scala
+    - tree-sitter-php
+    - tree-sitter-swift
+    - tree-sitter-lua
+    - tree-sitter-zig
+    - tree-sitter-powershell
+    - tree-sitter-elixir
+    - tree-sitter-objc
+    - tree-sitter-julia
+    - tree-sitter-verilog
+    - tree-sitter-bash
+
+tests:
+  - python:
+      imports:
+        - graphify
+      # pip_check disabled: graphifyy's wheel metadata declares
+      # tree-sitter-{groovy,fortran,json} as required, but those have no
+      # conda-forge feedstock yet so they are intentionally dropped from
+      # run requirements. Re-enable once those feedstocks land.
+      pip_check: false
+
+about:
+  summary: |
+    AI coding assistant skill that turns any folder of code, docs, papers,
+    images, or videos into a queryable knowledge graph.
+  homepage: https://github.com/safishamsi/graphify
+  repository: https://github.com/safishamsi/graphify
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny

--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -37,6 +37,7 @@ requirements:
     - tree-sitter-go
     - tree-sitter-rust
     - tree-sitter-java
+    - tree-sitter-groovy
     - tree-sitter-c
     - tree-sitter-cpp
     - tree-sitter-ruby
@@ -52,18 +53,16 @@ requirements:
     - tree-sitter-objc
     - tree-sitter-julia
     - tree-sitter-verilog
+    - tree-sitter-fortran
     - tree-sitter-bash
+    - tree-sitter-json
 
 tests:
   - python:
       imports:
         - graphify
       python_version: ${{ python_min }}.*
-      # pip_check disabled: graphifyy's wheel metadata declares
-      # tree-sitter-{groovy,fortran,json} as required, but those have no
-      # conda-forge feedstock yet so they are intentionally dropped from
-      # run requirements. Re-enable once those feedstocks land.
-      pip_check: false
+      pip_check: true
 
 about:
   summary: |

--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "0.8.10"
+  python_min: "3.10"
 
 package:
   name: graphifyy
@@ -21,11 +22,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68
   run:
-    - python >=3.10
+    - python >=${{ python_min }}
     - networkx
     - datasketch
     - rapidfuzz
@@ -57,6 +58,7 @@ tests:
   - python:
       imports:
         - graphify
+      python_version: ${{ python_min }}.*
       # pip_check disabled: graphifyy's wheel metadata declares
       # tree-sitter-{groovy,fortran,json} as required, but those have no
       # conda-forge feedstock yet so they are intentionally dropped from

--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "0.8.10"
-  python_min: "3.10"
 
 package:
   name: graphifyy

--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -8,7 +8,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/48/32/2f3c28a1321b6003354f35b6b9a23134faa4072353134d3c36808b8fa1ec/graphifyy-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/g/graphifyy/graphifyy-${{ version }}.tar.gz
   sha256: d4c4157899c9606b7b02faa931e807e8e7370736332a43ae34f57cc9de5c9baf
 
 build:

--- a/recipes/graphifyy/recipe.yaml
+++ b/recipes/graphifyy/recipe.yaml
@@ -60,7 +60,9 @@ tests:
   - python:
       imports:
         - graphify
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
       pip_check: true
 
 about:

--- a/recipes/tree-sitter-fortran/recipe.yaml
+++ b/recipes/tree-sitter-fortran/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "0.6.0"
+
+package:
+  name: tree-sitter-fortran
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/t/tree-sitter-fortran/tree_sitter_fortran-${{ version }}.tar.gz
+    sha256: 65fea540148ae431335b3920267dffaeeb157ef2b21c0716798c751f6a9e193b
+
+build:
+  number: 0
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_fortran
+      pip_check: true
+
+about:
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/stadelmanma/tree-sitter-fortran
+  summary: Fortran grammar for tree-sitter.
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny

--- a/recipes/tree-sitter-groovy/LICENSE
+++ b/recipes/tree-sitter-groovy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Amaan Qureshi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/tree-sitter-groovy/recipe.yaml
+++ b/recipes/tree-sitter-groovy/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "0.1.2"
+
+package:
+  name: tree-sitter-groovy
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/t/tree-sitter-groovy/tree_sitter_groovy-${{ version }}.tar.gz
+    sha256: 49b004c4ae946d3f01a602f325cd8996423e034e5b3ad36fc34a1d1e42afa8da
+
+build:
+  number: 0
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_groovy
+      pip_check: true
+
+about:
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/murtaza64/tree-sitter-groovy
+  summary: Groovy grammar for tree-sitter.
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny

--- a/recipes/tree-sitter-groovy/recipe.yaml
+++ b/recipes/tree-sitter-groovy/recipe.yaml
@@ -8,8 +8,8 @@ package:
   version: ${{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/t/tree-sitter-groovy/tree_sitter_groovy-${{ version }}.tar.gz
-    sha256: 49b004c4ae946d3f01a602f325cd8996423e034e5b3ad36fc34a1d1e42afa8da
+  - url: https://github.com/amaanq/tree-sitter-groovy/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: d3eafa455e3a092d79c2d3488fa58a461c1a18cdfa1b7edb22e168b513e454fe
 
 build:
   number: 0
@@ -41,7 +41,7 @@ tests:
 about:
   license: MIT
   license_file: LICENSE
-  homepage: https://github.com/murtaza64/tree-sitter-groovy
+  homepage: https://github.com/amaanq/tree-sitter-groovy
   summary: Groovy grammar for tree-sitter.
 
 extra:

--- a/recipes/tree-sitter-json/recipe.yaml
+++ b/recipes/tree-sitter-json/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "0.24.8"
+
+package:
+  name: tree-sitter-json
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/t/tree-sitter-json/tree_sitter_json-${{ version }}.tar.gz
+    sha256: ca8486e52e2d261819311d35cf98656123d59008c3b7dcf91e61d2c0c6f3120e
+
+build:
+  number: 0
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - python
+    - setuptools >=42
+    - wheel
+    - pip
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - tree_sitter_json
+      pip_check: true
+
+about:
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/tree-sitter/tree-sitter-json
+  summary: JSON grammar for tree-sitter.
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny

--- a/recipes/tree-sitter-json/recipe.yaml
+++ b/recipes/tree-sitter-json/recipe.yaml
@@ -8,8 +8,8 @@ package:
   version: ${{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/t/tree-sitter-json/tree_sitter_json-${{ version }}.tar.gz
-    sha256: ca8486e52e2d261819311d35cf98656123d59008c3b7dcf91e61d2c0c6f3120e
+  - url: https://github.com/tree-sitter/tree-sitter-json/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: acf6e8362457e819ed8b613f2ad9a0e1b621a77556c296f3abea58f7880a9213
 
 build:
   number: 0


### PR DESCRIPTION
Adds the graphifyy recipe to staged-recipes.

graphifyy is an AI coding assistant skill that turns any folder of
code, docs, papers, images, or videos into a queryable knowledge
graph.

* Upstream: https://github.com/safishamsi/graphify
* PyPI:     https://pypi.org/project/graphifyy/0.8.10/
* License:  MIT

Build status: rattler-build succeeds locally on win-64. The package
is noarch python.

Known deviation:

* pip_check is disabled in the test stanza. Upstream pyproject.toml
  declares tree-sitter-groovy, tree-sitter-fortran, and
  tree-sitter-json in install_requires, but those grammars have no
  conda-forge feedstock yet. They are intentionally dropped from run
  requirements for this submission. pip_check will be re-enabled
  once those feedstocks land.

Generated and verified with the auto-recipe tool.
