### PR TITLE
Add cs-tag: generate minimap2-like CS tags for BAM files

### DIFF
--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -18,14 +18,8 @@ build:
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
     content: |
-      echo "DEBUG: PREFIX=$PREFIX BUILD_PREFIX=$BUILD_PREFIX CONDA_TOOLCHAIN_HOST=$CONDA_TOOLCHAIN_HOST"
-      export LIBCLANG_PATH=$BUILD_PREFIX/lib
-      export BINDGEN_EXTRA_CLANG_ARGS="-I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
-      echo "DEBUG: LIBCLANG_PATH=$LIBCLANG_PATH"
-      echo "DEBUG: BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
-      ls $BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h 2>&1 || echo "DEBUG: stdint.h NOT FOUND"
-      ls $BUILD_PREFIX/lib/libclang* 2>&1 || echo "DEBUG: libclang NOT FOUND"
-      ls $PREFIX/include/htslib/hts.h 2>&1 || echo "DEBUG: hts.h NOT FOUND"
+      export LIBCLANG_PATH=${{ BUILD_PREFIX }}/lib
+      export BINDGEN_EXTRA_CLANG_ARGS="-I${{ PREFIX }}/include -I${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L${{ PREFIX }}/lib"
       cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
       cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -19,6 +19,7 @@ build:
       LIBZ_SYS_STATIC: "0"
     content:
       - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
+      - export BINDGEN_EXTRA_CLANG_ARGS="${CFLAGS} ${CPPFLAGS}"
       - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -19,7 +19,7 @@ build:
       LIBZ_SYS_STATIC: "0"
     content:
       - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
-      - export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$CONDA_BUILD_SYSROOT -I$PREFIX/include -L$PREFIX/lib"
+      - export BINDGEN_EXTRA_CLANG_ARGS="-I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
       - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -17,12 +17,14 @@ build:
       CARGO_PROFILE_RELEASE_STRIP: symbols
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
-      LIBCLANG_PATH: ${{ BUILD_PREFIX }}/lib
     content: |
-      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot -I${{ PREFIX }}/include -I${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L${{ PREFIX }}/lib"
-      echo "BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
-      echo "LIBCLANG_PATH=$LIBCLANG_PATH"
-      ls ${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h
+      export LIBCLANG_PATH=$BUILD_PREFIX/lib
+      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot -I${{ PREFIX }}/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L${{ PREFIX }}/lib"
+      echo "DEBUG: LIBCLANG_PATH=$LIBCLANG_PATH"
+      echo "DEBUG: BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
+      echo "DEBUG: CONDA_TOOLCHAIN_HOST=$CONDA_TOOLCHAIN_HOST"
+      echo "DEBUG: BUILD_PREFIX=$BUILD_PREFIX"
+      ls $BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h 2>&1 || echo "DEBUG: stdint.h NOT FOUND"
       cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
       cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -19,10 +19,7 @@ build:
       LIBZ_SYS_STATIC: "0"
     content:
       - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
-      - export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-      - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
-      - export CFLAGS="${CFLAGS} -O3 -Wno-implicit-function-declaration"
-      - export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$CONDA_BUILD_SYSROOT ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+      - export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$CONDA_BUILD_SYSROOT -I$PREFIX/include -L$PREFIX/lib"
       - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -11,19 +11,15 @@ source:
 
 build:
   number: 0
+  skip: win
   script:
     env:
       CARGO_PROFILE_RELEASE_STRIP: symbols
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
     content:
-      - if: unix
-        then:
-          - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
-          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
-        else:
-          - set LIBCLANG_PATH=%BUILD_PREFIX%\Library\lib
-          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path cs-tag
+      - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
+      - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 
 requirements:

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -38,7 +38,7 @@ requirements:
   host:
     - zlib
     - bzip2
-    - xz
+    - liblzma-devel
     - openssl
     - libcurl
   ignore_run_exports:
@@ -48,7 +48,6 @@ requirements:
       - liblzma
       - libzlib
       - openssl
-      - xz
       - zlib
 
 tests:

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -19,7 +19,10 @@ build:
       LIBZ_SYS_STATIC: "0"
     content:
       - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
-      - export BINDGEN_EXTRA_CLANG_ARGS="${CFLAGS} ${CPPFLAGS}"
+      - export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+      - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+      - export CFLAGS="${CFLAGS} -O3 -Wno-implicit-function-declaration"
+      - export BINDGEN_EXTRA_CLANG_ARGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
       - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 
@@ -30,7 +33,7 @@ requirements:
     - ${{ compiler('rust') }}
     - cargo-auditable
     - cargo-bundle-licenses
-    - clang
+    - clangdev
     - libclang
     - cmake
     - make

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -19,8 +19,10 @@ build:
     content:
       - if: unix
         then:
+          - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
           - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
         else:
+          - set LIBCLANG_PATH=%BUILD_PREFIX%\Library\lib
           - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 
@@ -32,6 +34,7 @@ requirements:
     - cargo-auditable
     - cargo-bundle-licenses
     - clang
+    - libclang
     - cmake
     - make
     - pkg-config
@@ -41,7 +44,6 @@ requirements:
     - liblzma-devel
     - openssl
     - libcurl
-    - libclang
   ignore_run_exports:
     by_name:
       - bzip2

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -18,9 +18,15 @@ build:
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
     content:
-      - export LIBCLANG_PATH=$BUILD_PREFIX/lib/libclang${SHLIB_EXT}
+      - echo "DEBUG: PREFIX=$PREFIX BUILD_PREFIX=$BUILD_PREFIX CONDA_TOOLCHAIN_HOST=$CONDA_TOOLCHAIN_HOST"
+      - export LIBCLANG_PATH=$BUILD_PREFIX/lib
       - export BINDGEN_EXTRA_CLANG_ARGS="-I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
-      - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
+      - echo "DEBUG: LIBCLANG_PATH=$LIBCLANG_PATH"
+      - echo "DEBUG: BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
+      - ls $BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h 2>&1 || echo "DEBUG: stdint.h NOT FOUND"
+      - ls $BUILD_PREFIX/lib/libclang* 2>&1 || echo "DEBUG: libclang NOT FOUND"
+      - ls $PREFIX/include/htslib/hts.h 2>&1 || echo "DEBUG: hts.h NOT FOUND"
+      - cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 
 requirements:

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -1,0 +1,79 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: cs-tag
+  version: ${{ version }}
+
+source:
+  url: https://github.com/jiangyun-fun/cs-tag/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: c4585bb71eb6bfaab4731434e4996d24ac1af2eb473e409f3a7166ed3fce18cf
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+      LIBZ_SYS_STATIC: "0"
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path cs-tag
+      - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-auditable
+    - cargo-bundle-licenses
+    - clang
+    - cmake
+    - make
+    - pkg-config
+  host:
+    - zlib
+    - bzip2
+    - xz
+    - openssl
+    - libcurl
+  ignore_run_exports:
+    by_name:
+      - bzip2
+      - libcurl
+      - liblzma
+      - libzlib
+      - openssl
+      - xz
+      - zlib
+
+tests:
+  - script:
+      - cs-tag --help
+      - cs-tag --version
+  - package_contents:
+      bin:
+        - cs-tag
+      strict: true
+
+about:
+  homepage: https://github.com/jiangyun-fun/cs-tag
+  summary: Generate minimap2-like CS tags for BAM files
+  description: |
+    CS tags encode the alignment between query and reference sequences in a
+    compact string representation. This tool computes CS tags from an existing
+    BAM alignment and a reference FASTA, then writes them as auxiliary tags
+    into the output BAM.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  repository: https://github.com/jiangyun-fun/cs-tag
+
+extra:
+  recipe-maintainers:
+    - jiangyun-fun

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -22,7 +22,7 @@ build:
       - export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
       - export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
       - export CFLAGS="${CFLAGS} -O3 -Wno-implicit-function-declaration"
-      - export BINDGEN_EXTRA_CLANG_ARGS="${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
+      - export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$CONDA_BUILD_SYSROOT ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
       - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path cs-tag
       - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -17,9 +17,12 @@ build:
       CARGO_PROFILE_RELEASE_STRIP: symbols
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
+      LIBCLANG_PATH: ${{ BUILD_PREFIX }}/lib
     content: |
-      export LIBCLANG_PATH=${{ BUILD_PREFIX }}/lib
-      export BINDGEN_EXTRA_CLANG_ARGS="-I${{ PREFIX }}/include -I${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L${{ PREFIX }}/lib"
+      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot -I${{ PREFIX }}/include -I${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L${{ PREFIX }}/lib"
+      echo "BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
+      echo "LIBCLANG_PATH=$LIBCLANG_PATH"
+      ls ${{ BUILD_PREFIX }}/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h
       cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
       cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -18,17 +18,8 @@ build:
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
     content: |
-      echo "=== ENV DUMP ==="
-      env | grep -E '^(PREFIX|BUILD_PREFIX|CONDA_TOOLCHAIN|LIBCLANG|BINDGEN|SRC_DIR)='
-      echo "=== RESOLVED PATHS ==="
-      echo "LIBCLANG_PATH=$BUILD_PREFIX/lib"
-      echo "SYSROOT=$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot"
-      ls "$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h" 2>&1 || echo "FAIL: stdint.h not found"
-      ls "$BUILD_PREFIX/lib/libclang.so" 2>&1 || echo "FAIL: libclang.so not found"
       export LIBCLANG_PATH=$BUILD_PREFIX/lib
-      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot -I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
-      echo "=== SET VARS ==="
-      env | grep -E '^(LIBCLANG_PATH|BINDGEN_EXTRA_CLANG_ARGS)='
+      export BINDGEN_EXTRA_CLANG_ARGS="$CFLAGS"
       cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
       cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -18,13 +18,17 @@ build:
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
     content: |
+      echo "=== ENV DUMP ==="
+      env | grep -E '^(PREFIX|BUILD_PREFIX|CONDA_TOOLCHAIN|LIBCLANG|BINDGEN|SRC_DIR)='
+      echo "=== RESOLVED PATHS ==="
+      echo "LIBCLANG_PATH=$BUILD_PREFIX/lib"
+      echo "SYSROOT=$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot"
+      ls "$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h" 2>&1 || echo "FAIL: stdint.h not found"
+      ls "$BUILD_PREFIX/lib/libclang.so" 2>&1 || echo "FAIL: libclang.so not found"
       export LIBCLANG_PATH=$BUILD_PREFIX/lib
-      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot -I${{ PREFIX }}/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L${{ PREFIX }}/lib"
-      echo "DEBUG: LIBCLANG_PATH=$LIBCLANG_PATH"
-      echo "DEBUG: BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
-      echo "DEBUG: CONDA_TOOLCHAIN_HOST=$CONDA_TOOLCHAIN_HOST"
-      echo "DEBUG: BUILD_PREFIX=$BUILD_PREFIX"
-      ls $BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h 2>&1 || echo "DEBUG: stdint.h NOT FOUND"
+      export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot -I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
+      echo "=== SET VARS ==="
+      env | grep -E '^(LIBCLANG_PATH|BINDGEN_EXTRA_CLANG_ARGS)='
       cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
       cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.1.0"
+  version: "0.2.0"
 
 package:
   name: cs-tag
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/jiangyun-fun/cs-tag/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: c4585bb71eb6bfaab4731434e4996d24ac1af2eb473e409f3a7166ed3fce18cf
+  sha256: 562121f8025975c57d7f0f9f766450ac800668f08102a22d65ada51c03f9321a
 
 build:
   number: 0

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -41,6 +41,7 @@ requirements:
     - liblzma-devel
     - openssl
     - libcurl
+    - libclang
   ignore_run_exports:
     by_name:
       - bzip2

--- a/recipes/cs-tag/recipe.yaml
+++ b/recipes/cs-tag/recipe.yaml
@@ -17,17 +17,17 @@ build:
       CARGO_PROFILE_RELEASE_STRIP: symbols
       CARGO_PROFILE_RELEASE_LTO: fat
       LIBZ_SYS_STATIC: "0"
-    content:
-      - echo "DEBUG: PREFIX=$PREFIX BUILD_PREFIX=$BUILD_PREFIX CONDA_TOOLCHAIN_HOST=$CONDA_TOOLCHAIN_HOST"
-      - export LIBCLANG_PATH=$BUILD_PREFIX/lib
-      - export BINDGEN_EXTRA_CLANG_ARGS="-I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
-      - echo "DEBUG: LIBCLANG_PATH=$LIBCLANG_PATH"
-      - echo "DEBUG: BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
-      - ls $BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h 2>&1 || echo "DEBUG: stdint.h NOT FOUND"
-      - ls $BUILD_PREFIX/lib/libclang* 2>&1 || echo "DEBUG: libclang NOT FOUND"
-      - ls $PREFIX/include/htslib/hts.h 2>&1 || echo "DEBUG: hts.h NOT FOUND"
-      - cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
-      - cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
+    content: |
+      echo "DEBUG: PREFIX=$PREFIX BUILD_PREFIX=$BUILD_PREFIX CONDA_TOOLCHAIN_HOST=$CONDA_TOOLCHAIN_HOST"
+      export LIBCLANG_PATH=$BUILD_PREFIX/lib
+      export BINDGEN_EXTRA_CLANG_ARGS="-I$PREFIX/include -I$BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include -L$PREFIX/lib"
+      echo "DEBUG: LIBCLANG_PATH=$LIBCLANG_PATH"
+      echo "DEBUG: BINDGEN_EXTRA_CLANG_ARGS=$BINDGEN_EXTRA_CLANG_ARGS"
+      ls $BUILD_PREFIX/$CONDA_TOOLCHAIN_HOST/sysroot/usr/include/stdint.h 2>&1 || echo "DEBUG: stdint.h NOT FOUND"
+      ls $BUILD_PREFIX/lib/libclang* 2>&1 || echo "DEBUG: libclang NOT FOUND"
+      ls $PREFIX/include/htslib/hts.h 2>&1 || echo "DEBUG: hts.h NOT FOUND"
+      cargo auditable install --no-track --bins --root ${{ PREFIX }} --path cs-tag
+      cd cs-tag && cargo-bundle-licenses --format yaml --output ${{ SRC_DIR }}/THIRDPARTY.yml
 
 requirements:
   build:


### PR DESCRIPTION
## Description

Adding **cs-tag**, a Rust CLI tool that generates [minimap2](https://github.com/lh3/minimap2)-like CS tags for BAM alignments.

### What it does
- Reads an existing BAM file and a reference FASTA
- Computes CS tags encoding the alignment between query and reference sequences
- Writes the CS tags as auxiliary tags into the output BAM

### Checklist
- [x] Package does not already exist on conda-forge (verified with `pixi search cs-tag`)
- [x] Source tarball SHA256 verified (`c4585bb71eb6bfaab4731434e4996d24ac1af2eb473e409f3a7166ed3fce18cf`)
- [x] Recipe uses v1 format (`recipe.yaml`) with rattler-build
- [x] Build tested locally on linux-64 — all tests pass
- [x] Uses `cargo-auditable` and `cargo-bundle-licenses` per Rust recipe guidelines
- [x] `license_file` includes both LICENSE and THIRDPARTY.yml
- [x] `recipe-maintainers` set to @jiangyun-fun

### Upstream
- **Repository**: https://github.com/jiangyun-fun/cs-tag
- **License**: MIT
- **Language**: Rust