### PR TITLE
Add CONDA_FORGE_NO_TTY=True option for cleaner logging to file

### DIFF
--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -44,7 +44,15 @@ mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done"
 rm -f "$DONE_CANARY"
 
-DOCKER_RUN_ARGS="-it ${CONDA_FORGE_DOCKER_RUN_ARGS}"
+# Use -it by default to get interactive progress output from micromamba and
+# rattler-build. When piping to a log file, set CONDA_FORGE_NO_TTY=True to drop
+# the -t flag — without this, ANSI escape sequences from progress bars pollute
+# the captured output.
+if [ "${CONDA_FORGE_NO_TTY:-False}" == "True" ]; then
+    DOCKER_RUN_ARGS="-i ${CONDA_FORGE_DOCKER_RUN_ARGS}"
+else
+    DOCKER_RUN_ARGS="-it ${CONDA_FORGE_DOCKER_RUN_ARGS}"
+fi
 
 if [ "${AZURE}" == "True" ]; then
     DOCKER_RUN_ARGS=""


### PR DESCRIPTION
Running
```
$ python build-locally.py linux64 2>&1 | tee old.log
```
outputs
```
...
 ^[[2m│^[[0m ^[[36m│^[[0m │ packaging        ┆               ┆ 26.2      ┆ pyhc364b38_0         ┆ conda-forge ┆   89.43 KiB │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ readline         ┆               ┆ 8.3       ┆ h853b02a_0           ┆ conda-forge ┆  336.99 KiB │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ tk               ┆               ┆ 8.6.13    ┆ noxft_h366c992_103   ┆ conda-forge ┆    3.15 MiB │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ tzdata           ┆               ┆ 2025c     ┆ hc9c84f9_1           ┆ conda-forge ┆  116.34 KiB │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ wheel            ┆               ┆ 0.47.0    ┆ pyhd8ed1ab_0         ┆ conda-forge ┆   32.71 KiB │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ zstd             ┆               ┆ 1.5.7     ┆ hb78ec9c_6           ┆ conda-forge ┆  587.28 KiB │^M
 ^[[2m│^[[0m ^[[36m│^[[0m ╰──────────────────┴───────────────┴───────────┴──────────────────────┴─────────────┴─────────────╯^M
 ^[[2m│^[[0m ^[[36m│^[[0m ^M
 ^[[2m│^[[0m ^[[36m│^[[0m Run dependencies:^M
 ^[[2m│^[[0m ^[[36m│^[[0m ╭───┬───╮^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ N ┆ S │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ a ┆ p │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ m ┆ e │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │ e ┆ c │^M
 ^[[2m│^[[0m ^[[36m│^[[0m ╞═══╪═══╡^M
 ^[[2m│^[[0m ^[[36m│^[[0m │^[[1m R ^[[0m┆   │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │^[[1m u ^[[0m┆   │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │^[[1m n ^[[0m┆   │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │^[[1m d ^[[0m┆   │^M
 ^[[2m│^[[0m ^[[36m│^[[0m │^[[1m e ^[[0m┆   │^M
...
```

Running
```
$ CONDA_FORGE_NO_TTY=True python build-locally.py linux64 2>&1 | tee new.log
```
outputs
```
...
 │ │ │ packaging        ┆               ┆ 26.2      ┆ pyhc364b38_0         ┆ conda-forge ┆   89.43 KiB │
 │ │ │ readline         ┆               ┆ 8.3       ┆ h853b02a_0           ┆ conda-forge ┆  336.99 KiB │
 │ │ │ tk               ┆               ┆ 8.6.13    ┆ noxft_h366c992_103   ┆ conda-forge ┆    3.15 MiB │
 │ │ │ tzdata           ┆               ┆ 2025c     ┆ hc9c84f9_1           ┆ conda-forge ┆  116.34 KiB │
 │ │ │ wheel            ┆               ┆ 0.47.0    ┆ pyhd8ed1ab_0         ┆ conda-forge ┆   32.71 KiB │
 │ │ │ zstd             ┆               ┆ 1.5.7     ┆ hb78ec9c_6           ┆ conda-forge ┆  587.28 KiB │
 │ │ ╰──────────────────┴───────────────┴───────────┴──────────────────────┴─────────────┴─────────────╯
 │ │  
 │ │ Run dependencies:
 │ │ ╭──────────────────┬────────────────────────╮
 │ │ │ Name             ┆ Spec                   │
 │ │ ╞══════════════════╪════════════════════════╡
 │ │ │ Run dependencies ┆                        │
 │ │ │ python           ┆ >=3.10                 │
 │ │ │                  ┆ (RE of [host: python]) │
 │ │ ╰──────────────────┴────────────────────────╯
...
```