### PR TITLE
Add qdiffusivity v0.1.0

### DIFF
--- a/recipes/qdiffusivity/meta.yaml
+++ b/recipes/qdiffusivity/meta.yaml
@@ -1,5 +1,5 @@
 {% set python_min = "3.9" %}
-{% set version = "0.2.0" %}
+{% set version = "0.2.1" %}
 
 package:
   name: qdiffusivity
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/q/qdiffusivity/qdiffusivity-{{ version }}.tar.gz
-  sha256: b04f6837f603d3f13e99a7a53ac36a91773c8ccdd8e2414b384c05b4c4e5a475
+  sha256: 1d3a04bc0af52b0fd987a2dacc10854bce7b5857c0a0e3bde3cd1f2e0995964e
 
 build:
   noarch: python

--- a/recipes/qdiffusivity/meta.yaml
+++ b/recipes/qdiffusivity/meta.yaml
@@ -1,5 +1,5 @@
 {% set python_min = "3.9" %}
-{% set version = "0.1.0" %}
+{% set version = "0.2.0" %}
 
 package:
   name: qdiffusivity
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/q/qdiffusivity/qdiffusivity-{{ version }}.tar.gz
-  sha256: 8eff9d73e5aa7c61f06958223f644edbe3861baf897bdeb762622a2ffc54b352
+  sha256: b04f6837f603d3f13e99a7a53ac36a91773c8ccdd8e2414b384c05b4c4e5a475
 
 build:
   noarch: python

--- a/recipes/qdiffusivity/meta.yaml
+++ b/recipes/qdiffusivity/meta.yaml
@@ -1,0 +1,49 @@
+{% set python_min = "3.9" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: qdiffusivity
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/q/qdiffusivity/qdiffusivity-{{ version }}.tar.gz
+  sha256: 8eff9d73e5aa7c61f06958223f644edbe3861baf897bdeb762622a2ffc54b352
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}.*
+    - setuptools >=77
+    - versioningit
+    - pip
+  run:
+    - python >={{ python_min }}
+    - mdanalysis >=2.0.0
+
+test:
+  imports:
+    - qdiffusivity
+    - qdiffusivity.density
+    - qdiffusivity.diffusivity
+    - qdiffusivity.binned
+  commands:
+    - pip check
+    - pytest --pyargs qdiffusivity.tests
+  requires:
+    - pip
+    - pytest >=6.0
+    - python {{ python_min }}.*
+
+about:
+  home: https://github.com/srtee/qdiffusivity
+  summary: Quantile-based estimation of local diffusivities in molecular dynamics simulations of nanoconfined liquids
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - srtee


### PR DESCRIPTION
## Summary

Adding `qdiffusivity` — a pure-Python MDAKit for quantile-based estimation of local diffusivities in molecular dynamics simulations of nanoconfined liquids.

- **PyPI**: https://pypi.org/project/qdiffusivity/
- **Source**: https://github.com/srtee/qdiffusivity
- **License**: MIT
- **Dependencies**: `mdanalysis >=2.0.0`, `versioningit` (build)
- **Tests**: `pytest --pyargs qdiffusivity.tests` (43 tests, all passing)

The recipe was generated with `grayskull` and manually edited to add module-level import tests, the pytest test suite, and the correct maintainer / project home.