### PR TITLE
Add openpkflow 2.7.0

### DIFF
--- a/recipes/openpkflow/meta.yaml
+++ b/recipes/openpkflow/meta.yaml
@@ -1,12 +1,13 @@
 {% set name = "openpkflow" %}
 {% set version = "2.3.0" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 923aa6b1e3b51460f9dbc497dae3f62a38181fc7bdc388f7ce97714f915855ee
 
 build:
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - hatchling
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - numpy >=1.24
     - pandas >=2.0
     - scipy >=1.10
@@ -43,6 +44,7 @@ test:
     - pip check
     - openpkflow version
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/openpkflow/meta.yaml
+++ b/recipes/openpkflow/meta.yaml
@@ -1,0 +1,60 @@
+{% set name = "openpkflow" %}
+{% set version = "2.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 923aa6b1e3b51460f9dbc497dae3f62a38181fc7bdc388f7ce97714f915855ee
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - hatchling
+  run:
+    - python >=3.10
+    - numpy >=1.24
+    - pandas >=2.0
+    - scipy >=1.10
+    - matplotlib-base >=3.7
+    - pydantic >=2.0
+    - typer >=0.12
+    - jinja2 >=3.1
+
+test:
+  imports:
+    - openpkflow
+    - openpkflow.nca
+    - openpkflow.dissolution
+    - openpkflow.sim
+    - openpkflow.be
+    - openpkflow.ivivc
+    - openpkflow.report
+    - openpkflow.validation
+  commands:
+    - pip check
+    - openpkflow version
+  requires:
+    - pip
+
+about:
+  home: https://github.com/priyamthakar/openpkflow
+  license: MIT
+  license_file: LICENSE
+  summary: >-
+    A transparent, reproducible, open-source Python workflow for dissolution,
+    NCA, PK/PD simulation, and pharmacometric reporting.
+  doc_url: https://priyamthakar.github.io/openpkflow/
+  dev_url: https://github.com/priyamthakar/openpkflow/
+
+extra:
+  recipe-maintainers:
+    - priyamthakar

--- a/recipes/openpkflow/meta.yaml
+++ b/recipes/openpkflow/meta.yaml
@@ -13,6 +13,8 @@ source:
 build:
   number: 0
   noarch: python
+  entry_points:
+    - openpkflow = openpkflow.cli:app
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipes/openpkflow/meta.yaml
+++ b/recipes/openpkflow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openpkflow" %}
-{% set version = "2.3.0" %}
+{% set version = "2.6.0" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 923aa6b1e3b51460f9dbc497dae3f62a38181fc7bdc388f7ce97714f915855ee
+  sha256: d5a36771000ec6b9535abd68718e3bb24fff0f7fc8848d323e4a6093397428f2
 
 build:
   number: 0
@@ -40,6 +40,7 @@ test:
     - openpkflow.sim
     - openpkflow.be
     - openpkflow.ivivc
+    - openpkflow.pipeline
     - openpkflow.report
     - openpkflow.validation
   commands:

--- a/recipes/openpkflow/meta.yaml
+++ b/recipes/openpkflow/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "openpkflow" %}
-{% set version = "2.6.0" %}
+{% set version = "2.7.0" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d5a36771000ec6b9535abd68718e3bb24fff0f7fc8848d323e4a6093397428f2
+  sha256: 51aeea0fb07dc33bccf16a3292f66d33243c6f5c0a1b3f6dac9d8d0a6c237946
 
 build:
   number: 0


### PR DESCRIPTION
openpkflow is a transparent, reproducible, open-source Python workflow for dissolution similarity, NCA, PK/PD simulation, bioequivalence, study orchestration, and pharmacometric reporting.

- PyPI release: https://pypi.org/project/openpkflow/2.7.0/
- Source: https://github.com/priyamthakar/openpkflow
- Release notes: https://github.com/priyamthakar/openpkflow/releases/tag/v2.7.0
- License: MIT
- Architecture: pure Python / `noarch: python`
- Core dependencies are available on conda-forge
- Recipe tests imports, the study-pipeline module, dependency consistency, and the `openpkflow version` CLI

The recipe targets the published 2.7.0 sdist. Its SHA-256 was verified independently against the downloaded PyPI artifact:
`51aeea0fb07dc33bccf16a3292f66d33243c6f5c0a1b3f6dac9d8d0a6c237946`.