### PR TITLE
Add intel-driver-compiler-npu

### DIFF
--- a/recipes/intel-driver-compiler-npu/build.sh
+++ b/recipes/intel-driver-compiler-npu/build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+# Builds libnpu_driver_compiler.so (the Compiler-in-Driver) from npu_compiler,
+# consuming the conda-forge OpenVINO runtime + the libopenvino-npu-compiler-support
+# shared lib rather than rebuilding OpenVINO. The Intel LLVM/MLIR fork
+# (npu_compiler/thirdparty/llvm-project) is built in-tree and statically fused
+# into the resulting shared lib.
+
+cd "$SRC_DIR/npu_compiler"
+
+# patch 0011 adds the -DNPU_CONDA_OUT_OF_TREE guard to npu_compiler's
+# CMakeLists.txt (selecting cmake/conda_dev_shim.cmake instead of
+# find_package(OpenVINODeveloperPackage)). The shim itself is shipped from the
+# recipe into the source's cmake/ dir so the patched include() resolves at
+# configure time.
+cp "$RECIPE_DIR/cmake/conda_dev_shim.cmake" cmake/
+
+mkdir -p build && pushd build
+
+# Use the feedstock-pinned gcc 14 (gcc 15 fails OpenVINO/Xbyak compute_hash.cpp
+# with -Wtemplate-body; the support lib + this compiler must share a toolchain).
+export CCACHE_DIR="${CCACHE_DIR:-$PWD/../.ccache}"
+
+# Configure validated 2026-05-25 via spike at ~/git/npu-cc-spike (env npucc):
+#   - conda_dev_shim.cmake replaces find_package(OpenVINODeveloperPackage)
+#   - ENABLE_TESTS=OFF (patch 0008: skips driver-compiler test/ dir)
+#   - WIN32-only vs_version.rc.in guarded (patch 0009)
+#   - add_tool_target post-ov_add_target guard (patch 0010)
+#   - openvino::runtime::dev + openvino::itt shim targets in shim (v6 support lib)
+#   - LLVM/MLIR configure passes cleanly; LibXml2/OCaml/BLAS are LLVM optional deps
+
+cmake ${CMAKE_ARGS} \
+    -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DNPU_CONDA_OUT_OF_TREE=ON \
+    -DBUILD_COMPILER_FOR_DRIVER=ON \
+    -DENABLE_PREBUILT_LLVM_MLIR_LIBS=OFF \
+    -DENABLE_TESTS=OFF \
+    -DLLVM_USE_LINKER=lld \
+    -DLLVM_PARALLEL_LINK_JOBS=2 \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -DOpenVINO_DIR="$PREFIX/lib/cmake/openvino${PKG_VERSION}" \
+    -DOpenVINONPUCompilerSupport_DIR="$PREFIX/lib/cmake/OpenVINONPUCompilerSupport" \
+    ..
+
+cmake --build . --parallel "${CPU_COUNT}"
+
+# Install only the driver compiler shared lib.
+install -d "$PREFIX/lib"
+install -m 0755 "$(find . -name 'libnpu_driver_compiler.so' | head -1)" "$PREFIX/lib/"
+
+popd

--- a/recipes/intel-driver-compiler-npu/cmake/conda_dev_shim.cmake
+++ b/recipes/intel-driver-compiler-npu/cmake/conda_dev_shim.cmake
@@ -1,0 +1,167 @@
+# conda_dev_shim.cmake — replaces OpenVINODeveloperPackage for the out-of-tree
+# conda-forge CiD build (intel-driver-compiler-npu). Injected by patch 0009 and
+# included from npu_compiler's root CMakeLists when -DNPU_CONDA_OUT_OF_TREE=ON.
+# Designed by the Phase B strategist (2026-05-25); validated incrementally via
+# the configure experiment in ~/git/npu-cc-spike.
+include_guard(GLOBAL)
+
+# Consumer OpenVINO (conda-forge libopenvino-dev) -> openvino::runtime
+find_package(OpenVINO REQUIRED COMPONENTS Runtime)
+# Phase-A support lib -> openvino::npu_compiler_support (npu_al/npu_ops/xml_util)
+find_package(OpenVINONPUCompilerSupport REQUIRED)
+
+# Shim npu_al / npu_ops / xml_util onto the support lib. They are used both as
+# link libs and via $<TARGET_PROPERTY:...,INTERFACE_INCLUDE_DIRECTORIES>, so each
+# must be a real linkable target re-exporting the support lib.
+foreach(_t npu_al npu_ops xml_util)
+    if(NOT TARGET openvino::${_t})
+        add_library(openvino::${_t} INTERFACE IMPORTED GLOBAL)
+        target_link_libraries(openvino::${_t} INTERFACE openvino::npu_compiler_support)
+    endif()
+endforeach()
+
+# openvino::runtime::dev — internal dev-API interface target. In the
+# conda-forge out-of-tree build the dev headers are shipped by the
+# libopenvino-npu-compiler-support package (_6+) at
+# $PREFIX/include/npu_compiler_support. Provide an INTERFACE target that
+# exposes those headers so npu_ov_utils and vpux_compiler_l0 compile cleanly.
+if(NOT TARGET openvino::runtime::dev)
+    get_target_property(_npucs_incdirs openvino::npu_compiler_support INTERFACE_INCLUDE_DIRECTORIES)
+    add_library(openvino_runtime_dev_shim INTERFACE IMPORTED GLOBAL)
+    target_include_directories(openvino_runtime_dev_shim INTERFACE ${_npucs_incdirs})
+    target_link_libraries(openvino_runtime_dev_shim INTERFACE openvino::runtime)
+    add_library(openvino::runtime::dev ALIAS openvino_runtime_dev_shim)
+endif()
+
+# openvino::itt — Intel ITT profiling interface. In a production package build
+# ITT is disabled; provide an empty INTERFACE target so the generator
+# expression $<TARGET_PROPERTY:openvino::itt,INTERFACE_COMPILE_DEFINITIONS>
+# resolves to nothing (no ENABLE_PROFILING_ITT define).
+if(NOT TARGET openvino::itt)
+    add_library(openvino_itt_shim INTERFACE IMPORTED GLOBAL)
+    add_library(openvino::itt ALIAS openvino_itt_shim)
+endif()
+
+# --- ov_* macros that must do real work ---
+if(NOT DEFINED OV_OPTIONS)
+    set(OV_OPTIONS "" CACHE INTERNAL "")
+endif()
+macro(ov_option var desc value)
+    option(${var} "${desc}" ${value})
+    list(APPEND OV_OPTIONS ${var})
+    set(OV_OPTIONS "${OV_OPTIONS}" CACHE INTERNAL "")
+endmacro()
+macro(ov_dependent_option var desc def cond fallback)
+    include(CMakeDependentOption)
+    cmake_dependent_option(${var} "${desc}" "${def}" "${cond}" "${fallback}")
+    list(APPEND OV_OPTIONS ${var})
+    set(OV_OPTIONS "${OV_OPTIONS}" CACHE INTERNAL "")
+endmacro()
+macro(ov_add_compiler_flags)
+    add_compile_options(${ARGN})
+endmacro()
+function(ov_link_system_libraries TARGET_NAME)
+    set(_scope PRIVATE)
+    set(_libs ${ARGN})
+    list(GET _libs 0 _maybe)
+    if(_maybe MATCHES "^(PRIVATE|PUBLIC|INTERFACE)$")
+        set(_scope ${_maybe})
+        list(REMOVE_AT _libs 0)
+    endif()
+    target_link_libraries(${TARGET_NAME} ${_scope} ${_libs})
+    foreach(_l ${_libs})
+        if(TARGET ${_l})
+            target_include_directories(${TARGET_NAME} SYSTEM ${_scope}
+                $<TARGET_PROPERTY:${_l},INTERFACE_INCLUDE_DIRECTORIES>)
+        endif()
+    endforeach()
+endfunction()
+function(ov_commit_hash OUT_VAR SRC_DIR)
+    find_package(Git QUIET)
+    set(_hash "0000000")
+    if(Git_FOUND)
+        execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            WORKING_DIRECTORY ${SRC_DIR} OUTPUT_VARIABLE _h
+            OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET RESULT_VARIABLE _rc)
+        if(_rc EQUAL 0 AND _h)
+            set(_hash "${_h}")
+        endif()
+    endif()
+    set(${OUT_VAR} "${_hash}" PARENT_SCOPE)
+endfunction()
+function(ov_add_version_defines VERSION_FILE TARGET_NAME)
+    if(NOT DEFINED CI_BUILD_NUMBER)
+        set(CI_BUILD_NUMBER "custom")
+    endif()
+    target_compile_definitions(${TARGET_NAME} PRIVATE CI_BUILD_NUMBER="${CI_BUILD_NUMBER}")
+endfunction()
+
+# --- logging / misc dev-package helpers (from OpenVINODeveloperScripts) ---
+macro(debug_message)
+    message(STATUS ${ARGN})
+endmacro()
+
+# --- pure no-op stubs ---
+macro(ov_build_target_faster)
+endmacro()
+macro(ov_add_api_validator_post_build_step)
+endmacro()
+macro(ov_set_temp_directory)
+endmacro()
+macro(ov_cpack)
+endmacro()
+macro(ov_cpack_add_component)
+endmacro()
+macro(ov_add_target)
+endmacro()
+macro(ov_add_test_target)
+endmacro()
+
+if(NOT DEFINED OV_CPACK_RUNTIMEDIR)
+    set(OV_CPACK_RUNTIMEDIR lib)
+endif()
+
+# OPENVINO_SOURCE_DIR is used by npu_compiler to reach common/transformations/include.
+# In the conda-forge out-of-tree build the transformations headers are shipped
+# at $PREFIX/include/npu_compiler_support/transformations_compat/
+# so that ${OPENVINO_SOURCE_DIR}/common/transformations/include resolves.
+# Requires support package v7+ which adds the transformations_compat tree.
+if(NOT DEFINED OPENVINO_SOURCE_DIR OR OPENVINO_SOURCE_DIR STREQUAL "")
+    get_target_property(_npucs_incdirs openvino::npu_compiler_support INTERFACE_INCLUDE_DIRECTORIES)
+    set(OPENVINO_SOURCE_DIR "${_npucs_incdirs}/transformations_compat" CACHE PATH
+        "Synthetic OV source dir for transformations headers" FORCE)
+endif()
+# Add the transformations include dir globally so ALL targets can reach
+# <transformations/...> headers (some targets include them without an explicit
+# per-target include_directories call, e.g. ELFNPU37XX/metadata.hpp).
+include_directories(SYSTEM "${OPENVINO_SOURCE_DIR}/common/transformations/include")
+
+# flatbuffers (conda-forge). npu_compiler reuses OpenVINO's in-tree flatc/targets
+# in the dev-package path; out-of-tree we supply them from conda-forge. NOTE: the
+# flatbuffers version MUST match what conda-forge OpenVINO was built against
+# (schema/flatc ABI). Verify in the configure experiment.
+find_package(Flatbuffers QUIET)
+if(NOT TARGET flatbuffers)
+    # Resolve include dir: conda-build uses PREFIX, direct env use CONDA_PREFIX.
+    set(_fb_prefix "$ENV{PREFIX}")
+    if(NOT _fb_prefix)
+        set(_fb_prefix "$ENV{CONDA_PREFIX}")
+    endif()
+    add_library(flatbuffers INTERFACE)
+    target_include_directories(flatbuffers INTERFACE "${_fb_prefix}/include")
+endif()
+if(NOT TARGET flatc)
+    # In conda-build: flatc lives in BUILD_PREFIX (the build env).
+    # In direct env usage (spike/dev): fall back to CONDA_PREFIX or PATH.
+    find_program(_flatc_exe flatc
+        HINTS "$ENV{BUILD_PREFIX}/bin" "$ENV{CONDA_PREFIX}/bin"
+        NO_DEFAULT_PATH)
+    if(NOT _flatc_exe)
+        find_program(_flatc_exe flatc)
+    endif()
+    if(NOT _flatc_exe)
+        message(FATAL_ERROR "flatc not found. Set BUILD_PREFIX or CONDA_PREFIX.")
+    endif()
+    add_executable(flatc IMPORTED GLOBAL)
+    set_target_properties(flatc PROPERTIES IMPORTED_LOCATION "${_flatc_exe}")
+endif()

--- a/recipes/intel-driver-compiler-npu/patches/0004-npu_compiler-undef-glibc-major-minor-macros.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0004-npu_compiler-undef-glibc-major-minor-macros.patch
@@ -1,0 +1,43 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-16
+Subject: npu_compiler: #undef glibc major/minor macros in version.hpp
+
+`vpux::config::Version` has data members named `major`, `minor` and
+`patch`.  glibc's <sys/sysmacros.h> defines `major` and `minor` as
+function-like macros (expanding to `gnu_dev_major` / `gnu_dev_minor`).
+
+On the conda-forge cos7 sysroot (glibc 2.17) <sys/types.h> still
+pulls in <sys/sysmacros.h> transitively, so by the time version.hpp
+is parsed `major`/`minor` are macros and the struct's member names
+and the constructor initializer list (`major(major_), minor(minor_)`)
+get macro-expanded, producing:
+
+    error: class 'vpux::config::Version' does not have any field
+           named 'gnu_dev_major'
+
+Intel's own CI builds on Ubuntu 22.04, whose newer glibc no longer
+leaks these macros from <sys/types.h>, so upstream never sees this.
+Building from source on the (older, deliberately ABI-conservative)
+conda sysroot does.  Undefining the macros at the top of the header
+is the minimal, portable fix.
+
+--- a/src/vpux_compiler/include/vpux/compiler/dialect/config/version.hpp
++++ b/src/vpux_compiler/include/vpux/compiler/dialect/config/version.hpp
+@@ -10,6 +10,17 @@
+ #include <cstdint>
+ #include <tuple>
+
++// glibc's <sys/sysmacros.h> (pulled in transitively by <sys/types.h>
++// on the conda-forge cos7 sysroot, glibc 2.17) defines `major` and
++// `minor` as function-like macros.  They would otherwise expand the
++// `major`/`minor` data members of `vpux::config::Version` below.
++#ifdef major
++#undef major
++#endif
++#ifdef minor
++#undef minor
++#endif
++
+ namespace vpux::config {
+
+ struct Version final {

--- a/recipes/intel-driver-compiler-npu/patches/0005-npu_compiler-dedup-Platform-constants-with-openvino.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0005-npu_compiler-dedup-Platform-constants-with-openvino.patch
@@ -1,0 +1,51 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-16
+Subject: npu_compiler: dedup ov::intel_npu::Platform constants vs OpenVINO
+
+npu_compiler's src/vpux_utils/include/vpux/utils/IE/private_properties.hpp
+defines `ov::intel_npu::Platform::NPU5000` and `::NPU5020`.  OpenVINO
+2026.1.0's src/plugins/intel_npu/src/al/include/intel_npu/
+npu_private_properties.hpp *also* defines `Platform::NPU5020` (along
+with NPU3720/NPU4000/NPU5010 and Platform::standardize()).
+
+When the NPU compiler is built as an OpenVINO extra module against
+OpenVINO 2026.1.0, a translation unit such as
+src/vpux_compiler/src/pipelines/options_mapper.cpp transitively
+includes both headers, producing:
+
+    error: redefinition of 'constexpr const std::string_view
+           ov::intel_npu::Platform::NPU5020'
+
+Intel's own CI builds the NPU compiler against an older OpenVINO
+revision that does not yet define the overlapping `NPU5020`, so it
+never sees the clash.
+
+Fix: include OpenVINO's npu_private_properties.hpp (already on the
+compiler's include path) for the shared constants, and keep only the
+npu_compiler-specific `NPU5000` here.
+
+--- a/src/vpux_utils/include/vpux/utils/IE/private_properties.hpp
++++ b/src/vpux_utils/include/vpux/utils/IE/private_properties.hpp
+@@ -9,11 +9,21 @@
+
+ #include <string_view>
+
++// OpenVINO 2026.1.0's intel_npu/npu_private_properties.hpp defines
++// ov::intel_npu::Platform::{NPU3720,NPU4000,NPU5010,NPU5020,...} and
++// Platform::standardize().  When the NPU compiler is built as an
++// OpenVINO extra module against 2026.1.0, a translation unit that
++// includes both that header and this one would get a redefinition of
++// the overlapping `NPU5020` constant.  Reuse OpenVINO's header for the
++// shared constants and only define the npu_compiler-specific `NPU5000`
++// here.  (Intel's own CI builds against an older OpenVINO commit that
++// lacks the overlapping definitions, so it never hits this.)
++#include "intel_npu/npu_private_properties.hpp"
++
+ namespace ov {
+ namespace intel_npu {
+ namespace Platform {
+ constexpr std::string_view NPU5000 = "5000";
+-constexpr std::string_view NPU5020 = "5020";
+ }  // namespace Platform
+ }  // namespace intel_npu
+ }  // namespace ov

--- a/recipes/intel-driver-compiler-npu/patches/0006-npu_compiler-drop-OptionMode-arg-from-Config-update.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0006-npu_compiler-drop-OptionMode-arg-from-Config-update.patch
@@ -1,0 +1,38 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-16
+Subject: npu_compiler: drop OptionMode argument from Config::update calls
+
+The npu_ud_2026_12_1_rc1 npu_compiler tag was developed against an
+internal OpenVINO branch whose `intel_npu::Config::update` takes a
+second `OptionMode` argument used to filter which option keys are
+applied.  The public OpenVINO 2026.1.0 release we build against only
+provides the single-argument `update(const ConfigMap&)` overload.
+
+`OptionsDesc::get()` already rejects unknown keys, so applying every
+key (instead of mode-filtering) is harmless for our purposes here:
+both call sites pass a config map that has already been sanitised by
+the caller.  Drop the second argument so the code compiles against the
+released OpenVINO headers.
+
+--- a/src/vpux_compiler/src/frontend/ov_batch_detection.cpp
++++ b/src/vpux_compiler/src/frontend/ov_batch_detection.cpp
+@@ -308,7 +308,7 @@
+                 autoDebatcherOptions->injectInto(config.get<intel_npu::BATCH_COMPILER_MODE_SETTINGS>());
+
+         intel_npu::Config newConfig = config;
+-        newConfig.update(toUpdate, intel_npu::OptionMode::CompileTime);
++        newConfig.update(toUpdate);
+         return newConfig;
+     };
+
+--- a/src/vpux_driver_compiler/src/vpux_compiler_l0/vcl_common.cpp
++++ b/src/vpux_driver_compiler/src/vpux_compiler_l0/vcl_common.cpp
+@@ -479,7 +479,7 @@
+
+     /// Update default compilation config options with the new values we parsed from user descriptions
+     try {
+-        parsedConfig.update(config, intel_npu::OptionMode::CompileTime);
++        parsedConfig.update(config);
+     } catch (const std::exception& error) {
+         logger->outputError(formatv("Failed to update default config:\n{0}", error.what()));
+         return VCL_RESULT_ERROR_INVALID_ARGUMENT;

--- a/recipes/intel-driver-compiler-npu/patches/0007-npu_compiler-fallback-commit-hash-for-archive-source.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0007-npu_compiler-fallback-commit-hash-for-archive-source.patch
@@ -1,0 +1,35 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-16
+Subject: npu_compiler: fall back to pinned commit hash for archive sources
+
+compiler_commit_hash.cmake runs `git rev-parse HEAD` in the npu_compiler
+source tree to embed the compiler's git commit into the built library.
+The conda-forge feedstock builds from a GitHub archive tarball, which has
+no `.git` directory, so `git rev-parse` fails and the build aborts with
+"Failed to capture compiler git commit."
+
+The feedstock pins the npu_compiler source to a specific upstream commit
+(tag npu_ud_2026_12_1_rc1 -> 97d6545ee65327641e38707ad1f30479520d812c),
+so the commit is known at packaging time even without a git checkout.
+Fall back to that pinned hash when `git` is unavailable or fails, instead
+of treating it as a fatal error.
+
+--- a/cmake/compiler_commit_hash.cmake
++++ b/cmake/compiler_commit_hash.cmake
+@@ -10,10 +10,15 @@
+     OUTPUT_VARIABLE CURRENT_COMMIT_HASH
+     OUTPUT_STRIP_TRAILING_WHITESPACE
+     RESULT_VARIABLE ERROR_CODE
++    ERROR_QUIET
+ )
+ 
+ if (NOT ${ERROR_CODE} EQUAL 0)
+-    message(FATAL_ERROR "Failed to capture compiler git commit.")
++    # conda-forge builds from a GitHub archive tarball, which has no .git
++    # directory.  The source is pinned to a known upstream commit, so fall
++    # back to that pinned hash instead of failing the build.
++    set(CURRENT_COMMIT_HASH "97d6545ee65327641e38707ad1f30479520d812c")
++    message(STATUS "git rev-parse unavailable; using pinned commit hash ${CURRENT_COMMIT_HASH}")
+ endif()
+ 
+ set(LAST_COMMIT_HASH "")

--- a/recipes/intel-driver-compiler-npu/patches/0008-npu_compiler-gate-vpux-driver-compiler-tests.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0008-npu_compiler-gate-vpux-driver-compiler-tests.patch
@@ -1,0 +1,32 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-24
+Subject: npu_compiler: gate vpux_driver_compiler tests on ENABLE_TESTS
+
+src/vpux_driver_compiler/CMakeLists.txt adds its test/ subdirectory
+unconditionally.  test/functional/CMakeLists.txt then needs a `gtest`
+target; since the feedstock builds with ENABLE_TESTS=OFF, OpenVINO never
+creates one, so it falls back to
+`add_subdirectory(${OpenVINO_SOURCE_DIR}/thirdparty/gtest gtest)` -- which
+forced the feedstock to vendor openvinotoolkit/googletest into
+thirdparty/gtest/gtest just so configure would not fail on the empty
+submodule, and then compiled libgtest.a plus four test executables
+(vpuxCompilerL0Test, compilerTest, profilingTest, loaderTest) we never run
+or ship.
+
+Gate the test subdirectory on ENABLE_TESTS (default OFF) like the rest of
+the OpenVINO/NPU test trees.  This drops the gtest dependency entirely and
+skips building the unused test binaries.
+
+--- a/src/vpux_driver_compiler/CMakeLists.txt
++++ b/src/vpux_driver_compiler/CMakeLists.txt
+@@ -28,7 +28,9 @@
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+ add_subdirectory(src)
+-add_subdirectory(test)
++if(ENABLE_TESTS)
++    add_subdirectory(test)
++endif()
+
+ install(
+     FILES

--- a/recipes/intel-driver-compiler-npu/patches/0009-npu_compiler-guard-vs-version-rc-win32-only.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0009-npu_compiler-guard-vs-version-rc-win32-only.patch
@@ -1,0 +1,29 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-25
+Subject: npu_compiler: guard vs_version.rc.in configure_file to WIN32 only
+
+The configure_file call references ${IEDevScripts_DIR}/vs_version/vs_version.rc.in,
+which is a Windows version resource file.  IEDevScripts_DIR is only set when
+building inside the OpenVINO source tree.  On Linux the variable is empty so
+CMake tries to configure_file("/vs_version/vs_version.rc.in", ...) which
+immediately errors with "File /vs_version/vs_version.rc.in does not exist."
+
+Wrap the configure_file + source_group + target_sources calls in if(WIN32)
+so the file is only generated (and needed) on Windows.
+
+--- a/src/vpux_driver_compiler/src/vpux_compiler_l0/CMakeLists.txt
++++ b/src/vpux_driver_compiler/src/vpux_compiler_l0/CMakeLists.txt
+@@ -60,10 +60,12 @@ set(OV_VS_VER_COMPANY_NAME_STR "Intel Corporation")
+ set(OV_VS_VER_COPYRIGHT_STR "${COPYRIGHT_STR}")
+ set(OV_VS_VER_ORIGINALFILENAME_STR "${CMAKE_SHARED_LIBRARY_PREFIX}${TARGET_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+ set(OV_VS_VER_INTERNALNAME_STR ${TARGET_NAME})
+-set(vs_version_output "${CMAKE_CURRENT_BINARY_DIR}/vs_version.rc")
+-configure_file("${IEDevScripts_DIR}/vs_version/vs_version.rc.in" "${vs_version_output}" @ONLY)
+-source_group("src" FILES ${vs_version_output})
+-target_sources(${TARGET_NAME} PRIVATE ${vs_version_output})
++if(WIN32)
++    set(vs_version_output "${CMAKE_CURRENT_BINARY_DIR}/vs_version.rc")
++    configure_file("${IEDevScripts_DIR}/vs_version/vs_version.rc.in" "${vs_version_output}" @ONLY)
++    source_group("src" FILES ${vs_version_output})
++    target_sources(${TARGET_NAME} PRIVATE ${vs_version_output})
++endif()

--- a/recipes/intel-driver-compiler-npu/patches/0010-npu_compiler-guard-add-tool-target-after-ov-add-target.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0010-npu_compiler-guard-add-tool-target-after-ov-add-target.patch
@@ -1,0 +1,30 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Date: 2026-05-25
+Subject: npu_compiler: guard add_tool_target post-creation code on target existence
+
+In the out-of-tree conda-forge build, ov_add_target is a no-op stub macro
+(the real implementation lives in OpenVINO's developer package scripts).
+When add_tool_target's dependency-check loop passes (because all LINK_LIBRARIES
+like npu_mlir_compiler_static are defined as real CMake targets by the time
+add_tool_target runs), ov_add_target creates nothing, and the subsequent
+set_target_properties call then fails with:
+
+  set_target_properties Can not find target to add properties to: vpux-opt
+
+Add an early-return guard after ov_add_target: if the named target was not
+actually created (because ov_add_target was a no-op), return immediately
+before set_target_properties and the install() calls.
+
+--- a/cmake/add_tool_target.cmake
++++ b/cmake/add_tool_target.cmake
+@@ -94,6 +94,10 @@ function(add_tool_target)
+                       ${ARG_UNPARSED_ARGUMENTS})
+     endif()
+
++    if(NOT TARGET ${ARG_NAME})
++        return()
++    endif()
++
+     set_target_properties(${ARG_NAME} PROPERTIES
+                           FOLDER ${ARG_ROOT}
+                           CXX_STANDARD 17)

--- a/recipes/intel-driver-compiler-npu/patches/0011-npu_compiler-guard-developer-package-for-conda.patch
+++ b/recipes/intel-driver-compiler-npu/patches/0011-npu_compiler-guard-developer-package-for-conda.patch
@@ -1,0 +1,29 @@
+From: hmaarrfk <mark.harfouche@conda-forge.org>
+Subject: npu_compiler: guard the OpenVINO developer package for conda out-of-tree builds
+
+When configured with -DNPU_CONDA_OUT_OF_TREE=ON, consume the prebuilt
+conda-forge OpenVINO runtime plus the libopenvino-npu-compiler-support shared
+library (via cmake/conda_dev_shim.cmake, shipped by the recipe) instead of the
+in-tree OpenVINO developer package. Default behavior (find_package of the
+developer package) is unchanged when the option is off.
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e88d1b4..f151bd0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -49,7 +49,15 @@ if (ENABLE_NPU_MONO)
+     set (NPU_MONO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/..)
+ endif()
+ 
+-find_package(OpenVINODeveloperPackage REQUIRED)
++if(NPU_CONDA_OUT_OF_TREE)
++    # conda-forge out-of-tree build: consume the prebuilt OpenVINO runtime +
++    # the libopenvino-npu-compiler-support shared lib instead of the in-tree
++    # OpenVINO developer package. See cmake/conda_dev_shim.cmake (shipped by the
++    # recipe).
++    include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/conda_dev_shim.cmake)
++else()
++    find_package(OpenVINODeveloperPackage REQUIRED)
++endif()
+ 
+ # Ensure output directory is available
+ if(NOT CMAKE_LIBRARY_OUTPUT_DIRECTORY AND OV_LIBRARY_OUTPUT_DIRECTORY)

--- a/recipes/intel-driver-compiler-npu/recipe.yaml
+++ b/recipes/intel-driver-compiler-npu/recipe.yaml
@@ -1,0 +1,120 @@
+schema_version: 1
+
+# Builds libnpu_driver_compiler.so — the Intel NPU "Compiler-in-Driver" (CiD),
+# the MLIR/VPUX compiler that lowers OpenVINO IR to NPU blobs. Built from source
+# from openvinotoolkit/npu_compiler, consuming the conda-forge OpenVINO runtime
+# plus the libopenvino-npu-compiler-support shared lib, instead of rebuilding
+# OpenVINO. Honors conda-forge norms: only Intel-specific sources that have no
+# conda-forge package (npu_compiler, Intel's LLVM/MLIR fork, npu_plugin_elf,
+# npu-nn-cost-model) are vendored; everything else is consumed from conda-forge;
+# and no static libraries are shipped (the single artifact is the shared
+# libnpu_driver_compiler.so, with the Intel LLVM/MLIR fork statically fused in).
+#
+# DEPENDENCY ORDERING (reviewers): the host dep libopenvino-npu-compiler-support
+# is a new output added to the openvino feedstock (conda-forge/openvino-feedstock
+# PR forthcoming). This recipe can only build on CI once that output is published
+# to conda-forge. The recipe is validated end-to-end locally (builds clean;
+# libnpu_driver_compiler.so loads with zero unresolved symbols against the support
+# lib + libopenvino, and runs NPU inference). Pins/patches based on PR #163.
+
+context:
+  version: "2026.1.0"
+  npu_compiler_rev: "97d6545ee65327641e38707ad1f30479520d812c"
+  llvm_fork_rev: "cf3934f4e8ada928544a743481e037935a21e857"
+  npu_elf_rev: "82c444bcb9feb0f55fa33e18fbd711ec35426fba"
+  vpucostmodel_rev: "33ef9a69b4e694ad5bfc521af829a9cc9ce19b4c"
+
+package:
+  name: intel-driver-compiler-npu
+  version: ${{ version }}
+
+source:
+  # npu_compiler (the MLIR/VPUX NPU compiler). No conda-forge package exists.
+  - url: https://github.com/openvinotoolkit/npu_compiler/archive/${{ npu_compiler_rev }}.tar.gz
+    sha256: e8801f45449c731d3b3fe38f264652c5824d3e48ebadeaddc37c53292c1f0ee4
+    target_directory: npu_compiler
+    patches:
+      - patches/0004-npu_compiler-undef-glibc-major-minor-macros.patch
+      - patches/0005-npu_compiler-dedup-Platform-constants-with-openvino.patch
+      - patches/0006-npu_compiler-drop-OptionMode-arg-from-Config-update.patch
+      - patches/0007-npu_compiler-fallback-commit-hash-for-archive-source.patch
+      - patches/0008-npu_compiler-gate-vpux-driver-compiler-tests.patch
+      # Guard Windows-only vs_version.rc.in configure_file (blocker on Linux)
+      - patches/0009-npu_compiler-guard-vs-version-rc-win32-only.patch
+      # Guard add_tool_target post-creation code when ov_add_target is a no-op stub
+      - patches/0010-npu_compiler-guard-add-tool-target-after-ov-add-target.patch
+      # Under -DNPU_CONDA_OUT_OF_TREE=ON, include cmake/conda_dev_shim.cmake
+      # (shipped by the recipe) instead of find_package(OpenVINODeveloperPackage).
+      - patches/0011-npu_compiler-guard-developer-package-for-conda.patch
+  # Intel's LLVM/MLIR 20.x fork (NPU MLIR dialects). No conda-forge equivalent;
+  # built in-tree and statically fused into libnpu_driver_compiler.so.
+  - url: https://github.com/intel-staging/npu-compiler-llvm/archive/${{ llvm_fork_rev }}.tar.gz
+    sha256: 0c4c304c51ed9b1de4e92733201597ea22d53516ca4044cacd5d063699debb28
+    target_directory: npu_compiler/thirdparty/llvm-project
+  - url: https://github.com/openvinotoolkit/npu_plugin_elf/archive/${{ npu_elf_rev }}.tar.gz
+    sha256: 75ca714b84b5426ed2261e3ec798111f6dafde8d38f01351be0210021b689257
+    target_directory: npu_compiler/thirdparty/elf
+  - url: https://github.com/intel/npu-nn-cost-model/archive/${{ vpucostmodel_rev }}.tar.gz
+    sha256: cb4a0cce989763401a910ec6020b799ef56a9adec87df70bfec001678477a1b8
+    target_directory: npu_compiler/thirdparty/vpucostmodel
+
+build:
+  number: 1
+  skip: not linux64
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - ccache
+    - lld          # links the in-tree Intel LLVM/MLIR fork
+    - python       # build scripts / tablegen helpers
+    - pkg-config
+  host:
+    # Phase A shared support lib (npu_al/npu_ops/xml_util symbols) + its headers.
+    - libopenvino-npu-compiler-support
+    # public OpenVINO consumer headers (incl. common/transformations/include, R3)
+    - libopenvino-dev
+    - tbb-devel
+    - pugixml
+    - zlib
+    - level-zero-devel
+    # flatbuffers: npu_compiler normally reuses OpenVINO's in-tree flatc/schema
+    # (24.3.25). conda-forge ships 25.9.23 -> schema/flatc version match must be
+    # verified; if incompatible, pin/patch. See NOTES.md.
+    - flatbuffers
+  run_exports:
+    - ${{ pin_subpackage('intel-driver-compiler-npu', upper_bound='x.x') }}
+
+tests:
+  - requirements:
+      run:
+        - binutils
+    script:
+      - test -f $PREFIX/lib/libnpu_driver_compiler.so
+      # CiD compiler is self-contained: must not dynamically need a second
+      # OpenVINO copy beyond the conda-forge shared libopenvino it links.
+      - test -z "$(nm -D -u $PREFIX/lib/libnpu_driver_compiler.so | grep -i 'mlir::' )"
+
+about:
+  homepage: https://github.com/openvinotoolkit/npu_compiler
+  summary: Intel NPU driver compiler (Compiler-in-Driver, libnpu_driver_compiler.so)
+  description: |
+    libnpu_driver_compiler.so is the MLIR/VPUX compiler that the Intel NPU
+    userspace driver (libze_intel_npu.so, package intel-level-zero-npu) loads to
+    lower OpenVINO IR to NPU blobs (the "Compiler-in-Driver" path). Built from
+    source against the conda-forge OpenVINO runtime + the
+    libopenvino-npu-compiler-support shared library, with Intel's LLVM/MLIR fork
+    statically fused in. Co-install with openvino + intel-level-zero-npu (+ NPU
+    firmware system-wide) to run OpenVINO inference on Intel NPU.
+  license: Apache-2.0 AND Apache-2.0 WITH LLVM-exception
+  license_file:
+    - npu_compiler/LICENSE
+    - npu_compiler/thirdparty/llvm-project/llvm/LICENSE.TXT
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk


### PR DESCRIPTION
<details><summary>Claude's draft</summary>

New recipe for the Intel NPU "Compiler-in-Driver" (libnpu_driver_compiler.so), the MLIR/VPUX compiler that lowers OpenVINO IR to NPU blobs and is dlopen'd by the Level Zero NPU userspace driver (intel-level-zero-npu). Built from source from openvinotoolkit/npu_compiler, consuming the conda-forge OpenVINO runtime + the libopenvino-npu-compiler-support shared lib rather than rebuilding OpenVINO. Only Intel-specific sources with no conda-forge package are vendored (npu_compiler, Intel LLVM/MLIR fork, npu_plugin_elf, npu-nn-cost-model); no static libraries are shipped. linux-64 only.

Note: depends on the new libopenvino-npu-compiler-support output landing in conda-forge openvino first (PR forthcoming) before CI can build this.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 2b485e84-4ef9-47a5-b90d-9fb51634d5c9
```
</details>

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
