### PR TITLE
Add histoseg

### DIFF
--- a/recipes/histoseg/meta.yaml
+++ b/recipes/histoseg/meta.yaml
@@ -1,0 +1,70 @@
+{% set name = "histoseg" %}
+{% set version = "0.1.9.3" %}
+{% set python_min = "3.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/h/histoseg/histoseg-{{ version }}.tar.gz
+  sha256: cdd1ae0e35687ec867240de68fd90511afbd6e98eb9a5025d007bbe127154614
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - histoseg-gui = histoseg.gui.gui_app:main
+    - histoseg-ai-pathologist = histoseg.spatial_pathologist.cli:main
+    - histoseg-ai-pathologist-full-auto = histoseg.spatial_pathologist.full_auto_cli:main
+    - histoseg-he = histoseg.he.cli:main
+    - histoseg-contour = histoseg.contour.cli:main
+    - histoseg-3d = histoseg.threed.cli:main
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68
+    - setuptools-scm >=8
+    - wheel
+  run:
+    - python >={{ python_min }}
+    - numpy
+    - pandas
+    - pyarrow
+    - scipy
+    - scikit-image
+    - scikit-learn
+    - seaborn
+    - shapely
+    - matplotlib-base
+    - networkx
+    - openai >=1.0.0
+
+test:
+  imports:
+    - histoseg
+    - histoseg.contour
+    - histoseg.geometry
+    - histoseg.io
+  commands:
+    - histoseg-contour --help
+    - histoseg-3d --help
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/hutaobo/HistoSeg
+  doc_url: https://histoseg.readthedocs.io
+  dev_url: https://github.com/hutaobo/HistoSeg
+  summary: Python toolkit for H&E image analysis, spatial contour analysis, and 3D contour reconstruction.
+  license: PolyForm-Noncommercial-1.0.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - hutaobo

--- a/recipes/histoseg/meta.yaml
+++ b/recipes/histoseg/meta.yaml
@@ -1,9 +1,8 @@
-{% set name = "histoseg" %}
 {% set version = "0.1.9.3" %}
 {% set python_min = "3.10" %}
 
 package:
-  name: {{ name|lower }}
+  name: histoseg
   version: {{ version }}
 
 source:
@@ -28,7 +27,6 @@ requirements:
     - pip
     - setuptools >=68
     - setuptools-scm >=8
-    - wheel
   run:
     - python >={{ python_min }}
     - numpy

--- a/recipes/histoseg/meta.yaml
+++ b/recipes/histoseg/meta.yaml
@@ -42,6 +42,7 @@ requirements:
     - matplotlib-base
     - networkx
     - openai >=1.0.0
+    - huggingface_hub
 
 test:
   imports:


### PR DESCRIPTION
Add HistoSeg 0.1.9.3 from PyPI as `histoseg`.

HistoSeg is a Python toolkit for H&E image analysis, spatial contour analysis, and 3D contour reconstruction.

Recipe notes:

- `noarch: python` package from the PyPI sdist.
- Runtime dependencies mirror the core PyPI requirements, with `matplotlib` mapped to `matplotlib-base`.
- Optional extras for H&E foundation models, raster IO, visualization, and serving are intentionally not included in the base package recipe.
- License is declared as `PolyForm-Noncommercial-1.0.0` with the upstream `LICENSE` file included.

Validation performed locally:

- Verified PyPI latest version is `histoseg==0.1.9.3`.
- Verified the sdist SHA256 matches `cdd1ae0e35687ec867240de68fd90511afbd6e98eb9a5025d007bbe127154614`.
- Checked the `v0.1.9.3` tag metadata against the PyPI sdist metadata.
- Checked recipe structure and whitespace locally.