### PR TITLE
Add kernels and kernels-data

### DIFF
--- a/recipes/kernels-data/recipe.yaml
+++ b/recipes/kernels-data/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "0.15.2"
+
+package:
+  name: kernels-data
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/k/kernels-data/kernels_data-${{ version }}.tar.gz
+    sha256: ebcf3c4c09a979d76ea5abf5e5132f8c055ff6afd7464510f84d65b14f5c33b9
+  - url: https://raw.githubusercontent.com/huggingface/kernels/v${{ version }}/LICENSE
+    sha256: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+    file_name: LICENSE
+
+build:
+  number: 0
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - maturin >=1,<2
+    - if: build_platform != target_platform
+      then:
+        - cross-python_${{ target_platform }}
+        - python
+  host:
+    - maturin >=1,<2
+    - pip
+    - python
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - kernels_data
+      pip_check: true
+
+about:
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  homepage: https://pypi.org/project/kernels-data
+  repository: https://github.com/huggingface/kernels
+  summary: Kernels data structures (Python bindings)
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/kernels/recipe.yaml
+++ b/recipes/kernels/recipe.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  version: "0.15.2"
+  python_min: "3.10"
+
+package:
+  name: kernels
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/k/kernels/kernels-${{ version }}.tar.gz
+  sha256: 5af4fab4a2d4eb67f01522dffabfdc3a4bcfc167ce68f7549c0d2828a73cbc19
+
+build:
+  number: 0
+  noarch: python
+  python:
+    entry_points:
+      - kernels=kernels.cli:main
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - huggingface_hub >=1.10.0
+    - kernels-data >=0.14.0
+    - packaging >=20.0
+    - pyyaml >=6
+    - sigstore >=4,<5
+    - tomli >=2.0
+    - tomlkit >=0.13.3
+    - typing_extensions >=4.0
+
+tests:
+  - python:
+      imports:
+        - kernels
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - kernels --help
+
+about:
+  homepage: https://github.com/huggingface/kernels
+  repository: https://github.com/huggingface/kernels
+  summary: Download compute kernels from Hugging Face Hub
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - baszalmstra


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package.", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

This PR adds two new packages:

- **`kernels-data`** — Rust/PyO3 extension providing data structures (bindings for the kernels project). Built with maturin. No Python runtime dependencies.
- **`kernels`** — Pure Python package for downloading and loading compute kernels from Hugging Face Hub ([github.com/huggingface/kernels](https://github.com/huggingface/kernels)).

### Notes

- `kernels-data` includes a second source entry to fetch the LICENSE from GitHub, as the PyPI sdist is missing the license file (upstream bug reported).
- This PR depends on #32321 (sigstore and dependencies) for the `sigstore>=4,<5` runtime requirement of `kernels`.

@conda-forge/help-python-c, ready for review!