### PR TITLE
Add editdistpy, symspellpy, and resolvekit recipes

### DIFF
--- a/recipes/editdistpy/recipe.yaml
+++ b/recipes/editdistpy/recipe.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+
+context:
+  version: "0.2.0"
+
+package:
+  name: editdistpy
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/e/editdistpy/editdistpy-${{ version }}.tar.gz
+  sha256: 6cd95c61687a2681b11e28c914a90c2d73a771dea3d38473dc94cc8c64563ed1
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - pip
+    - setuptools >=82.0.0
+    - cython >=3.2.4
+    - packaging >=26.0
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - editdistpy
+        - editdistpy.levenshtein
+        - editdistpy.damerau_osa
+      pip_check: true
+
+about:
+  summary: Fast Levenshtein and Damerau optimal string alignment algorithms.
+  description: |
+    editdistpy is a fast implementation of the Levenshtein and Damerau
+    optimal string alignment (OSA) edit distance algorithms, written as a
+    Cython/C++ extension. It is used by symspellpy for spelling correction.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/mammothb/editdistpy
+  repository: https://github.com/mammothb/editdistpy
+
+extra:
+  recipe-maintainers:
+    - jm-rivera

--- a/recipes/resolvekit/recipe.yaml
+++ b/recipes/resolvekit/recipe.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+context:
+  python_min: "3.12"
+  version: "0.1.11"
+
+package:
+  name: resolvekit
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/resolvekit/resolvekit-${{ version }}.tar.gz
+  sha256: c596b7eed53e5d846c761f66565925fc37579975c7e59cbbfdf8ad031ce9cc91
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - uv-build >=0.11.7,<0.12
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - packaging >=24.0
+    - pooch >=1.8.0,<2.0
+    - pydantic >=2.9,<3.0
+    - rapidfuzz >=3.0.0,<4.0
+    - symspellpy >=6.7.7,<7.0
+
+tests:
+  - python:
+      imports:
+        - resolvekit
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: Entity and place resolution system that maps messy place/entity strings and codes to canonical entities
+  description: |
+    resolvekit maps messy place and entity strings (and codes) to canonical
+    entities, supporting offline disambiguation and normalization for ISO
+    codes, geographic names, and other reference data.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/jm-rivera/resolvekit
+  documentation: https://jm-rivera.github.io/resolvekit/
+  repository: https://github.com/jm-rivera/resolvekit
+
+extra:
+  recipe-maintainers:
+    - jm-rivera

--- a/recipes/resolvekit/recipe.yaml
+++ b/recipes/resolvekit/recipe.yaml
@@ -15,19 +15,7 @@ source:
 build:
   number: 0
   noarch: python
-  script:
-    # Two workarounds for conda-forge's currently-unstable Windows runner, where
-    # late builds intermittently fail in Python's crypto/RNG primitives:
-    #   - PYTHONHASHSEED pins the hash seed so Python skips the OS-RNG read at
-    #     startup (else _Py_HashRandomization_Init fails to get random numbers).
-    #   - --use-deprecated=legacy-certs makes pip skip truststore SSL-context init
-    #     (truststore.SSLContext), which fails under OpenSSL 3.6.3 on Windows
-    #     (conda-forge/openssl-feedstock#237).
-    # Both are harmless here (noarch, offline --no-deps install); drop once the
-    # upstream OpenSSL/Python fix propagates.
-    env:
-      PYTHONHASHSEED: "0"
-    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --use-deprecated=legacy-certs
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipes/resolvekit/recipe.yaml
+++ b/recipes/resolvekit/recipe.yaml
@@ -15,7 +15,18 @@ source:
 build:
   number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    # On Windows, pip 26's truststore SSL-context init (truststore.SSLContext)
+    # fails under conda-forge's OpenSSL 3.6.3 (conda-forge/openssl-feedstock#237),
+    # aborting the build before any network use. --use-deprecated=legacy-certs
+    # makes pip skip truststore; harmless here since --no-deps --no-build-isolation
+    # performs no HTTPS. Drop once the upstream OpenSSL/Python fix propagates.
+    - if: win
+      then:
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --use-deprecated=legacy-certs
+    - if: unix
+      then:
+        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipes/resolvekit/recipe.yaml
+++ b/recipes/resolvekit/recipe.yaml
@@ -47,7 +47,9 @@ tests:
       imports:
         - resolvekit
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   summary: Entity and place resolution system that maps messy place/entity strings and codes to canonical entities

--- a/recipes/resolvekit/recipe.yaml
+++ b/recipes/resolvekit/recipe.yaml
@@ -16,17 +16,18 @@ build:
   number: 0
   noarch: python
   script:
-    # On Windows, pip 26's truststore SSL-context init (truststore.SSLContext)
-    # fails under conda-forge's OpenSSL 3.6.3 (conda-forge/openssl-feedstock#237),
-    # aborting the build before any network use. --use-deprecated=legacy-certs
-    # makes pip skip truststore; harmless here since --no-deps --no-build-isolation
-    # performs no HTTPS. Drop once the upstream OpenSSL/Python fix propagates.
-    - if: win
-      then:
-        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --use-deprecated=legacy-certs
-    - if: unix
-      then:
-        - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    # Two workarounds for conda-forge's currently-unstable Windows runner, where
+    # late builds intermittently fail in Python's crypto/RNG primitives:
+    #   - PYTHONHASHSEED pins the hash seed so Python skips the OS-RNG read at
+    #     startup (else _Py_HashRandomization_Init fails to get random numbers).
+    #   - --use-deprecated=legacy-certs makes pip skip truststore SSL-context init
+    #     (truststore.SSLContext), which fails under OpenSSL 3.6.3 on Windows
+    #     (conda-forge/openssl-feedstock#237).
+    # Both are harmless here (noarch, offline --no-deps install); drop once the
+    # upstream OpenSSL/Python fix propagates.
+    env:
+      PYTHONHASHSEED: "0"
+    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --use-deprecated=legacy-certs
 
 requirements:
   host:

--- a/recipes/symspellpy/recipe.yaml
+++ b/recipes/symspellpy/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "6.9.0"
+
+package:
+  name: symspellpy
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/symspellpy/symspellpy-${{ version }}.tar.gz
+  sha256: 5ce8cb8a13e531db03f664407abc9e42e272f16bab7c0639500a8bdd07eee482
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=61.0.0
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - editdistpy >=0.1.3
+
+tests:
+  - python:
+      imports:
+        - symspellpy
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: Python SymSpell
+  description: |
+    symspellpy is a Python port of SymSpell, a fast spelling correction and
+    fuzzy search library based on the Symmetric Delete spelling correction
+    algorithm.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/mammothb/symspellpy
+  documentation: https://symspellpy.readthedocs.io/en/latest
+  repository: https://github.com/mammothb/symspellpy
+
+extra:
+  recipe-maintainers:
+    - jm-rivera

--- a/recipes/symspellpy/recipe.yaml
+++ b/recipes/symspellpy/recipe.yaml
@@ -14,19 +14,7 @@ source:
 build:
   number: 0
   noarch: python
-  script:
-    # Two workarounds for conda-forge's currently-unstable Windows runner, where
-    # late builds intermittently fail in Python's crypto/RNG primitives:
-    #   - PYTHONHASHSEED pins the hash seed so Python skips the OS-RNG read at
-    #     startup (else _Py_HashRandomization_Init fails to get random numbers).
-    #   - --use-deprecated=legacy-certs makes pip skip truststore SSL-context init
-    #     (truststore.SSLContext), which fails under OpenSSL 3.6.3 on Windows
-    #     (conda-forge/openssl-feedstock#237).
-    # Both are harmless here (noarch, offline --no-deps install); drop once the
-    # upstream OpenSSL/Python fix propagates.
-    env:
-      PYTHONHASHSEED: "0"
-    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --use-deprecated=legacy-certs
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipes/symspellpy/recipe.yaml
+++ b/recipes/symspellpy/recipe.yaml
@@ -43,7 +43,9 @@ tests:
       imports:
         - symspellpy
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   summary: Python SymSpell

--- a/recipes/symspellpy/recipe.yaml
+++ b/recipes/symspellpy/recipe.yaml
@@ -15,13 +15,18 @@ build:
   number: 0
   noarch: python
   script:
-    # PYTHONHASHSEED pins the hash seed so Python skips the OS-RNG read at
-    # interpreter startup. Works around transient conda-forge Windows CI runs
-    # where _Py_HashRandomization_Init fails to get random numbers and aborts
-    # the build. Harmless: affects only hash-seed determinism, not package content.
+    # Two workarounds for conda-forge's currently-unstable Windows runner, where
+    # late builds intermittently fail in Python's crypto/RNG primitives:
+    #   - PYTHONHASHSEED pins the hash seed so Python skips the OS-RNG read at
+    #     startup (else _Py_HashRandomization_Init fails to get random numbers).
+    #   - --use-deprecated=legacy-certs makes pip skip truststore SSL-context init
+    #     (truststore.SSLContext), which fails under OpenSSL 3.6.3 on Windows
+    #     (conda-forge/openssl-feedstock#237).
+    # Both are harmless here (noarch, offline --no-deps install); drop once the
+    # upstream OpenSSL/Python fix propagates.
     env:
       PYTHONHASHSEED: "0"
-    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --use-deprecated=legacy-certs
 
 requirements:
   host:

--- a/recipes/symspellpy/recipe.yaml
+++ b/recipes/symspellpy/recipe.yaml
@@ -14,7 +14,14 @@ source:
 build:
   number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    # PYTHONHASHSEED pins the hash seed so Python skips the OS-RNG read at
+    # interpreter startup. Works around transient conda-forge Windows CI runs
+    # where _Py_HashRandomization_Init fails to get random numbers and aborts
+    # the build. Harmless: affects only hash-seed determinism, not package content.
+    env:
+      PYTHONHASHSEED: "0"
+    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
This PR adds three new recipes that form a dependency chain. They are bundled together because `resolvekit` (the package I ultimately need) depends on `symspellpy`, which depends on `editdistpy` — none of which are currently on conda-forge.

- **editdistpy** 0.2.0 — C++/Cython extension (Levenshtein / Damerau-OSA edit distance). Dependency of symspellpy.
- **symspellpy** 6.9.0 — noarch Python; runtime dep `editdistpy`.
- **resolvekit** 0.1.11 — noarch Python (requires Python >=3.12); runtime deps `packaging`, `pooch`, `pydantic`, `rapidfuzz`, `symspellpy`.

resolvekit is needed to package the latest [pydeflate](https://github.com/conda-forge/pydeflate-feedstock) release on conda-forge.

### Checklist
- [x] Title of this PR is meaningful.
- [x] License files are packaged (all three are MIT with a single `LICENSE`).
- [x] Source is from the official PyPI sdist with sha256 hashes.
- [x] All build/host/run dependencies are available on conda-forge (compatible versions verified).
- [x] I am a recipe maintainer for all three recipes.
