### PR TITLE
Adding oh-my-pi

### DIFF
--- a/recipes/oh-my-pi/build.bat
+++ b/recipes/oh-my-pi/build.bat
@@ -1,0 +1,37 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: Install all workspace dependencies
+bun install --frozen-lockfile
+if errorlevel 1 exit 1
+
+:: Compile the Rust native addon via napi-rs
+bun --cwd=packages\natives run build
+if errorlevel 1 exit 1
+
+:: Generate pre-bundled assets required at compile time
+bun --cwd=packages\stats scripts\generate-client-bundle.ts --generate
+if errorlevel 1 exit 1
+bun --cwd=packages\coding-agent scripts\generate-docs-index.ts --generate
+if errorlevel 1 exit 1
+bun --cwd=packages\coding-agent scripts\embed-mupdf-wasm.ts --generate
+if errorlevel 1 exit 1
+
+:: Embed the native addon so bun can bundle it
+bun --cwd=packages\natives run embed:native
+if errorlevel 1 exit 1
+
+:: Compile TypeScript + native addon into a standalone binary
+bun build ^
+  --compile ^
+  --no-compile-autoload-bunfig ^
+  --no-compile-autoload-dotenv ^
+  --no-compile-autoload-tsconfig ^
+  --no-compile-autoload-package-json ^
+  --minify-identifiers ^
+  --keep-names ^
+  --define "process.env.PI_COMPILED=true" ^
+  --root . ^
+  packages\coding-agent\src\cli.ts ^
+  --outfile="%SCRIPTS%\omp.exe"
+if errorlevel 1 exit 1

--- a/recipes/oh-my-pi/build.sh
+++ b/recipes/oh-my-pi/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+# Install all workspace dependencies
+bun install --frozen-lockfile
+
+# Compile the Rust native addon via napi-rs
+bun --cwd=packages/natives run build
+
+# Generate pre-bundled assets required at compile time
+bun --cwd=packages/stats scripts/generate-client-bundle.ts --generate
+bun --cwd=packages/coding-agent scripts/generate-docs-index.ts --generate
+bun --cwd=packages/coding-agent scripts/embed-mupdf-wasm.ts --generate
+
+# Embed the native addon so bun can bundle it
+bun --cwd=packages/natives run embed:native
+
+# Compile TypeScript + native addon into a standalone binary
+bun build \
+  --compile \
+  --no-compile-autoload-bunfig \
+  --no-compile-autoload-dotenv \
+  --no-compile-autoload-tsconfig \
+  --no-compile-autoload-package-json \
+  --minify-identifiers \
+  --keep-names \
+  --define 'process.env.PI_COMPILED=true' \
+  --root . \
+  ./packages/coding-agent/src/cli.ts \
+  --outfile="${PREFIX}/bin/omp"

--- a/recipes/oh-my-pi/build.sh
+++ b/recipes/oh-my-pi/build.sh
@@ -8,6 +8,9 @@ bun install --frozen-lockfile
 # Compile the Rust native addon via napi-rs
 bun --cwd=packages/natives run build
 
+# Bundle Rust dependency licenses
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
 # Generate pre-bundled assets required at compile time
 bun --cwd=packages/stats scripts/generate-client-bundle.ts --generate
 bun --cwd=packages/coding-agent scripts/generate-docs-index.ts --generate

--- a/recipes/oh-my-pi/recipe.yaml
+++ b/recipes/oh-my-pi/recipe.yaml
@@ -1,0 +1,47 @@
+context:
+  version: "16.1.18"
+
+package:
+  name: oh-my-pi
+  version: ${{ version }}
+
+source:
+  url: https://github.com/can1357/oh-my-pi/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 8bfb5fad6182abd1f3837daf6fa4f0c711b3730119a5d958beed32dcb2a10474
+
+build:
+  number: 0
+  script:
+    file: build
+  dynamic_linking:
+    binary_relocation: false
+  skip:
+    - ppc64le
+    - s390x
+
+requirements:
+  build:
+    - ${{ compiler('rust') }}
+    - bun
+
+tests:
+  - script:
+      - omp --version
+  - package_contents:
+      bin:
+        - omp
+
+about:
+  homepage: https://github.com/can1357/oh-my-pi
+  summary: AI coding agent for the terminal with hash-anchored edits, LSP, Python, browser, and subagents
+  description: |
+    oh-my-pi (omp) is an AI coding agent for the terminal. It features
+    hash-anchored edits, an optimized tool harness, LSP integration, Python
+    support, browser control, subagents, and more.
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/can1357/oh-my-pi
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/oh-my-pi/recipe.yaml
+++ b/recipes/oh-my-pi/recipe.yaml
@@ -18,11 +18,14 @@ build:
   skip:
     - ppc64le
     - s390x
+    - win
 
 requirements:
   build:
+    - ${{ stdlib('c') }}
     - ${{ compiler('rust') }}
     - bun
+    - cargo-bundle-licenses
 
 tests:
   - script:
@@ -39,7 +42,9 @@ about:
     hash-anchored edits, an optimized tool harness, LSP integration, Python
     support, browser control, subagents, and more.
   license: MIT
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   repository: https://github.com/can1357/oh-my-pi
 
 extra:


### PR DESCRIPTION
## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

## Notes

[oh-my-pi](https://github.com/can1357/oh-my-pi) is an AI coding agent for the terminal (`omp` binary). It features hash-anchored edits, an optimized tool harness, LSP integration, Python support, browser control, and subagents.

**Build approach**: Builds from source using:
- **Bun** to compile TypeScript into a self-contained binary (`bun build --compile`). The output binary embeds the Bun runtime alongside the compiled TypeScript bytecode — similar to how Go embeds its runtime.
- **napi-rs** (via `@napi-rs/cli` from the locked `bun.lock`) to compile the Rust native addon (`packages/natives`) that provides shell, AST, and ISO capabilities.

The `dynamic_linking: binary_relocation: false` flag is set because the self-contained Bun binary cannot be patchelf'd/install_name_tool'd.

Third-party license bundling (for both npm and Rust crates) is a TODO — happy to add if required by reviewers.