### PR TITLE
Add ryl

### DIFF
--- a/recipes/ryl/recipe.yaml
+++ b/recipes/ryl/recipe.yaml
@@ -1,0 +1,72 @@
+context:
+  version: "0.17.0"
+
+package:
+  name: ryl
+  version: ${{ version }}
+
+source:
+  url: https://github.com/owenlamont/ryl/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 32cd1b37f045e8f1b4bb013c3ada81e9b4d604b0e544d2f6a0eb4c08c4c4d74a
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+      - if: unix
+        then:
+          - mkdir -p $PREFIX/share/zsh/site-functions $PREFIX/share/bash-completion/completions $PREFIX/share/fish/vendor_completions.d
+          - $PREFIX/bin/ryl --generate-completions zsh > $PREFIX/share/zsh/site-functions/_ryl
+          - $PREFIX/bin/ryl --generate-completions bash > $PREFIX/share/bash-completion/completions/ryl
+          - $PREFIX/bin/ryl --generate-completions fish > $PREFIX/share/fish/vendor_completions.d/ryl.fish
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script:
+      - ryl --version
+      - ryl --help
+  - package_contents:
+      bin:
+        - ryl
+      files:
+        - if: unix
+          then:
+            - share/bash-completion/completions/ryl
+            - share/fish/vendor_completions.d/ryl.fish
+            - share/zsh/site-functions/_ryl
+      strict: true
+
+about:
+  homepage: https://github.com/owenlamont/ryl
+  summary: Fast YAML linter inspired by yamllint
+  description: |
+    ryl is a fast YAML linter written in Rust, intended as a drop-in
+    replacement for yamllint. It reads yamllint-compatible YAML config and
+    adds a native TOML config, lints YAML embedded in Markdown, applies safe
+    fixes, and emits standard, GitHub, JUnit, and GitLab output formats.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://ryl-docs.pages.dev/
+  repository: https://github.com/owenlamont/ryl
+
+extra:
+  recipe-maintainers:
+    - owenlamont


### PR DESCRIPTION
Adds a recipe for [ryl](https://github.com/owenlamont/ryl), a fast YAML linter written in Rust, intended as a drop-in replacement for yamllint.

Recipe follows the conda-forge Rust example: builds from the GitHub tag tarball with `${{ compiler('rust') }}`, embeds a dependency SBOM via `cargo auditable`, and bundles all transitive dependency licenses into `THIRDPARTY.yml` via `cargo-bundle-licenses`. Shell completions (bash/zsh/fish) are generated from the `ryl --generate-completions <shell>` flag.

Built and tested locally with rattler-build against the conda-forge pinning (linux-64): conda-forge ships rust 1.96.0, which matches ryl's MSRV. The package builds, completions are generated, and the `ryl --version` / `ryl --help` / package-contents tests pass.

Note on completions and osx-arm64: generating completions runs the native binary, which cannot run under osx-64 -> osx-arm64 cross-compilation. This does not affect this PR (staged-recipes builds x64 only); native osx-arm64 builds will be enabled in the feedstock so completions generate on arm.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (`LICENSE` plus `THIRDPARTY.yml` for the statically linked Rust dependencies).
- [x] Source is from official source (GitHub release tag tarball).
- [x] Package does not vendor other packages. (Rust crates are statically linked at build time; their licenses are packaged in `THIRDPARTY.yml`.)
- [x] If static libraries are linked in, the license of the static library is packaged (via `THIRDPARTY.yml`).
- [x] Package does not ship static libraries. (Only the `ryl` binary is installed.)
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (@owenlamont is the package author and sole maintainer.)
- [x] When in trouble, please check our knowledge base documentation before pinging a team.
