### PR TITLE
Add pyvae

### DIFF
--- a/recipes/pyvae/recipe.yaml
+++ b/recipes/pyvae/recipe.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+context:
+  name: pyvae
+  version: "0.0.1"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  # Built from the PyPI sdist (conda-forge does not build from git for releases).
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 669823ba13d8097689a65adc8bbf30cfdafe384254f7e3800ad51e41aa5d1fac
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.10
+    - setuptools >=69
+    - wheel
+    - pip
+  run:
+    - python >=3.10
+    - pytorch >=2.3,<3
+    - numpy >=1.26,<3
+    - pandas >=2.0,<3
+    - scanpy >=1.11,<2
+    - tqdm >=4.66,<5
+
+tests:
+  # v1 `python` test runs the imports AND an automatic `pip check`.
+  - python:
+      imports:
+        - pyvae
+      pip_check: true
+
+about:
+  homepage: https://github.com/aipher-group/pyvae
+  repository: https://github.com/aipher-group/pyvae
+  documentation: https://github.com/aipher-group/pyvae
+  license: MIT
+  license_file: LICENSE
+  summary: Informed Variational Autoencoder (iVAE) with biologically constrained encoder layers.
+  description: |
+    pyvae implements an Informed Variational Autoencoder (iVAE) whose encoder
+    layers are constrained by biological priors (e.g. Reactome pathways) for
+    interpretable representation learning on gene-expression data.
+
+extra:
+  recipe-maintainers:
+    - loucerac

--- a/recipes/pyvae/recipe.yaml
+++ b/recipes/pyvae/recipe.yaml
@@ -34,11 +34,13 @@ requirements:
     - tqdm >=4.66,<5
 
 tests:
-  # v1 `python` test runs the imports AND an automatic `pip check`.
   - python:
       imports:
         - pyvae
-      pip_check: true
+      # pip_check disabled: conda-forge's scikit-misc reports its version as
+      # 0.0.0 to pip, which spuriously fails pyvae's `scikit-misc>=0.3` metadata
+      # requirement. The import test above still validates the install.
+      pip_check: false
 
 about:
   homepage: https://github.com/aipher-group/pyvae

--- a/recipes/pyvae/recipe.yaml
+++ b/recipes/pyvae/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: pyvae
-  version: "0.0.1"
+  version: "0.1.0"
 
 package:
   name: ${{ name|lower }}
@@ -11,7 +11,7 @@ package:
 source:
   # Built from the PyPI sdist (conda-forge does not build from git for releases).
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 669823ba13d8097689a65adc8bbf30cfdafe384254f7e3800ad51e41aa5d1fac
+  sha256: d4ea4e9271962e91f964d7cbf4ea4a2b8313d24d62ec74f1bb13d83ccb30fc56
 
 build:
   noarch: python

--- a/recipes/pyvae/recipe.yaml
+++ b/recipes/pyvae/recipe.yaml
@@ -30,6 +30,7 @@ requirements:
     - numpy >=1.26,<3
     - pandas >=2.0,<3
     - scanpy >=1.11,<2
+    - scikit-misc >=0.3
     - tqdm >=4.66,<5
 
 tests:

--- a/recipes/pyvae/recipe.yaml
+++ b/recipes/pyvae/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: pyvae
-  version: "0.1.0"
+  version: "0.1.1"
 
 package:
   name: ${{ name|lower }}
@@ -11,7 +11,7 @@ package:
 source:
   # Built from the PyPI sdist (conda-forge does not build from git for releases).
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: d4ea4e9271962e91f964d7cbf4ea4a2b8313d24d62ec74f1bb13d83ccb30fc56
+  sha256: ac35b7ce99684a773ab6a7160953ff0c2fb2470e264bddba647c4d7d1cd050f1
 
 build:
   noarch: python
@@ -30,17 +30,13 @@ requirements:
     - numpy >=1.26,<3
     - pandas >=2.0,<3
     - scanpy >=1.11,<2
-    - scikit-misc >=0.3
     - tqdm >=4.66,<5
 
 tests:
   - python:
       imports:
         - pyvae
-      # pip_check disabled: conda-forge's scikit-misc reports its version as
-      # 0.0.0 to pip, which spuriously fails pyvae's `scikit-misc>=0.3` metadata
-      # requirement. The import test above still validates the install.
-      pip_check: false
+      pip_check: true
 
 about:
   homepage: https://github.com/aipher-group/pyvae


### PR DESCRIPTION
Adds a recipe for **pyvae** — an Informed Variational Autoencoder (iVAE) in PyTorch with biologically constrained encoder layers.

- PyPI: https://pypi.org/project/pyvae/ · Source: https://github.com/aipher-group/pyvae
- `noarch: python`, built from the PyPI sdist.
- License: MIT, with `license_file`.
- All runtime dependencies are available on conda-forge (`pytorch`, `numpy`, `pandas`, `scanpy`, `tqdm`).
- Tests: `python` imports + automatic `pip check`.
- v1 `recipe.yaml` format.

#### Checklist
- [x] Title of this PR is meaningful: "Add pyvae".
- [x] License file is packaged (see `about.license_file`).
- [x] Source is from the package's official PyPI release with a pinned sha256.
- [x] All dependencies are available on conda-forge.
