### PR TITLE
fix: bump webservices linter on merge groups

### DIFF
--- a/.github/workflows/scripts/bump_webservices_linter.py
+++ b/.github/workflows/scripts/bump_webservices_linter.py
@@ -12,11 +12,15 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    requests.post(
-        "https://conda-forge.herokuapp.com/staged-recipes/merge-queue-linting-hook",
-        headers={
-            "CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]
-        },
-        json={"full_name": args.full_name, "head_sha": args.head_sha, "head_ref": args.head_ref},
-        timeout=(None, 0.00001),
-    )
+    try:
+        requests.post(
+            "https://conda-forge.herokuapp.com/staged-recipes/merge-queue-linting-hook",
+            headers={
+                "CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]
+            },
+            json={"full_name": args.full_name, "head_sha": args.head_sha, "head_ref": args.head_ref},
+            timeout=(None, 0.00001),
+        )
+    except requests.exceptions.ReadTimeout:
+        # we swallow this error since we do not wait for a response
+        pass

--- a/.github/workflows/scripts/bump_webservices_linter.py
+++ b/.github/workflows/scripts/bump_webservices_linter.py
@@ -1,0 +1,22 @@
+import argparse
+import os
+
+import requests
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Lint staged recipes.")
+    parser.add_argument("--full-name", type=str, required=True, help="the full repo name (e.g., conda-forge/staged-recipes)")
+    parser.add_argument("--head-ref", type=str, required=True, help="the `head_ref` property of the merge group")
+    parser.add_argument("--head-sha", type=str, required=True, help="the `head_sha` property of the merge group")
+
+    args = parser.parse_args()
+
+    requests.post(
+        "https://conda-forge.herokuapp.com/staged-recipes/merge-queue-linting-hook",
+        headers={
+            "CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]
+        },
+        json={"full_name": args.full_name, "head_sha": args.head_sha, "head_ref": args.head_ref},
+        timeout=(None, 0.00001),
+    )

--- a/.github/workflows/scripts/bump_webservices_linter.py
+++ b/.github/workflows/scripts/bump_webservices_linter.py
@@ -5,22 +5,18 @@ import requests
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Lint staged recipes.")
+    parser = argparse.ArgumentParser(description="bump webservices linter for staged-recipes merge groups")
     parser.add_argument("--full-name", type=str, required=True, help="the full repo name (e.g., conda-forge/staged-recipes)")
     parser.add_argument("--head-ref", type=str, required=True, help="the `head_ref` property of the merge group")
     parser.add_argument("--head-sha", type=str, required=True, help="the `head_sha` property of the merge group")
 
     args = parser.parse_args()
 
-    try:
-        requests.post(
+    r = requests.post(
             "https://conda-forge.herokuapp.com/staged-recipes/merge-queue-linting-hook",
             headers={
                 "CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]
             },
             json={"full_name": args.full_name, "head_sha": args.head_sha, "head_ref": args.head_ref},
-            timeout=(None, 0.00001),
         )
-    except requests.exceptions.ReadTimeout:
-        # we swallow this error since we do not wait for a response
-        pass
+    r.raise_for_status()

--- a/.github/workflows/staged-recipes-linter.yml
+++ b/.github/workflows/staged-recipes-linter.yml
@@ -59,7 +59,7 @@ jobs:
         if: github.event_name == 'merge_group'
         run: |
           python .github/workflows/scripts/bump_webservices_linter.py \
-            --full-name=${{ github.repository.full_name }} \
+            --full-name=${{ github.repository }} \
             --head-ref=${{ github.event.merge_group.head_ref }} \
             --head-sha=${{ github.event.merge_group.head_sha }}
         env:

--- a/.github/workflows/staged-recipes-linter.yml
+++ b/.github/workflows/staged-recipes-linter.yml
@@ -55,6 +55,16 @@ jobs:
           owner: ${{ github.event_name == 'merge_group' && github.repository_owner || github.event.pull_request.head.repo.owner.login }}
           branch: ${{ github.event_name == 'merge_group' && github.ref || github.event.pull_request.head.ref }}
 
+      - name: bump conda-forge-webservices linting
+        if: github.event_name == 'merge_group'
+        run: |
+          python .github/workflows/scripts/bump_webservices_linter.py \
+            --full-name=${{ github.repository.full_name }} \
+            --head-ref=${{ github.event.merge_group.head_ref }} \
+            --head-sha=${{ github.event.merge_group.head_sha }}
+        env:
+          CF_WEBSERVICES_TOKEN: ${{ secrets.CF_WEBSERVICES_TOKEN }}
+
       - name: lint
         run: |
           python .github/workflows/scripts/linter.py \


### PR DESCRIPTION
This PR attempts to fix merge group handling by bumping the webservices linter on merge group events. The merge group webhoook events appear unreliable for reasons.

To Do:

- [x] add endpoint to webservices (https://github.com/conda-forge/conda-forge-webservices/pull/1382)
- [x] share secrets (https://github.com/conda-forge/infrastructure/pull/50)
- [ ] enable in staged-recipes (this PR)