### PR TITLE
torch-c-dlpack-ext

### DIFF
--- a/recipes/torch-c-dlpack-ext/recipe.yaml
+++ b/recipes/torch-c-dlpack-ext/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "0.1.5"
-  python_min: "3.10"
 
 package:
   name: torch-c-dlpack-ext
@@ -14,21 +13,15 @@ source:
 
 build:
   number: 0
+  # For pytorch >=2.10, this package is a nearly a no-op as the API is included in pytorch
+  # and the python code will not try to load any C library.
+  noarch: python
   script:
     - cd addons/torch_c_dlpack_ext
-    - python -m tvm_ffi.utils._build_optional_torch_c_dlpack --output-dir torch_c_dlpack_ext
+    # - python -m tvm_ffi.utils._build_optional_torch_c_dlpack --output-dir torch_c_dlpack_ext
     - python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
-  build:
-    - ${{ compiler('c') }}
-    - ${{ compiler('cxx') }}
-    - ${{ stdlib('c') }}
-    - if: build_platform != target_platform
-      then:
-        - python
-        - cross-python_${{ target_platform }}
-        - pytorch
   host:
     - python ${{ python_min }}.*
     - pip
@@ -37,7 +30,7 @@ requirements:
     - apache-tvm-ffi >=0.1.1
   run:
     - python >=${{ python_min }}
-    - pytorch
+    - pytorch >=2.10
 
 tests:
   - python:

--- a/recipes/torch-c-dlpack-ext/recipe.yaml
+++ b/recipes/torch-c-dlpack-ext/recipe.yaml
@@ -1,0 +1,64 @@
+schema_version: 1
+
+context:
+  version: "0.1.5"
+  python_min: "3.10"
+
+package:
+  name: torch-c-dlpack-ext
+  version: ${{ version }}
+
+source:
+  url: https://github.com/apache/tvm-ffi/archive/f9b5e7ddeef75d32f042901b25a3f5b40c1c383e.tar.gz
+  sha256: 1b4a0150a95c3633071d6d78bdf3e8f1b0f549c68ef38020843a6e0c0f607f0d
+
+build:
+  number: 0
+  script:
+    - cd addons/torch_c_dlpack_ext
+    - python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - pytorch
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - pytorch
+    - setuptools >=61
+    - apache-tvm-ffi >=0.1.1
+  run:
+    - python >=${{ python_min }}
+    - pytorch
+
+tests:
+  - python:
+      imports:
+        - torch_c_dlpack_ext
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/apache/tvm-ffi
+  summary: "torch c dlpack ext"
+  description: |
+    This package provides an Ahead-Of-Time (AOT) compiled module to support faster
+    DLPack conversion in DLPack v1.2 for PyTorch. Installing this wheel allows users
+    to avoid JIT compilation overhead and also avoid the cases where the user environment
+    does not necessarily have a compiler toolchain to run JIT-compilation.
+  license: Apache-2.0
+  license_file:
+    - addons/torch_c_dlpack_ext/LICENSE
+    - addons/torch_c_dlpack_ext/NOTICE
+
+extra:
+  recipe-maintainers:
+    - xhochy

--- a/recipes/torch-c-dlpack-ext/recipe.yaml
+++ b/recipes/torch-c-dlpack-ext/recipe.yaml
@@ -31,6 +31,7 @@ requirements:
   run:
     - python >=${{ python_min }}
     - pytorch >=2.10
+    - packaging
 
 tests:
   - python:

--- a/recipes/torch-c-dlpack-ext/recipe.yaml
+++ b/recipes/torch-c-dlpack-ext/recipe.yaml
@@ -43,10 +43,10 @@ tests:
 
 about:
   homepage: https://github.com/apache/tvm-ffi
-  summary: "torch c dlpack ext"
+  summary: "DLPack conversion for PyTorch"
   description: |
     This package provides an Ahead-Of-Time (AOT) compiled module to support faster
-    DLPack conversion in DLPack v1.2 for PyTorch. Installing this wheel allows users
+    DLPack conversion in DLPack v1.2 for PyTorch. Installing this allows users
     to avoid JIT compilation overhead and also avoid the cases where the user environment
     does not necessarily have a compiler toolchain to run JIT-compilation.
   license: Apache-2.0

--- a/recipes/torch-c-dlpack-ext/recipe.yaml
+++ b/recipes/torch-c-dlpack-ext/recipe.yaml
@@ -16,11 +16,13 @@ build:
   number: 0
   script:
     - cd addons/torch_c_dlpack_ext
+    - python -m tvm_ffi.utils._build_optional_torch_c_dlpack --output-dir torch_c_dlpack_ext
     - python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
     - ${{ stdlib('c') }}
     - if: build_platform != target_platform
       then:


### PR DESCRIPTION
This is required by a lot of packages to ensure that copies to DLPack with `torch.Tensor` are efficient. Since `pytorch>=2.10` includes this natively, this becomes a small `noarch: python` package that does nearly nothing.