### PR TITLE
Add CalcHEP 

### DIFF
--- a/recipes/calchep/LICENSE
+++ b/recipes/calchep/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/recipes/calchep/activate.csh
+++ b/recipes/calchep/activate.csh
@@ -1,0 +1,6 @@
+# Export CALCHEP so the CalcHEP engine and downstream packages can locate the
+# run-in-place installation. See activate.sh for details.
+if ($?CALCHEP) then
+    setenv CALCHEP_CONDA_BACKUP "$CALCHEP"
+endif
+setenv CALCHEP "${CONDA_PREFIX}/share/calchep"

--- a/recipes/calchep/activate.fish
+++ b/recipes/calchep/activate.fish
@@ -1,0 +1,6 @@
+# Export CALCHEP so the CalcHEP engine and downstream packages can locate the
+# run-in-place installation. See activate.sh for details.
+if set -q CALCHEP
+    set -gx CALCHEP_CONDA_BACKUP $CALCHEP
+end
+set -gx CALCHEP "$CONDA_PREFIX/share/calchep"

--- a/recipes/calchep/activate.sh
+++ b/recipes/calchep/activate.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Export CALCHEP so the CalcHEP engine and downstream packages (e.g. micrOMEGAs)
+# can locate the run-in-place installation under $CONDA_PREFIX/share/calchep, and
+# so binaries that consult getenv("CALCHEP") are robust against relocation.
+# Back up any pre-existing value (a user may point at a hand-built tree).
+if [ -n "${CALCHEP:-}" ]; then
+    CALCHEP_CONDA_BACKUP="${CALCHEP}"
+    export CALCHEP_CONDA_BACKUP
+fi
+CALCHEP="${CONDA_PREFIX}/share/calchep"
+export CALCHEP

--- a/recipes/calchep/build_cache.sh
+++ b/recipes/calchep/build_cache.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+# Diagnostic: record the toolchain the conda activation provides.
+echo "toolchain: CC=${CC:-} CXX=${CXX:-} FC=${FC:-} HOST=${HOST:-} CPU_COUNT=${CPU_COUNT:-}"
+
+# CalcHEP is a run-in-place package: ``sbin/setPath`` and ``getFlags`` bake an
+# absolute install path into include/rootDir.h, FlagsForMake (CALCHEP=...),
+# FlagsForSh, and several bin/* helper scripts, and the engine JIT-compiles
+# generated process code at run time using the compiler recorded in FlagsForSh.
+# Build the tree directly under its final location so the embedded paths equal
+# the build prefix and conda's automatic prefix replacement (text + binary)
+# makes the package relocatable.
+CALCHEP_HOME="${PREFIX}/share/calchep"
+mkdir -p "${CALCHEP_HOME}"
+
+# Locate the source root (getFlags sits at the top level) robustly, whether or
+# not the archive's leading directory was stripped on extraction.
+SRC_ROOT="$(dirname "$(find . -maxdepth 2 -name getFlags -type f | head -1)")"
+cp -a "${SRC_ROOT}/." "${CALCHEP_HOME}/"
+cd "${CALCHEP_HOME}"
+
+# Pre-seed FlagsForSh so getFlags sources it (instead of probing a bare ``gcc``)
+# and builds with the conda-forge toolchain. Force "blind" mode (LX11/HX11 empty)
+# so there is no X11/xorg dependency; all symbolic, numeric and batch
+# functionality works -- only the interactive graphical menu is unavailable (the
+# calchep-gui output re-links it against X11).
+#
+# -fcommon is REQUIRED: CalcHEP's C relies on tentative definitions of globals in
+# shared headers, which GCC >= 10 (-fno-common by default) rejects as multiple
+# definitions at link time.
+#
+# GCC >= 14 promotes several legacy-C diagnostics to errors by default; CalcHEP's
+# older C trips them (e.g. a pthread_create thread routine typed `int *` rather
+# than `void *`). Downgrade them back to warnings so the upstream sources build
+# unmodified. (C-only; not added to CXXFLAGS.)
+#
+# lQuad is left EMPTY. CalcHEP only links libquadmath when nType.h selects
+# __float128 (the opt-in _QUADGCC_ high-precision mode); the default REAL=double
+# build never references it -- upstream getFlags sets lQuad="" via the same
+# _QUADGCC_ probe. Hardcoding -lquadmath added a spurious, unused NEEDED that is
+# also non-portable (libquadmath is an x86_64-with-gcc library: clang/macOS ships
+# none, and aarch64's native 128-bit long double makes it unnecessary). libgfortran
+# -- a genuine dependency of the SLHA Fortran bridge below -- still pulls libquadmath
+# in transitively on platforms whose libgfortran needs it (x86_64) and not elsewhere
+# (aarch64), which is exactly the portable behaviour.
+LEGACY_C="-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=int-conversion -Wno-error=implicit-int"
+
+# Platform-dependent link flags. macOS (clang + ld64) differs from Linux (gcc +
+# GNU ld): shared objects are built with -dynamiclib and named via -install_name,
+# there is no -rdynamic, and ranlib needs -c to index the -fcommon archives. These
+# mirror upstream getFlags' own Darwin branch. target_platform is set by the conda
+# build; fall back to uname. (getFlags sources this FlagsForSh as-is and propagates
+# the values to FlagsForMake, so the make build and build_gui.sh inherit them.)
+case "${target_platform:-}" in
+  osx-*) is_osx=1 ;;
+  "")    [ "$(uname -s)" = Darwin ] && is_osx=1 || is_osx=0 ;;
+  *)     is_osx=0 ;;
+esac
+if [ "${is_osx}" = 1 ]; then
+  _SHARED="-dynamiclib"; _SONAME="-install_name "; _lDL="-ldl";           _RANLIB="${RANLIB:-ranlib} -c"
+else
+  _SHARED="-shared";     _SONAME="";              _lDL="-rdynamic -ldl";  _RANLIB="${RANLIB:-ranlib}"
+fi
+
+cat > FlagsForSh <<EOF
+CC="${CC}"
+CFLAGS="${CFLAGS:-} -fsigned-char -std=gnu99 -fPIC -fcommon ${LEGACY_C}"
+HX11=
+LX11=""
+lDL="${_lDL}"
+SHARED="${_SHARED}"
+SONAME="${_SONAME}"
+SO=so
+SNUM=
+FC="${FC}"
+FFLAGS="${FFLAGS:-} -fno-automatic"
+lFort="-lgfortran"
+CXX="${CXX}"
+CXXFLAGS="${CXXFLAGS:-} -fPIC -fcommon"
+RANLIB="${_RANLIB}"
+MAKE=make
+lQuad=
+export CC CFLAGS lDL LX11 SHARED SONAME SO FC FFLAGS RANLIB CXX CXXFLAGS lFort lQuad MAKE
+EOF
+
+# A pristine tree has no work/bin symlink; the build creates it. Guard re-runs.
+rm -f work/bin
+
+# macOS ld64 has no --allow-shlib-undefined; patches/0004 bakes that GNU spelling
+# into c_source/dynamicME/vp_dynam.c (compiled into dynamic_vp.a) and bin/run_batch.
+# Translate it to the Darwin equivalent before building so both the compiled and the
+# script copy link VandP.so correctly. (Uses the conda GNU sed in the staging build
+# requirements; the ld_n/make_main consumer links are handled in install_calchep.sh.)
+if [ "${is_osx}" = 1 ]; then
+  grep -rl -- '-Wl,--allow-shlib-undefined' . 2>/dev/null | while IFS= read -r f; do
+    sed -i 's/-Wl,--allow-shlib-undefined/-Wl,-undefined,dynamic_lookup/g' "$f"
+  done
+fi
+
+# Serial build: the recursive c_source build has cross-subdirectory link-order
+# dependencies and is not -j safe. </dev/null guards any stray interactive read.
+make </dev/null
+
+# Re-assert the install path in include/rootDir.h and the bin/* helper scripts.
+./sbin/setPath "${CALCHEP_HOME}"
+
+# Bundle the numerical static archives into ONE shared library so the package ships
+# a shared lib instead of static .a (conda-forge prefers shared). A SINGLE combined
+# .so is required: CalcHEP's -fcommon tentative globals (nin_int, nprc_int, ...) are
+# shared across these archives and merged at link; separate per-archive .so would
+# give each its own copy and break the engine. --whole-archive pulls in every object
+# so all symbols are present; symbols provided by n_calchep.o and the per-process
+# libs stay undefined and resolve at the run-time n_calchep link (normal for a .so).
+# dummy.a (overridable stubs: usrfun/usrFF + the LHAPDF API) is intentionally kept
+# static and linked last by ld_n -- a static-archive member is pulled in only if its
+# symbol is otherwise undefined, so a user's real LHAPDF/usrfun overrides the stub (a
+# .so would always define them and shadow the user's, e.g. silently disabling LHAPDF).
+# dynamic_vp.a (vp_dynam.o) is likewise kept OUT of the .so: sbin/ld_n
+# never links it into n_calchep, and it defines the model tables (nModelParticles,
+# ModelPrtcls, varNames, varValues, ...) as -fcommon tentative globals. Those must
+# stay UNDEFINED in n_calchep so the run-time-dlopen'd VandP.so supplies the real
+# model; folding them into libcalchep.so (loaded NEEDED at startup) would define them
+# as zero-filled BSS that shadows VandP.so, so the engine reads an empty particle
+# table and segfaults during integration. dynamic_vp.a stays static, linked only by
+# bin/make_main (its sole consumer). The .so thus holds exactly the core archives that
+# n_calchep already linked statically -- no symbol it did not previously define.
+#
+# faux.o (the Fortran half of the SLHA bridge: fortranreadline_, cmixmatrix_, ...) is
+# linked in because the C half (libSLHAplus's fortran.o, pulled by --whole-archive)
+# calls it at run time, so -lgfortran is needed too (libgfortran is already a run dep
+# via the Fortran compiler's run-export). The LHAPDF interface (sf_lha.o) keeps its
+# undefined libLHAPDF symbols (evolvePDFm, ...): LHAPDF is opt-in, so they resolve
+# lazily at run time only when a user supplies LHAPDF -- hence the consumer links use
+# -Wl,--allow-shlib-undefined (see install_calchep.sh and patches/0004).
+# Linux uses GNU ld (--whole-archive); macOS uses ld64 (-force_load per archive,
+# -dynamiclib + -install_name, and -undefined dynamic_lookup because a macOS dylib
+# errors on undefined symbols by default -- here the optional LHAPDF/n_calchep.o
+# danglers the linux .so leaves to resolve at run time). install_name @rpath/...
+# lets consumers find it via the rpath they add to $CALCHEP/lib. ${LDFLAGS} is
+# passed explicitly on macOS: unlike the linux gcc wrapper the clang wrapper does
+# not auto-add -L$PREFIX/lib (so -lgfortran would not resolve), and it also brings
+# -headerpad_max_install_names for conda's install-name relocation. (The linux
+# branch omits ${LDFLAGS} on purpose -- its --gc-sections would fight --whole-archive.)
+if [ "${is_osx}" = 1 ]; then
+  ( cd lib && \
+    "${CC}" ${CFLAGS:-} ${LDFLAGS:-} -dynamiclib -install_name @rpath/libcalchep.so -o libcalchep.so \
+      -Wl,-force_load,num_c.a -Wl,-force_load,ntools.a -Wl,-force_load,dynamic_me.a \
+      -Wl,-force_load,libSLHAplus.a -Wl,-force_load,serv.a \
+      faux.o -lm -lgfortran -Wl,-undefined,dynamic_lookup )
+else
+  ( cd lib && \
+    "${CC}" ${CFLAGS:-} -shared -Wl,-soname,libcalchep.so -o libcalchep.so \
+      -Wl,--whole-archive \
+        num_c.a ntools.a dynamic_me.a libSLHAplus.a serv.a \
+      -Wl,--no-whole-archive \
+        faux.o -lm -lgfortran )
+fi
+
+# The work/bin symlink points at the absolute build-prefix bin/ and would not
+# survive relocation; drop it (mkWORKdir recreates a correct one per work dir).
+rm -f work/bin

--- a/recipes/calchep/build_gui.sh
+++ b/recipes/calchep/build_gui.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+echo "toolchain: CC=${CC:-} CXX=${CXX:-} HOST=${HOST:-}"
+
+# This output inherits the staging cache: the fully built (blind) tree plus all
+# intermediate objects at ${PREFIX}/share/calchep, built with the conda compiler
+# (FlagsForMake still records it here -- the bare-name rewrite happens only in the
+# calchep package output). Every library CalcHEP needs is X11-independent and
+# identical between the blind and GUI variants; only serv.a (the chep_crt console
+# layer) and the front-end binaries that link it differ. So we re-link just the
+# interactive s_calchep against X11, reusing the cached X11-independent libraries.
+CALCHEP_HOME="${PREFIX}/share/calchep"
+cd "${CALCHEP_HOME}"
+
+# Enable X11 for the re-link. xorg-libx11 (host dependency) provides the headers
+# under ${PREFIX}/include and libX11 under ${PREFIX}/lib.
+sed -i -E \
+  -e "s|^HX11 = .*|HX11 = -I${PREFIX}/include|" \
+  -e "s|^LX11 = .*|LX11 = -L${PREFIX}/lib -lX11|" \
+  FlagsForMake
+
+# Rebuild only chep_crt's objects. chep_crt's Makefile ``ar``-replaces just its
+# own objects in the shared serv.a (swapping the stub noxwin/X11_crt0.o for the
+# real xwin/X11_crt0.o), keeping service2's objects (writeF, pathtocalchep, ...).
+# Then re-link the symbolic front-end (s_calchep, make_VandP, ...) against the
+# cached X11-independent libraries + libX11.
+rm -f c_source/chep_crt/*.o bin/s_calchep
+make -C c_source/chep_crt </dev/null
+make -C c_source/symb </dev/null
+
+# Install the X11-enabled s_calchep into the calchep-gui package's own location.
+# Its compiled-in rootDir points at share/calchep, whose data/libraries are
+# supplied by the calchep run dependency.
+mkdir -p "${PREFIX}/share/calchep-gui/bin" "${PREFIX}/bin"
+cp -a bin/s_calchep "${PREFIX}/share/calchep-gui/bin/s_calchep"
+ln -s "../share/calchep-gui/bin/s_calchep" "${PREFIX}/bin/calchep-gui"

--- a/recipes/calchep/deactivate.csh
+++ b/recipes/calchep/deactivate.csh
@@ -1,0 +1,7 @@
+# Restore CALCHEP to its pre-activation value (see activate.csh).
+if ($?CALCHEP_CONDA_BACKUP) then
+    setenv CALCHEP "$CALCHEP_CONDA_BACKUP"
+    unsetenv CALCHEP_CONDA_BACKUP
+else
+    unsetenv CALCHEP
+endif

--- a/recipes/calchep/deactivate.fish
+++ b/recipes/calchep/deactivate.fish
@@ -1,0 +1,7 @@
+# Restore CALCHEP to its pre-activation value (see activate.fish).
+if set -q CALCHEP_CONDA_BACKUP
+    set -gx CALCHEP $CALCHEP_CONDA_BACKUP
+    set -e CALCHEP_CONDA_BACKUP
+else
+    set -e CALCHEP
+end

--- a/recipes/calchep/deactivate.sh
+++ b/recipes/calchep/deactivate.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Restore CALCHEP to its pre-activation value (see activate.sh).
+if [ -n "${CALCHEP_CONDA_BACKUP:-}" ]; then
+    CALCHEP="${CALCHEP_CONDA_BACKUP}"
+    export CALCHEP
+    unset CALCHEP_CONDA_BACKUP
+else
+    unset CALCHEP
+fi

--- a/recipes/calchep/install_calchep.sh
+++ b/recipes/calchep/install_calchep.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+# This output inherits the fully built (blind) tree from the staging cache at
+# ${PREFIX}/share/calchep. Here we only finalize it: fix the recorded run-time
+# compiler, expose the user-facing tools on PATH, and ship activation scripts.
+CALCHEP_HOME="${PREFIX}/share/calchep"
+
+# Platform branch: the run-time JIT compiler is gcc on Linux and clang on macOS
+# (matching upstream getFlags), ranlib needs -c on macOS, and the per-binary rpath
+# token is $ORIGIN on Linux vs @loader_path on macOS.
+case "${target_platform:-}" in
+  osx-*) is_osx=1 ;;
+  "")    [ "$(uname -s)" = Darwin ] && is_osx=1 || is_osx=0 ;;
+  *)     is_osx=0 ;;
+esac
+if [ "${is_osx}" = 1 ]; then
+  _CC=clang; _CXX=clang++; _RANLIB="ranlib -c"; _ORIGIN="@loader_path"
+else
+  _CC=gcc;   _CXX=g++;     _RANLIB="ranlib";    _ORIGIN="'\$ORIGIN'"
+fi
+
+# Record portable, bare compiler names for the run-time JIT compilation step.
+# The build-time conda compiler (e.g. x86_64-conda-linux-gnu-cc) does not exist
+# at run time, and its build-only CFLAGS (sysroot, -fdebug-prefix-map, ...) would
+# be wrong there too. Reset to CalcHEP's portable defaults; the bare gcc (Linux) /
+# clang (macOS) is a package run dependency (see recipe.yaml), so the run-time JIT
+# always has a compiler. -fcommon is kept for the same reason it is needed at build
+# time. SNUM/SO/lDL/lFort/lQuad determined by getFlags are left
+# untouched so run-time compilation matches the shipped libraries. The
+# -Wno-error=* flags keep on-demand process compilation working on the user's
+# GCC >= 14 (which errors on the same legacy-C constructs as at build time).
+LEGACY_C="-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=int-conversion -Wno-error=implicit-int"
+sed -i -E \
+  -e "s|^CC=.*|CC=\"${_CC}\"|" \
+  -e "s|^CXX=.*|CXX=\"${_CXX}\"|" \
+  -e 's|^FC=.*|FC="gfortran"|' \
+  -e "s|^CFLAGS=.*|CFLAGS=\"-g -fsigned-char -std=gnu99 -fPIC -fcommon ${LEGACY_C}\"|" \
+  -e 's|^CXXFLAGS=.*|CXXFLAGS="-g -fPIC -fcommon"|' \
+  -e 's|^FFLAGS=.*|FFLAGS="-fno-automatic"|' \
+  -e "s|^RANLIB=.*|RANLIB=\"${_RANLIB}\"|" \
+  "${CALCHEP_HOME}/FlagsForSh"
+sed -i -E \
+  -e "s|^CC = .*|CC = ${_CC}|" \
+  -e "s|^CXX=.*|CXX=${_CXX}|" \
+  -e 's|^FC = .*|FC = gfortran|' \
+  -e "s|^CFLAGS = .*|CFLAGS = -g -fsigned-char -std=gnu99 -fPIC -fcommon ${LEGACY_C}|" \
+  -e 's|^CXXFLAGS = .*|CXXFLAGS = -g -fPIC -fcommon|' \
+  -e 's|^FFLAGS = .*|FFLAGS = -fno-automatic|' \
+  -e "s|^RANLIB = .*|RANLIB = ${_RANLIB}|" \
+  "${CALCHEP_HOME}/FlagsForMake"
+
+# Make the bundled Perl scripts (e.g. bin/run_batch, reached from a work dir via
+# its bin -> $CALCHEP/bin symlink) portable: rewrite the hard-coded
+# ``#!/usr/bin/perl`` shebang to an env-based one so they resolve perl from the
+# active environment (the ``perl`` run dependency) instead of a fixed system
+# path. conda does not rewrite this automatically (it is not a prefix path).
+while IFS= read -r script; do
+  sed -i '1s@^#![[:space:]]*/usr/bin/perl@#!/usr/bin/env perl@' "${script}"
+done < <(grep -rlE '^#![[:space:]]*/usr/bin/perl' "${CALCHEP_HOME}" 2>/dev/null || true)
+
+# CalcHEP's shell scripts use the historical Bourne convention of a bare ":"
+# first line instead of a "#!" shebang, and sbin/setPath re-bakes that ":" into
+# several of them (mkWORKdir, bin/mkLibstat, ...). A script with no shebang cannot
+# be exec'd directly -- it fails with ENOEXEC ("Exec format error") under strict
+# launchers such as pixi's task shell (deno), even though /bin/sh-based callers
+# (system(), bash) silently fall back to sh. Give every such script (they are all
+# Bourne) a real "#!/bin/sh". Binaries are excluded via grep -I; perl scripts
+# (rewritten above) start with "#!" so they do not match.
+while IFS= read -r -d '' script; do
+  head -1 "${script}" | grep -qxE ':[[:space:]]*' \
+    && sed -i '1s|^:[[:space:]]*$|#!/bin/sh|' "${script}"
+done < <(grep -rlIZE '^:[[:space:]]*$' "${CALCHEP_HOME}" 2>/dev/null || true)
+
+# mkWORKdir additionally writes a ":" header for the per-work-dir launcher scripts
+# it generates (./calchep, ./calchep_batch); emit "#!/bin/sh" instead so those are
+# directly executable too. Their cat'd bodies are /bin/sh; run_batch (perl) keeps
+# its own env shebang.
+sed -i 's|^echo ":|echo "#!/bin/sh|' "${CALCHEP_HOME}/mkWORKdir"
+
+# When CalcHEP builds a process's n_calchep at run time, sbin/ld_n links it
+# against the per-process lf*.so libraries sitting beside it and relies on
+# LD_RUN_PATH="$PWD" to record that directory as the rpath. But the conda-forge
+# gcc wrapper injects its own -Wl,-rpath,$CONDA_PREFIX/lib, and an explicit
+# -rpath makes the linker ignore LD_RUN_PATH -- so n_calchep ends up unable to
+# load its sibling lf*.so ("cannot open shared object file"). Add an explicit
+# $ORIGIN (Linux) / @loader_path (macOS) rpath so n_calchep always finds the
+# libraries next to itself. (Delimiter is | not @: the macOS @loader_path value
+# contains @, which would prematurely close an s@...@...@ expression.)
+sed -i "s| -o n_calchep| -Wl,-rpath,${_ORIGIN} -o n_calchep|" "${CALCHEP_HOME}/sbin/ld_n"
+
+# Link the run-time numerical executables against the combined shared library
+# (libcalchep.so, produced by the staging build) instead of the individual static
+# archives: replace num_c.a with -lcalchep + an rpath to $CALCHEP/lib (so the
+# freshly built n_calchep finds it), and drop the other core archives now subsumed
+# by the .so. -Wl,--allow-shlib-undefined is required because the combined .so also
+# contains CalcHEP's optional-feature objects (the LHAPDF interface sf_lha.o and the
+# Fortran-SLHA bridge fortran.o) whose external symbols (evolvePDFm, fortranreadline_,
+# ...) are absent unless those features are used; they resolve lazily at run time only
+# if exercised (otherwise dead). dummy.a stays static and last (overridable user
+# stubs), as does dynamic_vp.a (the model-table storage that must NOT enter the .so;
+# bin/make_main is its only consumer -- see build_cache.sh); sqme_aux.so and the
+# per-process lib_0.a/ld*.a/lf*.so are untouched.
+# -rdynamic stays so the dlopen'd lf*.so resolve callbacks against n_calchep + the
+# (global) libcalchep.so. sbin/ld_n uses $cLib; bin/make_main uses $lib.
+sed -i -E \
+  -e 's@\$cLib/num_c\.a@-L$cLib -Wl,-rpath,$cLib -Wl,--allow-shlib-undefined -lcalchep@' \
+  -e 's@\$cLib/(ntools|dynamic_me|libSLHAplus|serv)\.a@@g' \
+  "${CALCHEP_HOME}/sbin/ld_n"
+sed -i -E \
+  -e 's@\$lib/num_c\.a@-L$lib -Wl,-rpath,$lib -Wl,--allow-shlib-undefined -lcalchep@' \
+  -e 's@\$lib/(ntools|dynamic_me|libSLHAplus|serv)\.a@@g' \
+  "${CALCHEP_HOME}/bin/make_main"
+
+# macOS ld64 spelling of the consumer-link allow-undefined flag (mirrors the
+# build_cache.sh translation for VandP.so): GNU's --allow-shlib-undefined ->
+# Darwin's -undefined dynamic_lookup, applied to the run-time linker scripts.
+if [ "${is_osx}" = 1 ]; then
+  sed -i 's/-Wl,--allow-shlib-undefined/-Wl,-undefined,dynamic_lookup/g' \
+    "${CALCHEP_HOME}/sbin/ld_n" "${CALCHEP_HOME}/bin/make_main"
+fi
+
+# Ship the shared library; drop the now-redundant static archives. Keep dummy.a
+# (static overridable stubs), dynamic_vp.a (model-table storage; bin/make_main links
+# it at run time -- it must not be folded into the .so, see build_cache.sh) and
+# sqme_aux.so. symb.a is build-time only (the s_calchep / make_VandP / makeVrtLib
+# binaries are already linked and never relink at run time); servNoX11.a is a
+# micrOMEGAs-only variant (the blind engine uses serv).
+rm -f "${CALCHEP_HOME}/lib/"{num_c,ntools,dynamic_me,libSLHAplus,serv,servNoX11,symb}.a
+
+# libcalchep.so deliberately stays under share/calchep/lib and is NOT symlinked
+# into ${PREFIX}/lib. CalcHEP is run-in-place: every binary it JIT-builds finds
+# the library through an absolute rpath to $CALCHEP/lib (the -Wl,-rpath baked in
+# by the ld_n/make_main edits above), never via the default loader path.
+# Downstream consumers (e.g. micrOMEGAs) are CalcHEP-aware and link against
+# $CALCHEP/lib the same way, so they do not need it in ${PREFIX}/lib either.
+# Keeping this generically-named, unversioned .so out of the global lib dir also
+# avoids polluting every environment's library namespace.
+
+# Expose the user-facing tools via relative (relocatable) symlinks under their
+# upstream names. Internal JIT helpers (make_main, mkLibstat, mkLibshared,
+# subproc_cycle, make_VandP, Int) and the work-dir-internal ``calc`` are
+# intentionally not exposed; they remain reachable via ${CALCHEP}/bin.
+mkdir -p "${PREFIX}/bin"
+ln -s "../share/calchep/mkWORKdir" "${PREFIX}/bin/mkWORKdir"
+for tool in s_calchep event2lhe events2tab lhe2tab event_mixer \
+            show_distr sum_distr lhapdf2pdt; do
+  ln -s "../share/calchep/bin/${tool}" "${PREFIX}/bin/${tool}"
+done
+
+# Activation scripts (bash/POSIX, csh, fish) export CALCHEP so the engine and
+# downstream packages (e.g. micrOMEGAs) can locate the installation, and so the
+# binaries that consult getenv("CALCHEP") are robust against any relocation edge
+# case.
+for stage in activate deactivate; do
+  mkdir -p "${PREFIX}/etc/conda/${stage}.d"
+  for ext in sh csh fish; do
+    cp "${RECIPE_DIR}/${stage}.${ext}" \
+       "${PREFIX}/etc/conda/${stage}.d/calchep_${stage}.${ext}"
+  done
+done

--- a/recipes/calchep/patches/0001-fix-initStrFun-out-of-bounds-write-segfault.patch
+++ b/recipes/calchep/patches/0001-fix-initStrFun-out-of-bounds-write-segfault.patch
@@ -1,0 +1,26 @@
+Fix out-of-bounds global write in initStrFun that corrupts an adjacent
+pointer and segfaults the numerical session during integration.
+
+initStrFun(i1) computes i = i1 - 1 and writes nnan[i] and sf_be[i] before
+validating i1.  It is routinely called as initStrFun(0) (the "initialise
+both beams" sentinel; see the i1<=0 branch just below and alphas2.c), which
+makes i == -1 and writes nnan[-1] / sf_be[-1] out of bounds.  In the
+conda-forge -O2 build the BSS places nnan[] immediately after the static
+pointer plist (allInP), so nnan[-1] zeroes the high 32 bits of plist and the
+next realloc(plist, ...) dereferences a truncated pointer and crashes.
+Only write nnan[i]/sf_be[i] for valid i1 in {1,2}; the i1==0 case already
+initialises both via the recursive initStrFun(1)/initStrFun(2) calls.
+
+diff --git a/c_source/strfun/strfun.c b/c_source/strfun/strfun.c
+--- a/c_source/strfun/strfun.c
++++ b/c_source/strfun/strfun.c
+@@ -98,8 +98,7 @@
+ {
+   int l,i=i1-1;
+   
+-  nnan[i]=0;
+-  sf_be[i]=1;
++  if(i1>=1 && i1<=2) { nnan[i]=0; sf_be[i]=1; }
+ 
+   if(nin_int!=2) {sf_alpha[0]=NULL; sf_alpha[1]=NULL; return 0;}
+    

--- a/recipes/calchep/patches/0002-qcdScale-guard-zero-arg-min-max-overflow.patch
+++ b/recipes/calchep/patches/0002-qcdScale-guard-zero-arg-min-max-overflow.patch
@@ -1,0 +1,20 @@
+Guard the zero-argument min()/max() case in the QCD-scale expression parser.
+
+In act_num_ the "min"/"max" branch computes l = sum_i (strlen(args[i]) + 8).
+When called with n == 0 the loop never runs, l stays 0, malloc(0) yields a
+zero-size buffer and strcpy(p, args[0]) both reads a non-existent args[0] and
+overflows the destination (flagged by -Wstringop-overflow under -O2).  Return
+NULL for the empty case, consistent with the other error returns in this
+function.
+
+diff --git a/c_source/num/qcdScale.c b/c_source/num/qcdScale.c
+--- a/c_source/num/qcdScale.c
++++ b/c_source/num/qcdScale.c
+@@ -159,6 +159,7 @@
+    if(strcmp(ch,"min")==0 || strcmp(ch,"max")==0)
+    { int l=0,i;
+      char *q;
++     if(n<=0) return NULL;
+      for(i=0;i<n;i++) l+=strlen((char*)args[i])+8;
+      p=malloc(l);
+      q=malloc(l);

--- a/recipes/calchep/patches/0003-histogram-calloc-distribution-record.patch
+++ b/recipes/calchep/patches/0003-histogram-calloc-distribution-record.patch
@@ -1,0 +1,22 @@
+Zero-initialise the per-distribution record read from the session file.
+
+readDistributions() malloc()s a histRec and fills it with fscanf(); when a
+field is absent or unparsable (nPoints, hMin/hMax, or trailing f[]/ff[] bins)
+fscanf leaves it uninitialised, and writeDistributions() later prints those
+bytes (valgrind: "Conditional jump ... depends on uninitialised value(s)" in
+__printf_fp via writeDistributions).  Harmless in practice but undefined;
+calloc() makes any gap a defined 0.  (The other histRec allocation, in the
+menu path, already initialises every field explicitly.)
+
+diff --git a/c_source/num/histogram.c b/c_source/num/histogram.c
+--- a/c_source/num/histogram.c
++++ b/c_source/num/histogram.c
+@@ -271,7 +271,7 @@
+   linelist rec;
+   for(rec=histTab.strings;rec;rec=rec->next)
+   {  int Nread; 
+-     histRec * hist=malloc(sizeof(histRec));
++     histRec * hist=calloc(1,sizeof(histRec));
+ 
+      hist->next=histPtr;
+      hist->mother=rec;

--- a/recipes/calchep/patches/0004-link-VandP.so-against-libcalchep.patch
+++ b/recipes/calchep/patches/0004-link-VandP.so-against-libcalchep.patch
@@ -1,0 +1,33 @@
+Link the runtime-generated VandP.so against the combined shared library.
+
+With the numerical core shipped as libcalchep.so instead of the individual
+static archives, the two places that compile the per-model VandP.so at run
+time -- the Makefile rule emitted by bin/run_batch and the compile string in
+c_source/dynamicME/vp_dynam.c -- link -lcalchep (with an rpath to $CALCHEP/lib)
+in place of dynamic_me.a/libSLHAplus.a/ntools.a/serv.a. -Wl,--allow-shlib-undefined
+is needed because libcalchep.so also carries CalcHEPs optional-feature objects
+(LHAPDF, Fortran-SLHA bridge) whose external symbols resolve at run time only if
+used. dummy.a (overridable stubs) is kept.
+
+--- a/bin/run_batch
++++ b/bin/run_batch
+@@ -3866,7 +3866,7 @@
+ endif
+ 
+ VandP.so:VandP.c \$(DEPEND) models/extlib$model_num.mdl
+-\t\$(CC) \$(CFLAGS)  -shared -o VandP.so \$(soname_VandP) VandP.c \$(CALCHEP)/include/VandPgate.c  \$(EXTLIB) \$(CALCHEP)/lib/dynamic_me.a  \$(CALCHEP)/lib/libSLHAplus.a \$(CALCHEP)/lib/ntools.a \$(CALCHEP)/lib/serv.a \$(CALCHEP)/lib/dummy.a  -lm \$(lQuad) -lpthread
++\t\$(CC) \$(CFLAGS)  -shared -o VandP.so \$(soname_VandP) VandP.c \$(CALCHEP)/include/VandPgate.c  \$(EXTLIB) -L\$(CALCHEP)/lib -Wl,-rpath,\$(CALCHEP)/lib -Wl,--allow-shlib-undefined -lcalchep \$(CALCHEP)/lib/dummy.a  -lm \$(lQuad) -lpthread
+ ENDMK
+   close(MAKEFILE);
+ #  system("make -C $dir");
+--- a/c_source/dynamicME/vp_dynam.c
++++ b/c_source/dynamicME/vp_dynam.c
+@@ -41,7 +41,7 @@
+                      "$CALCHEP/bin/make_VandP models 1 6 \n"
+                      " . $CALCHEP/FlagsForSh;"
+                      " . ./EXTLIBsh;"
+-                     "$CC $CFLAGS $SHARED -o so_generated/VandP.so VandP.c $CALCHEP/include/VandPgate.c $EXTLIB  $CALCHEP/lib/dummy.a  $CALCHEP/lib/dynamic_me.a    $CALCHEP/lib/libSLHAplus.a $CALCHEP/lib/ntools.a $CALCHEP/lib/serv.a  -lm -lpthread -ldl"
++                     "$CC $CFLAGS $SHARED -o so_generated/VandP.so VandP.c $CALCHEP/include/VandPgate.c $EXTLIB  $CALCHEP/lib/dummy.a  -L$CALCHEP/lib -Wl,-rpath,$CALCHEP/lib -Wl,--allow-shlib-undefined -lcalchep  -lm -lpthread -ldl"
+                     ,rootDir,compDir);
+      err=system(command);
+ //printf("%s\n", command);     

--- a/recipes/calchep/recipe.yaml
+++ b/recipes/calchep/recipe.yaml
@@ -1,0 +1,263 @@
+context:
+  version: "3.8.4"
+
+recipe:
+  name: calchep
+  version: ${{ version }}
+
+source:
+  - url: https://theory.sinp.msu.ru/~pukhov/CALCHEP/calchep_${{ version }}.tgz
+    sha256: 802b7d7e776643b3a46f0611bb4f43f1ba9a84ebe071c251b2caf7ddb36e5043
+    patches:
+      # initStrFun() writes nnan[i1-1]/sf_be[i1-1] before validating i1; called
+      # as initStrFun(0) it writes nnan[-1], which the -O2 BSS layout overlaps
+      # with the adjacent ``plist`` pointer -> truncated pointer -> SIGSEGV in
+      # realloc during numerical integration. (Reported upstream.)
+      - patches/0001-fix-initStrFun-out-of-bounds-write-segfault.patch
+      # Zero-argument min()/max() in the QCD-scale parser: malloc(0)+strcpy
+      # overflow / out-of-bounds args[0] read (latent; reported upstream).
+      - patches/0002-qcdScale-guard-zero-arg-min-max-overflow.patch
+      # readDistributions() reads a session record into a malloc'd histRec;
+      # fscanf gaps leave fields uninitialised (later printed). calloc zero-
+      # fills them (valgrind-clean; harmless but undefined behaviour).
+      - patches/0003-histogram-calloc-distribution-record.patch
+      # Link the run-time-generated VandP.so against the combined shared library
+      # (libcalchep.so) instead of the individual static archives that are no
+      # longer shipped. (Pairs with the ld_n/make_main link edits in install_calchep.sh.)
+      - patches/0004-link-VandP.so-against-libcalchep.patch
+
+build:
+  number: 0
+  # POSIX build system (Makefile + getFlags + sh); no Windows support.
+  # osx (osx-64 + osx-arm64) is enabled via Darwin-specific handling in
+  # build_cache.sh / install_calchep.sh (clang -dynamiclib, -install_name,
+  # `ranlib -c`, no -rdynamic, -force_load, -undefined dynamic_lookup,
+  # @loader_path). That macOS link path could not be validated locally, so it may
+  # still need iteration against conda-forge's osx builders.
+  skip:
+    - win
+
+outputs:
+  # The staging output builds the run-in-place tree (in blind, non-X11 mode) once
+  # under $PREFIX/share/calchep, including every X11-independent library and all
+  # intermediate objects. Both package outputs inherit it: ``calchep`` ships the
+  # blind tree as-is, while ``calchep-gui`` re-links only the interactive
+  # front-end against X11, reusing the cached libraries.
+  - staging:
+      name: calchep-build
+
+    build:
+      script:
+        file: build_cache
+
+    requirements:
+      build:
+        - ${{ stdlib("c") }}
+        - ${{ compiler("c") }}
+        - ${{ compiler("cxx") }}
+        - ${{ compiler("fortran") }}
+        - make
+        # GNU sed: on macOS build_cache.sh rewrites the GNU allow-undefined link
+        # flag to the ld64 spelling before building, and the system BSD sed differs.
+        - sed
+
+  - package:
+      name: calchep
+    inherit: calchep-build
+
+    build:
+      script:
+        file: install_calchep
+      files:
+        - share/calchep/**
+        - bin/*
+        - etc/conda/**
+
+    requirements:
+      build:
+        # The shipped binaries/libraries come from the staging build; the C and
+        # Fortran compilers are declared here only so their run-exports (libgcc,
+        # libgfortran) become this package's run dependencies. compiler("cxx") is
+        # omitted: CalcHEP's C++ sources link no libstdc++ runtime, so nothing
+        # shipped needs it (verified with readelf). The run-time JIT compiler is a
+        # real ``run`` dependency (below).
+        - ${{ stdlib("c") }}
+        - ${{ compiler("c") }}
+        - ${{ compiler("fortran") }}
+        - sed
+      run:
+        # The run-time-generated bin/ scripts (run_batch, ...) are Perl.
+        - perl
+        # Process generation JIT-compiles C on demand with the compiler recorded in
+        # FlagsForSh, so ship it: gcc on Linux, clang on macOS.
+        - if: linux
+          then: gcc
+        - if: osx
+          then: clang
+      run_exports:
+        - ${{ pin_subpackage("calchep", upper_bound="x.x") }}
+
+    tests:
+      - package_contents:
+          bin:
+            - s_calchep
+            - mkWORKdir
+            - event2lhe
+            - event_mixer
+            - events2tab
+            - lhapdf2pdt
+            - lhe2tab
+            - show_distr
+            - sum_distr
+          files:
+            - share/calchep/FlagsForSh
+            - share/calchep/calchep.ini
+            - share/calchep/bin/s_calchep
+            - share/calchep/bin/calc
+            # The numerical core ships as one shared library (libcalchep.so);
+            # dummy.a and dynamic_vp.a must stay static (see build_cache.sh for the
+            # link-semantics reasons) and sqme_aux.so is already shared.
+            - share/calchep/lib/libcalchep.so
+            - share/calchep/lib/dummy.a
+            - share/calchep/lib/dynamic_vp.a
+            - share/calchep/lib/sqme_aux.so
+            - etc/conda/activate.d/calchep_activate.sh
+            - etc/conda/activate.d/calchep_activate.csh
+            - etc/conda/activate.d/calchep_activate.fish
+            - etc/conda/deactivate.d/calchep_deactivate.sh
+            - etc/conda/deactivate.d/calchep_deactivate.csh
+            - etc/conda/deactivate.d/calchep_deactivate.fish
+
+      - script:
+          # --version needs no compiler and exits before opening any display.
+          - s_calchep --version
+          # The activation script must export CALCHEP into the (run-in-place) tree.
+          - test -n "${CALCHEP}"
+          - test -f "${CALCHEP}/calchep.ini"
+
+      # End-to-end batch run, event/distribution post-processing, and the make_main
+      # C-API check. Runs on every platform: CalcHEP JIT-generates, compiles and
+      # integrates the process on demand using the run-time toolchain (gcc on linux,
+      # clang on macOS -- a package run dependency) plus make and gnuplot (pulled
+      # into the test environment only).
+      - requirements:
+          run:
+            - make
+            - gnuplot
+            - grep
+            - awk
+        script:
+          - mkWORKdir _example
+          - cd _example
+          # -help is a single dash; --help is unrecognized and exits 6.
+          - ./calchep_batch -help
+          - ./calchep_batch "${CALCHEP}/utile/batch_file"
+          # A cross-section result must actually be produced, and the
+          # distribution plots require gnuplot. Both land at the top of
+          # batch_results/ (run name "test", so plots are test-Mh*_*.jpg).
+          - test -f batch_results/test-cs.dat
+          - test -f batch_results/test-Mh120_1.jpg
+          # Post-processing utilities on the generated outputs. lhe2tab
+          # histograms the LHE events (M(5,-5) = M(b,bbar), always in the final
+          # state) and records the worst energy-momentum imbalance; assert the
+          # events conserve 4-momentum (~1e-11, far below the 1e-6 tolerance).
+          # (gzip -dc, not zcat: macOS zcat is the legacy compress tool and looks
+          # for a .Z file instead of decompressing the .gz.)
+          - gzip -dc batch_results/test-Mh120.lhe.gz > events.lhe
+          - lhe2tab "M(5,-5)" 0 400 50 < events.lhe > hist.txt
+          - grep -q "lost_momenta_max" hist.txt
+          - awk '/lost_momenta_max.Etot/{for(i=2;i<=NF;i++) if($i+0>1e-6) exit 1}' hist.txt
+          # sum_distr merges same-specification distribution files into one.
+          - sum_distr batch_results/test-Mh120.distr batch_results/test-Mh125.distr > combined.distr
+          - grep -q "M(b,B)" combined.distr
+          # make_main builds a standalone program against CalcHEP's C
+          # matrix-element API -- the path other packages (e.g. micrOMEGAs) use,
+          # and the sole consumer of the static dynamic_vp.a. make_main derives
+          # the output name from its argument and writes it to the current
+          # directory, so the source is copied into a fresh (writable) work dir
+          # and passed by bare name.
+          - cd ..
+          - mkWORKdir _main
+          - cd _main
+          - cp "${CALCHEP}/utile/main_22.c" .
+          - ${CALCHEP}/bin/make_main main_22.c
+          - ./main_22 > main_22.out
+          - grep -q "sigmaTot" main_22.out
+
+  - package:
+      name: calchep-gui
+    inherit: calchep-build
+
+    build:
+      script:
+        file: build_gui
+      files:
+        - share/calchep-gui/**
+        - bin/calchep-gui
+
+    requirements:
+      build:
+        - ${{ stdlib("c") }}
+        - ${{ compiler("c") }}
+        - ${{ compiler("cxx") }}
+        - make
+        - sed
+      host:
+        # X11/Xlib.h + libX11 from xorg-libx11; the X11/X.h protocol headers it
+        # includes come from xorg-xorgproto.
+        - xorg-libx11
+        - xorg-xorgproto
+      run:
+        # The GUI binary's data tree and libraries come from the blind package.
+        - ${{ pin_subpackage("calchep", exact=True) }}
+
+    tests:
+      - package_contents:
+          bin:
+            - calchep-gui
+          files:
+            - share/calchep-gui/bin/s_calchep
+      - script:
+          - calchep-gui --version
+          # The GUI front-end's defining feature over the blind package is the X11
+          # link; verify it directly. bin/calchep-gui is a symlink to the X11-linked
+          # s_calchep. ldd is the linux tool; otool -L is its macOS equivalent.
+          - if: linux
+            then: ldd "${PREFIX}/bin/calchep-gui" | grep -q libX11
+          - if: osx
+            then: otool -L "${PREFIX}/bin/calchep-gui" | grep -q libX11
+
+about:
+  homepage: https://theory.sinp.msu.ru/~pukhov/calchep.html
+  documentation: https://theory.sinp.msu.ru/~pukhov/calchep.html
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  summary: Calculation of Feynman diagrams and integration over multi-particle phase space
+  description: |
+    CalcHEP is a package for automatic calculations of elementary particle decay
+    and collision properties in the lowest order of perturbation theory
+    (the tree approximation).
+    The main idea prescribed into the CalcHEP is to make available passing on
+    from the Lagrangian to the final distributions effectively with a high
+    level of automation.
+
+    Two variants are provided:
+
+    * `calchep` builds in "blind" (non-interactive) mode, with no X11
+      dependency. The symbolic engine, numerical integration, batch operation,
+      and matrix-element generation all work; only the interactive graphical
+      menu is unavailable.
+    * `calchep-gui` adds the X11-enabled interactive `calchep-gui` front-end
+      (it depends on `calchep` for the shared data and libraries).
+
+    CalcHEP is a run-in-place package installed under `$CONDA_PREFIX/share/calchep`;
+    activation exports the `CALCHEP` environment variable. Generating a new process
+    compiles C code on demand at run time, so the package depends on a C compiler
+    (`gcc` on Linux, `clang` on macOS) and works out of the box. (A Fortran compiler
+    is only needed for models that use user-defined Fortran functions; standard
+    process generation is C only.)
+
+extra:
+  feedstock-name: calchep
+  recipe-maintainers:
+    - matthewfeickert


### PR DESCRIPTION
* Add CalcHEP v3.8.4
   - c.f. https://theory.sinp.msu.ru/~pukhov/calchep.html
   - https://github.com/hep-packaging-coordination/.github/issues/87
* CalcHEP is a required dependency of [MicrOMEGAs](https://lapth.cnrs.fr/micromegas/) that MicrOMEGAs currently vendors. This is moving CalcHEP out as a separate package which will then allow for MicrOMEGAs to have the vendored CalcHEP be patched out.

CalcHEP's upstream source builds a statically linked library, but this recipe includes multiple patches to make it dynamically linked instead. This PR produces two outputs: `caclhep` and `calchep-gui`.

## Disclosure

This recipe is (obviously) generated by agentic model Claude Code Opus 4.8 following my plan for a multi-output recipe. I have not cleaned up the comments fully (just a bit on the most critical parts) but I'm happy to do so.


## Why `dummy.a` and `dynamic_vp.a` ship as static archives

CalcHEP's numerical core is shipped as a shared library (`libcalchep.so`) &mdash; the core was previously a set of static archives that are now collapsed into it. Only two small archives (~19 KB combined) remain static, and that is deliberate: both rely on static-archive linking semantics that a shared library cannot reproduce. They are not general-purpose libraries that other packages link against. They are internal pieces of CalcHEP's run-in-place model, in which the engine JIT-compiles and links per-process code on demand at run time.

### `dummy.a`: overridable fallback stubs

`dummy.a` holds default (no-op) implementations of the user-overridable hooks: the `usrfun`/`usrFF` model functions and the LHAPDF interface. It is linked **last**. The defining property of a static archive is that the linker pulls in a member **only if it resolves an otherwise-undefined symbol**:

- If the user supplies a real LHAPDF (or their own `usrfun`), the linker takes *their* definition and never pulls the stub.
- If they don't, the stub is pulled in as a graceful fallback.

This "use the real one if present, otherwise fall back" behavior is exactly what makes LHAPDF support **opt-in**. As a `.so`, the stubs would always be defined symbols in the global scope and would **shadow** the user's real LHAPDF/functions, silently disabling them. A shared library has no way to express "define this symbol only if nothing else does."

### `dynamic_vp.a`: model-table storage for `make_main`

`dynamic_vp.a` (a single object) defines the model tables (`ModelPrtcls`, `nModelParticles`, …) as `-fcommon` globals and is linked only by CalcHEP's `make_main` helper. Those globals are meant to live in the executable and be populated at run time from the per-model library (`VandP.so`) that the engine `dlopen`s. If this object is folded into `libcalchep.so` (which loads as a `NEEDED` dependency at startup), the globals become defined, zero-filled symbols that **shadow the real `VandP.so`** — the engine then reads an empty particle table and segfaults during integration. (We hit exactly this while doing the shared-library conversion.)

Both archives are **link-mechanism objects**, not reusable libraries. conda-forge's shared-library guidance targets the latter (ABI duplication, security updates for downstream consumers), which does not apply here. Converting either to a shared object reintroduces symbol-shadowing bugs for ~19 KB of savings, so they are kept static by design.

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [N/A] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
   - See above for why there are still two statically linked libraries in this recipe. Is this okay, or does it need to be marked as `-static`?
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
