### PR TITLE
Add Vicem, an ASE/OpenMM toolkit

### DIFF
--- a/recipes/vicem/meta.yaml
+++ b/recipes/vicem/meta.yaml
@@ -12,7 +12,6 @@ source:
   sha256: dbb5c3f9b1de48c725cde7d79e880fb41a5e789f50a21943e575c39ee46bf297
 
 build:
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
   # AmberTools is required for the recommended Vicem workflows and is not

--- a/recipes/vicem/meta.yaml
+++ b/recipes/vicem/meta.yaml
@@ -1,0 +1,55 @@
+{% set name = "vicem" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # Release archive used for the conda-forge/staged-recipes PR.
+  url: https://gitlab.com/asod/vicem/-/archive/v{{ version }}/vicem-v{{ version }}.tar.gz
+  sha256: dbb5c3f9b1de48c725cde7d79e880fb41a5e789f50a21943e575c39ee46bf297
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >=3.11
+    - ase >=3.22
+    - openmm >=8.0
+    - numpy >=1.20
+    - scipy
+    - matplotlib-base
+    - numba
+    - h5py >=3.8
+    - ambertools
+    - packmol
+    - parmed
+
+test:
+  imports:
+    - vicem
+  commands:
+    - python -c "from vicem import OpenMMCalculator; print(OpenMMCalculator)"
+    - python -c "import shutil; assert shutil.which('antechamber')"
+    - python -c "import shutil; assert shutil.which('packmol')"
+
+about:
+  home: https://gitlab.com/asod/vicem
+  summary: ASE/OpenMM tools for approximate solute force fields and solution-phase solvent-shell sampling
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://gitlab.com/asod/vicem
+  doc_url: https://vicem.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - asod

--- a/recipes/vicem/meta.yaml
+++ b/recipes/vicem/meta.yaml
@@ -13,9 +13,10 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
-  # AmberTools is required for the recommended Vicem workflows and is not
-  # currently available on Windows via conda-forge.
-  skip: true  # [py<311 or win]
+  # AmberTools is required for the recommended Vicem workflows. The current
+  # conda-forge AmberTools stack does not solve for Python 3.13 in this recipe,
+  # and AmberTools is not currently available on Windows via conda-forge.
+  skip: true  # [py<311 or py>=313 or win]
 
 requirements:
   host:

--- a/recipes/vicem/meta.yaml
+++ b/recipes/vicem/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "vicem" %}
 {% set version = "0.1.0" %}
+{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -14,15 +15,18 @@ build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  # AmberTools is required for the recommended Vicem workflows and is not
+  # currently available on Windows via conda-forge.
+  skip: true  # [win]
 
 requirements:
   host:
-    - python >=3.11
+    - python {{ python_min }}
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.11
+    - python >={{ python_min }}
     - ase >=3.22
     - openmm >=8.0
     - numpy >=1.20
@@ -35,6 +39,8 @@ requirements:
     - parmed
 
 test:
+  requires:
+    - python {{ python_min }}
   imports:
     - vicem
   commands:
@@ -52,4 +58,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - asod
+    - asmusod

--- a/recipes/vicem/meta.yaml
+++ b/recipes/vicem/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "vicem" %}
 {% set version = "0.1.0" %}
-{% set python_min = "3.11" %}
 
 package:
   name: {{ name|lower }}
@@ -16,16 +15,16 @@ build:
   number: 0
   # AmberTools is required for the recommended Vicem workflows and is not
   # currently available on Windows via conda-forge.
-  skip: true  # [win]
+  skip: true  # [py<311 or win]
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >={{ python_min }}
+    - python
     - ase >=3.22
     - openmm >=8.0
     - numpy >=1.20
@@ -39,7 +38,7 @@ requirements:
 
 test:
   requires:
-    - python {{ python_min }}
+    - python
   imports:
     - vicem
   commands:


### PR DESCRIPTION
This PR adds Vicem, an ASE/OpenMM toolkit for setting up, simulating, and analyzing solvated molecular systems, with a focus on restrained approximate solute models and solvent-shell RDF workflows for solution-phase scattering analysis (and more).

Dependency notes:
- `ambertools` is included because the recommended DummyFF workflow uses `antechamber`, `parmchk2`, and `tleap` for GAFF-style LJ typing, charge assignment, and organic-solvent system assembly.
- `packmol` is included because organic-solvent box construction calls the Packmol executable.
- `parmed` is included for Amber/GROMACS/OpenMM topology conversion and export paths.
- The OpenFF/Sage benchmarking stack is intentionally not included in the default recipe.


Checklist:
- [x] Title of this PR is meaningful.
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] Static libraries are not linked in.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (`git_url`) has been used.