### PR TITLE
Add pybmodes

### DIFF
--- a/recipes/pybmodes/meta.yaml
+++ b/recipes/pybmodes/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pybmodes" %}
-{% set version = "1.14.1" %}
+{% set version = "1.15.1" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4f3b8c76a1e655c1eaf09ef61ccca5be9be3c80fa3e4c71e1f91a0e3b73aa49a
+  sha256: 8246c8ede87781d65f07ac5482b1b9654505c7c8e23acd90be48a8a4b6b6f5d1
 
 build:
   noarch: python

--- a/recipes/pybmodes/meta.yaml
+++ b/recipes/pybmodes/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pybmodes" %}
-{% set version = "1.14.0" %}
+{% set version = "1.14.1" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a135c2299ba277a3a3973fd4ba72aed10cfcf2f9574a9bbf36bee0f4eb48ff98
+  sha256: 4f3b8c76a1e655c1eaf09ef61ccca5be9be3c80fa3e4c71e1f91a0e3b73aa49a
 
 build:
   noarch: python

--- a/recipes/pybmodes/meta.yaml
+++ b/recipes/pybmodes/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "pybmodes" %}
+{% set version = "1.14.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a135c2299ba277a3a3973fd4ba72aed10cfcf2f9574a9bbf36bee0f4eb48ff98
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - pybmodes = pybmodes.cli:main
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.11
+    - numpy >=1.26
+    - scipy >=1.11
+
+test:
+  imports:
+    - pybmodes
+  commands:
+    - pip check
+    - pybmodes --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/SMI-Lab-Inha/pyBModes
+  summary: Python finite-element library for wind turbine blade and tower modal analysis (OpenFAST/ElastoDyn)
+  description: |
+    pybmodes is a pure-Python finite-element library for wind-turbine blade
+    and tower modal analysis. It reads OpenFAST (ElastoDyn / SubDyn /
+    HydroDyn / MoorDyn), BModes .bmi, and WISDEM / WindIO ontology YAML
+    inputs; solves the coupled flap, lag, torsion and axial vibration modes
+    with a 15-DOF Bernoulli-Euler beam element; and emits
+    ElastoDyn-compatible mode-shape polynomials, MAC-tracked Campbell
+    diagrams, and bundled Markdown / HTML / CSV reports. Validated against
+    the BModes Fortran reference solver to better than 0.01 percent on the
+    benchmark cases.
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  doc_url: https://pybmodes.readthedocs.io/
+  dev_url: https://github.com/SMI-Lab-Inha/pyBModes
+
+extra:
+  recipe-maintainers:
+    - SMI-Lab-Inha

--- a/recipes/pybmodes/meta.yaml
+++ b/recipes/pybmodes/meta.yaml
@@ -1,13 +1,12 @@
-{% set name = "pybmodes" %}
 {% set version = "1.15.1" %}
 {% set python_min = "3.11" %}
 
 package:
-  name: {{ name|lower }}
+  name: "pybmodes"
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pybmodes/pybmodes-{{ version }}.tar.gz
   sha256: 8246c8ede87781d65f07ac5482b1b9654505c7c8e23acd90be48a8a4b6b6f5d1
 
 build:
@@ -22,7 +21,6 @@ requirements:
     - python {{ python_min }}
     - pip
     - setuptools >=68
-    - wheel
   run:
     - python >={{ python_min }}
     - numpy >=1.26

--- a/recipes/pybmodes/meta.yaml
+++ b/recipes/pybmodes/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pybmodes" %}
 {% set version = "1.14.0" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -18,12 +19,12 @@ build:
 
 requirements:
   host:
-    - python >=3.11
+    - python {{ python_min }}
     - pip
     - setuptools >=68
     - wheel
   run:
-    - python >=3.11
+    - python >={{ python_min }}
     - numpy >=1.26
     - scipy >=1.11
 
@@ -34,6 +35,7 @@ test:
     - pip check
     - pybmodes --help
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/pybmodes/recipe.yaml
+++ b/recipes/pybmodes/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "1.15.1"
+  python_min: "3.11"
 
 package:
   name: "pybmodes"

--- a/recipes/pybmodes/recipe.yaml
+++ b/recipes/pybmodes/recipe.yaml
@@ -1,43 +1,47 @@
-{% set version = "1.15.1" %}
-{% set python_min = "3.11" %}
+schema_version: 1
+
+context:
+  version: "1.15.1"
 
 package:
   name: "pybmodes"
-  version: {{ version }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/p/pybmodes/pybmodes-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pybmodes/pybmodes-${{ version }}.tar.gz
   sha256: 8246c8ede87781d65f07ac5482b1b9654505c7c8e23acd90be48a8a4b6b6f5d1
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  entry_points:
-    - pybmodes = pybmodes.cli:main
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - pybmodes = pybmodes.cli:main
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - numpy >=1.26
     - scipy >=1.11
 
-test:
-  imports:
-    - pybmodes
-  commands:
-    - pip check
-    - pybmodes --help
-  requires:
-    - python {{ python_min }}
-    - pip
+tests:
+  - python:
+      imports:
+        - pybmodes
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - pybmodes --help
 
 about:
-  home: https://github.com/SMI-Lab-Inha/pyBModes
+  homepage: https://github.com/SMI-Lab-Inha/pyBModes
   summary: Python finite-element library for wind turbine blade and tower modal analysis (OpenFAST/ElastoDyn)
   description: |
     pybmodes is a pure-Python finite-element library for wind-turbine blade
@@ -50,10 +54,9 @@ about:
     the BModes Fortran reference solver to better than 0.01 percent on the
     benchmark cases.
   license: Apache-2.0
-  license_family: APACHE
   license_file: LICENSE
-  doc_url: https://pybmodes.readthedocs.io/
-  dev_url: https://github.com/SMI-Lab-Inha/pyBModes
+  repository: https://github.com/SMI-Lab-Inha/pyBModes
+  documentation: https://pybmodes.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
New recipe for **pybmodes**, a pure-Python finite-element library for wind-turbine blade and tower modal analysis (OpenFAST / ElastoDyn). It is pure Python (numpy + scipy only at runtime), so the recipe is `noarch: python`.

- Source: PyPI sdist for 1.14.0, sha256 verified against the downloaded tarball.
- LICENSE (Apache-2.0) ships in the sdist and is referenced via `license_file`.
- Tests import the package, run `pip check`, and exercise the `pybmodes` console script.

Maintainer: @SMI-Lab-Inha (package author).

Project: https://github.com/SMI-Lab-Inha/pyBModes  ·  Docs: https://pybmodes.readthedocs.io/