### PR TITLE
Add font-monocraft and font-comic-mono

### DIFF
--- a/recipes/font-comic-mono/recipe.yaml
+++ b/recipes/font-comic-mono/recipe.yaml
@@ -1,0 +1,37 @@
+context:
+  version: "1.0"
+  commit: 13eb162648d01d61ece424088dbf750ec80a1a62
+
+package:
+  name: font-comic-mono
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/dtinth/comic-mono-font/archive/${{ commit }}.tar.gz
+    sha256: 880b2dd3fbbfaa6953dc4baf74be746f07b8ac208b78c7f476cbf8d9a9ab9882
+
+build:
+  noarch: generic
+  number: 0
+  script:
+    - mkdir -p $PREFIX/fonts
+    - cp ComicMono.ttf $PREFIX/fonts
+    - cp ComicMono-Bold.ttf $PREFIX/fonts
+
+tests:
+  - package_contents:
+      files:
+        - fonts/ComicMono.ttf
+        - fonts/ComicMono-Bold.ttf
+      strict: true
+
+about:
+  homepage: https://dtinth.github.io/comic-mono-font
+  summary: A legible monospace font
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/dtinth/comic-mono-font
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/font-monocraft/recipe.yaml
+++ b/recipes/font-monocraft/recipe.yaml
@@ -1,0 +1,67 @@
+context:
+  version: "4.2.1"
+
+package:
+  name: font-monocraft
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/IdreesInc/Monocraft/releases/download/v${{ version }}/Monocraft-otf.zip
+    sha256: e623b72f1021062ad0156cc41f54b108e70bd35e2b295127475bb572d8ade61d
+    target_directory: otf
+  - url: https://github.com/IdreesInc/Monocraft/releases/download/v${{ version }}/Monocraft-ttf.zip
+    sha256: 897faffbef8cc27fadd0d5aa51872ab5f908e22a89bb8fa5b191366025d503e0
+    target_directory: ttf
+  - url: https://raw.githubusercontent.com/IdreesInc/Monocraft/v${{ version }}/LICENSE
+    sha256: f69c147003e052dbc9d96c40a9f73647e72766cfda95a597b94ed827fe25acb1
+    file_name: LICENSE
+
+build:
+  noarch: generic
+  number: 0
+  script:
+    - mkdir -p $PREFIX/fonts
+    - cp otf/Monocraft.otf $PREFIX/fonts
+    - cp otf/weights/* $PREFIX/fonts
+    - cp ttf/Monocraft.ttf $PREFIX/fonts
+    - cp ttf/weights/* $PREFIX/fonts
+
+tests:
+  - package_contents:
+      files:
+        - fonts/Monocraft.otf
+        - fonts/Monocraft-Black.otf
+        - fonts/Monocraft-Black-Italic.otf
+        - fonts/Monocraft-Bold.otf
+        - fonts/Monocraft-Bold-Italic.otf
+        - fonts/Monocraft-ExtraLight.otf
+        - fonts/Monocraft-ExtraLight-Italic.otf
+        - fonts/Monocraft-Italic.otf
+        - fonts/Monocraft-Light.otf
+        - fonts/Monocraft-Light-Italic.otf
+        - fonts/Monocraft-SemiBold.otf
+        - fonts/Monocraft-SemiBold-Italic.otf
+        - fonts/Monocraft.ttf
+        - fonts/Monocraft-Black.ttf
+        - fonts/Monocraft-Black-Italic.ttf
+        - fonts/Monocraft-Bold.ttf
+        - fonts/Monocraft-Bold-Italic.ttf
+        - fonts/Monocraft-ExtraLight.ttf
+        - fonts/Monocraft-ExtraLight-Italic.ttf
+        - fonts/Monocraft-Italic.ttf
+        - fonts/Monocraft-Light.ttf
+        - fonts/Monocraft-Light-Italic.ttf
+        - fonts/Monocraft-SemiBold.ttf
+        - fonts/Monocraft-SemiBold-Italic.ttf
+      strict: true
+
+about:
+  homepage: https://github.com/IdreesInc/Monocraft
+  summary: A monospaced programming font inspired by the Minecraft typeface
+  license: OFL-1.1
+  license_file: LICENSE
+  repository: https://github.com/IdreesInc/Monocraft
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds two monospace fonts:

- **font-monocraft** — [Monocraft](https://github.com/IdreesInc/Monocraft), a monospaced programming font inspired by the Minecraft typeface (OTF + TTF, all weights, from release v4.2.1). OFL-1.1.
- **font-comic-mono** — [Comic Mono](https://github.com/dtinth/comic-mono-font), a legible monospace font forked from Comic Shanns (regular + bold). MIT. Upstream has no releases/tags, so the recipe pins the latest commit with a date-based version.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
