### PR TITLE
Add demucs-onnx

### DIFF
--- a/recipes/demucs-onnx/meta.yaml
+++ b/recipes/demucs-onnx/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "demucs-onnx" %}
+{% set version = "0.3.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/demucs_onnx-{{ version }}.tar.gz
+  sha256: 83d50f2ec6d08cbd4ca6eb9ff6cb4a5a1157331ee34d5fc3331edd7be519d8aa
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  entry_points:
+    - demucs-onnx = demucs_onnx.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling >=1.18
+  run:
+    - python >=3.10
+    - onnxruntime >=1.17
+    - numpy >=1.24
+    - python-soundfile >=0.12
+    - huggingface_hub >=0.24
+    - python-soxr >=0.3
+    - tqdm >=4.65
+
+test:
+  imports:
+    - demucs_onnx
+  commands:
+    - pip check
+    - demucs-onnx --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/StemSplit/demucs-onnx
+  summary: Run HTDemucs stem separation with ONNX Runtime — no PyTorch required
+  description: |
+    demucs-onnx provides fast audio stem separation (vocals, drums, bass, other)
+    using HTDemucs models exported to ONNX format. Runs on CPU, GPU, CoreML, and
+    in the browser via ONNX Runtime Web. No PyTorch dependency required.
+    Supports htdemucs_ft (4-stem bag), htdemucs (single-file 4-stem), and
+    htdemucs_6s (6-stem with guitar + piano). Includes karaoke / acapella CLI,
+    browser-demo scaffolder, auto-resampling, and auto execution provider routing.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://stemsplit.github.io/demucs-onnx/
+  dev_url: https://github.com/StemSplit/demucs-onnx
+
+extra:
+  recipe-maintainers:
+    - StemSplit


### PR DESCRIPTION
## Package info

- **Package name:** demucs-onnx
- **PyPI:** https://pypi.org/project/demucs-onnx/
- **GitHub:** https://github.com/StemSplit/demucs-onnx
- **License:** MIT
- **Version:** 0.3.3

## Description

`demucs-onnx` provides audio stem separation (vocals, drums, bass, other) using HTDemucs models exported to ONNX format. It runs without PyTorch, making it suitable for production environments, edge devices, and browser-based applications via ONNX Runtime Web.

Supports:
- `htdemucs_ft` (4-stem bag of models)
- `htdemucs` (single-file 4-stem)
- `htdemucs_6s` (6-stem with guitar + piano)

Includes karaoke/acapella CLI, auto-resampling, and auto execution-provider routing (CPU, CUDA, CoreML, DirectML).

## Dependency notes

All runtime dependencies are available on conda-forge:
- `onnxruntime >=1.17` → `onnxruntime`
- `numpy >=1.24` → `numpy`
- `soundfile >=0.12` → `python-soundfile`
- `huggingface-hub >=0.24` → `huggingface_hub`
- `soxr >=0.3` → `python-soxr`
- `tqdm >=4.65` → `tqdm`

Build backend: `hatchling`

## Checklist

- [x] Title matches package name on PyPI
- [x] `noarch: python` — pure Python package
- [x] All dependencies are available on conda-forge
- [x] Tests verify importability and CLI entry point
- [x] License is MIT with `license_file: LICENSE`
- [x] `pip check` included in test commands

Made with [Cursor](https://cursor.com)