### PR TITLE
Add dressrun

### DIFF
--- a/recipes/dressrun/recipe.yaml
+++ b/recipes/dressrun/recipe.yaml
@@ -1,0 +1,54 @@
+context:
+  version: "0.1.0"
+  # dressrun requires Python >=3.12, above conda-forge's global python_min
+  python_min: "3.12"
+
+package:
+  name: dressrun
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/d/dressrun/dressrun-${{ version }}.tar.gz
+  sha256: e28a7b6953382eef88b35d023949494f7d4f7abea73612a157d6052d78b8aa6e
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pytest >=8.0
+    - pytest-bdd >=8.0
+
+tests:
+  - python:
+      imports:
+        - dressrun
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/cshaley/dressrun
+  summary: Write a behavior spec once; run it at multiple altitudes — in-memory, HTTP, or browser
+  description: |
+    dressrun is a pytest plugin layered on pytest-bdd for spec-driven
+    development. Step definitions call an injected "driver" instead of the
+    application directly; interchangeable drivers fulfill the same contract at
+    different "altitudes" — in-process domain code (milliseconds), a live HTTP
+    server, or a real browser — so a single Gherkin spec runs fast in the
+    edit-verify inner loop and honestly end-to-end before shipping. On failure
+    it reports a per-step ladder, a full driver call trace, and a hint to
+    bisect the fault by re-running the spec at a lower altitude.
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/cshaley/dressrun
+
+extra:
+  recipe-maintainers:
+    - cshaley

--- a/recipes/dressrun/recipe.yaml
+++ b/recipes/dressrun/recipe.yaml
@@ -31,7 +31,9 @@ tests:
       imports:
         - dressrun
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/cshaley/dressrun


### PR DESCRIPTION
Adds **dressrun** — a pytest plugin (layered on pytest-bdd) for spec-driven development: write a Gherkin behavior spec once and run it at multiple "altitudes" (in-process domain code, live HTTP server, real browser) via interchangeable drivers.

- PyPI: https://pypi.org/project/dressrun/ (v1 `recipe.yaml`, source from the PyPI sdist)
- Upstream: https://github.com/cshaley/dressrun (MIT)
- Pure Python, `noarch: python`; runtime deps `pytest` and `pytest-bdd` are both on conda-forge
- `python_min` overridden to 3.12 per upstream `requires-python`

Checklist:
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/2a3a9d4c3c0b1b3b3ac0f24245cdb3e2c6d76b6a/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be split into separate packages.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (I am the sole maintainer and the PR author.)
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)