### PR TITLE
Add package mmx (Mathemagix)

### DIFF
--- a/recipes/mmx/build.sh
+++ b/recipes/mmx/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+packages=$(
+  make -s -f Makefile.in -f - print-ALL_PACKAGES <<'EOF'
+print-ALL_PACKAGES:
+	@printf '%s\n' '$(ALL_PACKAGES)'
+EOF
+)
+
+# mmxlight/build/Makefile.am contains 'mmx_light_PATCH_1 = \#\#\# BEGINNING OF MMXPATCH',
+# leading to
+#     build/Makefile.am:79: warning: escaping \# comment markers is not portable
+# The following is a workaround. An alternative is to inline the variable:
+# - https://www.mail-archive.com/libtool-patches%40gnu.org/msg07752.html
+# - https://github.com/ddclient/ddclient/commit/a12398c315b9b909e57e87acf9fd3a15a0b3e213
+for pkg in $packages; do
+  sed -i 's/ -Werror//g' "$pkg/configure.ac"
+done
+
+# Regenerate configure/libtool files because the checked-in files have a bug
+# fixed in libtool 2.5.4.
+# See https://www.mail-archive.com/libtool-patches%40gnu.org/msg07524.html
+autoreconf -fi
+for pkg in $packages; do
+  autoreconf -fi "$pkg"
+done
+
+sed -i 's|#define CXX \\"$CXX\\"|#define CXX \\"$prefix/bin/c++\\"|' basix/configure
+grep -F '#define CXX \"$prefix/bin/c++\"' basix/configure
+
+./configure --prefix="${PREFIX}" --enable-mmcomp --enable-mmxlight
+make -j"${CPU_COUNT}"
+make install

--- a/recipes/mmx/recipe.yaml
+++ b/recipes/mmx/recipe.yaml
@@ -1,0 +1,61 @@
+context:
+  version: "0.4"
+  # top-level `./configure` has `PACKAGE_VERSION='0.4'`, `mmx-light --version` (old interpreter) reports `0.4`,
+  # but `mmi --version` (newer interpreter) and `mmc --version` report `1.0.3`
+
+package:
+  name: mmx
+  version: ${{ version }}
+
+source:
+  url: https://github.com/user202729/mmx/archive/9940f05764f98545f34a4aa45911362af0b00832.tar.gz
+  sha256: 1c28a56b0941d15d2207bb6a333da461627991ae65f866f885a83d2aa972c721
+
+build:
+  number: 0
+  skip:
+    - win
+    - osx
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - autoconf
+    - automake
+    - bison
+    - libtool >=2.5.4
+    - make
+  host:
+    - gmp
+    - libtool >=2.5.4
+    - mpfr
+    - readline
+  run:
+    - cxx-compiler
+    - libtool
+
+tests:
+  - script:
+    - mmx-light --help
+    - mmi --help
+    - printf 'include "basix/fundamental.mmx";\nmmout << "1" << lf;\n' > test-string.mmx
+    - mmi test-string.mmx
+    - mmc
+    # oddly mmc doesn't accept --help, no-argument prints out usage
+
+about:
+  homepage: https://www.mathemagix.org
+  summary: Computer algebra and analysis system
+  license: GPL-2.0-only AND GPL-3.0-only
+  # algebramix and larrix are GPL-2.0-only, the rest are GPL-3.0-only
+  # algebramix is required by mmcomp
+  license_file:
+    # each package has a separate LICENSE file
+    - algebramix/LICENSE
+    - basix/LICENSE
+
+extra:
+  recipe-maintainers:
+    - user202729


### PR DESCRIPTION


Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- Source is from official source. (**see explanation below**)
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


------

Points for discussion

- Mathemagix is a high-level programming language by Joris van der Hoeven and Grégoire Lecerf. Upstream URL: https://www.mathemagix.org/www/mmdoc/doc/html/main/index.en.html
- As far as I know, upstream does not provide tarballs. So I'm downloading it from my unofficial mirror https://github.com/user202729/mmx. I don't think it's possible to do any other way (`svn_url`?)
- This program is complex: `mmi` and `mmc` may invoke `g++` the compiler (it's itself a compiler that lower programs to C++), and because of how it's written, it would detect the build-time `c++` compiler instead of the run-time one. Thus the patch to point `CXX` to `$prefix/bin/c++`.
- the GPL v2 only AND GPL v3 only looks weird (maybe the authors really intend it to be GPL v2 or later AND GPL v3 or later, which resolves to GPL v3 or later. Some source code files' preambles imply this (search for `any later version` and `GNU GPL version 3 or later`), but not all.
- This repo actually consist of several "sub-packages". When you run `./configure`, you'll see

```
Options:
[*] optimizations
[*] debugging
[*] C++ exception handling
[ ] low-level verifications
[ ] embedded glue
[*] glue compilation for interpreter
[*] compilation of additional test programs
[ ] compilation of additional benchmarks
[*] simd level yes
[ ] C++ move operators
[ ] multi-threading
[*] shared libraries
[ ] static libraries
[ ] building as standalone
[ ] building with unstable code
[ ] doxygen HAVE_DOT
[ ] documention
Packages:
[ ] automagix
[*] basix
[ ] mmancient
[*] mmcompileregg
[*] mmcompiler
[ ] mcoq
[ ] mmail
[ ] mmdoc
[ ] mmxtools
[ ] msqlite3
[*] numerix
[*] algebramix
[*] analyziz
[ ] finitefieldz
[ ] graphix
[ ] holonomix
[ ] lattiz
[ ] linalg
[ ] borderbasix
[ ] lindalg
[ ] mgf2x
[ ] mmaple
[ ] mpari
[ ] realroot
[ ] mmps
[*] runtime
[*] justinline
[*] multimix
[*] continewz
[ ] factorix
[ ] geomsolvex
[ ] gregorix
[ ] lacunaryx
[ ] mblad
[ ] mfgb
[ ] larrix
[ ] quintix
[ ] shape
[*] symbolix
[*] asymptotix
[ ] columbus
[*] jorix
[*] mmcomp
[ ] mmxlight
[ ] caas
```

Should each checkbox be a separate conda package, or should it just be bundled like this? (Actually I'm not entirely sure if the former is supported by the repo's build system)