### PR TITLE
Add cell-gps

### DIFF
--- a/recipes/cell-gps/recipe.yaml
+++ b/recipes/cell-gps/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.0.6"
+
+package:
+  name: cell-gps
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/cell-gps/cell_gps-${{ version }}.tar.gz
+  sha256: 7e273f817c35977e535872962f71cfd6c8b346ddf9d96f8a069daf1c1b52fc4c
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  python:
+    entry_points:
+      - cellgps-gui = cellgps.gui.gui_app:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - pandas >=1.3
+    - numpy >=1.21
+    - matplotlib-base >=3.4
+    - seaborn >=0.11
+    - scikit-learn >=1.0
+    - scipy >=1.7
+    - psutil >=5.8
+    - joblib >=1.1
+    - tqdm >=4.60
+    - pillow
+
+tests:
+  - python:
+      imports:
+        - cellgps
+        - sfplot
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/hutaobo/Cell-GPS
+  repository: https://github.com/hutaobo/Cell-GPS
+  documentation: https://github.com/hutaobo/Cell-GPS#readme
+  summary: Cell-GPS spatial topology analysis for spatial omics data.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - hutaobo


### PR DESCRIPTION
Add Cell-GPS 0.0.6 from PyPI as `cell-gps`.

Cell-GPS is a Python package and reference implementation for Cophenetic Spatial Topology Embedding (COSTE), a spatial topology analysis framework for spatial omics data. The recipe is `noarch: python` and builds from the PyPI sdist.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in the recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, checked the conda-forge knowledge base documentation.
