### PR TITLE
Added recipe for ministats package from PyPI

### DIFF
--- a/recipes/ministats/recipe.yaml
+++ b/recipes/ministats/recipe.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+
+context:
+  python_min: "3.11"
+  version: "0.5.14"
+
+package:
+  name: ministats
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/ministats/ministats-${{ version }}.tar.gz
+  sha256: 8df3600949a0f69c69183effe4bb24113be6c2282ca53b5a8634562e71dceba2
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - numpy <2.4
+    - scipy ==1.17.1
+    - pandas ==3.0.1
+    - seaborn ==0.13.2
+    - bambi ==0.17.2
+    - pymc ==5.28.1
+    - pytensor ==2.38.2
+    - arviz <1.0
+    - statsmodels ==0.14.6
+    - matplotlib-base ==3.10.8
+    - pingouin ==0.6.0
+
+tests:
+  - python:
+      imports:
+        - ministats
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: Common statistical testing procedures used for STATS 101 topics. The code is intentionally simple to make it easy to follow for beginners.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/minireference/ministats
+
+extra:
+  recipe-maintainers:
+    - ivanistheone


### PR DESCRIPTION
@conda-forge/help-python  This is a pretty simple source-only package. Users asked to make it available via conda install.


Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [n/a] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
