### PR TITLE
Add mesa-reader

### DIFF
--- a/recipes/mesa-reader/recipe.yaml
+++ b/recipes/mesa-reader/recipe.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "0.4.0"
+
+package:
+  name: mesa-reader
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/mesa-reader/mesa_reader-${{ version }}.tar.gz
+  sha256: 072da6c58eaac8b4bf0a2b2320e4a737e3a50a066d3a6613dd145432afc97735
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - numpy
+    - pandas
+
+tests:
+  - python:
+      imports:
+        - mesa_reader
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: Tools for interacting with output from MESA star and MESA binary
+  description: |
+    A Python package for easily accessing and manipulating the output of the
+    Modules for Experiments in Stellar Astrophysics (MESA) stellar evolution
+    code.
+  license: LGPL-3.0-only
+  license_file:
+    - COPYING.LESSER
+    - COPYING
+  homepage: https://github.com/wmwolf/py_mesa_reader
+  repository: https://github.com/wmwolf/py_mesa_reader
+  documentation: https://billwolf.space/py_mesa_reader
+
+extra:
+  recipe-maintainers:
+    - wmwolf


### PR DESCRIPTION
Adds a recipe for [`mesa-reader`](https://pypi.org/project/mesa-reader/) — a small, pure-Python library for reading and manipulating output from the MESA (Modules for Experiments in Stellar Astrophysics) stellar evolution code.

- Pure Python → `noarch: python`
- Sourced from the PyPI sdist (with `sha256`)
- Runtime deps (`numpy`, `pandas`) are on conda-forge
- License **LGPL-3.0-only**; both `COPYING` and `COPYING.LESSER` are packaged in the sdist and listed in `license_file`

### Checklist
- [x] Title of this PR is "Add mesa-reader"
- [x] License file is packaged (see `about/license_file`)
- [x] Source is from a tagged/released sdist with a `sha256`
- [x] Recipe maintainer (@wmwolf) is the upstream author
- [x] No comments left in the recipe; `tests` section present

Upstream: https://github.com/wmwolf/py_mesa_reader