### PR TITLE
Add clang-tools-static-binaries recipe

### DIFF
--- a/recipes/clang-tools-static-binaries/LICENSE
+++ b/recipes/clang-tools-static-binaries/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/recipes/clang-tools-static-binaries/build.bat
+++ b/recipes/clang-tools-static-binaries/build.bat
@@ -1,0 +1,4 @@
+@echo off
+REM build.bat – no-op build script for clang-tools-static-binaries (Windows)
+REM All work happens in the per-output install scripts.
+echo No build steps needed; pre-built binaries are downloaded in install scripts.

--- a/recipes/clang-tools-static-binaries/build.sh
+++ b/recipes/clang-tools-static-binaries/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# build.sh – no-op build script for clang-tools-static-binaries
+# All work happens in the per-output install scripts.
+echo "No build steps needed; pre-built binaries are downloaded in install scripts."

--- a/recipes/clang-tools-static-binaries/install.bat
+++ b/recipes/clang-tools-static-binaries/install.bat
@@ -1,0 +1,89 @@
+@echo off
+REM install.bat – conda-build install script for a single clang-tools version (Windows)
+REM
+REM Environment variables (set by meta.yaml):
+REM   RELEASE_TAG    GitHub release tag (e.g. 2026.06.04-14db129d)
+REM   CLANG_VERSION  Clang major version (e.g. 20)
+REM   PREFIX         Conda install prefix
+
+setlocal enabledelayedexpansion
+
+set "RELEASE_URL=https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/%RELEASE_TAG%"
+set "TOOLS=clang-format clang-tidy clang-query clang-apply-replacements"
+
+REM On Windows the binary suffix is always windows-amd64
+set "SUFFIX=%CLANG_VERSION%_windows-amd64"
+
+echo RELEASE_TAG  = %RELEASE_TAG%
+echo CLANG_VERSION = %CLANG_VERSION%
+echo SUFFIX        = %SUFFIX%
+echo PREFIX        = %PREFIX%
+
+if not exist "%PREFIX%\bin" mkdir "%PREFIX%\bin"
+if not exist "%PREFIX%\share\clang-tools-static" mkdir "%PREFIX%\share\clang-tools-static"
+
+REM ------------------------------------------------------------------
+REM Download, verify, and install each tool
+REM ------------------------------------------------------------------
+for %%t in (%TOOLS%) do (
+    set "BINARY_NAME=%%t-%SUFFIX%.exe"
+    set "CHECKSUM_NAME=%%t-%SUFFIX%.exe.sha512sum"
+    set "DEST=%PREFIX%\bin\%%t-%CLANG_VERSION%.exe"
+
+    echo.
+    echo --- %%t ---
+
+    REM Download binary
+    echo   Downloading !BINARY_NAME! ...
+    curl -fSL --retry 3 --retry-delay 10 ^
+        -o "!DEST!" ^
+        "%RELEASE_URL%/!BINARY_NAME!"
+    if errorlevel 1 exit /b 1
+
+    REM Download checksum
+    echo   Downloading !CHECKSUM_NAME! ...
+    curl -fSL --retry 3 --retry-delay 10 ^
+        -o "%TEMP%\conda-clang-tools.sha512" ^
+        "%RELEASE_URL%/!CHECKSUM_NAME!"
+    if errorlevel 1 exit /b 1
+
+    REM Verify SHA-512
+    echo   Verifying SHA-512 ...
+    REM Windows doesn't have sha512sum; we use certutil
+    for /f "tokens=1" %%h in (%TEMP%\conda-clang-tools.sha512) do set "EXPECTED_HASH=%%h"
+
+    REM Compute actual hash with certutil
+    certutil -hashfile "!DEST!" SHA512 > "%TEMP%\conda-actual-hash.txt"
+    REM certutil output is multiline; second line has the hash
+    for /f "skip=1 delims=" %%a in (%TEMP%\conda-actual-hash.txt) do (
+        set "ACTUAL_HASH=%%a"
+        goto :hash_done
+    )
+    :hash_done
+    REM Remove spaces
+    set "ACTUAL_HASH=!ACTUAL_HASH: =!"
+
+    if /i not "!EXPECTED_HASH!"=="!ACTUAL_HASH!" (
+        echo ERROR: SHA-512 mismatch for !BINARY_NAME!
+        echo   expected: !EXPECTED_HASH!
+        echo   got:      !ACTUAL_HASH!
+        exit /b 1
+    )
+    echo   SHA-512 OK
+
+    echo   Installed !DEST!
+)
+
+REM ------------------------------------------------------------------
+REM Install versions.json for reference (best-effort)
+REM ------------------------------------------------------------------
+echo.
+echo --- versions.json (best-effort) ---
+curl -fSL --retry 2 --retry-delay 5 ^
+    -o "%PREFIX%\share\clang-tools-static\versions.json" ^
+    "%RELEASE_URL%/versions.json" 2>nul || ^
+    echo   (versions.json not available in this release - will be present in future releases)
+
+echo.
+echo Installation complete.
+dir "%PREFIX%\bin"

--- a/recipes/clang-tools-static-binaries/install.sh
+++ b/recipes/clang-tools-static-binaries/install.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# install.sh – conda-build install script for a single clang-tools version (Unix)
+#
+# Environment variables (set by meta.yaml):
+#   RELEASE_TAG    GitHub release tag (e.g. 2026.06.04-14db129d)
+#   CLANG_VERSION  Clang major version (e.g. 20)
+#   PREFIX         Conda install prefix
+#
+# Platform detection:
+#   The script translates conda's target_platform into the upstream suffix
+#   used in binary names (e.g. linux-amd64, macos-arm64).
+set -euo pipefail
+
+RELEASE_URL="https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/${RELEASE_TAG}"
+TOOLS=("clang-format" "clang-tidy" "clang-query" "clang-apply-replacements")
+
+# ------------------------------------------------------------------
+# 1. Map conda target_platform → upstream binary suffix
+# ------------------------------------------------------------------
+case "${target_platform:-}" in
+    linux-64)       SUFFIX="${CLANG_VERSION}_linux-amd64" ;;
+    linux-aarch64)  SUFFIX="${CLANG_VERSION}_linux-arm64" ;;
+    osx-64)         SUFFIX="${CLANG_VERSION}_macos-amd64" ;;
+    osx-arm64)      SUFFIX="${CLANG_VERSION}_macos-arm64" ;;
+    *)
+        echo "ERROR: unknown target_platform '${target_platform:-}'" >&2
+        exit 1
+        ;;
+esac
+
+echo "RELEASE_TAG  = ${RELEASE_TAG}"
+echo "CLANG_VERSION = ${CLANG_VERSION}"
+echo "SUFFIX        = ${SUFFIX}"
+echo "PREFIX        = ${PREFIX}"
+
+mkdir -p "${PREFIX}/bin"
+
+# ------------------------------------------------------------------
+# 2. Download, verify, and install each tool
+# ------------------------------------------------------------------
+for tool in "${TOOLS[@]}"; do
+    binary_name="${tool}-${SUFFIX}"
+    checksum_name="${binary_name}.sha512sum"
+    dest="${PREFIX}/bin/${tool}-${CLANG_VERSION}"
+
+    echo ""
+    echo "--- ${tool} ---"
+
+    # Download binary
+    echo "  Downloading ${binary_name} ..."
+    curl -fSL --retry 3 --retry-delay 10 \
+        -o "${dest}" \
+        "${RELEASE_URL}/${binary_name}"
+
+    # Download checksum
+    echo "  Downloading ${checksum_name} ..."
+    curl -fSL --retry 3 --retry-delay 10 \
+        -o /tmp/conda-clang-tools.sha512 \
+        "${RELEASE_URL}/${checksum_name}"
+
+    # Verify
+    echo "  Verifying SHA-512 ..."
+    EXPECTED=$(awk '{print $1}' /tmp/conda-clang-tools.sha512)
+    # macOS uses 'shasum -a 512', Linux uses 'sha512sum'
+    if command -v sha512sum &>/dev/null; then
+        ACTUAL=$(sha512sum "${dest}" | awk '{print $1}')
+    else
+        ACTUAL=$(shasum -a 512 "${dest}" | awk '{print $1}')
+    fi
+    if [[ "${EXPECTED}" != "${ACTUAL}" ]]; then
+        echo "ERROR: SHA-512 mismatch for ${binary_name}" >&2
+        echo "  expected: ${EXPECTED}" >&2
+        echo "  got:      ${ACTUAL}" >&2
+        exit 1
+    fi
+    echo "  SHA-512 OK"
+
+    # Make executable
+    chmod +x "${dest}"
+
+    echo "  Installed ${dest}"
+    rm -f /tmp/conda-clang-tools.sha512
+done
+
+# ------------------------------------------------------------------
+# 3. Install versions.json for reference (best-effort)
+# ------------------------------------------------------------------
+mkdir -p "${PREFIX}/share/clang-tools-static"
+echo ""
+echo "--- versions.json (best-effort) ---"
+curl -fSL --retry 2 --retry-delay 5 \
+    -o "${PREFIX}/share/clang-tools-static/versions.json" \
+    "${RELEASE_URL}/versions.json" 2>/dev/null || \
+    echo "  (versions.json not available in this release — will be present in future releases)"
+
+echo ""
+echo "Installation complete."
+ls -la "${PREFIX}/bin/"

--- a/recipes/clang-tools-static-binaries/meta.yaml
+++ b/recipes/clang-tools-static-binaries/meta.yaml
@@ -1,0 +1,78 @@
+# conda-forge recipe for cpp-linter/clang-tools-static-binaries
+#
+# Pre-built static binaries of clang-format, clang-tidy, clang-query, and
+# clang-apply-replacements. No compilation occurs — binaries are downloaded
+# from GitHub Releases, verified against published SHA-512 checksums, and
+# installed into $PREFIX/bin.
+#
+# Users install a specific version with:
+#   conda install conda-forge::clang-tools-20-static
+#
+# The conda package version tracks the upstream release date.
+# Multiple clang versions can be installed side by side.
+
+{% set release_tag = os.environ.get("RELEASE_TAG", "master-14db129d") %}
+{% set release_base = "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/" ~ release_tag %}
+{% set repo_commit = "14db129d" %}
+
+# Major clang versions in every release (keep in sync with upstream build.py)
+{% set clang_versions = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22] %}
+{% set tools = ["clang-format", "clang-tidy", "clang-query", "clang-apply-replacements"] %}
+
+package:
+  name: clang-tools-static-binaries-meta
+  version: 2026.06.04
+
+source:
+  url: https://github.com/cpp-linter/clang-tools-static-binaries/archive/{{ repo_commit }}.tar.gz
+  sha256: fa4b57d5f099d988da934f4c63cfea260872bddd46fcd34f77cb9dc18d8c660a
+
+build:
+  number: 0
+
+# =========================================================================
+# Outputs
+# =========================================================================
+outputs:
+{% for ver in clang_versions %}
+  - name: clang-tools-{{ ver }}-static
+    script: install.sh   # [unix]
+    script: install.bat  # [win]
+    build:
+      script_env:
+        - RELEASE_TAG={{ release_tag }}
+        - CLANG_VERSION={{ ver }}
+    requirements:
+      build: []
+      run_constrained:
+        - clang-tools-static-binaries-meta >={{ version }}
+    test:
+      commands:
+{% for tool in tools %}
+        - test -f ${PREFIX}/bin/{{ tool }}-{{ ver }}            # [unix]
+        - ${PREFIX}/bin/{{ tool }}-{{ ver }} --version          # [unix]
+        - if not exist %PREFIX%\bin\{{ tool }}-{{ ver }}.exe exit 1   # [win]
+        - '%PREFIX%\bin\{{ tool }}-{{ ver }}.exe --version'     # [win]
+{% endfor %}
+
+{% endfor %}
+
+about:
+  home: https://github.com/cpp-linter/clang-tools-static-binaries
+  license: Apache-2.0 WITH LLVM-exception
+  license_file: LICENSE
+  summary: Pre-built static binaries of clang-format, clang-tidy, clang-query, and clang-apply-replacements
+  description: |
+    Statically-linked, dependency-free binaries of clang-format, clang-tidy,
+    clang-query, and clang-apply-replacements for Linux (x86_64, ARM64),
+    macOS (x86_64, ARM64), and Windows (x86_64).
+
+    Each ``clang-tools-<V>-static`` package contains the four tools for a
+    single major clang version. Install multiple versions side by side:
+
+        conda install conda-forge::clang-tools-18-static
+        conda install conda-forge::clang-tools-20-static
+
+    Binaries are verified against published SHA-512 checksums.
+  doc_url: https://github.com/cpp-linter/clang-tools-static-binaries#readme
+  dev_url: https://github.com/cpp-linter/clang-tools-static-binaries

--- a/recipes/clang-tools-static-binaries/meta.yaml
+++ b/recipes/clang-tools-static-binaries/meta.yaml
@@ -11,9 +11,9 @@
 # The conda package version tracks the upstream release date.
 # Multiple clang versions can be installed side by side.
 
-{% set release_tag = os.environ.get("RELEASE_TAG", "master-14db129d") %}
+{% set release_tag = os.environ.get("RELEASE_TAG", "2026.06.05-5a535621") %}
 {% set release_base = "https://github.com/cpp-linter/clang-tools-static-binaries/releases/download/" ~ release_tag %}
-{% set repo_commit = "14db129d" %}
+{% set repo_commit = "5a535621" %}
 
 # Major clang versions in every release (keep in sync with upstream build.py)
 {% set clang_versions = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22] %}
@@ -21,11 +21,11 @@
 
 package:
   name: clang-tools-static-binaries-meta
-  version: 2026.06.04
+  version: 2026.06.05
 
 source:
   url: https://github.com/cpp-linter/clang-tools-static-binaries/archive/{{ repo_commit }}.tar.gz
-  sha256: fa4b57d5f099d988da934f4c63cfea260872bddd46fcd34f77cb9dc18d8c660a
+  sha256: ac7393962a4ac475bd9e5c58844be28d56188310d14d1121e1b5c3d7eef4209d
 
 build:
   number: 0

--- a/recipes/clang-tools-static-binaries/meta.yaml
+++ b/recipes/clang-tools-static-binaries/meta.yaml
@@ -76,3 +76,8 @@ about:
     Binaries are verified against published SHA-512 checksums.
   doc_url: https://github.com/cpp-linter/clang-tools-static-binaries#readme
   dev_url: https://github.com/cpp-linter/clang-tools-static-binaries
+
+extra:
+  recipe-maintainers:
+    - shenxianpeng
+  feedstock-name: clang-tools-static-binaries


### PR DESCRIPTION
## Description

Add conda-forge recipe for [cpp-linter/clang-tools-static-binaries](https://github.com/cpp-linter/clang-tools-static-binaries) — pre-built statically-linked binaries of **clang-format**, **clang-tidy**, **clang-query**, and **clang-apply-replacements**.

### What this provides

This is a **multi-output** recipe that produces one package per major clang version:

```bash
conda install conda-forge::clang-tools-20-static  # get clang v20 tools
conda install conda-forge::clang-tools-18-static  # also install v18 (they coexist!)
```

### Key characteristics

- **No compilation** — binaries are downloaded from [GitHub Releases](https://github.com/cpp-linter/clang-tools-static-binaries/releases) and verified against published SHA-512 checksums
- **Supports 12 clang versions**: 11 through 22
- **All platforms**: linux-64, linux-aarch64, osx-64, osx-arm64, win-64
- **4 tools per version**: clang-format, clang-tidy, clang-query, clang-apply-replacements
- **License**: Apache-2.0 WITH LLVM-exception

### Upstream

- Homepage: https://github.com/cpp-linter/clang-tools-static-binaries
- This project is actively maintained (part of the cpp-linter organization)
- The static binaries are used by the [clang-tools-pip](https://github.com/cpp-linter/clang-tools-pip) Python package and [asdf-clang-tools](https://github.com/cpp-linter/asdf-clang-tools)

---

Checklist:

- [x] Title is meaningful
- [x] License file is packaged (LICENSE included in recipe)
- [x] Source is from official source (GitHub archive + GitHub Releases assets)
- [x] Package does not vendor other packages
- [x] Package does not ship static libraries (ships executables only)
- [x] Build number is 0
- [x] A tarball (url) is used for source
- [x] Recipe maintainer (@shenxianpeng) is willing to maintain

@conda-forge/help-c-cpp, still work in progress