### PR TITLE
Add xslope

### DIFF
--- a/recipes/xslope/meta.yaml
+++ b/recipes/xslope/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "xslope" %}
 {% set version = "0.1.52" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -16,15 +17,15 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools >=68,<77
     - wheel
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - numpy
     - pandas
-    - matplotlib
+    - matplotlib-base
     - scipy
     - shapely
     - openpyxl
@@ -36,6 +37,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/xslope/meta.yaml
+++ b/recipes/xslope/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "xslope" %}
+{% set version = "0.1.52" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: bf4730661b8d26f72c3f60cdddba7f6dcb4131387a09390d74058df07d38be22
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68,<77
+    - wheel
+  run:
+    - python >=3.9
+    - numpy
+    - pandas
+    - matplotlib
+    - scipy
+    - shapely
+    - openpyxl
+    - python-gmsh
+
+test:
+  imports:
+    - xslope
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/njones61/xslope
+  summary: Slope stability analysis (limit equilibrium and FEM) in Python.
+  description: |
+    xslope is a Python package for limit equilibrium slope stability analysis.
+    It provides multiple solution methods including the Ordinary Method of Slices,
+    Bishop's Simplified Method, Janbu, Spencer's, Corps of Engineers, Lowe &
+    Karafiath, and rapid drawdown analysis, along with seepage and finite element
+    mesh capabilities.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://xslope.readthedocs.io/en/latest/
+  dev_url: https://github.com/njones61/xslope
+
+extra:
+  recipe-maintainers:
+    - njones61

--- a/recipes/xslope/meta.yaml
+++ b/recipes/xslope/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xslope" %}
-{% set version = "0.1.52" %}
+{% set version = "0.2.0" %}
 {% set python_min = "3.9" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bf4730661b8d26f72c3f60cdddba7f6dcb4131387a09390d74058df07d38be22
+  sha256: e2515e03fe3fed2da4c11db153b9885f014ea8a7da62810b9acf90ff76bc5173
 
 build:
   noarch: python
@@ -29,6 +29,8 @@ requirements:
     - scipy
     - shapely
     - openpyxl
+    - lxml
+    - tabulate
     - python-gmsh
 
 test:
@@ -44,11 +46,15 @@ about:
   home: https://github.com/njones61/xslope
   summary: Slope stability analysis (limit equilibrium and FEM) in Python.
   description: |
-    xslope is a Python package for limit equilibrium slope stability analysis.
-    It provides multiple solution methods including the Ordinary Method of Slices,
-    Bishop's Simplified Method, Janbu, Spencer's, Corps of Engineers, Lowe &
-    Karafiath, and rapid drawdown analysis, along with seepage and finite element
-    mesh capabilities.
+    xslope is an open-source package for slope stability and seepage analysis.
+    It integrates seven limit equilibrium methods (Ordinary Method of Slices,
+    Bishop, Janbu, Spencer, Morgenstern-Price, Corps of Engineers, Lowe &
+    Karafiath), finite element seepage (steady-state and transient, saturated
+    and unsaturated), finite element strength reduction (SSRM), rapid drawdown,
+    and probabilistic/reliability analysis, all driven from a single shared
+    problem definition. It reads and writes GeoStudio (SLOPE/W) files and
+    imports Rocscience (Slide2, RS2) models, and is validated against more
+    than 600 published verification cases.
   license: Apache-2.0
   license_file: LICENSE
   doc_url: https://xslope.readthedocs.io/en/latest/


### PR DESCRIPTION
Adds a recipe for [xslope](https://github.com/njones61/xslope), a pure-Python package for limit equilibrium and finite element slope stability analysis.

- PyPI: https://pypi.org/project/xslope/
- Source: https://github.com/njones61/xslope
- License: Apache-2.0
- noarch: python

Checklist:
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.