### PR TITLE
Add recipe for fars-toolkit

### DIFF
--- a/recipes/fars-toolkit/meta.yaml
+++ b/recipes/fars-toolkit/meta.yaml
@@ -1,0 +1,62 @@
+{% set name = "fars-toolkit" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/fars_toolkit-{{ version }}.tar.gz
+  sha256: af87d42aba69687c492ebeb14141d90a3430f0b89b6f2238c957254104baed1e
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  entry_points:
+    - fars-toolkit = fars_toolkit.cli:main
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=3.9
+
+test:
+  imports:
+    - fars_toolkit
+  requires:
+    - pip
+  commands:
+    - pip check
+    - fars-toolkit --help
+
+about:
+  home: https://github.com/MarvinBregiosa/fars-toolkit
+  summary: Download, filter, and aggregate NHTSA FARS fatal-crash data with zero non-stdlib dependencies.
+  description: |
+    fars-toolkit is a small, focused Python library for downloading,
+    filtering, and aggregating data from NHTSA's Fatality Analysis Reporting
+    System (FARS) National CSV downloads. Designed for indie data-journalism
+    workflows and academic researchers who want reproducible per-city or
+    per-state series without spinning up Spark or pulling pandas.
+
+    Handles the encoding quirks of the 2018-2024 FARS vintages (BOM bytes,
+    varying folder layouts) and the BODY_TYP truck-class join out of the box.
+    No dependencies outside the standard library.
+
+    Companion to the published Vision Zero Report Card 2026 research:
+    https://accidentlawyerreview.com/research/vision-zero-report-card/
+    Permanent dataset DOI: https://doi.org/10.5281/zenodo.20487070
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/MarvinBregiosa/fars-toolkit#readme
+  dev_url: https://github.com/MarvinBregiosa/fars-toolkit
+
+extra:
+  recipe-maintainers:
+    - MarvinBregiosa


### PR DESCRIPTION
Adding a recipe for [fars-toolkit](https://pypi.org/project/fars-toolkit/) — a small Python toolkit for downloading, filtering, and aggregating NHTSA Fatality Analysis Reporting System (FARS) fatal-crash data.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Add recipe for fars-toolkit"
- [x] License is included and is correct (MIT)
- [x] Source url is from a trusted source (PyPI)
- [x] Package builds with `noarch: python`
- [x] Package follows PEP 8
- [x] Maintainers listed (myself)
- [x] No external runtime dependencies (stdlib only)

## About the package

`fars-toolkit` provides:

- Download helpers for NHTSA FARS National CSV zips from `static.nhtsa.gov`
- Encoding-tolerant CSV reader that handles the BOM-byte quirk across the 2018-2024 vintages
- Truck-class filtering via FARS `BODY_TYP` codes (matches the standard NHTSA / IIHS truck-crash definition)
- Per-city and per-state fatality aggregation primitives
- A thin CLI for the common one-liners

Zero non-stdlib dependencies. Pure Python, `noarch: python`.

## Companion research

This package was extracted from the production pipeline behind the [Vision Zero Report Card 2026](https://accidentlawyerreview.com/research/vision-zero-report-card/), a 7-year analysis of truck-involved fatalities across 19 US cities. The dataset has a permanent DOI on Zenodo: [10.5281/zenodo.20487070](https://doi.org/10.5281/zenodo.20487070).

## Maintainer

I am the package author and will maintain the recipe.