### PR TITLE
Add playa-pdf

### DIFF
--- a/recipes/playa-pdf/recipe.yaml
+++ b/recipes/playa-pdf/recipe.yaml
@@ -1,0 +1,62 @@
+context:
+  name: playa-pdf
+  version: "1.1.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/playa_pdf-${{ version }}.tar.gz
+  sha256: 6414a0779fdcc96284588767738c2bd71ed3aa65a1a8fa647a4ab09dce4ff017
+
+build:
+  number: 0
+  # playa-pdf's PyPI wheels are mypyc-compiled (opt-in via the
+  # HATCH_BUILD_HOOK_ENABLE_MYPYC=1 hook). The default sdist build is
+  # pure-Python and supports every platform/Python that conda-forge serves,
+  # so we ship one noarch build to keep the maintenance burden low.
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - playa = playa.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling >=1.27.0
+    - hatch-vcs
+  run:
+    - python >=${{ python_min }}
+    - mypy_extensions
+
+tests:
+  - python:
+      imports:
+        - playa
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - playa --version
+
+about:
+  homepage: https://github.com/dhdaines/playa
+  summary: Parallel and LazY Analyzer for PDFs
+  description: |
+    PLAYA is a pure-Python PDF parser focused on lazy, parallel access to
+    page content and structure. It is the successor to pdfminer.six and is
+    used by downstream libraries (e.g. camelot-py) for low-level PDF
+    layout extraction.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://dhdaines.github.io/playa
+  repository: https://github.com/dhdaines/playa
+
+extra:
+  recipe-maintainers:
+    - dhdaines
+    - bosd


### PR DESCRIPTION
### Recipe-maintainer(s)

- @dhdaines (upstream author)
- @bosd (camelot-py maintainer, contributing this recipe)

### Description

[`playa-pdf`](https://github.com/dhdaines/playa) is a pure-Python PDF parser by David Huggins-Daines, designed as the successor to `pdfminer.six` with a focus on lazy/parallel access to page content and structure. Adding it here so it can become a runtime dependency of the existing [`camelot-py` feedstock](https://github.com/conda-forge/camelot-py-feedstock) — `camelot-py` 2.0 (currently `2.0.0rc1` on PyPI) replaces `pdfminer.six` with `playa-pdf` as its core text-extraction backend, and a conda-forge release of camelot 2.0 is blocked on this package being available.

Coordinated upstream at [dhdaines/playa#228](https://github.com/dhdaines/playa/issues/228) — @dhdaines is willing to maintain the feedstock but doesn't use conda himself, so I'm contributing the initial recipe and we're co-maintaining.

### Why noarch

`playa-pdf` ships per-platform wheels on PyPI because its build enables a `mypyc` compilation hook (`HATCH_BUILD_HOOK_ENABLE_MYPYC=1`) for a runtime speed boost. The hook is **opt-in** — the default `hatchling` sdist build is pure-Python and works on every platform/Python conda-forge serves. Shipping a single `noarch: python` build keeps the maintenance load low for a maintainer who doesn't use conda; a per-platform mypyc-enabled variant can always be added later by someone with the bandwidth.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/d10d4235cf80c3c7339a1c0f599904f9bd6577f5/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#source-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.

> Note: @dhdaines's willingness to maintain is confirmed in [dhdaines/playa#228](https://github.com/dhdaines/playa/issues/228) (the upstream issue thread).