### PR TITLE
Add corvinos 0.9.52

### DIFF
--- a/recipes/corvinos/meta.yaml
+++ b/recipes/corvinos/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "corvinos" %}
 {% set version = "0.9.52" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -23,11 +24,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - anthropic >=0.25
     - cryptography >=42
     - fastapi >=0.110
@@ -49,10 +50,11 @@ test:
     - corvin-serve --help
   requires:
     - pip
+    - python {{ python_min }}
 
 about:
   home: https://github.com/CorvinLabs/CorvinOS
-  summary: "Self-hosted agentic AI assistant for Discord, Telegram, WhatsApp, Slack & Email"
+  summary: "Self-hosted agentic OS. EU AI Act 2026 & GDPR compliance by design."
   description: |
     CorvinOS is a self-hosted agentic OS that connects local Ollama models and cloud
     providers to Discord, Telegram, WhatsApp, Slack, and Email. EU AI Act 2026

--- a/recipes/corvinos/meta.yaml
+++ b/recipes/corvinos/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "corvinos" %}
-{% set version = "0.9.52" %}
+{% set version = "0.10.19" %}
 {% set python_min = "3.10" %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/corvinos-{{ version }}.tar.gz
-  sha256: c956078c48fd8d6f2e11cbdabde4ba25cd3258e25812ad62a36ce29e211529d5
+  sha256: 987da71bcf12ae4739638a64868feb7c2b1a04a66ee0564ace511f2cc4ade3e7
 
 build:
   noarch: python
@@ -27,6 +27,7 @@ requirements:
     - python {{ python_min }}
     - pip
     - setuptools
+    - hatchling
   run:
     - python >={{ python_min }}
     - anthropic >=0.25

--- a/recipes/corvinos/meta.yaml
+++ b/recipes/corvinos/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "corvinos" %}
+{% set version = "0.9.52" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/corvinos-{{ version }}.tar.gz
+  sha256: c956078c48fd8d6f2e11cbdabde4ba25cd3258e25812ad62a36ce29e211529d5
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - corvin = ops.launcher.corvin.cli:main
+    - corvinos = ops.launcher.corvin.cli:main
+    - corvin-serve = ops.launcher.corvin.serve_entry:main
+    - corvinos-serve = ops.launcher.corvin.serve_entry:main
+    - corvin-install = corvinOS.installer:main_install
+    - corvin-uninstall = corvinOS.installer:main_uninstall
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools
+  run:
+    - python >=3.10
+    - anthropic >=0.25
+    - cryptography >=42
+    - fastapi >=0.110
+    - httpx >=0.27
+    - jsonschema >=4.0
+    - openai >=1.0
+    - pydantic >=2.4
+    - pyjwt >=2.8
+    - python-multipart >=0.0.6
+    - pyyaml >=6.0
+    - qrcode >=7.0
+    - uvicorn >=0.27
+
+test:
+  imports:
+    - corvinOS
+  commands:
+    - corvin --help
+    - corvin-serve --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/CorvinLabs/CorvinOS
+  summary: "Self-hosted agentic AI assistant for Discord, Telegram, WhatsApp, Slack & Email"
+  description: |
+    CorvinOS is a self-hosted agentic OS that connects local Ollama models and cloud
+    providers to Discord, Telegram, WhatsApp, Slack, and Email. EU AI Act 2026
+    governance and GDPR compliance are structural — built into the architecture, not
+    configured on top of it.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://corvin-labs.com/docs
+  dev_url: https://github.com/CorvinLabs/CorvinOS
+
+extra:
+  recipe-maintainers:
+    - veegee82


### PR DESCRIPTION
## Description

This adds a recipe for [corvinos](https://pypi.org/project/corvinos/) — CorvinOS, a self-hosted agentic AI assistant.

### What is CorvinOS?

CorvinOS connects local Ollama models and cloud providers (Anthropic, OpenAI) to Discord, Telegram, WhatsApp, Slack, and Email in a single install. EU AI Act 2026 and GDPR compliance are structural constraints, not configuration options.

- `pip install corvinos` → `corvin-serve` → Web console + bridge setup
- Ollama-native (local), also supports Anthropic/OpenAI cloud
- Hash-chained audit log, per-user consent gate (deny-by-default), GDPR Art. 17 erasure
- EU AI Act 2026 bot-disclosure built in

### Checklist

- [x] New package — not in conda-forge yet
- [x] `noarch: python` — pure Python package
- [x] License: Apache-2.0 (verified in LICENSE file)
- [x] SHA256 verified from PyPI
- [x] Entry points match pyproject.toml
- [x] Test imports verified against installed package
- [x] `python >=3.10` requirement matches upstream

### Links

- PyPI: https://pypi.org/project/corvinos/
- GitHub: https://github.com/CorvinLabs/CorvinOS
- Homepage: https://corvin-labs.com