### PR TITLE
Add py2opsin recipe

### DIFF
--- a/recipes/py2opsin/meta.yaml
+++ b/recipes/py2opsin/meta.yaml
@@ -44,3 +44,4 @@ about:
 extra:
   recipe-maintainers:
     - r-fedorov
+    

--- a/recipes/py2opsin/meta.yaml
+++ b/recipes/py2opsin/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 6e1fb22cc7ecaf9622dd770811ccaaced0348a011d6cb6e847dc3c82fd346147
 
 build:
@@ -21,7 +21,7 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >= {{ python_min }}
+    - python >={{ python_min }}
     - openjdk >=8
 
 test:

--- a/recipes/py2opsin/meta.yaml
+++ b/recipes/py2opsin/meta.yaml
@@ -44,4 +44,5 @@ about:
 extra:
   recipe-maintainers:
     - r-fedorov
+
     

--- a/recipes/py2opsin/meta.yaml
+++ b/recipes/py2opsin/meta.yaml
@@ -1,0 +1,46 @@
+{% set name = "py2opsin" %}
+{% set version = "1.2.0" %}
+{% set python_min = "3.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6e1fb22cc7ecaf9622dd770811ccaaced0348a011d6cb6e847dc3c82fd346147
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools
+  run:
+    - python >= {{ python_min }}
+    - openjdk >=8
+
+test:
+  imports:
+    - py2opsin
+  requires:
+    - python {{ python_min }}
+    - pip
+  commands:
+    - python -m pip check
+    - java -version
+    - python -c "from py2opsin import py2opsin; assert py2opsin('ethane') == 'CC'"
+
+about:
+  home: https://github.com/JacksonBurns/py2opsin
+  summary: Simple Python interface to OPSIN, the Open Parser for Systematic IUPAC nomenclature
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - r-fedorov

--- a/recipes/py2opsin/meta.yaml
+++ b/recipes/py2opsin/meta.yaml
@@ -44,5 +44,3 @@ about:
 extra:
   recipe-maintainers:
     - r-fedorov
-
-    


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [ ] Package does not vendor other packages. See note below.
- [x] If static libraries are linked in, the license of the static library is packaged. N/A — no static libraries are linked.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in this recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check the conda-forge knowledge base documentation before pinging a team.

This PR adds a conda-forge recipe for `py2opsin`, a Python interface to OPSIN for converting chemical names to SMILES.

The recipe uses the official PyPI source distribution, installs the package as `noarch: python`, and adds `openjdk` as a runtime dependency so that Java is installed automatically when users install `py2opsin`.

Note on vendoring: the upstream py2opsin source distribution includes the OPSIN CLI JAR. OPSIN is MIT licensed, and this recipe packages the upstream PyPI release tarball unchanged while adding openjdk as the Java runtime dependency. Since the included JAR is the upstream-distributed OPSIN CLI JAR, I believe this is acceptable, but I am happy to adjust the recipe if conda-forge reviewers would prefer OPSIN to be packaged separately.

