### PR TITLE
Add seed-audio-ai-site-kit

### DIFF
--- a/recipes/seed-audio-ai-site-kit/LICENSE
+++ b/recipes/seed-audio-ai-site-kit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Seed Audio AI Site Kit contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/seed-audio-ai-site-kit/meta.yaml
+++ b/recipes/seed-audio-ai-site-kit/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/seed_audio_ai_site_kit-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/seed_audio_ai_site_kit-{{ version }}.tar.gz
   sha256: e68b32868bf391aa065c0903fd271717cfbc0581e6d7777afef042d7e5d780c1
 
 build:

--- a/recipes/seed-audio-ai-site-kit/meta.yaml
+++ b/recipes/seed-audio-ai-site-kit/meta.yaml
@@ -9,6 +9,8 @@ package:
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/seed_audio_ai_site_kit-{{ version }}.tar.gz
   sha256: e68b32868bf391aa065c0903fd271717cfbc0581e6d7777afef042d7e5d780c1
+  patches:
+    - pyproject-license.patch
 
 build:
   noarch: python

--- a/recipes/seed-audio-ai-site-kit/meta.yaml
+++ b/recipes/seed-audio-ai-site-kit/meta.yaml
@@ -1,0 +1,45 @@
+{% set name = "seed-audio-ai-site-kit" %}
+{% set version = "0.1.0" %}
+{% set python_min = "3.8" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/seed_audio_ai_site_kit-{{ version }}.tar.gz
+  sha256: e68b32868bf391aa065c0903fd271717cfbc0581e6d7777afef042d7e5d780c1
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >={{ python_min }}
+
+test:
+  imports:
+    - seed_audio_ai_site_kit
+  commands:
+    - python -c "from seed_audio_ai_site_kit import SITE, seed_audio_url; assert SITE['homepage'] == 'https://seedaud.io/'; assert seed_audio_url('/text-to-speech/') == 'https://seedaud.io/text-to-speech/'"
+  requires:
+    - python {{ python_min }}
+
+about:
+  home: https://seedaud.io/
+  summary: Small unofficial metadata and URL helpers for Seed Audio AI at seedaud.io.
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/bbwdadfg/seed-audio-ai-site-kit
+  doc_url: https://github.com/bbwdadfg/seed-audio-ai-site-kit#readme
+
+extra:
+  recipe-maintainers:
+    - bbwdadfg

--- a/recipes/seed-audio-ai-site-kit/pyproject-license.patch
+++ b/recipes/seed-audio-ai-site-kit/pyproject-license.patch
@@ -1,0 +1,13 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 0b3b96c..3bc59a1 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -7,7 +7,7 @@ version = "0.1.0"
+ description = "Small unofficial metadata and URL helpers for Seed Audio AI at seedaud.io."
+ readme = "README.md"
+ requires-python = ">=3.8"
+-license = "MIT"
++license = { text = "MIT" }
+ authors = [{ name = "Seed Audio AI Site Kit contributors" }]
+ keywords = ["seed-audio-ai", "seedaud", "text-to-speech", "ai-voice", "site-kit"]
+ classifiers = [


### PR DESCRIPTION
Adds seed-audio-ai-site-kit 0.1.0 from PyPI.\n\nUpstream: https://github.com/bbwdadfg/seed-audio-ai-site-kit\nHomepage: https://seedaud.io/\nPyPI: https://pypi.org/project/seed-audio-ai-site-kit/0.1.0/\n\nThis is a small noarch Python metadata and URL helper for Seed Audio AI canonical URLs.