### PR TITLE
Add sweet-chem-o-mine

### DIFF
--- a/recipes/sweet-chem-o-mine/recipe.yaml
+++ b/recipes/sweet-chem-o-mine/recipe.yaml
@@ -1,0 +1,66 @@
+schema_version: 1
+
+context:
+  version: "0.2.0"
+  python_min: "3.11"
+
+package:
+  name: sweet-chem-o-mine
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Silh0uettie/Sweet-Chem-O-Mine/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 97fb25b64fb8d8d4c9dcc97b11099be6281303920fbf6764e34f22171acc8d52
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - scom = sweet_chem_o_mine.app:main
+      - sweet-chem-o-mine = sweet_chem_o_mine.app:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - matplotlib-base >=3.8
+    - numpy >=1.26
+    - openpyxl >=3.1
+    - pandas >=2.2
+    - pyside6 >=6.8,<6.9
+    - rdkit >=2024.3
+    - umap-learn >=0.5.6
+    - xlrd >=2.0.1
+
+tests:
+  - python:
+      imports:
+        - sweet_chem_o_mine
+        - sweet_chem_o_mine.analysis
+        - sweet_chem_o_mine.app
+        - sweet_chem_o_mine.project_file
+      python_version:
+        - ${{ python_min }}.*
+      pip_check: true
+
+about:
+  homepage: https://github.com/Silh0uettie/Sweet-Chem-O-Mine
+  repository: https://github.com/Silh0uettie/Sweet-Chem-O-Mine
+  license: MIT
+  license_file: LICENSE
+  summary: Desktop chemical UMAP explorer for structure-activity datasets.
+  description: |
+    Sweet Chem O' Mine is an interactive desktop application for exploring
+    chemical screening data in molecular-feature space using Morgan
+    fingerprints, UMAP projections, linked compound values, and rendered
+    chemical structures.
+
+extra:
+  recipe-maintainers:
+    - Silh0uettie


### PR DESCRIPTION
This PR adds a conda-forge recipe for sweet-chem-o-mine 0.2.0.\n\nLocal validation:\n- rattler-build build --recipe packaging/conda-forge/recipe.yaml --output-dir C:\\scom-conda-artifacts-fixed\n- recipe tests passed for Python 3.11\n- uploaded package dry-run from personal channel resolves with rdkit, pyside6, umap-learn, and other runtime dependencies