### PR TITLE
Add abvx-agent-skills

### DIFF
--- a/recipes/abvx-agent-skills/recipe.yaml
+++ b/recipes/abvx-agent-skills/recipe.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+
+context:
+  version: 0.10.0
+  python_min: "3.10"
+
+package:
+  name: abvx-agent-skills
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/abvx-agent-skills/abvx_agent_skills-${{ version }}.tar.gz
+  sha256: 87c2cabafedeb2e2206efacd4d7c55e7b812e20c4fc5550d6720680105540854
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling >=1.25.0
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pyyaml >=6.0
+
+tests:
+  - python:
+      imports:
+        - abvx_agent_skills
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+  - script:
+      - abvx-skills list
+
+about:
+  homepage: https://github.com/markoblogo/abvx-agent-skills
+  repository: https://github.com/markoblogo/abvx-agent-skills
+  summary: Small, reviewable, validation-gated agent skills for Codex-style project work.
+  description: |
+    ABVX Agent Skills publishes compact, reviewable skillpacks for coding agents.
+    The package bundles SKILL.md workflows, skill cards, and CLI helpers for
+    listing, installing, validating, and auditing reusable agent capabilities.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - markoblogo

--- a/recipes/abvx-agent-skills/recipe.yaml
+++ b/recipes/abvx-agent-skills/recipe.yaml
@@ -35,7 +35,7 @@ tests:
         - "*"
       pip_check: true
   - script:
-      - abvx-skills list
+      - ${{ PYTHON }} -m abvx_agent_skills.cli list
 
 about:
   homepage: https://github.com/markoblogo/abvx-agent-skills


### PR DESCRIPTION
## Checklist
- [x] Package name is available on conda-forge
- [x] Source is a PyPI sdist for `abvx-agent-skills 0.10.0`
- [x] Local wheel/sdist build and smoke install passed
- [x] PyPI publish for `0.10.0` completed before opening this PR

## Package summary
`abvx-agent-skills` is a pure-Python `noarch` package that bundles reusable Codex-style agent skills plus a small CLI for listing, installing, validating, and auditing those skills.

## Notes
- Runtime deps are minimal: `python`, `pyyaml`
- Build backend: `hatchling`
- CLI smoke check used locally: `abvx-skills list`
