### PR TITLE
Add recipe for libhpipm package

### DIFF
--- a/recipes/hpipm/build.bat
+++ b/recipes/hpipm/build.bat
@@ -1,0 +1,27 @@
+rmdir /s /q build
+mkdir build
+cd build
+
+cmake %CMAKE_ARGS% ^
+    -G "Ninja" ^
+    -DHPIPM_FIND_BLASFEO:BOOL=ON ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTING:BOOL=ON ^
+    -DHPIPM_TESTING:BOOL=ON ^
+    -DBUILD_SHARED_LIBS:BOOL=ON ^
+    -DTARGET=%HPIPM_TARGET% ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1
+
+:: Test.
+ctest --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipes/hpipm/build.sh
+++ b/recipes/hpipm/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+rm -rf build
+mkdir build
+cd build
+
+# HPIPM_TARGET is set in the recipe.yaml's
+# script_env section, depending on the microarch
+# level being built
+cmake ${CMAKE_ARGS} -GNinja .. \
+      -DHPIPM_FIND_BLASFEO:BOOL=ON \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING:BOOL=ON \
+      -DHPIPM_TESTING:BOOL=ON \
+      -DBUILD_SHARED_LIBS:BOOL=ON \
+      -DTARGET=${HPIPM_TARGET}
+
+cmake --build . --config Release
+cmake --build . --config Release --target install
+
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR}" != "" ]]; then
+  ctest --output-on-failure -C Release
+fi

--- a/recipes/hpipm/conda_build_config.yaml
+++ b/recipes/hpipm/conda_build_config.yaml
@@ -1,0 +1,3 @@
+microarch_level:
+  - 1
+  - 3  # [x86_64]

--- a/recipes/hpipm/recipe.yaml
+++ b/recipes/hpipm/recipe.yaml
@@ -60,7 +60,7 @@ requirements:
       then: _x86_64-microarch-level >=${{ microarch_level | default("1") }}
 
   run_exports:
-    - ${{ pin_subpackage(name, upper_bound="x.x.x") }}
+    - ${{ pin_subpackage("libhpipm", upper_bound="x.x.x") }}
 
 tests:
   - package_contents:
@@ -88,4 +88,3 @@ extra:
   feedstock-name: hpipm
   recipe-maintainers:
     - traversaro
-```

--- a/recipes/hpipm/recipe.yaml
+++ b/recipes/hpipm/recipe.yaml
@@ -1,12 +1,9 @@
-schema_version: 1
-
 context:
-  name: libhpipm
   version: "0.1.4"
   build: 0
 
 package:
-  name: ${{ name }}
+  name: libhpipm
   version: ${{ version }}
 
 source:

--- a/recipes/hpipm/recipe.yaml
+++ b/recipes/hpipm/recipe.yaml
@@ -1,0 +1,94 @@
+schema_version: 1
+
+context:
+  name: libhpipm
+  version: "0.1.4"
+  build: 0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/giaf/hpipm/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 1af1041fb6610f5bfcde3e8d8c02731dc52a937e589d65db73e28dcfa8c4cef3
+
+build:
+  number: >-
+    ${{ build + (
+        100 if x86_64 and (microarch_level | default(1)) in [1, "1"]
+        else 300 if x86_64 and (microarch_level | default(1)) in [3, "3"]
+        else 400 if x86_64 and (microarch_level | default(1)) in [4, "4"]
+        else 0
+    ) }}
+
+  # Selects build.sh on Unix and build.bat on Windows.
+  script:
+    file: build
+    env:
+      # HPIPM provides an AVX implementation and a generic implementation.
+      #
+      # microarch_level == 1 does not guarantee AVX support, so use GENERIC.
+      # microarch_level == 3 and 4 guarantee AVX support, so use AVX.
+      #
+      # All non-x86_64 architectures use the generic implementation.
+      HPIPM_TARGET: >-
+        ${{
+          "AVX"
+          if x86_64 and (microarch_level | default(1)) in [3, "3", 4, "4"]
+          else "GENERIC"
+        }}
+
+requirements:
+  build:
+    # Note that x86_64-microarch-level doesn't support win,
+    # but we can still specify microarch_level for win builds.
+    # HPIPM's custom build translates that variant into AVX or GENERIC.
+    - if: unix and x86_64
+      then: x86_64-microarch-level ==${{ microarch_level | default("1") }}
+
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+
+    - if: win
+      then: clang
+
+  host:
+    - libblasfeo
+
+  run:
+    - if: x86_64
+      then: _x86_64-microarch-level >=${{ microarch_level | default("1") }}
+
+  run_exports:
+    - ${{ pin_subpackage(name, upper_bound="x.x.x") }}
+
+tests:
+  - package_contents:
+      include:
+        - hpipm_d_ocp_qp.h
+      lib:
+        - hpipm
+
+  - script:
+      - cmake-package-check hpipm --targets hpipm
+    requirements:
+      run:
+        - cmake-package-check
+        - ${{ compiler("c") }}
+        - cmake
+
+about:
+  homepage: https://github.com/giaf/hpipm
+  repository: https://github.com/giaf/hpipm
+  license: BSD-2-Clause
+  license_file: LICENSE.txt
+  summary: High-performance interior-point-method QP and QCQP solvers
+
+extra:
+  feedstock-name: hpipm
+  recipe-maintainers:
+    - traversaro
+```

--- a/recipes/hpipm/recipe.yaml
+++ b/recipes/hpipm/recipe.yaml
@@ -75,6 +75,7 @@ tests:
       run:
         - cmake-package-check
         - ${{ compiler("c") }}
+        - ${{ compiler("cxx") }}
         - cmake
 
 about:


### PR DESCRIPTION
This PR adds a recipe for the `libhpipm` library, a C library providing High-performance interior-point-method QP and QCQP solvers: https://github.com/giaf/hpipm .

The feedstock is named `hpipm` so that if in the future the feedstock will support multiple outputs, we are not stick with `lib` in its name.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
