### PR TITLE
Add dicom-map

### DIFF
--- a/recipes/dicom-map/meta.yaml
+++ b/recipes/dicom-map/meta.yaml
@@ -1,0 +1,52 @@
+{% set name = "dicom-map" %}
+{% set version = "0.2.7" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/d/{{ name }}/dicom_map-{{ version }}.tar.gz
+  sha256: 79fbfbff2bde1b71f5d45d2e9c0d1ef8fe623b006f320813eadeed5871444cf1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+  run:
+    - python
+
+test:
+  imports:
+    - dicom_map
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/dicom-atlas/
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Memory-mapped O(log n) DICOM tag dictionary (private + public tags)
+  description: |
+    dicom-map is a fast, memory-mapped dictionary of DICOM data-element
+    tags - both the public standard tags and a large registry of private
+    vendor tags - with O(log n) lookup, written in Rust with Python
+    bindings. Bring your own compiled `tags.dmap` dictionary at runtime.
+  doc_url: https://sigilweaver.app/dicom-atlas/docs/
+  dev_url: https://github.com/Sigilweaver/DICOM-Atlas
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Adds a recipe for [dicom-map](https://pypi.org/project/dicom-map/), a memory-mapped O(log n) dictionary of DICOM data-element tags (public standard tags plus a large private/vendor tag registry), written in Rust with Python bindings.

### Checklist

- [x] Title of this PR is meaningful: "Add dicom-map".
- [x] License is an [approved SPDX identifier](https://spdx.org/licenses/): `Apache-2.0`.
- [x] License file is packaged (present in the sdist as `LICENSE`).
- [x] Source is the PyPI sdist, pinned by sha256.
- [x] Tests pass: `import dicom_map` and `pip check`.

### Build verification

Built and tested locally against the `condaforge/linux-anvil-cos7-x86_64` image with the conda-forge pinning config. The extension builds via `maturin`, `import dicom_map` succeeds, and `pip check` reports no broken requirements.
