### PR TITLE
Adding smokeping_prober

### DIFF
--- a/recipes/smokeping_prober/recipe.yaml
+++ b/recipes/smokeping_prober/recipe.yaml
@@ -1,0 +1,55 @@
+context:
+  version: "0.12.0"
+
+package:
+  name: smokeping_prober
+  version: ${{ version }}
+
+source:
+  url: https://github.com/SuperQ/smokeping_prober/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 9c5adb3862aea47f8c39df244470dc14f4ad5d2ab5442aa02a25b8c53fb9e152
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save . --save_path ../library_licenses
+    - >-
+      go build -v -o $PREFIX/bin/smokeping_prober
+      -ldflags="-s -w
+      -X github.com/prometheus/common/version.Version=${{ version }}
+      -X github.com/prometheus/common/version.Revision=v${{ version }}
+      -X github.com/prometheus/common/version.Branch=HEAD
+      -X github.com/prometheus/common/version.BuildUser=conda-forge
+      -X github.com/prometheus/common/version.BuildDate=1970-01-01"
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+
+tests:
+  - script: smokeping_prober --version
+  - package_contents:
+      bin:
+        - smokeping_prober
+      strict: true
+
+about:
+  homepage: https://github.com/SuperQ/smokeping_prober
+  summary: Prometheus exporter to gather ICMP ping metrics
+  description: |
+    The smokeping_prober is a Prometheus exporter that performs ICMP/UDP
+    pings against a set of target hosts and exposes round-trip time and
+    packet loss metrics, similar to the classic SmokePing tool.
+  license: Apache-2.0
+  license_file:
+    - src/LICENSE
+    - library_licenses/
+  documentation: https://github.com/SuperQ/smokeping_prober/blob/master/README.md
+  repository: https://github.com/SuperQ/smokeping_prober
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/smokeping_prober/recipe.yaml
+++ b/recipes/smokeping_prober/recipe.yaml
@@ -15,14 +15,23 @@ build:
   script:
     - cd src
     - go-licenses save . --save_path ../library_licenses
-    - >-
-      go build -v -o $PREFIX/bin/smokeping_prober
-      -ldflags="-s -w
-      -X github.com/prometheus/common/version.Version=${{ version }}
-      -X github.com/prometheus/common/version.Revision=v${{ version }}
-      -X github.com/prometheus/common/version.Branch=HEAD
-      -X github.com/prometheus/common/version.BuildUser=conda-forge
-      -X github.com/prometheus/common/version.BuildDate=1970-01-01"
+    - if: unix
+      then: >-
+        go build -v -o $PREFIX/bin/smokeping_prober
+        -ldflags="-s -w
+        -X github.com/prometheus/common/version.Version=${{ version }}
+        -X github.com/prometheus/common/version.Revision=v${{ version }}
+        -X github.com/prometheus/common/version.Branch=HEAD
+        -X github.com/prometheus/common/version.BuildUser=conda-forge
+        -X github.com/prometheus/common/version.BuildDate=1970-01-01"
+      else: >-
+        go build -v -o %LIBRARY_BIN%\smokeping_prober.exe
+        -ldflags="-s -w
+        -X github.com/prometheus/common/version.Version=${{ version }}
+        -X github.com/prometheus/common/version.Revision=v${{ version }}
+        -X github.com/prometheus/common/version.Branch=HEAD
+        -X github.com/prometheus/common/version.BuildUser=conda-forge
+        -X github.com/prometheus/common/version.BuildDate=1970-01-01"
 
 requirements:
   build:


### PR DESCRIPTION
Adds a recipe for [smokeping_prober](https://github.com/SuperQ/smokeping_prober), a Prometheus exporter that gathers ICMP/UDP ping metrics (round-trip time and packet loss) against a set of target hosts, similar to the classic SmokePing tool.

Built as a static Go binary via `go-nocgo`. Version metadata is injected through `-ldflags` against `github.com/prometheus/common/version`, and the local build's `--version` test confirms it resolves correctly.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.