### PR TITLE
Add sigilyx

### DIFF
--- a/recipes/sigilyx/meta.yaml
+++ b/recipes/sigilyx/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "sigilyx" %}
+{% set version = "0.3.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/cb/b1/9772bb45b4b25f1f0f1ae3e623b1a7691452b8bcd1c89511be235fc5dabd/{{ name }}-{{ version }}.tar.gz
+  sha256: 5d9fea4838cfaa12d04f1d199218133a8212f378e855a1f0b4e3c57a209f7598
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.0,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.0,<2.0
+  run:
+    - python
+    - polars >=1.36.1
+
+test:
+  imports:
+    - sigilyx
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/sigilyx/
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: YXDB reader and writer for Python, backed by a Rust core
+  description: |
+    SigilYX reads and writes Alteryx YXDB files from Python, backed by a
+    Rust core. It returns Polars DataFrames and supports the full YXDB
+    format without requiring the vendor SDK.
+  doc_url: https://sigilweaver.app/sigilyx/
+  dev_url: https://github.com/Sigilweaver/SigilYX
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Adds a recipe for [sigilyx](https://pypi.org/project/sigilyx/), a Rust-backed reader and writer for Alteryx YXDB files with Python bindings, returning Polars DataFrames.

### Checklist

- [x] Title of this PR is meaningful: "Add sigilyx".
- [x] License is an [approved SPDX identifier](https://spdx.org/licenses/): `Apache-2.0`.
- [x] License file is packaged (present in the sdist as `LICENSE`).
- [x] Source is the PyPI sdist, pinned by sha256.
- [x] Tests pass: `import sigilyx` and `pip check`.

### Build verification

Built and tested locally against the `condaforge/linux-anvil-cos7-x86_64` image with the conda-forge pinning config. The Rust extension (which compiles a bundled C decompressor) builds via `maturin` against Python 3.12, `import sigilyx` succeeds, and `pip check` passes with the `polars` runtime dependency resolved.
