### PR TITLE
Add opentfraw

### DIFF
--- a/recipes/opentfraw/meta.yaml
+++ b/recipes/opentfraw/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "opentfraw" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/89/28/ee27dd951941eaf13c70a99cb68db4de962386aaee190f2fbd7bc656dfd2/{{ name }}-{{ version }}.tar.gz
+  sha256: 181c6bb9e2bcab97285221025c87eb9d843ab02244801cdfcdd53d52988a6586
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+    - numpy >=1.20
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - opentfraw
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/opentfraw/docs
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Rust parser for Thermo Fisher RAW mass spectrometry files
+  description: |
+    OpenTFRaw is a fast, open-source reader for Thermo Fisher .raw mass
+    spectrometry files written in Rust, with Python bindings. It returns
+    NumPy arrays and supports the full Thermo RAW format without requiring
+    the vendor SDK.
+  doc_url: https://sigilweaver.app/opentfraw/docs
+  dev_url: https://github.com/Sigilweaver/OpenTFRaw
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R

--- a/recipes/opentfraw/meta.yaml
+++ b/recipes/opentfraw/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - {{ compiler('rust') }}
     - {{ compiler('c') }}
+    - {{ stdlib("c") }}
     - maturin >=1.5,<2.0
   host:
     - python


### PR DESCRIPTION
Adds a recipe for [opentfraw](https://pypi.org/project/opentfraw/), a Rust parser (with Python bindings) for Thermo Fisher `.raw` mass spectrometry files.

### Checklist

- [x] Title of this PR is meaningful: "Add opentfraw".
- [x] License is an [approved SPDX identifier](https://spdx.org/licenses/): `Apache-2.0`.
- [x] License file is packaged (see the recipe's `about.license_file`).
- [x] Source is from an [approved source](https://conda-forge.org/docs/maintainer/adding_pkgs/#build-from-tarballs-not-repos): the PyPI sdist, pinned by sha256.
- [x] Package does not vendor pinned/bundled dependencies improperly.
- [x] Tests pass: `import opentfraw` and `pip check`.

### Build verification

Built and tested locally against the `condaforge/linux-anvil-cos7-x86_64` image (conda-build 24.9.0). The extension compiles via `maturin` against numpy 2.5.0 on Python 3.12, `import opentfraw` succeeds, and `pip check` reports no broken requirements.
