### PR TITLE
Add bmad-dashboard + mybmad-dashboard (BMad Method UI — VS Code extension + web app)

### DIFF
--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -46,11 +46,44 @@ fi
 
 echo "    pnpm:  $(pnpm --version)"
 
+# Keep package-manager caches OUT of $SRC_DIR so vsce doesn't vacuum them
+# into the .vsix. conda-forge nodejs activation seeds npm/pnpm caches under
+# $SRC_DIR for hermeticity (npm-cache/, .pnpm/, .pnpm-cache/, .pnpm-state/),
+# which adds ~400 MB of garbage to the .vsix. Park them next to $SRC_DIR
+# instead — still inside the per-build sandbox, so they're cleaned up with
+# the rest of the build.
+CACHE_ROOT="$(dirname "${SRC_DIR}")/_pkg_caches"
+mkdir -p "${CACHE_ROOT}/npm" "${CACHE_ROOT}/pnpm-store" "${CACHE_ROOT}/pnpm-state"
+export npm_config_cache="${CACHE_ROOT}/npm"
+export PNPM_STORE_PATH="${CACHE_ROOT}/pnpm-store"
+export XDG_STATE_HOME="${CACHE_ROOT}/pnpm-state"
+
 echo ">> fetching node dependencies"
 pnpm install --frozen-lockfile
 
 echo ">> building extension + webview"
 pnpm build
+
+# Defense in depth: vsce walks $SRC_DIR and ships everything not in
+# .vscodeignore. rattler-build writes its own wrapper scripts directly into
+# $SRC_DIR (build_env.{sh,bat}, conda_build.{sh,bat}, conda_build.log) so
+# even with caches relocated, those files would still ride along.
+echo ">> appending conda-build excludes to .vscodeignore"
+cat >> .vscodeignore <<'EOF'
+
+# Excluded by conda-forge recipe build.sh
+.pnpm/**
+.pnpm-cache/**
+.pnpm-state/**
+npm-cache/**
+build_env.sh
+build_env.bat
+conda_build.sh
+conda_build.bat
+conda_build.log
+_pkg_caches/**
+_pywrap/**
+EOF
 
 echo ">> packaging .vsix"
 pnpm vscode:package

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -148,16 +148,14 @@ EOF
 # only the compiled output in out/.
 # vscode:prepublish was already replaced with a no-op above so vsce won't try
 # to rebuild after node_modules is gone.
-echo ">> pinning vsce version from installed node_modules"
-VSCE_VERSION=$(node -e \
-    "console.log(require('./node_modules/@vscode/vsce/package.json').version)")
-echo "    @vscode/vsce: ${VSCE_VERSION}"
-
 echo ">> removing node_modules to prevent vsce false-positive secret scan"
 rm -rf node_modules
 
+# @vscode/vsce is not a devDependency; the vscode:package script invokes it
+# via npx (on-demand download). We call it the same way here so there is no
+# version to pin from node_modules.
 echo ">> packaging .vsix"
-npx --yes "@vscode/vsce@${VSCE_VERSION}" package --no-dependencies -o out/
+npx --yes @vscode/vsce package --no-dependencies -o out/
 
 VSIX_SRC=$(ls out/*.vsix | head -n 1)
 test -f "${VSIX_SRC}" || { echo "ERROR: no .vsix produced under out/"; exit 1; }

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -61,6 +61,28 @@ export XDG_STATE_HOME="${CACHE_ROOT}/pnpm-state"
 echo ">> fetching node dependencies"
 pnpm install --frozen-lockfile
 
+# Rebrand package.json before any build step bakes the identity in.
+# Upstream's package.json at the pinned commit still self-IDs as
+# elvince/bmad-dashboard-extension, but bmad-code-org/bmad-method-ui is the
+# canonical home. Rewrite the fields vsce reads so VS Code sees
+# bmad-code-org.bmad-method-ui (not elvince.bmad-dashboard) after install.
+echo ">> rebranding package.json -> bmad-code-org.bmad-method-ui"
+"${PYTHON}" - <<'PY'
+import json, pathlib
+p = pathlib.Path("package.json")
+pj = json.loads(p.read_text(encoding="utf-8"))
+pj["name"] = "bmad-method-ui"
+pj["publisher"] = "bmad-code-org"
+pj["displayName"] = "BMad Method UI"
+pj["repository"] = {
+    "type": "git",
+    "url": "https://github.com/bmad-code-org/bmad-method-ui.git",
+}
+pj["homepage"] = "https://github.com/bmad-code-org/bmad-method-ui#readme"
+pj["bugs"] = {"url": "https://github.com/bmad-code-org/bmad-method-ui/issues"}
+p.write_text(json.dumps(pj, indent=2) + "\n", encoding="utf-8")
+PY
+
 echo ">> building extension + webview"
 pnpm build
 
@@ -88,7 +110,7 @@ EOF
 echo ">> packaging .vsix"
 pnpm vscode:package
 
-VSIX_SRC=$(ls out/bmad-dashboard-*.vsix | head -n 1)
+VSIX_SRC=$(ls out/*.vsix | head -n 1)
 test -f "${VSIX_SRC}" || { echo "ERROR: no .vsix produced under out/"; exit 1; }
 VSIX_NAME=$(basename "${VSIX_SRC}")
 echo "    built: ${VSIX_NAME}"

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -64,22 +64,37 @@ pnpm install --frozen-lockfile
 # Rebrand package.json before any build step bakes the identity in.
 # Upstream's package.json at the pinned commit still self-IDs as
 # elvince/bmad-dashboard-extension, but bmad-code-org/bmad-method-ui is the
-# canonical home. Rewrite the fields vsce reads so VS Code sees
-# bmad-code-org.bmad-method-ui (not elvince.bmad-dashboard) after install.
+# canonical home. Rewrite both the marketplace metadata fields and the
+# user-visible UI labels in contributes so VS Code shows the bmad-method-ui
+# identity everywhere (extension card, sidebar title, command palette).
 echo ">> rebranding package.json -> bmad-code-org.bmad-method-ui"
 "${PYTHON}" - <<'PY'
 import json, pathlib
 p = pathlib.Path("package.json")
 pj = json.loads(p.read_text(encoding="utf-8"))
+
+# Marketplace identity
 pj["name"] = "bmad-method-ui"
 pj["publisher"] = "bmad-code-org"
 pj["displayName"] = "BMad Method UI"
+pj["description"] = "Interactive dashboard for BMad Method V6 projects"
 pj["repository"] = {
     "type": "git",
     "url": "https://github.com/bmad-code-org/bmad-method-ui.git",
 }
 pj["homepage"] = "https://github.com/bmad-code-org/bmad-method-ui#readme"
 pj["bugs"] = {"url": "https://github.com/bmad-code-org/bmad-method-ui/issues"}
+
+# User-visible labels (sidebar header, command palette)
+contributes = pj.get("contributes", {})
+for vc in contributes.get("viewsContainers", {}).get("activitybar", []):
+    if vc.get("title") == "BMAD Dashboard":
+        vc["title"] = "BMad Method UI"
+for cmd in contributes.get("commands", []):
+    title = cmd.get("title", "")
+    if title.startswith("BMAD:"):
+        cmd["title"] = "BMad:" + title[len("BMAD:"):]
+
 p.write_text(json.dumps(pj, indent=2) + "\n", encoding="utf-8")
 PY
 

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Build the BMAD Dashboard VS Code extension as a conda package.
+#
+# Strategy:
+#   1. Provision pnpm 10.26.2 (upstream's pinned packageManager) via corepack,
+#      with `npm install -g pnpm@10.26.2` as a fallback.
+#   2. `pnpm install --frozen-lockfile && pnpm build && pnpm vscode:package`
+#      produces out/bmad-dashboard-1.2.2.vsix.
+#   3. Layer a small Python wrapper around the .vsix that exposes a
+#      `bmad-dashboard-install` CLI entry point. The wrapper sources live
+#      under $RECIPE_DIR/wrapper/.
+#   4. Pip-install the wrapper so conda-build picks up the entry point.
+set -euo pipefail
+
+echo ">> environment"
+echo "    node:  $(node --version)"
+echo "    npm:   $(npm --version)"
+
+PNPM_VERSION="10.26.2"
+
+if command -v corepack >/dev/null 2>&1; then
+    echo ">> activating pnpm ${PNPM_VERSION} via corepack"
+    export COREPACK_HOME="${BUILD_PREFIX:-$PREFIX}/corepack"
+    mkdir -p "${COREPACK_HOME}"
+    corepack enable --install-directory "${BUILD_PREFIX:-$PREFIX}/bin"
+    corepack prepare "pnpm@${PNPM_VERSION}" --activate
+else
+    echo ">> corepack not found, installing pnpm via npm"
+    npm install -g "pnpm@${PNPM_VERSION}"
+fi
+
+echo "    pnpm:  $(pnpm --version)"
+
+echo ">> fetching node dependencies"
+pnpm install --frozen-lockfile
+
+echo ">> building extension + webview"
+pnpm build
+
+echo ">> packaging .vsix"
+pnpm vscode:package
+
+VSIX_SRC=$(ls out/bmad-dashboard-*.vsix | head -n 1)
+test -f "${VSIX_SRC}" || { echo "ERROR: no .vsix produced under out/"; exit 1; }
+VSIX_NAME=$(basename "${VSIX_SRC}")
+echo "    built: ${VSIX_NAME}"
+
+echo ">> staging Python wrapper"
+WRAP="${SRC_DIR}/_pywrap"
+rm -rf "${WRAP}"
+mkdir -p "${WRAP}"
+cp -r "${RECIPE_DIR}/wrapper/." "${WRAP}/"
+mkdir -p "${WRAP}/src/bmad_dashboard/data"
+cp "${VSIX_SRC}" "${WRAP}/src/bmad_dashboard/data/${VSIX_NAME}"
+cp "${SRC_DIR}/LICENSE.md" "${WRAP}/LICENSE"
+
+echo ">> pip install wrapper"
+cd "${WRAP}"
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+
+echo ">> done"

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -19,50 +19,40 @@ echo ">> environment"
 echo "    node:  $(node --version)"
 echo "    npm:   $(npm --version)"
 
+# Keep package-manager caches OUT of $SRC_DIR so vsce doesn't vacuum them
+# into the .vsix. Also keep pnpm itself here so it doesn't land in $PREFIX
+# and get packaged into the conda output (rattler-build rejects symlinks).
+# CACHE_ROOT must be defined before pnpm is installed.
+CACHE_ROOT="$(dirname "${SRC_DIR}")/_pkg_caches"
+mkdir -p "${CACHE_ROOT}/npm" "${CACHE_ROOT}/pnpm-cli" "${CACHE_ROOT}/corepack" \
+         "${CACHE_ROOT}/pnpm-store" "${CACHE_ROOT}/pnpm-state" \
+         "${CACHE_ROOT}/xdg_data"
+
 PNPM_VERSION="10.26.2"
-
-# rattler-build on Windows can leak BUILD_PREFIX into bash as the literal
-# CMD placeholder `%BUILD_PREFIX%`. Treat that (and a plain-empty value) as
-# unset and fall back to $PREFIX.
-case "${BUILD_PREFIX:-}" in
-    ""|*%*) BP="${PREFIX}" ;;
-    *)      BP="${BUILD_PREFIX}" ;;
-esac
-
-# conda's Windows layout puts shims under Library/bin; *nix uses bin.
-if [[ -d "${BP}/Library/bin" ]]; then
-    BP_BIN="${BP}/Library/bin"
-else
-    BP_BIN="${BP}/bin"
-fi
 
 if command -v corepack >/dev/null 2>&1; then
     echo ">> activating pnpm ${PNPM_VERSION} via corepack"
-    export COREPACK_HOME="${BP}/corepack"
-    mkdir -p "${COREPACK_HOME}" "${BP_BIN}"
-    corepack enable --install-directory "${BP_BIN}"
+    export COREPACK_HOME="${CACHE_ROOT}/corepack"
+    corepack enable --install-directory "${CACHE_ROOT}/pnpm-cli"
     corepack prepare "pnpm@${PNPM_VERSION}" --activate
+    export PATH="${CACHE_ROOT}/pnpm-cli:${PATH}"
 else
     echo ">> corepack not found, installing pnpm via npm"
-    npm install -g "pnpm@${PNPM_VERSION}"
+    # Install to CACHE_ROOT/pnpm-cli, NOT to $PREFIX, so pnpm files don't end
+    # up in the conda package output. rattler-build rejects packages that
+    # contain symlinks (npm's global install creates python-scripts/pnpm ->
+    # ../lib/node_modules/pnpm/... on Linux, which trips the symlink check).
+    npm install -g --prefix "${CACHE_ROOT}/pnpm-cli" "pnpm@${PNPM_VERSION}"
+    export PATH="${CACHE_ROOT}/pnpm-cli/bin:${PATH}"
 fi
 
 echo "    pnpm:  $(pnpm --version)"
 
-# Keep package-manager caches OUT of $SRC_DIR so vsce doesn't vacuum them
-# into the .vsix. conda-forge nodejs activation seeds npm/pnpm caches under
-# $SRC_DIR for hermeticity (npm-cache/, .pnpm/, .pnpm-cache/, .pnpm-state/),
-# which adds ~400 MB of garbage to the .vsix. Park them next to $SRC_DIR
-# instead — still inside the per-build sandbox, so they're cleaned up with
-# the rest of the build.
-#
 # XDG_DATA_HOME controls where pnpm puts its store (default ~/.local/share).
 # Relocating it here keeps the store on the same filesystem as $SRC_DIR so
 # pnpm can use hardlinks instead of symlinks, avoiding vsce scanning the
 # global store through dangling symlinks in node_modules/.pnpm.
-CACHE_ROOT="$(dirname "${SRC_DIR}")/_pkg_caches"
-mkdir -p "${CACHE_ROOT}/npm" "${CACHE_ROOT}/pnpm-store" "${CACHE_ROOT}/pnpm-state" \
-         "${CACHE_ROOT}/xdg_data"
+# XDG_STATE_HOME keeps pnpm's state files out of ~/.local/state.
 export npm_config_cache="${CACHE_ROOT}/npm"
 export XDG_DATA_HOME="${CACHE_ROOT}/xdg_data"
 export XDG_STATE_HOME="${CACHE_ROOT}/pnpm-state"

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -18,11 +18,26 @@ echo "    npm:   $(npm --version)"
 
 PNPM_VERSION="10.26.2"
 
+# rattler-build on Windows can leak BUILD_PREFIX into bash as the literal
+# CMD placeholder `%BUILD_PREFIX%`. Treat that (and a plain-empty value) as
+# unset and fall back to $PREFIX.
+case "${BUILD_PREFIX:-}" in
+    ""|*%*) BP="${PREFIX}" ;;
+    *)      BP="${BUILD_PREFIX}" ;;
+esac
+
+# conda's Windows layout puts shims under Library/bin; *nix uses bin.
+if [[ -d "${BP}/Library/bin" ]]; then
+    BP_BIN="${BP}/Library/bin"
+else
+    BP_BIN="${BP}/bin"
+fi
+
 if command -v corepack >/dev/null 2>&1; then
     echo ">> activating pnpm ${PNPM_VERSION} via corepack"
-    export COREPACK_HOME="${BUILD_PREFIX:-$PREFIX}/corepack"
-    mkdir -p "${COREPACK_HOME}"
-    corepack enable --install-directory "${BUILD_PREFIX:-$PREFIX}/bin"
+    export COREPACK_HOME="${BP}/corepack"
+    mkdir -p "${COREPACK_HOME}" "${BP_BIN}"
+    corepack enable --install-directory "${BP_BIN}"
     corepack prepare "pnpm@${PNPM_VERSION}" --activate
 else
     echo ">> corepack not found, installing pnpm via npm"

--- a/recipes/bmad-dashboard/build.sh
+++ b/recipes/bmad-dashboard/build.sh
@@ -4,12 +4,15 @@
 # Strategy:
 #   1. Provision pnpm 10.26.2 (upstream's pinned packageManager) via corepack,
 #      with `npm install -g pnpm@10.26.2` as a fallback.
-#   2. `pnpm install --frozen-lockfile && pnpm build && pnpm vscode:package`
-#      produces out/bmad-dashboard-1.2.2.vsix.
-#   3. Layer a small Python wrapper around the .vsix that exposes a
+#   2. `pnpm install --frozen-lockfile && pnpm build` compiles the extension.
+#   3. node_modules is removed so vsce's secret scanner cannot flag tokens
+#      in devDependencies (e.g. semantic-release, @octokit packages).
+#      vscode:prepublish is overridden to a no-op before this removal.
+#   4. `vsce package --no-dependencies` produces out/bmad-method-ui-1.2.2.vsix.
+#   5. Layer a small Python wrapper around the .vsix that exposes a
 #      `bmad-dashboard-install` CLI entry point. The wrapper sources live
 #      under $RECIPE_DIR/wrapper/.
-#   4. Pip-install the wrapper so conda-build picks up the entry point.
+#   6. Pip-install the wrapper so conda-build picks up the entry point.
 set -euo pipefail
 
 echo ">> environment"
@@ -52,10 +55,16 @@ echo "    pnpm:  $(pnpm --version)"
 # which adds ~400 MB of garbage to the .vsix. Park them next to $SRC_DIR
 # instead — still inside the per-build sandbox, so they're cleaned up with
 # the rest of the build.
+#
+# XDG_DATA_HOME controls where pnpm puts its store (default ~/.local/share).
+# Relocating it here keeps the store on the same filesystem as $SRC_DIR so
+# pnpm can use hardlinks instead of symlinks, avoiding vsce scanning the
+# global store through dangling symlinks in node_modules/.pnpm.
 CACHE_ROOT="$(dirname "${SRC_DIR}")/_pkg_caches"
-mkdir -p "${CACHE_ROOT}/npm" "${CACHE_ROOT}/pnpm-store" "${CACHE_ROOT}/pnpm-state"
+mkdir -p "${CACHE_ROOT}/npm" "${CACHE_ROOT}/pnpm-store" "${CACHE_ROOT}/pnpm-state" \
+         "${CACHE_ROOT}/xdg_data"
 export npm_config_cache="${CACHE_ROOT}/npm"
-export PNPM_STORE_PATH="${CACHE_ROOT}/pnpm-store"
+export XDG_DATA_HOME="${CACHE_ROOT}/xdg_data"
 export XDG_STATE_HOME="${CACHE_ROOT}/pnpm-state"
 
 echo ">> fetching node dependencies"
@@ -67,6 +76,10 @@ pnpm install --frozen-lockfile
 # canonical home. Rewrite both the marketplace metadata fields and the
 # user-visible UI labels in contributes so VS Code shows the bmad-method-ui
 # identity everywhere (extension card, sidebar title, command palette).
+#
+# vscode:prepublish is replaced with a no-op because we run `pnpm build`
+# explicitly below; this prevents vsce from re-running it after node_modules
+# has been removed (see the "remove node_modules" step before packaging).
 echo ">> rebranding package.json -> bmad-code-org.bmad-method-ui"
 "${PYTHON}" - <<'PY'
 import json, pathlib
@@ -95,6 +108,11 @@ for cmd in contributes.get("commands", []):
     if title.startswith("BMAD:"):
         cmd["title"] = "BMad:" + title[len("BMAD:"):]
 
+# Replace vscode:prepublish with a no-op so vsce does not re-run the full
+# build after node_modules is removed for the secret-scan workaround below.
+pj.setdefault("scripts", {})["vscode:prepublish"] = \
+    "echo 'Pre-build completed by conda recipe build.sh'"
+
 p.write_text(json.dumps(pj, indent=2) + "\n", encoding="utf-8")
 PY
 
@@ -109,6 +127,7 @@ echo ">> appending conda-build excludes to .vscodeignore"
 cat >> .vscodeignore <<'EOF'
 
 # Excluded by conda-forge recipe build.sh
+node_modules/**
 .pnpm/**
 .pnpm-cache/**
 .pnpm-state/**
@@ -122,8 +141,23 @@ _pkg_caches/**
 _pywrap/**
 EOF
 
+# vsce's secret scanner walks the entire workspace for token patterns, even
+# files that are excluded by .vscodeignore.  devDependencies such as
+# semantic-release and @octokit contain GitHub token examples that trigger
+# false positives.  Remove node_modules before packaging so the scanner sees
+# only the compiled output in out/.
+# vscode:prepublish was already replaced with a no-op above so vsce won't try
+# to rebuild after node_modules is gone.
+echo ">> pinning vsce version from installed node_modules"
+VSCE_VERSION=$(node -e \
+    "console.log(require('./node_modules/@vscode/vsce/package.json').version)")
+echo "    @vscode/vsce: ${VSCE_VERSION}"
+
+echo ">> removing node_modules to prevent vsce false-positive secret scan"
+rm -rf node_modules
+
 echo ">> packaging .vsix"
-pnpm vscode:package
+npx --yes "@vscode/vsce@${VSCE_VERSION}" package --no-dependencies -o out/
 
 VSIX_SRC=$(ls out/*.vsix | head -n 1)
 test -f "${VSIX_SRC}" || { echo "ERROR: no .vsix produced under out/"; exit 1; }

--- a/recipes/bmad-dashboard/recipe.yaml
+++ b/recipes/bmad-dashboard/recipe.yaml
@@ -1,0 +1,79 @@
+schema_version: 1
+
+context:
+  version: "1.2.2.dev0"
+  commit: "33b330ef113c62f58a77413a241ca30f4f0b8a99"
+  python_min: "3.9"
+
+package:
+  name: bmad-dashboard
+  version: ${{ version }}
+
+source:
+  url: https://github.com/bmad-code-org/bmad-method-ui/archive/${{ commit }}.tar.gz
+  sha256: f3ffbe4fcad86f76a291e56300e47a24ac631daf7933379555f1e92893e1a9ad
+
+build:
+  noarch: python
+  number: 0
+  script: bash ${{ RECIPE_DIR }}/build.sh
+  python:
+    entry_points:
+      - bmad-dashboard-install = bmad_dashboard.installer:main
+
+requirements:
+  build:
+    - nodejs >=22
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - bmad_dashboard
+      python_version: ${{ python_min }}.*
+      pip_check: true
+  - script:
+      - bmad-dashboard-install --print-vsix
+      - bmad-dashboard-install --help
+
+about:
+  summary: BMAD Dashboard, a VS Code extension for BMad Method V6 projects
+  description: |
+    BMAD Dashboard is a VS Code extension that monitors BMad Method V6
+    workflow artifacts in real time, tracks sprint progress, and
+    recommends the next action to take, all from inside the editor.
+
+    This conda package bundles the prebuilt .vsix produced from the
+    upstream sources and exposes a `bmad-dashboard-install` command
+    that installs the extension into the user's local VS Code (or VS
+    Code Insiders, VSCodium, or code-server) using the editor's CLI.
+
+    The package does not require VS Code at install time. Run
+    `bmad-dashboard-install` after install to wire the extension into
+    your editor, `bmad-dashboard-install --list` to confirm, and
+    `bmad-dashboard-install --uninstall` to remove it.
+  homepage: https://github.com/bmad-code-org/bmad-method-ui
+  repository: https://github.com/bmad-code-org/bmad-method-ui
+  documentation: https://github.com/bmad-code-org/bmad-method-ui#readme
+  license: MIT
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny
+  upstream:
+    type: snapshot
+    commit: 33b330ef113c62f58a77413a241ca30f4f0b8a99
+    date: 2026-05-23
+    note: |
+      No upstream git tag exists yet; this recipe pins the GitHub
+      tarball by commit SHA. The package version 1.2.2.dev0 reflects
+      the version declared in upstream package.json with a PEP 440
+      .dev0 suffix to mark this as a pre-release snapshot.

--- a/recipes/bmad-dashboard/recipe.yaml
+++ b/recipes/bmad-dashboard/recipe.yaml
@@ -39,8 +39,8 @@ tests:
       python_version: ${{ python_min }}.*
       pip_check: true
   - script:
-      - bmad-dashboard-install --print-vsix
-      - bmad-dashboard-install --help
+      - python -m bmad_dashboard.installer --print-vsix
+      - python -m bmad_dashboard.installer --help
 
 about:
   summary: BMAD Dashboard, a VS Code extension for BMad Method V6 projects

--- a/recipes/bmad-dashboard/wrapper/README.md
+++ b/recipes/bmad-dashboard/wrapper/README.md
@@ -1,0 +1,16 @@
+# bmad-dashboard
+
+Conda package that bundles the prebuilt
+[BMAD Dashboard](https://github.com/bmad-code-org/bmad-method-ui)
+VS Code extension and provides a CLI to install it into a local
+VS Code (or Insiders, VSCodium, code-server) instance.
+
+## Usage
+
+```
+bmad-dashboard-install              # install into the first detected VS Code variant
+bmad-dashboard-install --list       # show installed extensions in that editor
+bmad-dashboard-install --editor code-insiders
+bmad-dashboard-install --uninstall  # remove the extension
+bmad-dashboard-install --print-vsix # print the bundled .vsix path
+```

--- a/recipes/bmad-dashboard/wrapper/pyproject.toml
+++ b/recipes/bmad-dashboard/wrapper/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bmad-dashboard"
+version = "1.2.2.dev0"
+description = "BMAD Dashboard VS Code extension, packaged for conda"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+authors = [
+    {name = "BMAD Code"},
+]
+keywords = ["vscode", "bmad", "dashboard", "conda"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Plugins",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development",
+]
+
+[project.scripts]
+bmad-dashboard-install = "bmad_dashboard.installer:main"
+
+[project.urls]
+Homepage = "https://github.com/bmad-code-org/bmad-method-ui"
+Repository = "https://github.com/bmad-code-org/bmad-method-ui"
+Issues = "https://github.com/bmad-code-org/bmad-method-ui/issues"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+bmad_dashboard = ["data/*.vsix"]

--- a/recipes/bmad-dashboard/wrapper/src/bmad_dashboard/__init__.py
+++ b/recipes/bmad-dashboard/wrapper/src/bmad_dashboard/__init__.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 __version__ = "1.2.2.dev0"
 
-EXTENSION_ID = "elvince.bmad-dashboard"
-"""The canonical <publisher>.<name> identifier used by VS Code."""
+EXTENSION_ID = "bmad-code-org.bmad-method-ui"
+"""The canonical <publisher>.<name> identifier used by VS Code.
+
+Note: upstream's package.json at the pinned commit still self-IDs as
+``elvince/bmad-dashboard-extension``; recipes/bmad-dashboard/build.sh rewrites
+those fields before ``vsce package`` so the built .vsix carries the correct
+bmad-code-org identity. Keep this ID in sync with that rewrite step."""
 
 UPSTREAM_COMMIT = "33b330ef113c62f58a77413a241ca30f4f0b8a99"
 """GitHub commit on bmad-code-org/bmad-method-ui this build was cut from."""

--- a/recipes/bmad-dashboard/wrapper/src/bmad_dashboard/__init__.py
+++ b/recipes/bmad-dashboard/wrapper/src/bmad_dashboard/__init__.py
@@ -1,0 +1,11 @@
+"""BMAD Dashboard VS Code extension, packaged for conda."""
+
+from __future__ import annotations
+
+__version__ = "1.2.2.dev0"
+
+EXTENSION_ID = "elvince.bmad-dashboard"
+"""The canonical <publisher>.<name> identifier used by VS Code."""
+
+UPSTREAM_COMMIT = "33b330ef113c62f58a77413a241ca30f4f0b8a99"
+"""GitHub commit on bmad-code-org/bmad-method-ui this build was cut from."""

--- a/recipes/bmad-dashboard/wrapper/src/bmad_dashboard/installer.py
+++ b/recipes/bmad-dashboard/wrapper/src/bmad_dashboard/installer.py
@@ -1,0 +1,169 @@
+"""CLI entry point that installs the bundled .vsix into a local VS Code.
+
+The conda package ships a single .vsix under ``bmad_dashboard.data``.  This
+module locates that file, finds a VS Code variant on ``PATH``, and shells out
+to ``<editor> --install-extension <vsix>``.  No VS Code is required at conda
+install time; the user runs ``bmad-dashboard-install`` once after install to
+wire the extension into their editor.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from importlib.resources import files
+from pathlib import Path
+from typing import Iterable
+
+from . import EXTENSION_ID
+
+DEFAULT_EDITORS: tuple[str, ...] = (
+    "code",
+    "code-insiders",
+    "codium",
+    "vscodium",
+    "code-server",
+)
+
+
+def _bundled_vsix() -> Path:
+    data_dir = files(__package__) / "data"
+    candidates = [
+        Path(str(entry))
+        for entry in data_dir.iterdir()
+        if entry.name.endswith(".vsix")
+    ]
+    if not candidates:
+        raise FileNotFoundError(
+            f"No .vsix found in {data_dir}. The conda package is malformed; "
+            "please reinstall."
+        )
+    candidates.sort()
+    return candidates[-1]
+
+
+def _resolve_editor(preferred: str | None) -> str:
+    if preferred:
+        path = shutil.which(preferred)
+        if path:
+            return path
+        raise FileNotFoundError(
+            f"Requested editor {preferred!r} is not on PATH. Pass --editor-path "
+            "with the absolute path to the CLI, or install the editor's shell "
+            "command (in VS Code: Command Palette -> 'Shell Command: Install "
+            "code command in PATH')."
+        )
+    for cmd in DEFAULT_EDITORS:
+        path = shutil.which(cmd)
+        if path:
+            return path
+    raise FileNotFoundError(
+        "No VS Code CLI found on PATH. Tried: "
+        + ", ".join(DEFAULT_EDITORS)
+        + ". Install VS Code and ensure its shell command is on PATH, or pass "
+        "--editor / --editor-path explicitly."
+    )
+
+
+def _run(cmd: Iterable[str]) -> int:
+    cmd_list = list(cmd)
+    print("$ " + " ".join(cmd_list), flush=True)
+    return subprocess.call(cmd_list)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bmad-dashboard-install",
+        description=(
+            "Install the bundled BMAD Dashboard VS Code extension into a "
+            "local VS Code (or Insiders, VSCodium, code-server) instance."
+        ),
+    )
+    parser.add_argument(
+        "--editor",
+        help=(
+            "Name of the VS Code CLI to use (looked up on PATH). "
+            "Default: auto-detect among "
+            + ", ".join(DEFAULT_EDITORS)
+            + "."
+        ),
+    )
+    parser.add_argument(
+        "--editor-path",
+        help="Absolute path to the VS Code CLI. Overrides --editor.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List installed extensions in the detected editor and exit.",
+    )
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help=f"Uninstall {EXTENSION_ID} from the detected editor and exit.",
+    )
+    parser.add_argument(
+        "--print-vsix",
+        action="store_true",
+        help="Print the bundled .vsix path and exit. Does not require an editor.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        default=True,
+        help="Pass --force to the editor (default: on; the .vsix is reinstalled "
+        "even when an equal or newer version is already present).",
+    )
+    parser.add_argument(
+        "--no-force",
+        dest="force",
+        action="store_false",
+        help="Do not pass --force; the editor will skip if the extension is "
+        "already installed at an equal or newer version.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    vsix = _bundled_vsix()
+
+    if args.print_vsix:
+        print(vsix)
+        return 0
+
+    if args.editor_path:
+        editor = args.editor_path
+        if not Path(editor).is_file():
+            print(
+                f"ERROR: --editor-path {editor!r} does not exist or is not a file.",
+                file=sys.stderr,
+            )
+            return 2
+    else:
+        editor = _resolve_editor(args.editor)
+
+    if args.list:
+        return _run([editor, "--list-extensions", "--show-versions"])
+
+    if args.uninstall:
+        return _run([editor, "--uninstall-extension", EXTENSION_ID])
+
+    cmd = [editor, "--install-extension", str(vsix)]
+    if args.force:
+        cmd.append("--force")
+    rc = _run(cmd)
+    if rc == 0:
+        print(
+            f"\nInstalled {EXTENSION_ID} from {vsix.name}. Reload the editor "
+            "window or restart VS Code to activate the extension.",
+            flush=True,
+        )
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipes/mybmad-dashboard/build.sh
+++ b/recipes/mybmad-dashboard/build.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Build the MyBMAD Dashboard (web/) as a conda package.
+#
+# Strategy (mirrors recipes/bmad-dashboard/build.sh, adapted for a Next.js
+# server app instead of a VS Code extension):
+#   1. Provision pnpm (upstream's package manager) via corepack, keeping all
+#      caches OUT of $SRC_DIR and $PREFIX.
+#   2. `pnpm install` + `prisma generate` + `next build` in web/ to produce the
+#      Next.js `standalone` server bundle (web/.next/standalone/server.js).
+#   3. Assemble a self-contained, symlink-free runner directory: the (possibly
+#      nested) standalone app root + static + public + the generated Prisma
+#      client/engine + the migration SQL files. Migrations are applied at
+#      runtime with psql, so the Prisma CLI is NOT shipped.
+#   4. Stage that runner dir as package-data inside a small Python wrapper that
+#      exposes the `mybmad` launcher CLI (wrapper sources live under
+#      $RECIPE_DIR/wrapper/).
+#   5. Pip-install the wrapper so conda-build picks up the entry point.
+#
+# NOTE: the upstream source is NOT patched. All conda-specific behavior lives
+# in the wrapper. This keeps the recipe faithful to upstream across bumps.
+set -euo pipefail
+
+echo ">> environment"
+echo "    node:  $(node --version)"
+echo "    npm:   $(npm --version)"
+
+# The web app is a subdirectory of the repo archive.
+WEB_DIR="${SRC_DIR}/web"
+test -d "${WEB_DIR}" || { echo "ERROR: ${WEB_DIR} not found in source archive"; exit 1; }
+
+# Keep package-manager caches OUT of $SRC_DIR (so they don't get packaged) and
+# OUT of $PREFIX (rattler-build rejects stray symlinks).
+CACHE_ROOT="$(dirname "${SRC_DIR}")/_pkg_caches"
+mkdir -p "${CACHE_ROOT}/npm" "${CACHE_ROOT}/pnpm-cli" "${CACHE_ROOT}/corepack" \
+         "${CACHE_ROOT}/pnpm-store" "${CACHE_ROOT}/pnpm-state" \
+         "${CACHE_ROOT}/xdg_data"
+
+# pnpm version: prefer the `packageManager` field in web/package.json; fall back
+# to a known-good pin. (Upstream web/ pins pnpm via packageManager / lockfile.)
+PNPM_VERSION="$("${PYTHON}" - "${WEB_DIR}/package.json" <<'PY'
+import json, sys
+pj = json.load(open(sys.argv[1]))
+pm = pj.get("packageManager", "")
+# format: "pnpm@10.28.1" -> 10.28.1 ; default if absent
+print(pm.split("@", 1)[1] if pm.startswith("pnpm@") else "10.28.1")
+PY
+)"
+echo ">> pnpm version: ${PNPM_VERSION}"
+
+if command -v corepack >/dev/null 2>&1; then
+    echo ">> activating pnpm ${PNPM_VERSION} via corepack"
+    export COREPACK_HOME="${CACHE_ROOT}/corepack"
+    corepack enable --install-directory "${CACHE_ROOT}/pnpm-cli"
+    corepack prepare "pnpm@${PNPM_VERSION}" --activate
+    export PATH="${CACHE_ROOT}/pnpm-cli:${PATH}"
+else
+    echo ">> corepack not found, installing pnpm via npm"
+    npm install -g --prefix "${CACHE_ROOT}/pnpm-cli" "pnpm@${PNPM_VERSION}"
+    export PATH="${CACHE_ROOT}/pnpm-cli/bin:${PATH}"
+fi
+echo "    pnpm:  $(pnpm --version)"
+
+# Relocate pnpm store/state onto the same filesystem as $SRC_DIR.
+export npm_config_cache="${CACHE_ROOT}/npm"
+export XDG_DATA_HOME="${CACHE_ROOT}/xdg_data"
+export XDG_STATE_HOME="${CACHE_ROOT}/pnpm-state"
+
+cd "${WEB_DIR}"
+
+# Force a FLAT (hoisted) node_modules. pnpm's default "isolated" linker builds
+# a symlink farm (node_modules/<pkg> -> .pnpm/...), which Next.js preserves as
+# symlinks in the standalone bundle. Those break two ways: rattler-build
+# rejects packages containing symlinks, and naively dereferencing them loses
+# pnpm's sibling-resolution topology (next can't find styled-jsx, etc.). The
+# hoisted linker lays out real, npm-style top-level packages -> the standalone
+# bundle is symlink-free and relocatable.
+export npm_config_node_linker=hoisted
+
+echo ">> installing node dependencies (web/, hoisted node-linker)"
+pnpm install --frozen-lockfile --node-linker=hoisted
+
+# `prisma generate` needs SOME DATABASE_URL even though it doesn't connect.
+# web/prisma.config.ts already supplies a placeholder for the `generate`
+# command, but export one anyway to be safe across prisma versions.
+export DATABASE_URL="postgresql://placeholder:placeholder@localhost:5432/placeholder"
+export BETTER_AUTH_SECRET="build-time-placeholder-not-used-at-runtime"
+export BETTER_AUTH_URL="http://localhost:3002"
+
+echo ">> generating Prisma client"
+pnpm db:generate
+
+echo ">> building Next.js standalone bundle"
+pnpm build
+
+# Locate server.js dynamically. Next.js infers the workspace root by walking up
+# for lockfiles; because the repo root carries its own pnpm-lock.yaml (the VS
+# Code extension), Next selects $SRC_DIR as the root and NESTS the standalone
+# output under .next/standalone/web/server.js (rather than .../server.js). This
+# detection handles both the nested and flat layouts.
+SERVER_JS="$(find .next/standalone -maxdepth 4 -name server.js | head -1)"
+test -n "${SERVER_JS}" || {
+  echo "ERROR: no server.js under .next/standalone. Is output:'standalone' set?";
+  exit 1; }
+APPSRC="$(dirname "${SERVER_JS}")"
+echo "    standalone app root: ${APPSRC}"
+
+echo ">> staging Python wrapper"
+WRAP="${SRC_DIR}/_pywrap"
+rm -rf "${WRAP}"
+mkdir -p "${WRAP}"
+cp -r "${RECIPE_DIR}/wrapper/." "${WRAP}/"
+cp "${WEB_DIR}/LICENSE" "${WRAP}/LICENSE"
+
+# ---------------------------------------------------------------------------
+# Assemble the runner dir, mirroring upstream Dockerfile's `runner` stage.
+# ---------------------------------------------------------------------------
+APP="${WRAP}/src/mybmad_dashboard/app"
+rm -rf "${APP}"
+mkdir -p "${APP}"
+
+echo ">> assembling standalone runner into ${APP}"
+# rattler-build rejects packages containing symlinks. The hoisted build leaves
+# exactly one relative symlink in the standalone tree: the Prisma client alias
+#   .next/node_modules/@prisma/client-<hash> -> ../../../../web/node_modules/@prisma/client
+# The turbopack server runtime imports this alias to load the Prisma engine, so
+# it MUST survive. Its relative target only resolves in place, so dereference it
+# HERE — before the flatten move below — otherwise the move breaks the target
+# and the alias would be dropped, breaking every DB query at runtime. Genuinely
+# dangling links (none expected with the hoisted linker) are removed.
+find "${APPSRC}" -type l | while IFS= read -r link; do
+  if [ -e "${link}" ]; then
+    cp -RL "${link}" "${link}.deref" && rm "${link}" && mv "${link}.deref" "${link}"
+  else
+    rm -f "${link}"
+  fi
+done
+
+# Flatten: the standalone app root (APPSRC, possibly .../standalone/web) becomes
+# the package's app root, so the launcher always finds app/server.js. With the
+# hoisted node-linker the traced node_modules are real files, so a plain copy
+# preserves runtime module resolution.
+# 1. standalone server (server.js + real node_modules + .next/server)
+cp -R "${APPSRC}/." "${APP}/"
+# 2. static assets and public (not traced into standalone)
+mkdir -p "${APP}/.next"
+cp -R .next/static "${APP}/.next/static"
+[ -d public ] && cp -R public "${APP}/public"
+# 3. generated Prisma client + native query engine (Dockerfile copies this
+#    explicitly; the custom output path src/generated/prisma — including
+#    libquery_engine-<platform>.node — is what makes this package arch-specific).
+mkdir -p "${APP}/src"
+rm -rf "${APP}/src/generated"
+cp -R src/generated "${APP}/src/generated"
+# 4. Migration SQL only. The launcher applies these with psql at runtime via a
+#    small tracking table, so the Prisma CLI/engines are NOT shipped (they live
+#    behind pnpm symlinks and aren't needed once migrations are plain SQL).
+mkdir -p "${APP}/prisma"
+cp -R prisma/migrations "${APP}/prisma/migrations"
+
+# Assert the assembled tree is symlink-free (symlinks were dereferenced at the
+# source above). rattler-build rejects packages containing symlinks.
+REMAINING_LINKS="$(find "${APP}" -type l | wc -l | tr -d ' ')"
+test "${REMAINING_LINKS}" = "0" || {
+  echo "ERROR: ${REMAINING_LINKS} symlink(s) remain in ${APP}"; exit 1; }
+
+echo ">> pip install wrapper"
+cd "${WRAP}"
+${PYTHON} -m pip install . --no-deps --no-build-isolation -vv
+
+echo ">> done"

--- a/recipes/mybmad-dashboard/recipe.yaml
+++ b/recipes/mybmad-dashboard/recipe.yaml
@@ -53,6 +53,15 @@ build:
   # via Linux Docker. Revisit with a build.bat + Windows pg handling if needed.
   skip:
     - win
+  # The package ships a self-contained vendored Node runtime: the Next.js
+  # standalone server, the prebuilt Prisma query engine, and sharp's prebuilt
+  # libvips binaries. These are NOT conda-managed libraries. conda's macOS
+  # relinking (install_name_tool) hard-fails on sharp's dylib ("larger updated
+  # load commands do not fit") and is unnecessary for the rest: the Prisma
+  # engine is loaded via an absolute PRISMA_QUERY_ENGINE_LIBRARY path, and
+  # sharp's libs resolve via @loader_path inside the bundle. Disable relocation.
+  dynamic_linking:
+    binary_relocation: false
   script: bash ${{ RECIPE_DIR }}/build.sh
 
 requirements:

--- a/recipes/mybmad-dashboard/recipe.yaml
+++ b/recipes/mybmad-dashboard/recipe.yaml
@@ -27,7 +27,6 @@ context:
   # TODO(upstream-release): replace this pinned commit with the git tag that
   # upstream cuts for the web app, and bump `version` to match.
   commit: "33b330ef113c62f58a77413a241ca30f4f0b8a99"
-  python_min: "3.9"
 
 package:
   name: mybmad-dashboard
@@ -41,23 +40,33 @@ source:
 
 build:
   number: 0
-  # Arch-specific (native Prisma engine in the bundle) -> no `noarch:`.
-  script: bash ${{ RECIPE_DIR }}/build.sh
+  # Arch-specific (the bundle ships the native Prisma query engine) -> NOT
+  # noarch. But the package's only Python content is the launcher wrapper, which
+  # is pure Python and version-agnostic, so build ONE artifact per platform
+  # instead of an identical heavy (pnpm + next build) rebuild per Python version.
   python:
+    version_independent: true
     entry_points:
       - mybmad = mybmad_dashboard.launcher:main
+  # Windows is not supported: build.sh is bash-only and the launcher drives a
+  # POSIX PostgreSQL lifecycle (pg_ctl, unix sockets). Upstream itself deploys
+  # via Linux Docker. Revisit with a build.bat + Windows pg handling if needed.
+  skip:
+    - win
+  script: bash ${{ RECIPE_DIR }}/build.sh
 
 requirements:
   build:
     # Node toolchain to run `pnpm install` + `next build` + `prisma generate`.
     - nodejs >=22
   host:
-    - python ${{ python_min }}.*
+    # Non-noarch package: python is unconstrained (the build variant pins it).
+    - python
     - pip
     - setuptools >=64
     - wheel
   run:
-    - python >=${{ python_min }}
+    - python
     # Runtime: the standalone server is plain Node; Postgres backs the app.
     - nodejs >=22
     - postgresql >=14

--- a/recipes/mybmad-dashboard/recipe.yaml
+++ b/recipes/mybmad-dashboard/recipe.yaml
@@ -1,0 +1,116 @@
+schema_version: 1
+
+# -----------------------------------------------------------------------------
+# MyBMAD Dashboard (the standalone Next.js web app under `web/` of the
+# bmad-method-ui repo) packaged as a conda app.
+#
+# This is the SIBLING recipe to `bmad-dashboard` (the VS Code extension). Where
+# that recipe ships a prebuilt .vsix and installs it into an editor, this one
+# builds the Next.js `standalone` server bundle and ships a `mybmad` launcher
+# that provisions a local PostgreSQL cluster and runs the app.
+#
+# DESIGN NOTE — "stay true to upstream":
+#   The upstream source is used UNMODIFIED. Everything conda-specific (the
+#   Postgres lifecycle, secret generation, the launcher CLI) lives in the
+#   Python wrapper under wrapper/, NOT as source patches. Upstream version
+#   bumps therefore only require: new commit/sha256 + a rebuild. No rebasing
+#   of patches.
+#
+# NOT noarch: the Prisma `classic` query engine is a per-platform native
+# binary, so the built bundle is architecture-specific.
+# -----------------------------------------------------------------------------
+
+context:
+  # web/package.json declares 0.1.0 with an "Unreleased" CHANGELOG, so this is
+  # a pre-release snapshot. PEP 440 .dev0 suffix marks it as such.
+  version: "0.1.0.dev0"
+  # TODO(upstream-release): replace this pinned commit with the git tag that
+  # upstream cuts for the web app, and bump `version` to match.
+  commit: "33b330ef113c62f58a77413a241ca30f4f0b8a99"
+  python_min: "3.9"
+
+package:
+  name: mybmad-dashboard
+  version: ${{ version }}
+
+source:
+  # Same repo archive as the bmad-dashboard recipe (same commit) -> identical
+  # sha256. The web app lives in the web/ subdirectory of this archive.
+  url: https://github.com/bmad-code-org/bmad-method-ui/archive/${{ commit }}.tar.gz
+  sha256: f3ffbe4fcad86f76a291e56300e47a24ac631daf7933379555f1e92893e1a9ad
+
+build:
+  number: 0
+  # Arch-specific (native Prisma engine in the bundle) -> no `noarch:`.
+  script: bash ${{ RECIPE_DIR }}/build.sh
+  python:
+    entry_points:
+      - mybmad = mybmad_dashboard.launcher:main
+
+requirements:
+  build:
+    # Node toolchain to run `pnpm install` + `next build` + `prisma generate`.
+    - nodejs >=22
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    # Runtime: the standalone server is plain Node; Postgres backs the app.
+    - nodejs >=22
+    - postgresql >=14
+
+tests:
+  - python:
+      imports:
+        - mybmad_dashboard
+      python_version: ${{ python_min }}.*
+      pip_check: true
+  - script:
+      # All DB-free, so they run in CI without a Postgres cluster.
+      - mybmad --help
+      - mybmad info --print-app-dir
+      - mybmad info --print-server-js
+
+about:
+  summary: MyBMAD Dashboard, a self-hosted web app for BMad Method V6 projects
+  description: |
+    MyBMAD Dashboard is a standalone Next.js web application that visualizes
+    and tracks BMad Method (Breakthrough Method of Agile AI-Driven Development)
+    projects from GitHub repositories or local folders. It shows epics, stories
+    (Kanban + table), sprint/velocity metrics, and a docs browser, with
+    multi-user auth (email/password + optional GitHub OAuth).
+
+    This conda package builds the upstream `web/` app into a Next.js standalone
+    server bundle and ships a `mybmad` launcher that:
+      * provisions and manages a local PostgreSQL cluster (via the bundled
+        `postgresql` dependency) in a per-user data directory,
+      * generates and persists application secrets on first run,
+      * applies database migrations, and
+      * starts the web server (default http://localhost:3002).
+
+    The upstream source is used unmodified; all conda-specific orchestration
+    lives in the launcher. Run `mybmad up` to start the dashboard,
+    `mybmad promote-admin --email you@example.com` to grant admin after you
+    register, and `mybmad stop` to stop the database.
+  homepage: https://github.com/bmad-code-org/bmad-method-ui/tree/main/web
+  repository: https://github.com/bmad-code-org/bmad-method-ui
+  documentation: https://github.com/bmad-code-org/bmad-method-ui/blob/main/web/README.md
+  license: MIT
+  license_file: web/LICENSE
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny
+  upstream:
+    type: snapshot
+    commit: 33b330ef113c62f58a77413a241ca30f4f0b8a99
+    date: 2026-05-23
+    note: |
+      No upstream git tag exists yet; this recipe pins the GitHub tarball by
+      commit SHA. The web app self-declares 0.1.0 (Unreleased), so the package
+      version carries a PEP 440 .dev0 suffix. Replace the pinned commit and
+      bump the version once upstream cuts a release/tag for the web app.

--- a/recipes/mybmad-dashboard/wrapper/MANIFEST.in
+++ b/recipes/mybmad-dashboard/wrapper/MANIFEST.in
@@ -1,0 +1,8 @@
+# Graft the entire built runner directory as package data.
+#
+# `graft` is used (instead of [tool.setuptools.package-data] globs) because the
+# bundle contains dotfile directories such as `.next/`, which setuptools'
+# default package-data globbing skips. graft + include-package-data=true keeps
+# every file, dotfiles included.
+graft src/mybmad_dashboard/app
+include LICENSE

--- a/recipes/mybmad-dashboard/wrapper/README.md
+++ b/recipes/mybmad-dashboard/wrapper/README.md
@@ -1,0 +1,47 @@
+# MyBMAD Dashboard (conda package)
+
+This package builds the upstream **MyBMAD Dashboard** web app (the `web/`
+directory of [bmad-method-ui](https://github.com/bmad-code-org/bmad-method-ui))
+into a Next.js standalone server bundle and ships a `mybmad` launcher that runs
+it with a self-managed local PostgreSQL database.
+
+The upstream source is used **unmodified** — all conda-specific orchestration
+(Postgres lifecycle, secret generation, migrations) lives in this wrapper.
+
+## Quick start
+
+```bash
+mybmad up              # start Postgres + apply migrations + run the web server
+```
+
+Then open <http://localhost:3002>, register an account, and (in another shell):
+
+```bash
+mybmad promote-admin --email you@example.com   # grant admin role
+mybmad stop                                    # stop the local database
+```
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `mybmad up` | Provision/start the local Postgres cluster, generate secrets on first run, apply migrations, then run the web server (foreground). Stops Postgres on exit. |
+| `mybmad stop` | Stop the launcher-managed Postgres cluster. |
+| `mybmad migrate` | Apply pending database migrations and exit. |
+| `mybmad promote-admin --email <e>` | Set a registered user's role to `admin`. |
+| `mybmad info` | Print resolved paths, data dir, ports, and env. |
+
+## Configuration (environment variables)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `MYBMAD_HOME` | `~/.local/share/mybmad` (XDG) | Data dir: Postgres cluster, logs, secrets. |
+| `MYBMAD_PORT` | `3002` | Web server port. |
+| `MYBMAD_DB_PORT` | `54329` | Local Postgres port. |
+| `MYBMAD_ENABLE_LOCAL_FS` | `true` | Allow importing BMAD projects from local folders. |
+| `MYBMAD_ALLOW_REGISTRATION` | `true` | Allow self-registration (turn off after creating your account). |
+| `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | unset | Optional GitHub OAuth login. |
+| `GITHUB_PAT` | unset | Optional GitHub token to raise API rate limits. |
+
+Secrets (`BETTER_AUTH_SECRET`, `REVALIDATE_SECRET`) are generated once and
+persisted in `$MYBMAD_HOME/config.json`.

--- a/recipes/mybmad-dashboard/wrapper/pyproject.toml
+++ b/recipes/mybmad-dashboard/wrapper/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mybmad-dashboard"
+version = "0.1.0.dev0"
+description = "MyBMAD Dashboard (BMad Method V6 web app), packaged for conda"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+authors = [
+    {name = "Hichem (DevHDI)"},
+]
+keywords = ["bmad", "dashboard", "nextjs", "conda", "web"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Web Environment",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development",
+]
+
+[project.scripts]
+mybmad = "mybmad_dashboard.launcher:main"
+
+[project.urls]
+Homepage = "https://github.com/bmad-code-org/bmad-method-ui/tree/main/web"
+Repository = "https://github.com/bmad-code-org/bmad-method-ui"
+Issues = "https://github.com/bmad-code-org/bmad-method-ui/issues"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+# Only the Python package — the bundled `app/` tree is data, pulled in via
+# MANIFEST.in (graft) so dotfiles like `.next/` are preserved.
+include = ["mybmad_dashboard*"]

--- a/recipes/mybmad-dashboard/wrapper/src/mybmad_dashboard/__init__.py
+++ b/recipes/mybmad-dashboard/wrapper/src/mybmad_dashboard/__init__.py
@@ -1,0 +1,22 @@
+"""MyBMAD Dashboard — conda packaging wrapper.
+
+The conda package ships a prebuilt Next.js `standalone` server bundle under
+``mybmad_dashboard/app`` and exposes a ``mybmad`` launcher (see
+:mod:`mybmad_dashboard.launcher`) that provisions a local PostgreSQL cluster
+and runs the web app.
+"""
+
+from __future__ import annotations
+
+__version__ = "0.1.0.dev0"
+
+# Default web server port (upstream `next dev`/`next start` use 3002).
+DEFAULT_PORT = 3002
+
+# Default local PostgreSQL port for the launcher-managed cluster. Chosen to be
+# unlikely to collide with a system Postgres on 5432/5433.
+DEFAULT_DB_PORT = 54329
+
+# Database/user names for the launcher-managed cluster.
+DB_NAME = "bmad_dashboard"
+DB_USER = "bmad"

--- a/recipes/mybmad-dashboard/wrapper/src/mybmad_dashboard/launcher.py
+++ b/recipes/mybmad-dashboard/wrapper/src/mybmad_dashboard/launcher.py
@@ -1,0 +1,565 @@
+"""``mybmad`` launcher: run the MyBMAD Dashboard web app with a self-managed
+local PostgreSQL database.
+
+The conda package ships a prebuilt Next.js ``standalone`` server bundle under
+``mybmad_dashboard/app``. This module:
+
+  * resolves a per-user data directory (``$MYBMAD_HOME``),
+  * provisions/starts a local PostgreSQL cluster there (``initdb``/``pg_ctl``),
+  * generates and persists application secrets on first run,
+  * applies Prisma migrations (offline, using the bundled Prisma CLI),
+  * runs the web server (``node server.js``) in the foreground.
+
+It uses ONLY the Python standard library, plus the ``node`` and PostgreSQL
+binaries (``initdb``, ``pg_ctl``, ``createdb``, ``psql``) provided as conda
+runtime dependencies. The upstream source is not modified; this is pure glue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import atexit
+import json
+import os
+import secrets
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from importlib.resources import files
+from pathlib import Path
+
+from . import DB_NAME, DB_USER, DEFAULT_DB_PORT, DEFAULT_PORT
+
+# ---------------------------------------------------------------------------
+# Path / config resolution
+# ---------------------------------------------------------------------------
+
+
+def _app_dir() -> Path:
+    """Return the bundled Next.js standalone runner directory."""
+    app = Path(str(files(__package__) / "app"))
+    if not app.is_dir():
+        raise FileNotFoundError(
+            f"Bundled app not found at {app}. The conda package is malformed; "
+            "please reinstall."
+        )
+    return app
+
+
+def _server_js() -> Path:
+    server = _app_dir() / "server.js"
+    if not server.is_file():
+        raise FileNotFoundError(
+            f"server.js not found at {server}. The standalone bundle is "
+            "incomplete; please reinstall."
+        )
+    return server
+
+
+def _query_engine() -> Path | None:
+    """Locate the bundled Prisma native query engine library.
+
+    The filename is platform-specific (libquery_engine-<target>.{dylib.,so.,}node);
+    exactly one is bundled — the build platform's — so glob and return it.
+    """
+    gen = _app_dir() / "src" / "generated" / "prisma"
+    if not gen.is_dir():
+        return None
+    libs = sorted(gen.glob("libquery_engine-*.node"))
+    return libs[0] if libs else None
+
+
+def _data_dir() -> Path:
+    """Per-user data directory for the Postgres cluster, logs, and secrets."""
+    override = os.environ.get("MYBMAD_HOME")
+    if override:
+        base = Path(override).expanduser()
+    elif sys.platform.startswith("win"):
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local")) / "mybmad"
+    else:
+        xdg = os.environ.get("XDG_DATA_HOME")
+        base = (Path(xdg) if xdg else Path.home() / ".local" / "share") / "mybmad"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _pgdata(data_dir: Path) -> Path:
+    return data_dir / "pgdata"
+
+
+def _pg_log(data_dir: Path) -> Path:
+    return data_dir / "postgres.log"
+
+
+def _config_path(data_dir: Path) -> Path:
+    return data_dir / "config.json"
+
+
+def _load_or_init_config(data_dir: Path) -> dict:
+    """Load persisted secrets, generating them on first run."""
+    path = _config_path(data_dir)
+    if path.is_file():
+        cfg = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        cfg = {}
+    changed = False
+    if not cfg.get("better_auth_secret"):
+        cfg["better_auth_secret"] = secrets.token_urlsafe(48)
+        changed = True
+    if not cfg.get("revalidate_secret"):
+        cfg["revalidate_secret"] = secrets.token_hex(32)
+        changed = True
+    if changed:
+        path.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass  # best effort on platforms without POSIX perms
+    return cfg
+
+
+def _port(env_var: str, default: int) -> int:
+    raw = os.environ.get(env_var)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise SystemExit(f"{env_var} must be an integer, got {raw!r}")
+
+
+def _bool_env(env_var: str, default: bool) -> bool:
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _which(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        raise SystemExit(
+            f"Required executable {name!r} not found on PATH. Ensure the conda "
+            "environment with `nodejs` and `postgresql` is active."
+        )
+    return path
+
+
+def _database_url(db_port: int) -> str:
+    # `initdb` below uses trust auth on localhost, so no password is needed.
+    return f"postgresql://{DB_USER}@127.0.0.1:{db_port}/{DB_NAME}"
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL lifecycle
+# ---------------------------------------------------------------------------
+
+
+def _run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    print("$ " + " ".join(cmd), flush=True)
+    return subprocess.run(cmd, **kwargs)
+
+
+def _pg_is_running(data_dir: Path) -> bool:
+    pg_ctl = shutil.which("pg_ctl")
+    if not pg_ctl:
+        return False
+    res = subprocess.run(
+        [pg_ctl, "-D", str(_pgdata(data_dir)), "status"],
+        capture_output=True,
+    )
+    return res.returncode == 0
+
+
+def _wait_for_pg(db_port: int, timeout: float = 30.0) -> None:
+    """Block until Postgres accepts TCP connections on db_port."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(1.0)
+            if s.connect_ex(("127.0.0.1", db_port)) == 0:
+                return
+        time.sleep(0.5)
+    raise SystemExit(
+        f"PostgreSQL did not become ready on port {db_port} within {timeout:.0f}s. "
+        f"Check the log at {_pg_log(_data_dir())}."
+    )
+
+
+def _ensure_pg_initialized(data_dir: Path) -> None:
+    pgdata = _pgdata(data_dir)
+    if (pgdata / "PG_VERSION").is_file():
+        return
+    initdb = _which("initdb")
+    print(f">> initializing PostgreSQL cluster at {pgdata}", flush=True)
+    pgdata.mkdir(parents=True, exist_ok=True)
+    # `trust` auth: only this local user can reach 127.0.0.1; no password to
+    # manage. The cluster lives in the user's private data dir.
+    res = _run(
+        [initdb, "-D", str(pgdata), "-U", DB_USER, "--auth=trust", "--encoding=UTF8"],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout + res.stderr)
+        raise SystemExit("initdb failed.")
+
+
+def _start_pg(data_dir: Path, db_port: int) -> None:
+    if _pg_is_running(data_dir):
+        print(">> PostgreSQL already running", flush=True)
+        return
+    pg_ctl = _which("pg_ctl")
+    pgdata = _pgdata(data_dir)
+    log = _pg_log(data_dir)
+    print(f">> starting PostgreSQL on port {db_port}", flush=True)
+    # -k '' disables the unix socket dir default oddities; bind localhost only.
+    res = _run(
+        [
+            pg_ctl,
+            "-D", str(pgdata),
+            "-l", str(log),
+            "-o", f"-p {db_port} -c listen_addresses=127.0.0.1",
+            "-w",  # wait for startup
+            "start",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout + res.stderr)
+        raise SystemExit(f"pg_ctl start failed. See log: {log}")
+    _wait_for_pg(db_port)
+
+
+def _stop_pg(data_dir: Path) -> None:
+    if not _pg_is_running(data_dir):
+        return
+    pg_ctl = _which("pg_ctl")
+    print(">> stopping PostgreSQL", flush=True)
+    _run(
+        [pg_ctl, "-D", str(_pgdata(data_dir)), "-m", "fast", "-w", "stop"],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _ensure_database(db_port: int) -> None:
+    """Create the application database if it does not exist."""
+    psql = _which("psql")
+    check = subprocess.run(
+        [
+            psql, "-h", "127.0.0.1", "-p", str(db_port), "-U", DB_USER,
+            "-d", "postgres", "-tAc",
+            f"SELECT 1 FROM pg_database WHERE datname='{DB_NAME}'",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if check.stdout.strip() == "1":
+        return
+    createdb = _which("createdb")
+    print(f">> creating database {DB_NAME}", flush=True)
+    res = _run(
+        [createdb, "-h", "127.0.0.1", "-p", str(db_port), "-U", DB_USER, DB_NAME],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout + res.stderr)
+        raise SystemExit("createdb failed.")
+
+
+# ---------------------------------------------------------------------------
+# Migrations (psql, no Prisma CLI/engine at runtime)
+# ---------------------------------------------------------------------------
+#
+# Upstream's prisma/migrations/<name>/migration.sql files are plain PostgreSQL
+# DDL. We apply them with psql, tracking applied migrations in a small table so
+# re-runs are idempotent. This avoids shipping the Prisma CLI + native engines
+# (which live behind pnpm symlinks and would otherwise need a network download).
+
+_MIGRATIONS_TABLE = "_mybmad_migrations"
+
+
+def _migrations_dir() -> Path:
+    d = _app_dir() / "prisma" / "migrations"
+    if not d.is_dir():
+        raise FileNotFoundError(
+            f"Migrations not found at {d}. The package is malformed; reinstall."
+        )
+    return d
+
+
+def _psql_base(db_port: int) -> list[str]:
+    return [
+        _which("psql"),
+        "-h", "127.0.0.1",
+        "-p", str(db_port),
+        "-U", DB_USER,
+        "-d", DB_NAME,
+        "-v", "ON_ERROR_STOP=1",
+    ]
+
+
+def _apply_migrations(db_port: int) -> None:
+    base = _psql_base(db_port)
+
+    # Ensure the tracking table exists.
+    res = subprocess.run(
+        base + ["-c", (
+            f"CREATE TABLE IF NOT EXISTS {_MIGRATIONS_TABLE} "
+            "(name text PRIMARY KEY, applied_at timestamptz NOT NULL DEFAULT now())"
+        )],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout + res.stderr)
+        raise SystemExit("Failed to create migration tracking table.")
+
+    # Which migrations are already applied?
+    res = subprocess.run(
+        base + ["-tAc", f"SELECT name FROM {_MIGRATIONS_TABLE}"],
+        capture_output=True, text=True,
+    )
+    applied = {line.strip() for line in res.stdout.splitlines() if line.strip()}
+
+    mig_dir = _migrations_dir()
+    names = sorted(p.name for p in mig_dir.iterdir() if p.is_dir())
+    pending = [n for n in names if n not in applied]
+    if not pending:
+        print(">> database schema up to date", flush=True)
+        return
+
+    for name in pending:
+        sql_file = mig_dir / name / "migration.sql"
+        if not sql_file.is_file():
+            continue
+        print(f">> applying migration {name}", flush=True)
+        # Run the migration and record it atomically in one transaction.
+        script = (
+            "BEGIN;\n"
+            f"\\i {sql_file}\n"
+            f"INSERT INTO {_MIGRATIONS_TABLE}(name) VALUES ('{name}');\n"
+            "COMMIT;\n"
+        )
+        res = subprocess.run(base, input=script, text=True)
+        if res.returncode != 0:
+            raise SystemExit(f"Migration {name} failed.")
+
+
+# ---------------------------------------------------------------------------
+# Web server
+# ---------------------------------------------------------------------------
+
+
+def _server_env(data_dir: Path, web_port: int, db_port: int) -> dict:
+    cfg = _load_or_init_config(data_dir)
+    env = os.environ.copy()
+    env.update(
+        {
+            "NODE_ENV": "production",
+            "NEXT_TELEMETRY_DISABLED": "1",
+            "PORT": str(web_port),
+            "HOSTNAME": os.environ.get("MYBMAD_HOSTNAME", "127.0.0.1"),
+            "DATABASE_URL": _database_url(db_port),
+            "BETTER_AUTH_SECRET": cfg["better_auth_secret"],
+            "BETTER_AUTH_URL": os.environ.get(
+                "MYBMAD_BETTER_AUTH_URL", f"http://localhost:{web_port}"
+            ),
+            "REVALIDATE_SECRET": cfg["revalidate_secret"],
+            # Local self-host: enable local-folder import by default (the
+            # primary "develop projects on this machine" use case).
+            "ENABLE_LOCAL_FS": "true" if _bool_env("MYBMAD_ENABLE_LOCAL_FS", True) else "false",
+            "ALLOW_REGISTRATION": "true" if _bool_env("MYBMAD_ALLOW_REGISTRATION", True) else "false",
+        }
+    )
+    # Point Prisma directly at the bundled native query engine. Flattening the
+    # standalone bundle (removing the upstream `web/` nesting level) breaks
+    # Prisma's relative engine auto-discovery, so it would otherwise search the
+    # wrong paths ("Query Engine for runtime ... could not be located"). This
+    # override is authoritative and platform-agnostic.
+    engine = _query_engine()
+    if engine:
+        env["PRISMA_QUERY_ENGINE_LIBRARY"] = str(engine)
+
+    # Pass through optional GitHub OAuth / PAT if the user set them.
+    for key in ("GITHUB_CLIENT_ID", "GITHUB_CLIENT_SECRET", "GITHUB_PAT"):
+        if os.environ.get(key):
+            env[key] = os.environ[key]
+    return env
+
+
+def _start_server(data_dir: Path, web_port: int, db_port: int) -> int:
+    node = _which("node")
+    app = _app_dir()
+    env = _server_env(data_dir, web_port, db_port)
+    print(
+        f">> starting MyBMAD Dashboard at http://localhost:{web_port}\n"
+        f"   (data dir: {data_dir})\n"
+        f"   Press Ctrl+C to stop.",
+        flush=True,
+    )
+    proc = subprocess.Popen([node, str(_server_js())], cwd=str(app), env=env)
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def cmd_up(args: argparse.Namespace) -> int:
+    data_dir = _data_dir()
+    web_port = _port("MYBMAD_PORT", args.port or DEFAULT_PORT)
+    db_port = _port("MYBMAD_DB_PORT", args.db_port or DEFAULT_DB_PORT)
+
+    _ensure_pg_initialized(data_dir)
+    _start_pg(data_dir, db_port)
+    if not args.keep_db_running:
+        atexit.register(_stop_pg, data_dir)
+    _ensure_database(db_port)
+    _apply_migrations(db_port)
+    return _start_server(data_dir, web_port, db_port)
+
+
+def cmd_stop(_args: argparse.Namespace) -> int:
+    _stop_pg(_data_dir())
+    return 0
+
+
+def cmd_migrate(args: argparse.Namespace) -> int:
+    data_dir = _data_dir()
+    db_port = _port("MYBMAD_DB_PORT", args.db_port or DEFAULT_DB_PORT)
+    _ensure_pg_initialized(data_dir)
+    _start_pg(data_dir, db_port)
+    _ensure_database(db_port)
+    _apply_migrations(db_port)
+    return 0
+
+
+def cmd_promote_admin(args: argparse.Namespace) -> int:
+    """Set a registered user's role to admin via a plain SQL update.
+
+    `role` is a plain column (no password hashing involved), so a direct SQL
+    UPDATE is safe and avoids shipping the upstream tsx create-admin script.
+    Register the account first via the web UI, then run this.
+    """
+    data_dir = _data_dir()
+    db_port = _port("MYBMAD_DB_PORT", args.db_port or DEFAULT_DB_PORT)
+    _start_pg(data_dir, db_port)
+    psql = _which("psql")
+    email = args.email.replace("'", "''")  # minimal SQL-literal escaping
+    res = _run(
+        [
+            psql, "-h", "127.0.0.1", "-p", str(db_port), "-U", DB_USER,
+            "-d", DB_NAME, "-tAc",
+            f"UPDATE users SET role='admin' WHERE email='{email}' RETURNING email",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout + res.stderr)
+        return 1
+    if res.stdout.strip():
+        print(f">> {res.stdout.strip()} is now an admin.", flush=True)
+        return 0
+    print(
+        f">> No user with email {args.email!r} found. Register at the web UI "
+        "first, then re-run.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_info(args: argparse.Namespace) -> int:
+    data_dir = _data_dir()
+    web_port = _port("MYBMAD_PORT", DEFAULT_PORT)
+    db_port = _port("MYBMAD_DB_PORT", DEFAULT_DB_PORT)
+
+    if args.print_app_dir:
+        print(_app_dir())
+        return 0
+    if args.print_server_js:
+        print(_server_js())
+        return 0
+
+    print(f"app dir:       {_app_dir()}")
+    print(f"server.js:     {_server_js()}")
+    print(f"data dir:      {data_dir}")
+    print(f"pg data:       {_pgdata(data_dir)}")
+    print(f"pg log:        {_pg_log(data_dir)}")
+    print(f"web port:      {web_port}")
+    print(f"db port:       {db_port}")
+    print(f"database url:  {_database_url(db_port)}")
+    print(f"pg running:    {_pg_is_running(data_dir)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mybmad",
+        description=(
+            "Run the MyBMAD Dashboard web app with a self-managed local "
+            "PostgreSQL database."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p_up = sub.add_parser("up", help="Start the database and web server (default).")
+    p_up.add_argument("--port", type=int, help=f"Web server port (default {DEFAULT_PORT}).")
+    p_up.add_argument("--db-port", type=int, help=f"Local Postgres port (default {DEFAULT_DB_PORT}).")
+    p_up.add_argument(
+        "--keep-db-running",
+        action="store_true",
+        help="Leave PostgreSQL running after the web server exits.",
+    )
+    p_up.set_defaults(func=cmd_up)
+
+    p_stop = sub.add_parser("stop", help="Stop the managed PostgreSQL cluster.")
+    p_stop.set_defaults(func=cmd_stop)
+
+    p_mig = sub.add_parser("migrate", help="Apply database migrations and exit.")
+    p_mig.add_argument("--db-port", type=int)
+    p_mig.set_defaults(func=cmd_migrate)
+
+    p_adm = sub.add_parser("promote-admin", help="Grant admin role to a registered user.")
+    p_adm.add_argument("--email", required=True, help="Email of the user to promote.")
+    p_adm.add_argument("--db-port", type=int)
+    p_adm.set_defaults(func=cmd_promote_admin)
+
+    p_info = sub.add_parser("info", help="Print resolved paths and settings.")
+    p_info.add_argument("--print-app-dir", action="store_true", help="Print the bundled app dir and exit.")
+    p_info.add_argument("--print-server-js", action="store_true", help="Print server.js path and exit.")
+    p_info.set_defaults(func=cmd_info)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    # Default subcommand: `up`.
+    if not getattr(args, "command", None):
+        args = parser.parse_args(["up", *(argv or [])])
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Checklist

- [x] Title of this PR is meaningful.
- [x] License files are packaged (`about.license_file: LICENSE.md` for both recipes).
- [x] Source is from the official upstream (`github.com/bmad-code-org/bmad-method-ui`, commit `33b330e`).
- [x] Packages do not vendor other packages. Upstream npm dependencies are fetched via `pnpm install --frozen-lockfile` from the upstream lockfiles.
- [x] No static libraries are shipped.
- [x] Build numbers are 0.
- [x] Tarball URLs are used (`archive/<commit>.tar.gz` with sha256).
- [x] **Maintainer confirmed**: @mgorny has confirmed co-maintenance (see comment below).
- [x] Reviewed the [maintainer knowledge base](https://conda-forge.org/docs/maintainer/knowledge_base.html).

## Summary

This PR adds **two sibling recipes** from the same upstream repository (`bmad-code-org/bmad-method-ui`, commit `33b330e`):

| Recipe | Package | Description |
|---|---|---|
| `recipes/bmad-dashboard/` | `bmad-dashboard 1.2.2.dev0` | VS Code extension that monitors BMAD V6 workflow artifacts inside the editor (`noarch: python`) |
| `recipes/mybmad-dashboard/` | `mybmad-dashboard 0.1.0.dev0` | Standalone Next.js web app for visualizing BMAD Method projects (arch-specific, ships Prisma query engine) |

Both packages pin the same upstream commit. Neither has a tagged release yet (upstream semantic-release CI is unconfigured), so both carry PEP 440 `.dev0` suffixes. Follow-up version bumps will replace the commit pin with a tag URL once upstream cuts a release.

---

## `bmad-dashboard` — recipe architecture

This is unusual for conda-forge: a VS Code extension delivered through a conda package. The architecture:

1. `nodejs >=22` is pulled into the build environment, `corepack` activates `pnpm@10.26.2` (upstream's pinned `packageManager`).
2. `pnpm install --frozen-lockfile && pnpm build && pnpm vscode:package` produces `out/bmad-dashboard-1.2.2.vsix` (`vsce` is fetched via `npx` from the upstream `vscode:package` script).
3. A small Python wrapper (shipped under `recipes/bmad-dashboard/wrapper/`) is staged, the `.vsix` is dropped into `bmad_dashboard/data/`, and the wrapper is pip installed. This produces a `noarch: python` package with a single entry point: `bmad-dashboard-install`.
4. End users run `bmad-dashboard-install` after `conda install` to invoke `code --install-extension <bundled.vsix>` against their local VS Code (or Insiders, VSCodium, code-server). The conda package does not require VS Code to be present at install time.

---

## `mybmad-dashboard` — recipe architecture

The upstream `web/` Next.js app is built into a self-contained server bundle:

1. `nodejs >=22` + `corepack` activate `pnpm` (version from `web/package.json#packageManager`). A **hoisted** node-linker is forced (`--node-linker=hoisted`) so `pnpm install` lays out a flat, symlink-free `node_modules` — Next.js standalone output otherwise contains symlinks that rattler-build rejects.
2. `prisma generate` + `next build` (with `output: 'standalone'` in `next.config.ts`) produce `.next/standalone/server.js` plus the compiled Prisma query engine native binary (making this package arch-specific — not noarch).
3. The standalone server, static assets, generated Prisma client, and migration SQL files are assembled into a runner directory inside a Python wrapper (`recipes/mybmad-dashboard/wrapper/`). The Prisma CLI is not shipped; migrations are applied at runtime via `psql`.
4. The wrapper is pip-installed, exposing a `mybmad` entry point. Users run `mybmad up` to provision a local PostgreSQL cluster and start the web server at `http://localhost:3002`.

**Why a Python wrapper?** The upstream source is used **unmodified**; all conda-specific lifecycle code (PostgreSQL provisioning, secret generation, migration tracking) lives in the wrapper, not as source patches. Version bumps therefore only need a new commit SHA + sha256.

**Why not noarch?** The Prisma `classic` query engine is a per-platform native binary bundled in the standalone output.

**macOS note:** Binary relocation is disabled (`binary_relocation: false`) because `sharp`'s prebuilt `libvips` dylibs cause `install_name_tool` to fail ("larger updated load commands do not fit"). The Prisma engine loads via an absolute `PRISMA_QUERY_ENGINE_LIBRARY` path; `sharp`'s libs resolve via `@loader_path` inside the bundle — relocation is not needed.

---

## Why a commit pin instead of a release

Upstream has not cut a tagged release yet (CI for semantic release is unconfigured). The recipes pin the GitHub tarball by full commit SHA so the sha256 is reproducible. Once upstream tags a release, a follow-up version bump can replace the snapshot with a plain tag URL.

---

## Local verification

**`bmad-dashboard`:**
- `rattler-build build --render-only` resolves a single `noarch: python` output `bmad-dashboard-1.2.2.dev0-pyh4616a5c_0`.
- Static checks pass: `schema_version: 1`, no Jinja, no legacy selectors, sha256 matches the downloaded tarball, license file present.
- Python wrapper pip-installed against a fake `.vsix`; CLI paths exercised (`--print-vsix`, `--help`, `--editor-path` validation, missing editor detection).
- Full `rattler-build build` was attempted locally but hit a known pnpm-on-Windows issue with `@esbuild/win32-x64` (aggravated by an OneDrive path). The recipe is `noarch`, so the canonical build target is the conda-forge linux-64 CI runner where this does not reproduce.

**`mybmad-dashboard`:**
- `rattler-build build --render-only` resolves an arch-specific output `mybmad-dashboard-0.1.0.dev0`.
- Static checks pass: `schema_version: 1`, sha256 verified, license file `web/LICENSE` present, no symlinks in assembled runner dir asserted by build script.
- Python wrapper pip-installed; `mybmad --help`, `mybmad info --print-app-dir`, and `mybmad info --print-server-js` exercised without a live Postgres cluster.

cc @killua156