### PR TITLE
Add ai-agent-skills recipe

### DIFF
--- a/recipes/ai-agent-skills/meta.yaml
+++ b/recipes/ai-agent-skills/meta.yaml
@@ -1,0 +1,39 @@
+{% set name = "ai-agent-skills" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/aiagentskills-site-kit/aiagentskills_site_kit-{{ version }}.tar.gz
+  sha256: 0e3264e3463cfd5d7f1e9fbbd3c8358b13584a19ca073886dc8d56392a6f9224
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - hatchling
+  run:
+    - python >=3.9
+
+test:
+  imports:
+    - aiagentskills_site_kit
+
+about:
+  home: https://aiagentskills.net
+  summary: URL helpers for AI Agent Skills.
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/bbwdadfg/aiagentskills-site-kit
+  doc_url: https://aiagentskills.net/skills/
+
+extra:
+  recipe-maintainers:
+    - bbwdadfg


### PR DESCRIPTION
Checklist
- [x] Title follows conda-forge staged-recipes convention.
- [x] Recipe builds from the published PyPI source archive.
- [x] Package exposes a small real helper for AI Agent Skills links.

This adds a noarch Python helper package for AI Agent Skills: https://aiagentskills.net.

Source package: https://pypi.org/project/aiagentskills-site-kit/
Upstream repository: https://github.com/bbwdadfg/aiagentskills-site-kit