### PR TITLE
Add pymcurl and quickjs-ng

### DIFF
--- a/recipes/pymcurl/recipe.yaml
+++ b/recipes/pymcurl/recipe.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+context:
+  python_min: "3.10"
+  version: "8.19.0.1"
+
+package:
+  name: pymcurl
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pymcurl/pymcurl-${{ version }}.tar.gz
+  sha256: 2c555621c356ebef9fc0f0c35b232f0b492f58c95dd7d3a1bde1bd67e8aa0c73
+  patches:
+    - use-conda-forge-libcurl.patch
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: win
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cffi
+        - cross-python_${{ target_platform }}
+  host:
+    - python
+    - cffi
+    - libcurl
+    - pip
+    - setuptools
+  run:
+    - python
+    - cffi
+
+tests:
+  - python:
+      imports:
+        - mcurl
+      pip_check: true
+
+about:
+  summary: Manage outbound HTTP connections using Curl & CurlMulti
+  license: MIT
+  license_file: LICENSE.txt
+  homepage: https://github.com/genotrance/mcurl
+  repository: https://github.com/genotrance/mcurl
+
+extra:
+  recipe-maintainers:
+    - ytausch

--- a/recipes/pymcurl/use-conda-forge-libcurl.patch
+++ b/recipes/pymcurl/use-conda-forge-libcurl.patch
@@ -1,0 +1,110 @@
+diff -ruN pymcurl-orig/mcurl/gen.py pymcurl-mod/mcurl/gen.py
+--- pymcurl-orig/mcurl/gen.py	2026-05-19 09:53:59
++++ pymcurl-mod/mcurl/gen.py	2026-05-19 14:17:56
+@@ -1,14 +1,15 @@
+-import glob
+ import os
+ import re
+-import shutil
+ import subprocess
+ import sys
+-import tempfile
+ 
+ import cffi
+-import jbb
+ 
++
++def _conda_prefix():
++    # Conda-forge: PYMCURL_PREFIX points at the host prefix that ships libcurl.
++    return os.environ.get("PYMCURL_PREFIX") or os.environ.get("PREFIX") or sys.prefix
++
+ # Platform specific additions
+ if sys.platform == "linux":
+     CDEF_HEADER = """
+@@ -23,9 +24,9 @@
+ typedef long time_t;
+ 
+ typedef struct {
+-    long %s int fds_bits[%d];
++    long int fds_bits[%d];
+ } fd_set;
+-""" % ("unsigned" if jbb.get_libc() == "musl" else "", 16 if sys.maxsize > 2**32 else 32)
++""" % (16 if sys.maxsize > 2**32 else 32,)
+ 
+     HEADER = """
+ #include <sys/socket.h>
+@@ -205,7 +206,7 @@
+ 
+ def get_preprocessor(sfile, incs=[], defines=[], recurse=False):
+     # Get preprocessed output from the C/C++ compiler
+-    args = ["gcc"]
++    args = [os.environ.get("CC", "gcc")]
+     start = False
+ 
+     sfileName = os.path.basename(sfile)
+@@ -349,48 +350,14 @@
+ 
+ 
+ def source_prep():
+-    # Download libcurl from JBB for Linux and Windows
+-    key = jbb.get_key()
+-    outdir = os.path.join(os.environ.get("TMP", tempfile.gettempdir()), "mcurl", key)
+-    version = get_libcurl_version()
+-    libs = []
+-    if sys.platform != "darwin":
+-        libs.extend(jbb.jbb(f"LibCURL-v{version}", outdir=outdir, project="genotrance", quiet=False))
+-
+-        # On Windows, jbb returns bin/ dirs but mingw32 linker needs lib/ dirs
+-        # for import libraries (.dll.a / .a). Add lib/ equivalents.
+-        if sys.platform == "win32":
+-            lib_dirs = []
+-            for d in libs:
+-                lib_dirs.append(d)
+-                lib_dir = d.replace(os.sep + "bin", os.sep + "lib")
+-                if lib_dir != d and os.path.isdir(lib_dir):
+-                    lib_dirs.append(lib_dir)
+-            libs = lib_dirs
+-
+-        # Header file location
+-        curlh = f"{outdir}{os.sep}LibCURL{os.sep}include{os.sep}curl{os.sep}curl.h"
+-    else:
+-        prefix = subprocess.check_output("brew --prefix", shell=True, text=True).strip()
+-        deps = ["curl"] + subprocess.check_output("brew deps -n --installed curl", shell=True, text=True).splitlines()
+-        for dep in deps:
+-            if dep == "ca-certificates":
+-                continue
+-            libs.append(prefix + "/opt/" + dep + "/lib")
+-
+-        curlh = prefix + "/opt/curl/include/curl/curl.h"
+-
+-    # Include directory
++    # Use libcurl from the active conda-forge environment
++    prefix = _conda_prefix()
++    libs = [os.path.join(prefix, "lib")]
++    curlh = os.path.join(prefix, "include", "curl", "curl.h")
+     inc = os.path.dirname(curlh)
+ 
+-    # Download CAcerts
+-    pemdst = "mcurl/cacert.pem"
+-    jbb.jbb("mozillaCACerts", outdir=outdir, quiet=False)
+-    pemsrc = glob.glob(f"{outdir}/**/cacert.pem", recursive=True)[0]
+-    try:
+-        shutil.copy(pemsrc, pemdst)
+-    except shutil.SameFileError:
+-        pass
++    # cacert.pem: conda-forge's libcurl uses ca-certificates from the active
++    # environment via SSL_CERT_FILE / curl-config defaults. No bundled pem.
+ 
+     # Preprocess and clean code
+     cdef = get_preprocessor(curlh, recurse=True)
+diff -ruN pymcurl-orig/pyproject.toml pymcurl-mod/pyproject.toml
+--- pymcurl-orig/pyproject.toml	2026-05-19 09:53:59
++++ pymcurl-mod/pyproject.toml	2026-05-19 09:54:05
+@@ -1,6 +1,6 @@
+ [build-system]
+ build-backend = "setuptools.build_meta"
+-requires = ["cffi", "jbb", "setuptools"]
++requires = ["cffi", "setuptools"]
+ 
+ [project]
+ name = "pymcurl"

--- a/recipes/quickjs-ng/recipe.yaml
+++ b/recipes/quickjs-ng/recipe.yaml
@@ -55,7 +55,9 @@ tests:
 about:
   summary: Thin Python wrapper of quickjs-ng
   license: MIT
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - upstream-quickjs/LICENSE
   homepage: https://github.com/genotrance/quickjs-ng
   repository: https://github.com/genotrance/quickjs-ng
 

--- a/recipes/quickjs-ng/recipe.yaml
+++ b/recipes/quickjs-ng/recipe.yaml
@@ -1,0 +1,64 @@
+schema_version: 1
+
+context:
+  python_min: "3.10"
+  version: "0.14.0.1"
+  # Pinned upstream quickjs commit (the upstream-quickjs git submodule
+  # of genotrance/quickjs-ng at tag v${{ version }}). The PyPI sdist
+  # ships only a partial copy of the submodule, so we re-fetch it here.
+  upstream_quickjs_rev: "6d2a9bacbc9feb5c1f46f80b3cf4c25bedd2187b"
+
+package:
+  name: quickjs-ng
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/q/quickjs-ng/quickjs_ng-${{ version }}.tar.gz
+    sha256: 08c166ad61a5f0fdc8593ff604cb26d6c34421ec7d5698586dbc16d6cb898486
+  - url: https://github.com/quickjs-ng/quickjs/archive/${{ upstream_quickjs_rev }}.tar.gz
+    sha256: fa2dfa8c00f27d442aef101b4f32316536b04b029b7650bc05c02e18b20be66c
+    target_directory: _upstream
+
+build:
+  number: 0
+  # The PyPI sdist ships only some files from the upstream-quickjs git submodule
+  # of genotrance/quickjs-ng, so overlay the full upstream tree from GitHub
+  # before building.
+  script:
+    - if: unix
+      then: cp -R _upstream/. upstream-quickjs/
+    - if: win
+      then: xcopy /E /Y _upstream\* upstream-quickjs\
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - quickjs
+      pip_check: true
+
+about:
+  summary: Thin Python wrapper of quickjs-ng
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/genotrance/quickjs-ng
+  repository: https://github.com/genotrance/quickjs-ng
+
+extra:
+  recipe-maintainers:
+    - ytausch


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

I used AI assistance (Claude Code) in creating this PR. Below is its output. I reviewed this PR manually myself.

--

Adds two recipes that are runtime dependencies of px-proxy v0.11.0 (which I plan to update separately once both land).

### `pymcurl`
- Python wrapper around libcurl (Curl + CurlMulti). Used by px-proxy 0.11.0 in place of `libcurl` + `python-curl-cffi`-style bindings.
- Upstream PyPI sdist downloads prebuilt libcurl binaries via `jbb` (Julia binary distribution) and Mozilla CA certs at build time. Conda-forge builds are offline, so I've patched `mcurl/gen.py` to:
  - Use libcurl headers/libs from `\$PREFIX` (i.e. the `libcurl` host dep)
  - Drop the `jbb` and `mozillaCACerts` downloads — conda-forge's `libcurl` reads CAs from `ca-certificates`
  - Use `\$CC` for header preprocessing instead of hardcoded `gcc`
- Skipped on Windows for now: upstream uses mingw32 + py_limited_api there, which doesn't fit conda-forge's MSVC toolchain. Can be revisited.

### `quickjs-ng`
- Thin Python wrapper around quickjs-ng (used as the PAC interpreter in px-proxy 0.11.0).
- The PyPI sdist for 0.14.0.1 ships only a partial copy of the upstream `quickjs-ng/quickjs` git submodule (e.g. `quickjs-c-atomics.h`, `builtin-array-fromasync.h` are missing). I've reported this is upstream-fixable, but as a workaround the recipe pulls a second source — the upstream submodule at the pinned commit `6d2a9ba` — and overlays it before building.

### Local testing
Both recipes built and the import test passed locally on osx-arm64 with rattler-build.