### PR TITLE
Add openqbw

### DIFF
--- a/recipes/openqbw/meta.yaml
+++ b/recipes/openqbw/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "openqbw" %}
+{% set version = "0.1.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/dd/a7/c8ff8d31509fdad1a1c995928febbd6a4dce3a0a640c5ed00b9626edbbd9/{{ name }}-{{ version }}.tar.gz
+  sha256: 48518bf66cc883aef1590874ad1e0ab518b1f719929b153c6bcc38ac53be695a
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+  run:
+    - python
+
+test:
+  imports:
+    - openqbw
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/openqbw/
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Python bindings for OpenQBW (QuickBooks .qbw file reader)
+  description: |
+    OpenQBW is a fast, open-source reader for Intuit QuickBooks Desktop
+    .qbw company files written in Rust, with Python bindings. It reads the
+    QuickBooks on-disk format without requiring the QuickBooks SDK.
+  doc_url: https://sigilweaver.app/openqbw/docs/
+  dev_url: https://github.com/Sigilweaver/OpenQBW
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Adds a recipe for [openqbw](https://pypi.org/project/openqbw/), a Rust reader (with Python bindings) for Intuit QuickBooks Desktop `.qbw` company files.

### Checklist

- [x] Title of this PR is meaningful: "Add openqbw".
- [x] License is an [approved SPDX identifier](https://spdx.org/licenses/): `Apache-2.0`.
- [x] License file is packaged (present in the sdist as `LICENSE`).
- [x] Source is the PyPI sdist, pinned by sha256.
- [x] Tests pass: `import openqbw` and `pip check`.

### Build verification

Built and tested locally against the `condaforge/linux-anvil-cos7-x86_64` image with the conda-forge pinning config. The Rust extension (which statically compiles a bundled SQLite via the C compiler) builds via `maturin` on Python 3.10, `import openqbw` succeeds, and `pip check` reports no broken requirements.
