### PR TITLE
Add productshotai-site-kit

### DIFF
--- a/recipes/productshotai-site-kit/meta.yaml
+++ b/recipes/productshotai-site-kit/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "productshotai-site-kit" %}
+{% set version = "0.1.2" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/bbwdadfg/productshotai-site-kit/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 9fc8b974735b95274943d537e3d569dfe42589a147852f9baa443a17b6b159e1
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  entry_points:
+    - productshotai-site-kit = productshotai_site_kit.cli:main
+
+requirements:
+  host:
+    - python >=3.8
+    - pip
+    - hatchling
+  run:
+    - python >=3.8
+
+test:
+  imports:
+    - productshotai_site_kit
+  commands:
+    - productshotai-site-kit urls
+    - productshotai-site-kit urls --format json
+    - mkdir productshotai-smoke
+    - touch productshotai-smoke/red-shoe.jpg
+    - productshotai-site-kit manifest productshotai-smoke
+    - productshotai-site-kit prompt-sheet productshotai-smoke --format json
+
+about:
+  home: https://productshotai.app
+  license: MIT
+  license_file: LICENSE
+  summary: Product photo batch manifest and URL helpers for ProductShot AI.
+  description: |
+    productshotai-site-kit provides a small Python CLI for preparing ecommerce
+    product-image manifests, prompt planning sheets, and ProductShot AI public
+    URL metadata without making network calls.
+  doc_url: https://github.com/bbwdadfg/productshotai-site-kit
+  dev_url: https://github.com/bbwdadfg/productshotai-site-kit
+
+extra:
+  recipe-maintainers:
+    - bbwdadfg


### PR DESCRIPTION
Add productshotai-site-kit 0.1.2, a noarch Python CLI for preparing ecommerce product-image manifests and ProductShot AI prompt planning sheets.\n\nChecklist:\n- upstream source: https://github.com/bbwdadfg/productshotai-site-kit/releases/tag/v0.1.2\n- package is pure Python/noarch\n- recipe tests cover CLI urls, manifest, and prompt-sheet commands