### PR TITLE
Add faircmakemodules recipe

### DIFF
--- a/recipes/faircmakemodules/build.bat
+++ b/recipes/faircmakemodules/build.bat
@@ -1,0 +1,4 @@
+cmake -G Ninja -S %SRC_DIR% -B build -DCMAKE_INSTALL_PREFIX=%PREFIX%\Library
+if errorlevel 1 exit 1
+cmake --build build --parallel %CPU_COUNT% --target install
+if errorlevel 1 exit 1

--- a/recipes/faircmakemodules/build.sh
+++ b/recipes/faircmakemodules/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+cmake -G Ninja -S ${SRC_DIR} -B build -DCMAKE_INSTALL_PREFIX=${PREFIX}
+cmake --build build --parallel ${CPU_COUNT} --target install

--- a/recipes/faircmakemodules/conda-forge.yml
+++ b/recipes/faircmakemodules/conda-forge.yml
@@ -1,0 +1,3 @@
+noarch_platforms:
+  - linux_64
+  - win_64

--- a/recipes/faircmakemodules/noarch-disable-cxx.patch
+++ b/recipes/faircmakemodules/noarch-disable-cxx.patch
@@ -1,0 +1,18 @@
+From: Oliver Lantwin <oliver@lantwin.de>
+Subject: Build as language-free CMake project for noarch packaging
+
+FairCMakeModules ships only .cmake files. Declaring LANGUAGES CXX
+triggers compiler detection at configure time, which forces noarch
+package builds to depend on a C++ toolchain they never use.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,7 +9,7 @@
+ cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+ cmake_policy(VERSION 3.15...3.20)
+
+-project(FairCMakeModules VERSION 1.0.0 LANGUAGES CXX
++project(FairCMakeModules VERSION 1.0.0 LANGUAGES NONE
+         HOMEPAGE_URL "https://github.com/FairRootGroup/FairCMakeModules")
+
+ if(NOT CMAKE_BUILD_TYPE)

--- a/recipes/faircmakemodules/recipe.yaml
+++ b/recipes/faircmakemodules/recipe.yaml
@@ -1,0 +1,51 @@
+context:
+  version: "1.0.0"
+
+package:
+  name: faircmakemodules
+  version: ${{ version }}
+
+source:
+  url: https://github.com/FairRootGroup/FairCMakeModules/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: ec60c31f38050c1173d512c58c684650db66736877c580936f7ecca33eeaf696
+  patches:
+    - noarch-disable-cxx.patch
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - ninja
+  run:
+    - if: unix
+      then: __unix
+      else: __win
+
+tests:
+  - package_contents:
+      strict: true
+      files:
+        - ${{ "Library/" if win else "" }}share/cmake/FairCMakeModules-${{ version }}/FairCMakeModulesConfig.cmake
+        - ${{ "Library/" if win else "" }}share/cmake/FairCMakeModules-${{ version }}/FairCMakeModulesConfigVersion.cmake
+        - ${{ "Library/" if win else "" }}share/faircmakemodules/modules/Fair*.cmake
+        - ${{ "Library/" if win else "" }}share/doc/FairCMakeModules/CHANGELOG.rst
+        - ${{ "Library/" if win else "" }}share/doc/FairCMakeModules/README.md
+
+about:
+  homepage: https://github.com/FairRootGroup/FairCMakeModules
+  summary: Reusable CMake modules from the FairRoot project
+  description: |
+    FairCMakeModules is a collection of reusable CMake modules originally
+    developed for the FairRoot project and used across the broader FairSoft
+    / FairRoot ecosystem. It includes helpers for project configuration,
+    dependency discovery, and CI / test summary output.
+  license: LGPL-3.0-only
+  license_file: LICENSE
+  repository: https://github.com/FairRootGroup/FairCMakeModules
+
+extra:
+  recipe-maintainers:
+    - olantwin


### PR DESCRIPTION
FairCMakeModules is a collection of reusable CMake modules originally developed for the FairRoot project and used across the broader FairSoft / FairRoot ecosystem. Required as a build dependency by FairRoot and several SHiP packages we plan to upstream next.

The recipe carries a one-line patch that switches the upstream project() declaration from LANGUAGES CXX to LANGUAGES NONE: the package ships only .cmake files, so enabling CXX would force noarch builds to depend on a C++ toolchain they never use. An upstream PR for this change will follow.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
