### PR TITLE
Add cetmodules recipe

### DIFF
--- a/recipes/cetmodules/auto-include-helpers.patch
+++ b/recipes/cetmodules/auto-include-helpers.patch
@@ -1,0 +1,31 @@
+From: Oliver Lantwin <oliver@lantwin.de>
+Subject: Auto-include core helpers in cetmodulesConfig.cmake
+
+Consumers of cetmodules (e.g. phlex, art, larsoft) call
+find_package(cetmodules) expecting the standard helper modules
+(CetCMakeEnv, CetCMakeUtils, CetCMakeConfig, CetMake,
+CetProvideDependency) to be available immediately. The default
+cetmodulesConfig.cmake only prepends Modules/ to CMAKE_MODULE_PATH,
+which forces every consumer to add the include() calls explicitly.
+
+Use the existing CONFIG_POST_TARGETS hook to inject the includes at
+the end of the generated config, so downstream code can rely on
+cet_cmake_env() and friends without further boilerplate.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -100,4 +100,6 @@ cet_cmake_config(
+   config/${PROJECT_NAME}-CMP0096.cmake
+   CONFIG_POST_VARS
+   config/${PROJECT_NAME}-no-in-tree-source-modules.cmake
++  CONFIG_POST_TARGETS
++  config/${PROJECT_NAME}-auto-include-helpers.cmake
+   )
+--- /dev/null
++++ b/config/cetmodules-auto-include-helpers.cmake
+@@ -0,0 +1,5 @@
++include(CetProvideDependency)
++include(CetCMakeEnv)
++include(CetCMakeUtils)
++include(CetCMakeConfig)
++include(CetMake)

--- a/recipes/cetmodules/build.bat
+++ b/recipes/cetmodules/build.bat
@@ -1,0 +1,19 @@
+cmake -G Ninja -S "%SRC_DIR%" -B build ^
+    -DCMAKE_INSTALL_PREFIX="%PREFIX%\Library" ^
+    -DCMAKE_INSTALL_LIBEXECDIR=libexec/cetmodules ^
+    -DBUILD_TESTING=OFF
+if errorlevel 1 exit 1
+cmake --build build --parallel %CPU_COUNT% --target install
+if errorlevel 1 exit 1
+
+REM Replace upstream symlinks with regular copies so the noarch package
+REM installs cleanly on Windows. cmd's COPY follows symlinks/reparse points,
+REM so this works whether tar extraction preserved the symlinks or not.
+for %%F in ("%PREFIX%\Library\share\cetmodules\Modules\FindFFTW3?.cmake") do (
+    if exist "%%~F" (
+        copy /B /Y "%%~F" "%%~F.real" >nul
+        if errorlevel 1 exit 1
+        move /Y "%%~F.real" "%%~F" >nul
+        if errorlevel 1 exit 1
+    )
+)

--- a/recipes/cetmodules/build.sh
+++ b/recipes/cetmodules/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+cmake -S ${SRC_DIR} -B build -G Ninja \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_INSTALL_LIBEXECDIR=libexec/cetmodules \
+    -DBUILD_TESTING=OFF
+cmake --build build --parallel ${CPU_COUNT} --target install
+
+# Replace upstream symlinks with copies so the noarch package installs
+# cleanly on Windows. The targets are tiny .cmake stubs.
+for link in "${PREFIX}"/share/cetmodules/Modules/FindFFTW3?.cmake; do
+    [ -L "${link}" ] || continue
+    cp -L "${link}" "${link}.real"
+    mv -f "${link}.real" "${link}"
+done

--- a/recipes/cetmodules/conda-forge.yml
+++ b/recipes/cetmodules/conda-forge.yml
@@ -1,0 +1,3 @@
+noarch_platforms:
+  - linux_64
+  - win_64

--- a/recipes/cetmodules/namespace-install-paths.patch
+++ b/recipes/cetmodules/namespace-install-paths.patch
@@ -1,0 +1,78 @@
+From: Oliver Lantwin <oliver@lantwin.de>
+Subject: Namespace install destinations under cetmodules/
+
+Upstream installs CMake helper modules to <prefix>/Modules/, internal
+helpers to <prefix>/libexec/, and make_bash_completions to <prefix>/bin/.
+On a shared prefix (conda env, /usr/local) these top-level destinations
+collide with files shipped by other packages, since names like "Modules",
+"checkClassVersion" and "make_bash_completions" are not unique.
+
+Relocate them under cetmodules-specific subdirectories:
+  Modules/*.cmake  -> share/cetmodules/Modules/
+  libexec/*        -> ${CMAKE_INSTALL_LIBEXECDIR} (set to libexec/cetmodules/)
+  bin/make_bash_completions -> ${CMAKE_INSTALL_LIBEXECDIR}
+
+We use ${CMAKE_INSTALL_LIBEXECDIR} (set by include(GNUInstallDirs)
+inside cet_cmake_env()) rather than the project_variable
+${cetmodules_LIBEXEC_DIR}: the latter is only defined once
+libexec/CMakeLists.txt has been processed, and the top-level CMakeLists
+adds bin/ as a subdirectory before libexec/, so the variable would
+still be empty at the moment bin/CMakeLists.txt evaluates.
+
+Downstream find_package(cetmodules) consumers are unaffected: the path
+registered with cet_cmake_module_directories() is what
+cetmodulesConfig.cmake bakes into CMAKE_MODULE_PATH, and the LIBEXEC_DIR
+project_variable already follows CMAKE_INSTALL_LIBEXECDIR.
+
+The make_bash_completions script previously located its companion
+filter-program-options via "${BASH_SOURCE%/*}/../libexec". Once the script
+itself lives in libexec/cetmodules/ alongside that companion, the relative
+path is just the script's own directory.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -72,7 +72,7 @@ project_variable(
+   )
+
+ # Make sure downstream packages can find our modules.
+-cet_cmake_module_directories(NO_LOCAL Modules Modules/compat)
++cet_cmake_module_directories(NO_LOCAL share/cetmodules/Modules share/cetmodules/Modules/compat)
+
+ # ##############################################################################
+ # Build components.
+--- a/Modules/CMakeLists.txt
++++ b/Modules/CMakeLists.txt
+@@ -21,7 +21,7 @@ list(APPEND generated_modules
+
+ install(
+   DIRECTORY ./
+-  DESTINATION Modules
++  DESTINATION share/cetmodules/Modules
+   FILES_MATCHING
+   PATTERN "*.cmake"
+   PATTERN "[.#]*.cmake" EXCLUDE
+@@ -35,4 +35,4 @@ file(
+   PATTERN "[.#]*.cmake" EXCLUDE
+   )
+
+-install(FILES ${generated_modules} DESTINATION Modules)
++install(FILES ${generated_modules} DESTINATION share/cetmodules/Modules)
+--- a/bin/CMakeLists.txt
++++ b/bin/CMakeLists.txt
+@@ -2,4 +2,4 @@
+ # Publicly-available scripts.
+ # ##############################################################################
+ include(CetMake)
+-cet_script(make_bash_completions)
++cet_script(make_bash_completions DESTINATION ${CMAKE_INSTALL_LIBEXECDIR})
+--- a/bin/make_bash_completions
++++ b/bin/make_bash_completions
+@@ -10,7 +10,7 @@
+ # =========================================================================
+
+ # Private utilities.
+-libexec=$(cd "${BASH_SOURCE%/*}/../libexec" && pwd -P)
++libexec=$(cd "${BASH_SOURCE%/*}" && pwd -P)
+
+ # Arguments.
+ output="$1"; shift

--- a/recipes/cetmodules/recipe.yaml
+++ b/recipes/cetmodules/recipe.yaml
@@ -1,0 +1,68 @@
+context:
+  version: "4.02.00"
+
+package:
+  name: cetmodules
+  version: ${{ version }}
+
+source:
+  url: https://github.com/FNALssi/cetmodules/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 431940833989cbb47879fcab27e2ce1778cdeb0e95a4ab26aa20aba942de836a
+  patches:
+    - auto-include-helpers.patch
+    - namespace-install-paths.patch
+
+build:
+  noarch: generic
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - ninja
+  run:
+    - if: unix
+      then:
+        - bash
+        - perl
+        - __unix
+      else:
+        - __win
+
+tests:
+  - package_contents:
+      files:
+        - ${{ "Library/" if win else "" }}share/cetmodules/cmake/cetmodulesConfig.cmake
+        - ${{ "Library/" if win else "" }}share/cetmodules/cmake/cetmodulesConfigVersion.cmake
+        - ${{ "Library/" if win else "" }}share/cetmodules/Modules/CetCMakeEnv.cmake
+        - ${{ "Library/" if win else "" }}share/cetmodules/Modules/CetCMakeUtils.cmake
+        - ${{ "Library/" if win else "" }}share/cetmodules/Modules/CetCMakeConfig.cmake
+        - ${{ "Library/" if win else "" }}share/cetmodules/Modules/CetMake.cmake
+        - ${{ "Library/" if win else "" }}share/cetmodules/Modules/CetProvideDependency.cmake
+        - ${{ "Library/" if win else "" }}libexec/cetmodules/checkClassVersion
+        - ${{ "Library/" if win else "" }}libexec/cetmodules/filter-program-options
+        - if: unix
+          then:
+            - libexec/cetmodules/make_bash_completions
+
+about:
+  homepage: https://github.com/FNALssi/cetmodules
+  summary: CMake modules for building interdependent scientific software (Fermilab)
+  description: |
+    cetmodules provides a set of CMake modules and helper scripts for
+    building and using interdependent scientific software. It is developed
+    by the Fermilab Scientific Computing Division and used as the build
+    infrastructure for the art / LArSoft / Phlex ecosystem.
+
+    Features include facilities for ROOT dictionary generation, assisted
+    production of libraries and executables using modern CMake idioms,
+    full-featured CMake config file generation with target import / export
+    and dependency management, and easy installation of FHiCL / GDML / source
+    data files.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  repository: https://github.com/FNALssi/cetmodules
+
+extra:
+  recipe-maintainers:
+    - olantwin


### PR DESCRIPTION
cetmodules is a collection of CMake modules and helper scripts developed by the Fermilab Scientific Computing Division for building interdependent scientific software (art / LArSoft / Phlex ecosystem). We need it as a build dependency for Phlex, which we plan to upstream next.

The recipe carries a one-patch "auto-include-helpers.patch" that uses cetmodules' existing CONFIG_POST_TARGETS hook to inject include() calls for CetCMakeEnv / CetCMakeUtils / CetCMakeConfig / CetMake / CetProvideDependency into the generated cetmodulesConfig.cmake. Without this, downstream find_package(cetmodules) consumers have to add each include() call manually before they can use cet_cmake_env() etc. An upstream PR carrying the same fix will follow.

The package is noarch generic; the upstream ships three symlinks in Modules/FindFFTW3?.cmake which the build replaces with copies so the package installs cleanly on Windows.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
