### PR TITLE
Add pi (AI coding agent CLI)

### DIFF
--- a/recipes/pi/build.bat
+++ b/recipes/pi/build.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal enableextensions
+
+:: Repack the extracted package into a tarball, then install that tarball into the
+:: prefix. Installing from a tarball (rather than the unpacked folder) makes npm
+:: resolve and install the full dependency tree pinned by npm-shrinkwrap.json,
+:: including the sibling @earendil-works/pi-{ai,agent-core,tui} packages and the
+:: vendored prebuilt native addons.
+mkdir "%SRC_DIR%\packed" 2>nul
+pushd "%SRC_DIR%\app"
+call npm pack --pack-destination "%SRC_DIR%\packed"
+if errorlevel 1 ( popd & exit /b 1 )
+popd
+for /f "delims=" %%t in ('dir /b "%SRC_DIR%\packed\*.tgz"') do set "TGZ=%SRC_DIR%\packed\%%t"
+call npm install -g --prefix "%PREFIX%" "%TGZ%"
+if errorlevel 1 exit /b 1
+
+:: pi-tui's npm package bundles prebuilt native addons for every OS/arch. Keep
+:: only the prebuild matching this target platform and drop the rest.
+set "KEEP=win32-x64"
+if /i "%target_platform%"=="win-arm64" set "KEEP=win32-arm64"
+
+set "PI_TUI="
+for /f "delims=" %%d in ('dir /b /s /a:d "%PREFIX%\node_modules" 2^>nul ^| findstr /e "\\@earendil-works\\pi-tui"') do set "PI_TUI=%%d"
+if defined PI_TUI (
+  rmdir /s /q "%PI_TUI%\native\darwin" 2>nul
+  for /d %%a in ("%PI_TUI%\native\win32\prebuilds\*") do (
+    if /i not "%%~nxa"=="%KEEP%" rmdir /s /q "%%a" 2>nul
+  )
+)

--- a/recipes/pi/build.sh
+++ b/recipes/pi/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repack the extracted package into a tarball, then install that tarball into the
+# prefix. Installing from a tarball (rather than the unpacked folder) makes npm
+# resolve and install the full dependency tree pinned by npm-shrinkwrap.json,
+# including the sibling @earendil-works/pi-{ai,agent-core,tui} packages and the
+# vendored prebuilt native addons.
+mkdir -p "${SRC_DIR}/packed"
+( cd "${SRC_DIR}/app" && npm pack --pack-destination "${SRC_DIR}/packed" )
+npm install -g --prefix "${PREFIX}" "${SRC_DIR}/packed"/*.tgz
+
+# pi-tui's npm package bundles prebuilt native addons for every OS/arch in a
+# single tarball. Keep only the prebuild matching this target platform and drop
+# the rest, so each package ships exactly the binary it can load. (Keyed on the
+# conda target_platform, so this is correct under cross-compilation too.)
+case "${target_platform}" in
+  osx-64)    keep=darwin-x64   ;;
+  osx-arm64) keep=darwin-arm64 ;;
+  *)         keep=             ;;  # linux: pi-tui has no native addon at all
+esac
+pi_tui="$(find "${PREFIX}" -type d -path '*@earendil-works/pi-tui' -print -quit)"
+for d in "${pi_tui}"/native/*/prebuilds/*/; do
+  [ -d "${d}" ] || continue
+  [ "$(basename "${d}")" = "${keep}" ] || rm -rf "${d}"
+done
+# Prune now-empty OS / prebuilds directories left behind.
+find "${pi_tui}/native" -depth -type d -empty -delete 2>/dev/null || true

--- a/recipes/pi/check-macos-minos.sh
+++ b/recipes/pi/check-macos-minos.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Verify every shipped macOS native module's minimum-macOS version
+# (LC_BUILD_VERSION "minos" or the older LC_VERSION_MIN_MACOSX "version") is
+# within the deployment-target floor the package advertises through __osx
+# ($MACOS_BASELINE, taken from c_stdlib_version in recipe.yaml). Otherwise the
+# package could install on a macOS older than a shipped binary supports and then
+# fail to load it. This is the macOS analogue of check-native-glibc.sh.
+set -euo pipefail
+
+baseline="${MACOS_BASELINE:-11.0}"
+echo "Verifying shipped native modules target macOS <= ${baseline}"
+
+# Portable major.minor "greater than" — macOS /usr/bin/sort has no -V.
+ver_gt() {
+  local amaj="${1%%.*}" bmaj="${2%%.*}" amin bmin
+  amin="${1#*.}"; [ "$amin" = "$1" ] && amin=0; amin="${amin%%.*}"
+  bmin="${2#*.}"; [ "$bmin" = "$2" ] && bmin=0; bmin="${bmin%%.*}"
+  [ "$amaj" -gt "$bmaj" ] || { [ "$amaj" -eq "$bmaj" ] && [ "$amin" -gt "$bmin" ]; }
+}
+
+status=0; found=0
+for f in $(find "$PREFIX" -name '*.node' -type f); do
+  while IFS= read -r v; do
+    [ -n "$v" ] || continue
+    found=1
+    if ver_gt "$v" "$baseline"; then
+      echo "FAIL: $(basename "$f") targets macOS ${v} (> deployment target ${baseline})"
+      status=1
+    fi
+  done <<EOF
+$(llvm-objdump --macho --all-headers "$f" 2>/dev/null | awk '
+  /cmd LC_BUILD_VERSION/      { m="b" }
+  /cmd LC_VERSION_MIN_MACOSX/ { m="v" }
+  m == "b" && $1 == "minos"   { print $2; m="" }
+  m == "v" && $1 == "version" { print $2; m="" }
+')
+EOF
+done
+
+[ "$found" -eq 1 ] || { echo "FAIL: no .node with a macOS version load command found"; exit 1; }
+[ "$status" -eq 0 ] && echo "OK: all native modules target macOS <= ${baseline}"
+exit "$status"

--- a/recipes/pi/check-native-glibc.sh
+++ b/recipes/pi/check-native-glibc.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Guard the vendored prebuilt native modules against a future upstream rebuild
+# that links a newer glibc than the conda-forge baseline. Every shipped *.node
+# must stay within the c_stdlib_version floor advertised through __glibc;
+# otherwise the package would install on an old system and fail to load at
+# runtime. The baseline is passed in via $GLIBC_BASELINE (set from
+# c_stdlib_version in recipe.yaml).
+set -euo pipefail
+
+baseline="${GLIBC_BASELINE:-2.17}"
+echo "Verifying shipped native modules stay within glibc ${baseline}"
+
+bmaj="${baseline%%.*}"; brest="${baseline#*.}"; bmin="${brest%%.*}"
+status=0; found=0
+for f in $(find "$PREFIX" -name '*.node' -type f); do
+  found=1
+  for v in $(objdump -T "$f" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -uV); do
+    maj="${v%%.*}"; rest="${v#*.}"; min="${rest%%.*}"
+    if [ "$maj" -gt "$bmaj" ] || { [ "$maj" -eq "$bmaj" ] && [ "$min" -gt "$bmin" ]; }; then
+      echo "FAIL: $(basename "$f") requires GLIBC_${v} (> baseline ${baseline})"
+      status=1
+    fi
+  done
+done
+
+[ "$found" -eq 1 ] || { echo "FAIL: no .node files found to verify"; exit 1; }
+[ "$status" -eq 0 ] && echo "OK: all native modules are within glibc ${baseline}"
+exit "$status"

--- a/recipes/pi/recipe.yaml
+++ b/recipes/pi/recipe.yaml
@@ -25,6 +25,13 @@ build:
     file: build
     env:
       target_platform: ${{ target_platform }}
+  dynamic_linking:
+    # macOS only: the vendored prebuilt .node addons link nothing but system
+    # frameworks (nothing in the build prefix to relocate) and lack the header
+    # padding install_name_tool needs, so relocation there both fails and is
+    # unnecessary. On Linux relocation is REQUIRED -- it adds the $ORIGIN-relative
+    # rpath that lets the clipboard addon find libgcc_s.so.1 in the env lib dir.
+    binary_relocation: ${{ false if osx else true }}
 
 requirements:
   build:
@@ -39,13 +46,18 @@ requirements:
       then:
         - ${{ stdlib('c') }}
   host:
-    # libgcc_s.so.1, linked by the vendored clipboard .node on Linux. Declaring it
-    # in host satisfies the overlinking check; its run-export covers runtime.
+    # libgcc_s.so.1 is linked by the vendored clipboard .node on Linux. There is
+    # no compiler to provide the run-export, so libgcc is declared manually: in
+    # host so the binary check can resolve it, and in run (below) so the
+    # overlinking check sees its provider explicitly listed.
     - if: linux
       then:
-        - libgcc-ng
+        - libgcc
   run:
     - nodejs >=22.19.0
+    - if: linux
+      then:
+        - libgcc
 
 tests:
   - script:

--- a/recipes/pi/recipe.yaml
+++ b/recipes/pi/recipe.yaml
@@ -1,0 +1,95 @@
+schema_version: 1
+
+context:
+  version: "0.78.0"
+
+package:
+  name: pi
+  version: ${{ version }}
+
+source:
+  # The published CLI tarball ships dist/ (prebuilt JS) plus npm-shrinkwrap.json,
+  # which pins all 138 transitive dependencies, including the sibling
+  # @earendil-works/pi-{ai,agent-core,tui} packages.
+  - url: https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-${{ version }}.tgz
+    sha256: a047da75801d9135e368a4711d06d0ca4b6ab708801ab82fd1366dde1eedd0ee
+    target_directory: app
+  # The LICENSE file is not included in the npm tarball.
+  - url: https://raw.githubusercontent.com/earendil-works/pi/v${{ version }}/LICENSE
+    sha256: 0457f5bcec3b3b211605dfb5d1a49042fd638f3686a410fe099c24a25af13c48
+    file_name: LICENSE
+
+build:
+  number: 0
+  script:
+    file: build
+    env:
+      target_platform: ${{ target_platform }}
+
+requirements:
+  build:
+    - nodejs >=22.19.0
+    # On Linux the vendored clipboard .node links glibc (-> __glibc floor) and on
+    # macOS the prebuilts link system frameworks (-> __osx floor); stdlib supplies
+    # those baselines, both of which are virtual run-exports rather than packages.
+    # It is intentionally NOT added on Windows: the prebuilts there import only
+    # always-present OS DLLs and statically link the CRT, so stdlib('c') would
+    # only pull an unused vc14_runtime dependency.
+    - if: unix
+      then:
+        - ${{ stdlib('c') }}
+  host:
+    # libgcc_s.so.1, linked by the vendored clipboard .node on Linux. Declaring it
+    # in host satisfies the overlinking check; its run-export covers runtime.
+    - if: linux
+      then:
+        - libgcc-ng
+  run:
+    - nodejs >=22.19.0
+
+tests:
+  - script:
+      - pi --help
+  # Guard the vendored prebuilt native modules against a future upstream rebuild
+  # that links a newer glibc than the conda-forge baseline. Every shipped *.node
+  # must stay within the c_stdlib_version floor we advertise through __glibc;
+  # otherwise the package would install on an old system and fail to load.
+  - if: linux
+    then:
+      script:
+        file: check-native-glibc
+        env:
+          GLIBC_BASELINE: ${{ c_stdlib_version | default('2.17') }}
+      requirements:
+        run:
+          - binutils
+  # macOS analogue: every shipped .node's minimum-macOS (minos) must stay within
+  # the deployment target the package advertises through __osx, or it could load
+  # on a macOS older than a vendored binary supports.
+  - if: osx
+    then:
+      script:
+        file: check-macos-minos
+        env:
+          MACOS_BASELINE: ${{ c_stdlib_version | default('11.0') }}
+      requirements:
+        run:
+          - llvm-tools
+
+about:
+  homepage: https://github.com/earendil-works/pi
+  summary: AI coding agent CLI with read, bash, edit, write tools and session management
+  description: |
+    pi is an interactive AI coding assistant for the terminal. It provides a
+    coding agent with read, bash, edit, and write tools, persistent session
+    management, a unified multi-provider LLM API, and an interactive terminal
+    UI. The CLI works with multiple model providers (Anthropic, OpenAI, Google,
+    Mistral, AWS Bedrock, and others).
+  license: MIT
+  license_file:
+    - LICENSE
+  repository: https://github.com/earendil-works/pi
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds a recipe for [`pi`](https://github.com/earendil-works/pi) — an interactive AI coding agent CLI (the `pi` command), published to npm as `@earendil-works/pi-coding-agent`. MIT licensed.

### Notes for reviewers (Node.js)

- **Source / build**: uses the npm registry tarball for `@earendil-works/pi-coding-agent`. `build.sh`/`build.bat` repack the extracted package and `npm install -g` the tarball, so npm resolves the full dependency tree pinned by the package's bundled `npm-shrinkwrap.json` (same approach as e.g. `configurable-http-proxy`). `LICENSE` is fetched as a separate `url` source because it is not included in the npm tarball.
- **Vendored npm dependencies**: as with any Node.js application, the install bundles the package's npm dependency tree. Two dependencies ship prebuilt native addons: `@earendil-works/pi-tui` (its own small `.node`) and `@mariozechner/clipboard` (a Rust/napi-rs `.node`). The build keeps only the prebuilt matching the **target** platform and removes the rest, so each package ships exactly the binaries it can load.
- **Per-platform (not `noarch`)** because of those platform-specific binaries.
- **System-library dependencies of the vendored binaries** (verified with `objdump`/`llvm-objdump`):
  - **Linux**: glibc (max `GLIBC_2.14`) + `libgcc_s` → declared via `stdlib('c')` (yielding the virtual `__glibc`) + `libgcc-ng`.
  - **Windows**: only always-present OS DLLs (`kernel32`, `ntdll`, `advapi32`, `gdi32`, `user32`, `oleaut32`, `bcryptprimitives`); the Rust binary static-links its CRT, so no `vc14_runtime` is required — `stdlib('c')` is intentionally **omitted** on Windows to avoid an unused dependency.
  - **macOS**: only system frameworks + `/usr/lib/libSystem`, `libobjc`, `libiconv`.
- **Extra correctness tests**: `check-native-glibc.sh` (Linux) and `check-macos-minos.sh` (macOS) assert that no shipped `.node` requires a newer glibc / minimum-macOS than the `c_stdlib_version` baseline the package advertises through `__glibc` / `__osx`. They fail loudly if a future upstream rebuild raises that requirement.

### Checklist

- [x] Title of this PR is meaningful.
- [x] License file is packaged (`license_file: LICENSE`, fetched from the tagged source).
- [x] Source is from official source (npm registry + the project's tagged `LICENSE`).
- [x] Package does not vendor other packages — it bundles only its own npm dependency tree, as is standard for Node.js applications (see notes above).
- [x] If static libraries are linked in, the license of the static library is packaged — n/a (no conda static libraries linked).
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo is used in the recipe.
- [x] GitHub users listed in the maintainer section are willing to be listed — I (@baszalmstra) am the submitter and sole maintainer.
