### PR TITLE
Add openproteo-io

### DIFF
--- a/recipes/openproteo-io/meta.yaml
+++ b/recipes/openproteo-io/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "openproteo-io" %}
+{% set version = "1.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/3b/e8/9cf56f066de0b65eb50cd586c7c63627c8b45e1b04aab34e4ab9bed92306/openproteo_io-{{ version }}.tar.gz
+  sha256: e8f27cca04f36ea80b6669f046493e42d60a1e02e21e1979e3a9a2a2a30c6c92
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+    - numpy >=1.23
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - openproteo_io
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/openproteo/docs
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Vendor-neutral mass-spec I/O (Thermo / Bruker / Waters to mzML) with Arrow streaming
+  description: |
+    openproteo-io is the vendor-neutral I/O layer of the OpenProteo stack.
+    It detects Thermo .raw, Bruker .d / TDF, and Waters .raw acquisitions and
+    converts them to mzML, or streams spectra as Apache Arrow record batches,
+    without requiring any vendor SDK. This package provides the Python
+    bindings to the openproteo-io Rust crate; peak arrays are returned as
+    NumPy arrays.
+  doc_url: https://sigilweaver.app/openproteo/docs
+  dev_url: https://github.com/Sigilweaver/OpenProteo
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Adds a recipe for [openproteo-io](https://pypi.org/project/openproteo-io/), the vendor-neutral mass-spec I/O layer of the OpenProteo stack. It detects Thermo `.raw`, Bruker `.d` / TDF, and Waters `.raw` acquisitions and converts them to mzML (or streams spectra as Apache Arrow record batches) without any vendor SDK. This package provides the Python bindings to the `openproteo-io` Rust crate.

Checklist:

- [x] Title of this PR is meaningful: "Add openproteo-io".
- [x] License file is packaged (`license_file: LICENSE`; LICENSE is bundled in the sdist).
- [x] Source is from a trusted source (PyPI sdist), sha256 verified.
- [x] Built and tested locally in `condaforge/linux-anvil-cos7-x86_64` with the conda-forge pinning config: builds across Python 3.10-3.13, `import openproteo_io` succeeds, `pip check` clean.

Notes for reviewers:

- maturin/PyO3 build; the extension links the NumPy C API (rust-numpy), so numpy is in `host` and pinned via `{{ pin_compatible('numpy') }}` in `run`, mirroring the sibling `opentfraw` recipe.
- `pyarrow` is an optional extra (only needed for the Arrow-returning API), so it is intentionally not a required run dependency.