### PR TITLE
Add amgx

### DIFF
--- a/recipes/amgx/build.sh
+++ b/recipes/amgx/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# enable MPI for the parallel variants
+if [[ -n "${mpi:-}" && "${mpi}" != "nompi" ]]; then
+  MPI_ARGS="-DCMAKE_NO_MPI=OFF"
+else
+  MPI_ARGS="-DCMAKE_NO_MPI=ON"
+fi
+
+# configure
+cmake -B build -S . ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DCMAKE_CUDA_ARCHITECTURES="80-real;89-real;90-real;90-virtual" \
+  ${MPI_ARGS}
+
+# build (shared lib only)
+cmake --build build --target amgxsh -j"${CPU_COUNT}"
+
+install -Dm755 build/libamgxsh.so    "$PREFIX/lib/libamgxsh.so"
+install -Dm644 include/amgx_c.h      "$PREFIX/include/amgx_c.h"
+install -Dm644 include/amgx_config.h "$PREFIX/include/amgx_config.h"

--- a/recipes/amgx/build.sh
+++ b/recipes/amgx/build.sh
@@ -9,10 +9,13 @@ else
 fi
 
 # configure
+# pass CUDAARCHS explicitly (AmgX presets CMAKE_CUDA_ARCHITECTURES before
+# project()), keeping only sm_70+ as supported upstream
+CUDA_ARCHS=$(tr ';' '\n' <<< "${CUDAARCHS:?}" | awk '$0+0 >= 70' | paste -sd';')
 cmake -B build -S . ${CMAKE_ARGS} \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-  -DCMAKE_CUDA_ARCHITECTURES="80-real;89-real;90-real;90-virtual" \
+  -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
   ${MPI_ARGS}
 
 # build (shared lib only)

--- a/recipes/amgx/build.sh
+++ b/recipes/amgx/build.sh
@@ -18,9 +18,11 @@ cmake -B build -S . ${CMAKE_ARGS} \
   -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHS}" \
   ${MPI_ARGS}
 
-# build (shared lib only)
-cmake --build build --target amgxsh -j"${CPU_COUNT}"
+# build
+cmake --build build --target amgx amgxsh -j"${CPU_COUNT}"
 
-install -Dm755 build/libamgxsh.so    "$PREFIX/lib/libamgxsh.so"
-install -Dm644 include/amgx_c.h      "$PREFIX/include/amgx_c.h"
-install -Dm644 include/amgx_config.h "$PREFIX/include/amgx_config.h"
+# install headers + libs; skip subdir rules (examples, tests, sample configs)
+cmake -DCMAKE_INSTALL_LOCAL_ONLY=ON -P build/cmake_install.cmake
+
+# drop static library
+rm "$PREFIX/lib/libamgx.a"

--- a/recipes/amgx/conda_build_config.yaml
+++ b/recipes/amgx/conda_build_config.yaml
@@ -1,0 +1,4 @@
+mpi:
+  - nompi
+  - mpich
+  - openmpi

--- a/recipes/amgx/conda_build_config.yaml
+++ b/recipes/amgx/conda_build_config.yaml
@@ -1,4 +1,3 @@
+# mpich/openmpi variants will be added in the feedstock (staged-recipes CI 6 h limit)
 mpi:
   - nompi
-  - mpich
-  - openmpi

--- a/recipes/amgx/meta.yaml
+++ b/recipes/amgx/meta.yaml
@@ -1,0 +1,110 @@
+{% set name = "amgx" %}
+{% set version = "2.5.0" %}
+{% set build = 0 %}
+
+{% set mpi = mpi or 'nompi' %}
+# prioritize nompi variant
+{% if mpi == 'nompi' %}
+{% set build = build + 100 %}
+{% endif %}
+
+{% if mpi != 'nompi' %}
+{% set mpi_prefix = "mpi_" + mpi %}
+{% else %}
+{% set mpi_prefix = "nompi" %}
+{% endif %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/NVIDIA/AMGX/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 0e7ade653ac1f31b4c849ee9545f8eb573193eed9b1deff26ab07cb59f022af4
+
+build:
+  number: {{ build }}
+  skip: true  # [not linux or cuda_compiler_version == "None"]
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.18
+    - make
+    - {{ mpi }}  # [build_platform != target_platform and mpi != 'nompi']
+  host:
+    - cuda-version {{ cuda_compiler_version }}
+    - cuda-cudart-dev
+    - cuda-nvtx-dev
+    - libcublas-dev
+    - libcusparse-dev
+    - libcusolver-dev
+    - libcurand-dev
+    - cuda-cccl
+    - {{ mpi }}  # [mpi != 'nompi']
+
+outputs:
+  - name: libamgx
+    files:
+      - lib/libamgxsh.so
+    build:
+      string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
+      run_exports:
+        - {{ pin_subpackage('libamgx', max_pin='x.x') }}
+      ignore_run_exports:
+        - cuda-nvtx    # header-only
+        - libcurand    # not linked
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - {{ compiler('cuda') }}
+        - {{ stdlib('c') }}
+        - {{ mpi }}  # [build_platform != target_platform and mpi != 'nompi']
+      host:
+        - cuda-version {{ cuda_compiler_version }}
+        - cuda-cudart-dev
+        - cuda-nvtx-dev
+        - libcublas-dev
+        - libcusparse-dev
+        - libcusolver-dev
+        - libcurand-dev
+        - cuda-cccl
+        - {{ mpi }}  # [mpi != 'nompi']
+      run:
+        - {{ mpi }}  # [mpi != 'nompi']
+    test:
+      commands:
+        - test -f $PREFIX/lib/libamgxsh.so
+
+  - name: libamgx-dev
+    build:
+      string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
+    files:
+      - include/amgx_c.h
+      - include/amgx_config.h
+    requirements:
+      run:
+        - {{ pin_subpackage('libamgx', exact=True) }}
+    test:
+      commands:
+        - test -f $PREFIX/include/amgx_c.h
+        - test -f $PREFIX/include/amgx_config.h
+
+about:
+  home: https://github.com/NVIDIA/AMGX
+  license: BSD-3-Clause AND MIT AND Apache-2.0
+  license_file:
+    - LICENSES/BSD-3-Clause.txt
+    - NOTICES
+    - external/rapidjson/license.txt
+    - include/cusp/LICENSE
+  summary: NVIDIA AmgX — GPU-accelerated algebraic multigrid and Krylov solvers
+  dev_url: https://github.com/NVIDIA/AMGX
+
+extra:
+  recipe-maintainers:
+    - stevenliuyi

--- a/recipes/amgx/meta.yaml
+++ b/recipes/amgx/meta.yaml
@@ -83,6 +83,8 @@ outputs:
   - name: libamgx-devel
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
+      run_exports:
+        - {{ pin_subpackage('libamgx', max_pin='x.x') }}
     files:
       - include/amgx_c.h
       - include/amgx_config.h

--- a/recipes/amgx/meta.yaml
+++ b/recipes/amgx/meta.yaml
@@ -21,6 +21,8 @@ package:
 source:
   url: https://github.com/NVIDIA/AMGX/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 0e7ade653ac1f31b4c849ee9545f8eb573193eed9b1deff26ab07cb59f022af4
+  patches:
+    - patches/0001-Use-system-rapidjson.patch
 
 build:
   number: {{ build }}
@@ -44,6 +46,7 @@ requirements:
     - libcusolver-dev
     - libcurand-dev
     - cuda-cccl
+    - rapidjson
     - {{ mpi }}  # [mpi != 'nompi']
 
 outputs:
@@ -73,6 +76,7 @@ outputs:
         - libcusolver-dev
         - libcurand-dev
         - cuda-cccl
+        - rapidjson
         - {{ mpi }}  # [mpi != 'nompi']
       run:
         - {{ mpi }}  # [mpi != 'nompi']
@@ -98,11 +102,10 @@ outputs:
 
 about:
   home: https://github.com/NVIDIA/AMGX
-  license: BSD-3-Clause AND MIT AND Apache-2.0
+  license: BSD-3-Clause AND Apache-2.0
   license_file:
     - LICENSES/BSD-3-Clause.txt
     - NOTICES
-    - external/rapidjson/license.txt
     - include/cusp/LICENSE
   summary: NVIDIA AmgX — GPU-accelerated algebraic multigrid and Krylov solvers
   dev_url: https://github.com/NVIDIA/AMGX

--- a/recipes/amgx/meta.yaml
+++ b/recipes/amgx/meta.yaml
@@ -80,7 +80,7 @@ outputs:
       commands:
         - test -f $PREFIX/lib/libamgxsh.so
 
-  - name: libamgx-dev
+  - name: libamgx-devel
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
     files:

--- a/recipes/amgx/meta.yaml
+++ b/recipes/amgx/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('cuda') }}
     - {{ stdlib('c') }}
-    - cmake >=3.18
+    - cmake >=3.20
     - make
     - {{ mpi }}  # [build_platform != target_platform and mpi != 'nompi']
   host:

--- a/recipes/amgx/meta.yaml
+++ b/recipes/amgx/meta.yaml
@@ -14,6 +14,13 @@
 {% set mpi_prefix = "nompi" %}
 {% endif %}
 
+# consumers built against nompi may run with any variant, MPI builds must match
+{% if mpi != 'nompi' %}
+{% set build_pin = mpi_prefix + '_*' %}
+{% else %}
+{% set build_pin = '' %}
+{% endif %}
+
 package:
   name: {{ name }}
   version: {{ version }}
@@ -56,7 +63,7 @@ outputs:
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
       run_exports:
-        - {{ pin_subpackage('libamgx', max_pin='x.x') }}
+        - {{ pin_subpackage('libamgx', max_pin='x.x') }} {{ build_pin }}
       ignore_run_exports:
         - cuda-nvtx    # header-only
         - libcurand    # not linked
@@ -88,7 +95,7 @@ outputs:
     build:
       string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
       run_exports:
-        - {{ pin_subpackage('libamgx', max_pin='x.x') }}
+        - {{ pin_subpackage('libamgx', max_pin='x.x') }} {{ build_pin }}
     files:
       - include/amgx_c.h
       - include/amgx_config.h

--- a/recipes/amgx/patches/0001-Use-system-rapidjson.patch
+++ b/recipes/amgx/patches/0001-Use-system-rapidjson.patch
@@ -1,0 +1,76 @@
+From 8a4bd52a2485e9ede3eb42d9999978c93429074b Mon Sep 17 00:00:00 2001
+From: stevenliuyi <stevenliuyi@gmail.com>
+Date: Tue, 25 Aug 2026 16:39:30 -0400
+Subject: [PATCH] Use system rapidjson
+
+The vendored copy is rapidjson 0.11 (2012). Port to the 1.x API
+(FileStream removed, AddMember() no longer takes const char*) and
+find the headers with find_package(RapidJSON).
+---
+ CMakeLists.txt    |  3 ++-
+ src/amg_config.cu | 14 +++++++++-----
+ 2 files changed, 11 insertions(+), 6 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0de63cf..9276450 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -131,7 +131,8 @@ set(AMGX_INCLUDE_EXTERNAL True CACHE BOOL "Include external 3rd party libraries"
+ if (AMGX_INCLUDE_EXTERNAL)
+   set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -DRAPIDJSON_DEFINED)
+   set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -DRAPIDJSON_DEFINED)
+-  include_directories("${CMAKE_CURRENT_SOURCE_DIR}/external/rapidjson/include")
++  find_package(RapidJSON REQUIRED)
++  include_directories(${RapidJSON_INCLUDE_DIRS})
+ endif (AMGX_INCLUDE_EXTERNAL)
+ 
+ set(CMAKE_NO_MPI false CACHE BOOL "Force non-MPI build")
+diff --git a/src/amg_config.cu b/src/amg_config.cu
+index 0e67f4a..97fae73 100644
+--- a/src/amg_config.cu
++++ b/src/amg_config.cu
+@@ -18,7 +18,7 @@
+ #ifdef RAPIDJSON_DEFINED
+ #include "rapidjson/document.h"
+ #include "rapidjson/prettywriter.h"
+-#include "rapidjson/filestream.h"
++#include "rapidjson/filewritestream.h"
+ #endif
+ 
+ namespace amgx
+@@ -871,14 +871,16 @@ AMGX_ERROR AMG_Config::write_parameters_description_json(const char *filename)
+             // new entry
+             rapidjson::Value param_object(rapidjson::kObjectType);
+             // adding description
+-            param_object.AddMember("description", iter->second.description.c_str(), json_out.GetAllocator());
++            rapidjson::Value param_desc_str(iter->second.description.c_str(), json_out.GetAllocator());
++            param_object.AddMember("description", param_desc_str, json_out.GetAllocator());
+             // adding parameter type name
+             rapidjson::Value param_type(AMG_Config::getParamTypeName(iter->second.type).c_str(), json_out.GetAllocator());
+             param_object.AddMember("parameter_type", param_type, json_out.GetAllocator());
+             //adding default value
+             fillJSONValueWithParameter(param_object, iter->second, json_out.GetAllocator());
+             // adding entry to output doc
+-            json_out.AddMember(iter->first.c_str(), param_object, json_out.GetAllocator());
++            rapidjson::Value param_name(iter->first.c_str(), json_out.GetAllocator());
++            json_out.AddMember(param_name, param_object, json_out.GetAllocator());
+         }
+ 
+         // write json cfg to stdout
+@@ -890,9 +892,11 @@ AMGX_ERROR AMG_Config::write_parameters_description_json(const char *filename)
+             FatalError(tmp.c_str(), AMGX_ERR_IO);
+         }
+ 
+-        rapidjson::FileStream f(fout);
+-        rapidjson::PrettyWriter<rapidjson::FileStream> writer(f);
++        char write_buffer[65536];
++        rapidjson::FileWriteStream f(fout, write_buffer, sizeof(write_buffer));
++        rapidjson::PrettyWriter<rapidjson::FileWriteStream> writer(f);
+         json_out.Accept(writer);
++        f.Flush();
+         fclose(fout);
+ #endif
+     }
+-- 
+2.34.1
+


### PR DESCRIPTION
Adds a recipe for [AmgX](https://github.com/NVIDIA/AMGX) v2.5.0 — NVIDIA's GPU-accelerated algebraic multigrid and Krylov solver library.

### Notes
- Built with MPI variants (`nompi`/`mpich`/`openmpi`). The `nompi` build number is bumped to 100 so a bare install resolves to it.
- AmgX compiles in header-only rapidjson (MIT) and cusp (Apache-2.0). `license` is the combined `BSD-3-Clause AND MIT AND Apache-2.0`, with all license files packaged.

### Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
