### PR TITLE
Adding addlicense

### DIFF
--- a/recipes/addlicense/recipe.yaml
+++ b/recipes/addlicense/recipe.yaml
@@ -1,0 +1,50 @@
+context:
+  version: "1.2.0"
+
+package:
+  name: addlicense
+  version: ${{ version }}
+
+source:
+  url: https://github.com/google/addlicense/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d2e05668e6f3da9b119931c2fdadfa6dd19a8fc441218eb3f2aec4aa24ae3f90
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save . --save_path ../library_licenses
+    - if: unix
+      then: go build -v -o $PREFIX/bin/addlicense -ldflags="-s -w"
+      else: go build -v -o %LIBRARY_BIN%\addlicense.exe -ldflags="-s"
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+
+tests:
+  - script: addlicense -help
+  - package_contents:
+      bin:
+        - addlicense
+      strict: true
+
+about:
+  homepage: https://github.com/google/addlicense
+  summary: A program which ensures source code files have copyright license headers
+  description: |
+    addlicense scans directory patterns recursively and ensures that source
+    code files have copyright license headers, adding the headers in place if
+    they are missing.
+  license: Apache-2.0
+  license_file:
+    - src/LICENSE
+    - library_licenses/
+  documentation: https://pkg.go.dev/github.com/google/addlicense
+  repository: https://github.com/google/addlicense
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds a recipe for [addlicense](https://github.com/google/addlicense), a program which ensures source code files have copyright license headers by scanning directory patterns recursively.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
