### PR TITLE
Add opentimstdf

### DIFF
--- a/recipes/opentimstdf/meta.yaml
+++ b/recipes/opentimstdf/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "opentimstdf" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/d4/61/85c3be766aa6c2ccbad02290446fa2143a75c44d4acac188a9bb82c1914f/{{ name }}-{{ version }}.tar.gz
+  sha256: b689b6e0e2f8afa38e3d9c3cbe0774c38998f0ed430b2c65de51c675cb66ffe5
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+  run:
+    - python
+
+test:
+  imports:
+    - opentimstdf
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/opentimstdf/docs
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Rust and Python reader for Bruker timsTOF .d/ (TDF) acquisition bundles
+  description: |
+    OpenTimsTDF is a fast, open-source reader for Bruker timsTOF .d/ (TDF)
+    mass spectrometry acquisition bundles written in Rust, with Python
+    bindings. It reads the TDF format without requiring the vendor SDK.
+  doc_url: https://sigilweaver.app/opentimstdf/docs
+  dev_url: https://github.com/Sigilweaver/OpenTimsTDF
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Adds a recipe for [opentimstdf](https://pypi.org/project/opentimstdf/), a Rust reader (with Python bindings) for Bruker timsTOF `.d/` (TDF) mass spectrometry acquisition bundles.

### Checklist

- [x] Title of this PR is meaningful: "Add opentimstdf".
- [x] License is an [approved SPDX identifier](https://spdx.org/licenses/): `Apache-2.0`.
- [x] License file is packaged (present in the sdist as `LICENSE`).
- [x] Source is the PyPI sdist, pinned by sha256.
- [x] Tests pass: `import opentimstdf` and `pip check`.

### Build verification

Built and tested locally against the `condaforge/linux-anvil-cos7-x86_64` image. The extension builds via `maturin`, `import opentimstdf` succeeds, and `pip check` reports no broken requirements.
