### PR TITLE
Add brush

### DIFF
--- a/recipes/brush/recipe.yaml
+++ b/recipes/brush/recipe.yaml
@@ -58,3 +58,4 @@ about:
 extra:
   recipe-maintainers:
     - baszalmstra
+    - hoferjulian

--- a/recipes/brush/recipe.yaml
+++ b/recipes/brush/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: "0.4.0"
+
+package:
+  name: brush
+  version: ${{ version }}
+
+source:
+  url: https://github.com/reubeno/brush/archive/refs/tags/brush-shell-v${{ version }}.tar.gz
+  sha256: 0cce607454972c18bc4a30d2f44a2c91fccf02c458475fda7720370a3dc8a4f0
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path brush-shell
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path brush-shell
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script:
+      - brush --version
+      - brush -c "echo hello"
+  - package_contents:
+      bin:
+        - brush
+      strict: true
+
+about:
+  homepage: https://brush.sh
+  summary: A bash/POSIX-compatible shell implemented in Rust
+  description: |
+    brush (Bourne RUst SHell) is a shell implemented in Rust that aims to be
+    compatible with the POSIX sh specification as well as the bash shell.
+    It can run many common shell scripts and offers an interactive command-line
+    experience.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://brush.sh
+  repository: https://github.com/reubeno/brush
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/brush/recipe.yaml
+++ b/recipes/brush/recipe.yaml
@@ -58,4 +58,4 @@ about:
 extra:
   recipe-maintainers:
     - baszalmstra
-    - hoferjulian
+    - Hofer-Julian


### PR DESCRIPTION
Adds a recipe for [brush](https://github.com/reubeno/brush) — a bash/POSIX-compatible shell implemented in Rust.

- Homepage: https://brush.sh
- Source: GitHub release tarball `brush-shell-v0.4.0` (MIT)
- Builds the `brush` binary from the workspace's `brush-shell` crate using `cargo-auditable`, with dependency licenses bundled via `cargo-bundle-licenses`.
- Tested locally on linux-64: builds, and `brush --version` / `brush -c "echo hello"` pass.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our knowledge base documentation before pinging a team.