### PR TITLE
Add glassbox-framework

### DIFF
--- a/recipes/glassbox-framework/meta.yaml
+++ b/recipes/glassbox-framework/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = "1.0.2" %}
+{% set python_min = "3.10" %}
 
 package:
   name: glassbox-framework
@@ -17,11 +18,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - hatchling >=1.21
     - pip
   run:
-    - python >=3.10
+    - python >={{ python_min }}
 
 test:
   imports:
@@ -31,7 +32,7 @@ test:
     - glassbox --help
   requires:
     - pip
-    - python
+    - python {{ python_min }}
 
 about:
   home: https://github.com/TheBarmaEffect/glassbox

--- a/recipes/glassbox-framework/meta.yaml
+++ b/recipes/glassbox-framework/meta.yaml
@@ -42,4 +42,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - Karthik2617
+    - TheBarmaEffect

--- a/recipes/glassbox-framework/meta.yaml
+++ b/recipes/glassbox-framework/meta.yaml
@@ -1,0 +1,44 @@
+{% set version = "1.0.2" %}
+
+package:
+  name: glassbox-framework
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/g/glassbox-framework/glassbox_framework-{{ version }}.tar.gz
+  sha256: 4cf166c9adb7e39254cc7d99763d84b958c7f3295a26ba12d576aec086d77e1b
+
+build:
+  entry_points:
+    - glassbox = glassbox_framework.cli:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.10
+    - hatchling >=1.21
+    - pip
+  run:
+    - python >=3.10
+
+test:
+  imports:
+    - glassbox_framework
+  commands:
+    - pip check
+    - glassbox --help
+  requires:
+    - pip
+    - python
+
+about:
+  home: https://github.com/TheBarmaEffect/glassbox
+  summary: Glass Box Framework — runtime constitutional verification for AI answers. Every claim carries a reasoning chain. Every score breaks down. Every verdict is traceable.
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Karthik2617


### PR DESCRIPTION
## New package: glassbox-framework

### Summary

**Glass Box Framework** — runtime constitutional verification for AI answers.

- **PyPI:** https://pypi.org/project/glassbox-framework/
- **GitHub:** https://github.com/TheBarmaEffect/glassbox
- **License:** Apache-2.0

### What it does

A Python client SDK that spawns the Glass Box MCP server and exposes 6 verification tools:
- `verify_answer` — full pipeline (claims → ECS → red team → Trust Card)
- `extract_claims` — structured claim extraction with reasoning chains
- `score_ecs` — Epistemic Confidence Score with dimension breakdown
- `red_team` — 7-angle constitutional red team
- `generate_trust_card` — deterministic Trust Card assembly (zero LLM calls)
- `export_audit_report` — deterministic SHA-256 audit log

### Checklist

- [x] No obvious packaging errors
- [x] `noarch: python` (pure Python stdlib client)
- [x] Entry point: `glassbox = glassbox_framework.cli:main`
- [x] `requires-python >= 3.10`
- [x] License: Apache-2.0
- [x] Tests: imports + `pip check` + `glassbox --help`
- [x] Recipe generated via grayskull from PyPI 1.0.2