### PR TITLE
Add iso2gene

### DIFF
--- a/recipes/iso2gene/bld.bat
+++ b/recipes/iso2gene/bld.bat
@@ -1,0 +1,23 @@
+@echo on
+
+cmake -S "%SRC_DIR%" -B build -G Ninja %CMAKE_ARGS% ^
+  -DCMAKE_BUILD_TYPE=Release
+if errorlevel 1 exit /b 1
+
+cmake --build build --parallel %CPU_COUNT%
+if errorlevel 1 exit /b 1
+
+if not exist "%LIBRARY_BIN%" mkdir "%LIBRARY_BIN%"
+copy /Y build\iso2gene.exe "%LIBRARY_BIN%\iso2gene.exe"
+if errorlevel 1 exit /b 1
+
+set "DOC_DIR=%LIBRARY_PREFIX%\share\doc\iso2gene"
+if not exist "%DOC_DIR%" mkdir "%DOC_DIR%"
+copy /Y "%SRC_DIR%\LICENSE" "%DOC_DIR%\LICENSE"
+if errorlevel 1 exit /b 1
+copy /Y "%SRC_DIR%\README.md" "%DOC_DIR%\README.md"
+if errorlevel 1 exit /b 1
+copy /Y "%SRC_DIR%\THIRD_PARTY_NOTICES.txt" "%DOC_DIR%\THIRD_PARTY_NOTICES.txt"
+if errorlevel 1 exit /b 1
+xcopy /E /I /Y "%SRC_DIR%\LICENSES" "%DOC_DIR%\LICENSES"
+if errorlevel 1 exit /b 1

--- a/recipes/iso2gene/build.sh
+++ b/recipes/iso2gene/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S "${SRC_DIR}" -B build -G Ninja \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build --parallel "${CPU_COUNT:-1}"
+
+install -d "${PREFIX}/bin"
+install -m 755 build/iso2gene "${PREFIX}/bin/iso2gene"
+
+doc_dir="${PREFIX}/share/doc/iso2gene"
+install -d "${doc_dir}"
+install -m 644 "${SRC_DIR}/LICENSE" "${doc_dir}/LICENSE"
+install -m 644 "${SRC_DIR}/README.md" "${doc_dir}/README.md"
+install -m 644 "${SRC_DIR}/THIRD_PARTY_NOTICES.txt" "${doc_dir}/THIRD_PARTY_NOTICES.txt"
+cp -R "${SRC_DIR}/LICENSES" "${doc_dir}/LICENSES"

--- a/recipes/iso2gene/meta.yaml
+++ b/recipes/iso2gene/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "iso2gene" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: iso2gene-version-{{ version }}.tar.gz
+  url: https://codeload.github.com/tus-kondolab/iso2gene/tar.gz/refs/tags/version-{{ version }}
+  sha256: 6635c6d2ad734299a35c4cd390f5505519e3ac14999ad021eeda05ce7c248d71
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - cmake
+    - ninja
+
+test:
+  commands:
+    - iso2gene --version
+    - iso2gene --help
+
+about:
+  home: https://github.com/tus-kondolab/iso2gene
+  summary: Compact tximport-compatible gene-level summarization tool
+  description: |
+    iso2gene is a clean-room native command-line implementation of
+    tximport-compatible gene-level summarization for supported transcript
+    quantification inputs.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRD_PARTY_NOTICES.txt
+    - LICENSES/miniz-LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - tus-kondolab


### PR DESCRIPTION
This PR adds a conda-forge recipe for iso2gene.\n\niso2gene is a compact tximport-compatible gene-level summarization tool for supported transcript quantification inputs.\n\nNotes:\n- Source tag: https://github.com/tus-kondolab/iso2gene/releases/tag/version-1.0.0\n- License: MIT\n- Local checks: release tarball SHA256 verified; required license files are present in the source tarball.\n- conda-build/rattler-build was not available in my local environment, so package build validation is left to staged-recipes CI.