### PR TITLE
Add quantum-memory-graph recipe v1.2.2

### DIFF
--- a/recipes/quantum-memory-graph/meta.yaml
+++ b/recipes/quantum-memory-graph/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.1" %}
+{% set version = "1.2.2" %}
 
 package:
   name: quantum-memory-graph
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/q/quantum-memory-graph/quantum_memory_graph-{{ version }}.tar.gz
-  sha256: a60593ffe80cde8ce6881c46793e986ebb25d2a1813d151b6c818854c65ed23d
+  sha256: d191b57369576a76678384996dab788742d1557dfae098943c36ce1cf507e339
 
 build:
   noarch: python

--- a/recipes/quantum-memory-graph/meta.yaml
+++ b/recipes/quantum-memory-graph/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - pip
   run:
     - python >=3.9
-    - quantum-agent-memory >=0.1.0
     - sentence-transformers >=2.2.0
     - networkx >=3.0
     - numpy >=1.24.0

--- a/recipes/quantum-memory-graph/meta.yaml
+++ b/recipes/quantum-memory-graph/meta.yaml
@@ -1,0 +1,61 @@
+{% set version = "1.2.1" %}
+
+package:
+  name: quantum-memory-graph
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/q/quantum-memory-graph/quantum_memory_graph-{{ version }}.tar.gz
+  sha256: a60593ffe80cde8ce6881c46793e986ebb25d2a1813d151b6c818854c65ed23d
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - setuptools >=68.0
+    - wheel
+    - pip
+  run:
+    - python >=3.9
+    - quantum-agent-memory >=0.1.0
+    - sentence-transformers >=2.2.0
+    - networkx >=3.0
+    - numpy >=1.24.0
+    - qiskit >=1.0.0
+    - qiskit-aer >=0.13.0
+
+test:
+  imports:
+    - quantum_memory_graph
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/Dustin-a11y/quantum-memory-graph
+  summary: 'Quantum-optimized knowledge graph memory for AI agents. Relationship-aware subgraph selection via QAOA.'
+  description: |
+    Quantum Memory Graph provides relationship-aware memory for AI agents,
+    combining knowledge graphs with QAOA (Quantum Approximate Optimization Algorithm)
+    for optimal subgraph selection.
+
+    Features:
+    - Knowledge graph with weighted edges based on entity co-occurrence and source proximity
+    - QAOA-powered subgraph optimization maximizing relevance, connectivity, and coverage
+    - #1 ranked on LongMemEval (ICLR 2025 benchmark) with 94.26% NDCG@10
+    - Optional API server via FastAPI
+    - IBM quantum hardware support via qiskit-ibm-runtime
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/Dustin-a11y/quantum-memory-graph
+  dev_url: https://github.com/Dustin-a11y/quantum-memory-graph
+
+extra:
+  recipe-maintainers:
+    - Dustin-a11y


### PR DESCRIPTION
This PR adds a conda-forge recipe for [quantum-memory-graph](https://github.com/Dustin-a11y/quantum-memory-graph) v1.2.2.

## Package Description

Quantum-optimized knowledge graph memory for AI agents. Combines knowledge graphs with QAOA (Quantum Approximate Optimization Algorithm) for relationship-aware subgraph selection.

- **PyPI**: https://pypi.org/project/quantum-memory-graph/
- **GitHub**: https://github.com/Dustin-a11y/quantum-memory-graph
- **License**: MIT
- **Python**: >=3.9
- **#1 on LongMemEval** (ICLR 2025 benchmark): 94.26% NDCG@10

## Dependencies (all available on conda-forge)

- sentence-transformers >=2.2.0
- networkx >=3.0
- numpy >=1.24.0
- qiskit >=1.0.0
- qiskit-aer >=0.13.0

Note: The recipe does NOT depend on quantum-agent-memory (obsolete, absorbed into quantum-memory-graph).