### PR TITLE
Add ksfeatureselector

### DIFF
--- a/recipes/ksfeatureselector/meta.yaml
+++ b/recipes/ksfeatureselector/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "ksfeatureselector" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ksfeatureselector-{{ version }}.tar.gz
+  sha256: 28fdb468dfcd7eef4f0d69e911a8d3ef0c9b6ef4b3402ab7945657339cc713d5
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools >=61.0
+    - wheel
+    - pip
+  run:
+    - python >={{ python_min }}
+    - numpy >=1.21
+    - scipy >=1.7
+    - scikit-learn >=1.6
+    - pandas >=1.3
+
+test:
+  imports:
+    - ksfeatureselector
+  commands:
+    - pip check
+    - python -c "import numpy as np; from ksfeatureselector import KSFeatureSelector; rng = np.random.default_rng(0); X = np.vstack([rng.normal(0, 1, (20, 4)), rng.normal(3, 1, (20, 4))]); y = np.array([0] * 20 + [1] * 20); Xt = KSFeatureSelector().fit_transform(X, y); assert Xt.shape[0] == 40 and Xt.shape[1] <= 4"
+  requires:
+    - python {{ python_min }}
+    - pip
+
+about:
+  home: https://github.com/NikolaTesla-007/ksfeatureselector
+  summary: Scikit-learn compatible feature selection using the Kolmogorov-Smirnov test (binary and multi-class).
+  description: |
+    ksfeatureselector provides a scikit-learn compatible transformer for feature
+    selection in binary and multi-class classification using the
+    Kolmogorov-Smirnov (K-S) test. It supports pairwise and one-vs-rest class
+    comparison and Fisher, min, or max p-value aggregation, and integrates with
+    scikit-learn pipelines via the standard fit/transform API.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  dev_url: https://github.com/NikolaTesla-007/ksfeatureselector
+  doc_url: https://github.com/NikolaTesla-007/ksfeatureselector
+
+extra:
+  recipe-maintainers:
+    - NikolaTesla-007


### PR DESCRIPTION
This PR adds a recipe for **ksfeatureselector**, a scikit-learn compatible
feature selector that ranks features using the two-sample Kolmogorov-Smirnov
(K-S) test for binary and multi-class classification (pairwise / one-vs-rest
comparison, Fisher / min / max p-value aggregation). Pure-Python.

- PyPI: https://pypi.org/project/ksfeatureselector/
- Source: https://github.com/NikolaTesla-007/ksfeatureselector
- License: BSD-3-Clause (license file ships in the sdist)

Notes for reviewers:
- `noarch: python`.
- Runtime deps: numpy >=1.21, scipy >=1.7, scikit-learn >=1.6, pandas >=1.3.
- The test section imports the package, runs `pip check`, and fits/transforms
  a small synthetic dataset to exercise the estimator.

Checklist:
- [x] Title of this PR is meaningful.
- [x] License file is packaged (`license_file: LICENSE`).
- [x] Source is from a tagged release on PyPI with sha256.
- [x] I am the package author / authorized to maintain this feedstock.