### PR TITLE
Add cargo-hakari

### DIFF
--- a/recipes/cargo-hakari/recipe.yaml
+++ b/recipes/cargo-hakari/recipe.yaml
@@ -58,3 +58,4 @@ about:
 extra:
   recipe-maintainers:
     - baszalmstra
+    - Hofer-Julian

--- a/recipes/cargo-hakari/recipe.yaml
+++ b/recipes/cargo-hakari/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  name: cargo-hakari
+  version: "0.9.38"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/guppy-rs/guppy/archive/cargo-hakari-${{ version }}.tar.gz
+  sha256: bcf2f33bfbc112995ba1c2ff3e1c5b132204b9e82bdca4f11cbd973a4556ac64
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path ./tools/cargo-hakari
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path ./tools/cargo-hakari
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script: cargo-hakari --help
+  - package_contents:
+      bin:
+        - cargo-hakari
+      strict: true
+
+about:
+  homepage: https://github.com/guppy-rs/guppy/tree/main/tools/cargo-hakari
+  summary: Manage workspace-hack packages to speed up builds in large workspaces.
+  description: |
+    cargo hakari is a command-line application to manage workspace-hack
+    packages. It automates the creation and maintenance of a workspace-hack
+    crate, which unifies the features of dependencies across a Cargo workspace
+    to significantly speed up builds.
+  license: MIT OR Apache-2.0
+  license_file:
+    - LICENSE-APACHE
+    - LICENSE-MIT
+    - THIRDPARTY.yml
+  documentation: https://docs.rs/cargo-hakari
+  repository: https://github.com/guppy-rs/guppy
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Adds a recipe for [cargo-hakari](https://github.com/guppy-rs/guppy/tree/main/tools/cargo-hakari), a command-line tool to manage workspace-hack packages that speed up builds in large Cargo workspaces.

Built and tested locally on win-64 (rust 1.95, vs2022): the `--help` script test and `package_contents` binary check both pass, and licenses (MIT + Apache-2.0 + bundled THIRDPARTY.yml) are packaged.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our knowledge base documentation before pinging a team.
