### PR TITLE
Add pyaesa 1.2.6

### DIFF
--- a/recipes/pyaesa/meta.yaml
+++ b/recipes/pyaesa/meta.yaml
@@ -1,0 +1,64 @@
+{% set name = "pyaesa" %}
+{% set version = "1.2.6" %}
+{% set python_min = "3.11" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: f2607aebf0a0b4540e33014219aaa2b28943be874956ac421ddbc43ea0e182d2
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >={{ python_min }}
+    - matplotlib-base >=3.10,<4
+    - numpy >=1.24.4,<3
+    - pandas >=1.5,<4
+    - pyarrow >=11,<24
+    - pycountry >=22.3,<27
+    - pymrio >=0.5.1,<0.7
+    - python-calamine >=0.6,<1
+    - requests >=2.28,<3
+    - salib >=1.4.8,<2
+    - scipy >=1.10,<2
+    - statsmodels >=0.14,<1
+    - wbgapi >=1.0.12,<2
+    - xlsxwriter >=3.2,<4
+
+test:
+  imports:
+    - pyaesa
+  requires:
+    - python {{ python_min }}
+  commands:
+    - python -c "import pyaesa; assert pyaesa.__version__ == '{{ version }}'"
+
+about:
+  home: https://github.com/AESAtoolkit/pyaesa
+  summary: Research software for absolute environmental sustainability assessment workflows.
+  description: |
+    pyaesa is a scientific Python package for absolute environmental
+    sustainability assessment. It provides workspace initialization, data
+    acquisition and processing utilities, deterministic assessment functions,
+    IO-LCA support, uncertainty analysis, and tutorial assets for reproducible
+    research workflows.
+  license: GPL-3.0-only
+  license_file: LICENSE
+  dev_url: https://github.com/AESAtoolkit/pyaesa
+  doc_url: https://pyaesa.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - Ike-EDB


### PR DESCRIPTION
This pull request updates the conda-forge recipe for pyaesa 1.2.6.

pyaesa is published on PyPI:
https://pypi.org/project/pyaesa/1.2.6/

The recipe uses the PyPI source distribution and the corresponding SHA256 hash.