### PR TITLE
Add types-aiobotocore-bedrock-runtime

### DIFF
--- a/recipes/types-aiobotocore-bedrock-runtime/recipe.yaml
+++ b/recipes/types-aiobotocore-bedrock-runtime/recipe.yaml
@@ -1,0 +1,43 @@
+context:
+  version: "3.7.0"
+
+package:
+  name: types-aiobotocore-bedrock-runtime
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/types-aiobotocore-bedrock-runtime/types_aiobotocore_bedrock_runtime-${{ version }}.tar.gz
+  sha256: 9ab951a42d223b104e1718030ecd915378985ed2b8ec33f964ccfd4a5437aae3
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  host:
+    - pip
+    - python ${{ python_min }}.*
+    - setuptools >=60
+  run:
+    - python >=${{ python_min }}
+    - typing_extensions
+
+tests:
+  - python:
+      imports:
+        - types_aiobotocore_bedrock_runtime
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/youtype/mypy_boto3_builder
+  summary: Type annotations for aiobotocore BedrockRuntime 3.7.0 service generated with mypy-boto3-builder 8.12.0
+  documentation: https://youtype.github.io/types_aiobotocore_docs/types_aiobotocore_bedrock_runtime/
+  repository: https://github.com/youtype/mypy_boto3_builder
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - sodre

--- a/recipes/types-aiobotocore-bedrock-runtime/recipe.yaml
+++ b/recipes/types-aiobotocore-bedrock-runtime/recipe.yaml
@@ -29,7 +29,9 @@ tests:
       imports:
         - types_aiobotocore_bedrock_runtime
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/youtype/mypy_boto3_builder

--- a/recipes/types-aiobotocore-bedrock-runtime/recipe.yaml
+++ b/recipes/types-aiobotocore-bedrock-runtime/recipe.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools >=60
   run:
     - python >=${{ python_min }}
+    - aiobotocore
     - typing_extensions
 
 tests:


### PR DESCRIPTION
Adds a recipe for [`types-aiobotocore-bedrock-runtime`](https://pypi.org/project/types-aiobotocore-bedrock-runtime/) — type annotations for aiobotocore BedrockRuntime, generated with mypy-boto3-builder.

- v1 recipe format (`recipe.yaml`)
- `noarch: python`
- Runtime deps mirror upstream metadata: `python >=3.9` (via `python_min`) and `typing_extensions`

## Checklist
- [x] Title of this PR is meaningful
- [x] License file is packaged (`license_file: LICENSE`)
- [x] Recipe passes `conda-smithy recipe-lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)