### PR TITLE
Add purgedcv

### DIFF
--- a/recipes/purgedcv/meta.yaml
+++ b/recipes/purgedcv/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "purgedcv" %}
+{% set version = "0.1.2" %}
+{% set python_min = "3.10" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5d8ec69aed8b95eb862bf30602cbc2547f6508437c3d89dd14e6d884fb454580
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - hatchling
+    - pip
+  run:
+    - python >={{ python_min }}
+    - numpy >=1.24
+    - pandas >=2.0
+    - scikit-learn >=1.3
+    - scipy >=1.10
+
+test:
+  imports:
+    - purgedcv
+    - purgedcv.diagnostics
+  requires:
+    - python {{ python_min }}
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/eslazarev/purged-cross-validation
+  summary: scikit-learn-compatible purged and combinatorial cross-validation for time-series and financial machine learning
+  description: |
+    purgedcv implements purging and embargoing of overlapping labels,
+    walk-forward validation, purged and group-purged k-fold, Combinatorial
+    Purged Cross-Validation (CPCV) with backtest-path reconstruction, and the
+    Probabilistic Sharpe Ratio, Deflated Sharpe Ratio, Minimum Track Record
+    Length, and Minimum Backtest Length. Every splitter follows the
+    scikit-learn splitter protocol.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://eslazarev.github.io/purged-cross-validation/
+  dev_url: https://github.com/eslazarev/purged-cross-validation
+
+extra:
+  recipe-maintainers:
+    - eslazarev


### PR DESCRIPTION
Adds a recipe for [`purgedcv`](https://pypi.org/project/purgedcv/), a scikit-learn-compatible library for purged, group-purged, and combinatorial purged (CPCV) cross-validation, walk-forward splitting, and backtest-overfitting statistics (PSR, DSR, MinTRL, MinBTL) for time-series and financial machine learning. Pure Python -> `noarch: python`; runtime deps (`numpy`, `pandas`, `scikit-learn`, `scipy`) are all on conda-forge.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (`license_file: LICENSE`, bundled in the sdist).
- [x] Source is from official source (PyPI sdist tarball with `sha256`).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged. (N/A: pure Python, no static libraries.)
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (I am the package author and the sole maintainer, @eslazarev, and I confirm I am willing to be listed.)
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.