### PR TITLE
perf: fire and forget request for merge group checks

### DIFF
--- a/.github/workflows/scripts/bump_webservices_linter.py
+++ b/.github/workflows/scripts/bump_webservices_linter.py
@@ -12,11 +12,14 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    r = requests.post(
+    try:
+        requests.post(
             "https://conda-forge.herokuapp.com/staged-recipes/merge-queue-linting-hook",
             headers={
                 "CF_WEBSERVICES_TOKEN": os.environ["CF_WEBSERVICES_TOKEN"]
             },
             json={"full_name": args.full_name, "head_sha": args.head_sha, "head_ref": args.head_ref},
+            timeout=0.001,
         )
-    r.raise_for_status()
+    except requests.exceptions.Timeout:
+        pass


### PR DESCRIPTION
Let's try this for a while to see if it improves the merge queue. Sometimes the webserver doesn't respond even if the linting is happening.