### PR TITLE
Add moove recipe (v1.1.0.post1)

### DIFF
--- a/recipes/moove/meta.yaml
+++ b/recipes/moove/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "moove" %}
+{% set version = "1.1.0.post1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 29800776fed4bb3b12c338c4beb5473c4f826244ccc0d0c2e77d0e55b896e21a
+  # For local testing, replace with:
+  # path: ..
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - moovegui = moove.moovegui:main
+    - moovetaf = moove.moovetaf:main
+
+requirements:
+  host:
+    - python >=3.10,<3.13
+    - pip
+    - hatchling
+  run:
+    - python >=3.10,<3.13
+    # --- available on conda-forge ---
+    - matplotlib >=3.9.0
+    - pytorch >=2.6.0
+    - numpy >=2.1
+    - python-sounddevice >=0.5.0
+    - portaudio
+    - jinja2 >=3.1.4
+    - pandas >=2.2.2
+    - scikit-learn >=1.5.1
+    - seaborn >=0.13.2
+    - umap-learn >=0.5.6
+    - dash >=2.17.1
+    - pillow >=10.0.0
+    - pyqt6 >=6.5.0
+    - scipy >=1.13.0
+    # --- needs conda-forge feedstock first (recipe in conda.recipe/deps/) ---
+    - evfuncs >=0.3.5.post1
+
+test:
+  imports:
+    - moove
+    - moove.models.ConvMLP
+    - moove.models.CNN
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/veitlab/moove
+  summary: Real-time syllable segmentation and classification of birdsong for closed-loop experiments.
+  license: MIT
+  license_file: LICENSE


### PR DESCRIPTION
New package: moove v1.1.0.post1

Real-time syllable segmentation and classification of birdsong for closed-loop vocal learning experiments.

- PyPI: https://pypi.org/project/moove/
- GitHub: https://github.com/veitlab/moove
- License: MIT
- Python-only package (noarch)

- [x] Title of this PR is meaningful: "Add `moove`"
- [x] License file is included in the recipe (`license_file: LICENSE`)
- [x] SHA-256 checksum is provided
- [x] Build number is 0
- [x] Package is `noarch: python`
- [x] Tests are provided (`imports` + `pip check`)
- [x] `home` URL points to the upstream repository
- [ ] (not applicable) New dependencies that are not yet on conda-forge
- [ ] (not applicable) Compilation / C extensions