### PR TITLE
Add gabriellab-presence v0.0.1

### DIFF
--- a/recipes/gabriellab-presence/meta.yaml
+++ b/recipes/gabriellab-presence/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "gabriellab-presence" %}
+{% set version = "0.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/0riginal-claw/gabriellab-presence/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b477d33e3230209e8cffacd14078cd0f32eb22730ab72d23c5523548f98c469e
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  entry_points:
+    - gabriellab-presence = gabriellab_presence:main
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.8
+
+test:
+  imports:
+    - gabriellab_presence
+  commands:
+    - gabriellab-presence
+
+about:
+  home: https://github.com/0riginal-claw/gabriellab-presence
+  license: MIT
+  license_family: MIT
+  summary: Lab identity beacon for gabriellab — S&P 500 per-ticker mastery lab
+  description: |
+    Minimal package that prints the lab identity JSON on import or CLI run.
+    Useful for confirming the lab's presence across registries.
+
+extra:
+  recipe-maintainers:
+    - 0riginal-claw


### PR DESCRIPTION
## Description

New package: **gabriellab-presence** v0.0.1

Minimal lab identity beacon that prints a JSON identity record on import or CLI run. Used to confirm lab presence across registries.

### Package details

- **Source:** https://github.com/0riginal-claw/gabriellab-presence/archive/refs/tags/v0.0.1.tar.gz
- **SHA256:** b477d33e3230209e8cffacd14078cd0f32eb22730ab72d23c5523548f98c469e
- **License:** MIT
- **noarch:** python (pure Python, no compiled extensions)
- **Python:** >=3.8
- **Entry point:** `gabriellab-presence` → `gabriellab_presence:main`

### Checklist

- [x] License file present in source repo
- [x] noarch: python (pure Python package)
- [x] SHA256 verified against tarball
- [x] Tests: `import gabriellab_presence` + CLI entry point
- [x] recipe-maintainers: 0riginal-claw