### PR TITLE
adds `r-duckdbfs`

### DIFF
--- a/recipes/r-duckdbfs/bld.bat
+++ b/recipes/r-duckdbfs/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-duckdbfs/build.sh
+++ b/recipes/r-duckdbfs/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-duckdbfs/meta.yaml
+++ b/recipes/r-duckdbfs/meta.yaml
@@ -49,7 +49,8 @@ test:
     - "\"%R%\" -e \"library('duckdbfs')\""  # [win]
 
 about:
-  home: https://github.com/cboettig/duckdbfs, https://cboettig.github.io/duckdbfs/
+  home: https://cboettig.github.io/duckdbfs/
+  dev_url: https://github.com/cboettig/duckdbfs
   license: MIT
   summary: Provides friendly wrappers for creating 'duckdb'-backed connections to tabular datasets
     ('csv', parquet, etc) on local or remote file systems. This mimics the behaviour

--- a/recipes/r-duckdbfs/meta.yaml
+++ b/recipes/r-duckdbfs/meta.yaml
@@ -1,0 +1,87 @@
+{% set version = '0.1.2' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-duckdbfs
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/duckdbfs_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/duckdbfs/duckdbfs_{{ version }}.tar.gz
+  sha256: b960804923f799eb6994e20c51581275775e1a30d7c266676eb0c95e4649d220
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-dbi
+    - r-dbplyr
+    - r-dplyr
+    - r-duckdb >=1.1
+    - r-fs
+    - r-glue
+  run:
+    - r-base
+    - r-dbi
+    - r-dbplyr
+    - r-dplyr
+    - r-duckdb >=1.1
+    - r-fs
+    - r-glue
+
+test:
+  commands:
+    - $R -e "library('duckdbfs')"           # [not win]
+    - "\"%R%\" -e \"library('duckdbfs')\""  # [win]
+
+about:
+  home: https://github.com/cboettig/duckdbfs, https://cboettig.github.io/duckdbfs/
+  license: MIT
+  summary: Provides friendly wrappers for creating 'duckdb'-backed connections to tabular datasets
+    ('csv', parquet, etc) on local or remote file systems. This mimics the behaviour
+    of "open_dataset" in the 'arrow' package, but in addition to 'S3' file system also
+    generalizes to any list of 'http' URLs.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: duckdbfs
+# Title: High Performance Remote File System, Database and 'Geospatial' Access Using 'duckdb'
+# Version: 0.1.2
+# Authors@R: c(person("Carl", "Boettiger", , "cboettig@gmail.com", c("aut", "cre"), comment = c(ORCID = "0000-0002-1642-628X")), person("Michael D.","Sumner", role = c("ctb"), email = "mdsumner@gmail.com", comment=c(ORCID = "0000-0002-2471-7511")))
+# Description: Provides friendly wrappers for creating 'duckdb'-backed connections to tabular datasets ('csv', parquet, etc) on local or remote file systems. This mimics the behaviour of "open_dataset" in the 'arrow' package, but in addition to 'S3' file system also generalizes to any list of 'http' URLs.
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# RoxygenNote: 7.3.3
+# URL: https://github.com/cboettig/duckdbfs, https://cboettig.github.io/duckdbfs/
+# BugReports: https://github.com/cboettig/duckdbfs/issues
+# Depends: R (>= 4.2)
+# Imports: DBI, dbplyr, dplyr, duckdb (>= 1.1), fs, glue
+# Suggests: curl, sf, jsonlite, spelling, minioclient, testthat (>= 3.0.0)
+# Config/testthat/edition: 3
+# Language: en-US
+# NeedsCompilation: no
+# Packaged: 2025-10-12 05:58:07 UTC; cboettig
+# Author: Carl Boettiger [aut, cre] (ORCID: <https://orcid.org/0000-0002-1642-628X>), Michael D. Sumner [ctb] (ORCID: <https://orcid.org/0000-0002-2471-7511>)
+# Maintainer: Carl Boettiger <cboettig@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2025-10-12 06:20:02 UTC


### PR DESCRIPTION
Adds [CRAN package `duckdbfs`](https://cran.r-project.org/package=duckdbfs) as `r-duckdbfs`. Recipe generated with `conda_r_skeleton_helper`.

Needed by https://github.com/conda-forge/r-neonutilities-feedstock/pull/7.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
