### PR TITLE
Adding pyoctaveband

### DIFF
--- a/recipes/pyoctaveband/meta.yaml
+++ b/recipes/pyoctaveband/meta.yaml
@@ -1,0 +1,53 @@
+{% set version = "2.0.0" %}
+# The package requires Python >= 3.11 (numpy >= 2.4.4 floor).
+{% set python_min = "3.11" %}
+
+package:
+  name: pyoctaveband
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/P/PyOctaveBand/pyoctaveband-{{ version }}.tar.gz
+  sha256: 7c4994d5acb5ca0d1a63786eb2d0a395207e64827fe807882b19d9911c7f1003
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools >=82.0.1
+    - wheel
+    - pip
+  run:
+    - python >={{ python_min }}
+    - numpy >=2.4.4
+    - scipy >=1.17.1
+
+test:
+  imports:
+    - pyoctaveband
+  commands:
+    - pip check
+    - python -c "import numpy as np; from pyoctaveband import octavefilter; spl, freq = octavefilter(np.random.default_rng(0).standard_normal(48000), 48000, fraction=3); assert len(freq) == 33"
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/jmrplens/PyOctaveBand
+  summary: Octave-band and fractional octave-band filter bank for signals in the time domain.
+  description: |
+    Fractional octave filter banks (ANSI S1.11 / IEC 61260-1), A/C/Z
+    frequency weighting and Fast/Slow/Impulse time weighting (IEC 61672-1),
+    Leq/LN statistical levels and octave spectrograms for Python.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://jmrplens.github.io/PyOctaveBand/
+  dev_url: https://github.com/jmrplens/PyOctaveBand
+
+extra:
+  recipe-maintainers:
+    - jmrplens


### PR DESCRIPTION
Adding **pyoctaveband** 2.0.0: octave-band and fractional octave-band filter bank for Python signals in the time domain (ANSI S1.11 / IEC 61260-1 compliant filters, IEC 61672-1 A/C/Z and Fast/Slow/Impulse weighting, Leq/LN levels).

- Home: https://github.com/jmrplens/PyOctaveBand
- Docs: https://jmrplens.github.io/PyOctaveBand/
- PyPI: https://pypi.org/project/PyOctaveBand/2.0.0/

**Local verification**: built with `.scripts/run_docker_build.sh` (linux64, `quay.io/condaforge/linux-anvil-x86_64:alma9`); the noarch package built and passed its tests (`pip check` + a functional `octavefilter` smoke test) inside the container.

Note: `python_min` is overridden to `3.11` in the recipe (the package and its `numpy >=2.4.4` floor require it).

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (I am the package author and the sole listed maintainer.)
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.