### PR TITLE
Add rich-pixels

### DIFF
--- a/recipes/rich-pixels/recipe.yaml
+++ b/recipes/rich-pixels/recipe.yaml
@@ -1,7 +1,6 @@
 schema_version: 1
 
 context:
-  python_min: "3.9"
   version: "3.0.1"
 
 package:
@@ -32,7 +31,9 @@ tests:
       imports:
         - rich_pixels
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   summary: A Rich-compatible library for writing pixel images and ASCII art to the terminal.

--- a/recipes/rich-pixels/recipe.yaml
+++ b/recipes/rich-pixels/recipe.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "3.0.1"
+
+package:
+  name: rich-pixels
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/rich-pixels/rich_pixels-${{ version }}.tar.gz
+  sha256: 4a81977d45437ce5009cdcaf70af80256c3bdfab870e87ab802c577ba4133235
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - rich >=12.0.0
+    - pillow >=10.0.0
+
+tests:
+  - python:
+      imports:
+        - rich_pixels
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: A Rich-compatible library for writing pixel images and ASCII art to the terminal.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/darrenburns/rich-pixels
+  repository: https://github.com/darrenburns/rich-pixels
+
+extra:
+  recipe-maintainers:
+    - nh13


### PR DESCRIPTION
Adds `rich-pixels`, a Rich-compatible library for rendering images and ASCII art in the terminal.

- Pure-Python, builds `noarch`; license MIT (`LICENSE` is packaged).
- Runtime dependencies `pillow` and `rich` are both already on conda-forge.
- Needed as a runtime dependency of the bioconda `snakesee` package (its TUI image rendering); see bioconda/bioconda-recipes#66333.

Built and tested locally on osx-arm64 with `conda-build` 26.5.0: the `noarch` package builds, `import rich_pixels` succeeds, and `pip check` reports no broken requirements.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
