### PR TITLE
Add openwraw

### DIFF
--- a/recipes/openwraw/meta.yaml
+++ b/recipes/openwraw/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "openwraw" %}
+{% set version = "1.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/32/05/bf0a2acc5658a3924055c53fcd51b4fd5a35be66d2c8618c7216e301510a/{{ name }}-{{ version }}.tar.gz
+  sha256: 2f5fd70be8db2123fb1dba94122a6251d54936d1782c7acc8fac2e8d8c30c12b
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+  run:
+    - python
+
+test:
+  imports:
+    - openwraw
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/openwraw/docs
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Rust and Python reader for Waters MassLynx RAW mass spectrometry files
+  description: |
+    OpenWRaw is a fast, open-source reader for Waters MassLynx RAW mass
+    spectrometry files written in Rust, with Python bindings. It reads the
+    Waters RAW format without requiring the vendor SDK.
+  doc_url: https://sigilweaver.app/openwraw/docs
+  dev_url: https://github.com/Sigilweaver/OpenWRaw
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Adds a recipe for [openwraw](https://pypi.org/project/openwraw/), a Rust reader (with Python bindings) for Waters MassLynx RAW mass spectrometry files.

### Checklist

- [x] Title of this PR is meaningful: "Add openwraw".
- [x] License is an [approved SPDX identifier](https://spdx.org/licenses/): `Apache-2.0`.
- [x] License file is packaged (present in the sdist as `LICENSE`).
- [x] Source is the PyPI sdist, pinned by sha256.
- [x] Tests pass: `import openwraw` and `pip check`.

### Build verification

Built and tested locally against the `condaforge/linux-anvil-cos7-x86_64` image. The extension builds via `maturin`, `import openwraw` succeeds, and `pip check` reports no broken requirements.
