### PR TITLE
Add pyxenium

### DIFF
--- a/recipes/pyxenium/meta.yaml
+++ b/recipes/pyxenium/meta.yaml
@@ -1,9 +1,8 @@
-{% set name = "pyxenium" %}
 {% set version = "0.4.6" %}
 {% set python_min = "3.11" %}
 
 package:
-  name: {{ name|lower }}
+  name: pyxenium
   version: {{ version }}
 
 source:
@@ -22,7 +21,6 @@ requirements:
     - python {{ python_min }}
     - pip
     - setuptools >=68
-    - wheel
   run:
     - python >={{ python_min }}
     - anndata >=0.10

--- a/recipes/pyxenium/meta.yaml
+++ b/recipes/pyxenium/meta.yaml
@@ -1,0 +1,69 @@
+{% set name = "pyxenium" %}
+{% set version = "0.4.6" %}
+{% set python_min = "3.11" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pyxenium/pyxenium-{{ version }}.tar.gz
+  sha256: 38f5b5231a9c224b78ffcc2042256bba4f746a011d99e966228c078297330db8
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - pyxenium = pyXenium.__main__:main
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >={{ python_min }}
+    - anndata >=0.10
+    - numpy >=1.23
+    - pandas >=2.0
+    - scipy >=1.10
+    - scikit-learn >=1.3
+    - matplotlib-base >=3.8
+    - seaborn >=0.13
+    - statsmodels >=0.14
+    - scanpy >=1.10
+    - shapely >=2.0
+    - tifffile >=2024.8.10
+    - imagecodecs >=2024.6.1
+    - pillow >=10.0
+    - zarr >=3.1
+    - fsspec >=2024.6.0
+    - requests >=2.31
+    - pyyaml >=6.0
+    - pyarrow >=14.0
+    - aiohttp >=3.9
+    - click >=8.1
+
+test:
+  imports:
+    - pyXenium
+  commands:
+    - pyxenium --help
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/hutaobo/pyXenium
+  doc_url: https://pyxenium.readthedocs.io/en/latest/
+  dev_url: https://github.com/hutaobo/pyXenium
+  summary: Xenium I/O, multimodal analysis, topology workflows, contour-native spatial profiling, GMI inference, mechanostress analysis, and optional external workflow bridges.
+  license: AGPL-3.0-only
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - hutaobo


### PR DESCRIPTION
Add pyXenium 0.4.6 from PyPI as `pyxenium`.

pyXenium provides Xenium I/O, multimodal spatial analysis, topology workflows, contour-native spatial profiling, GMI inference, mechanostress analysis, and optional external workflow bridges.

Recipe notes:

- `noarch: python` package from the PyPI sdist.
- Runtime dependencies mirror the core PyPI requirements, with `matplotlib` mapped to `matplotlib-base` and `PyYAML` mapped to `pyyaml`.
- The conda recipe uses Python >=3.11 because the current dependency stack, especially `zarr>=3.1`, is better aligned with the maintained Python range than the older PyPI metadata.
- Optional extras are intentionally not included in the base package recipe.

Validation performed locally:

- Verified PyPI latest version is `pyXenium==0.4.6`.
- Verified the sdist SHA256 matches `38f5b5231a9c224b78ffcc2042256bba4f746a011d99e966228c078297330db8`.
- Checked recipe structure and whitespace locally.