### PR TITLE
Add phonometry

### DIFF
--- a/recipes/phonometry/meta.yaml
+++ b/recipes/phonometry/meta.yaml
@@ -1,0 +1,55 @@
+{% set version = "3.0.0" %}
+# The package requires Python >= 3.13.
+{% set python_min = "3.13" %}
+
+package:
+  name: phonometry
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/phonometry/phonometry-{{ version }}.tar.gz
+  sha256: de5ddd172d8e1c4a8c823f585bf7c74f8d4bf71c4d9911f1b6a3ba1bb639b1f3
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools >=82.0.1
+    - wheel
+    - pip
+  run:
+    - python >={{ python_min }}
+    - numpy >=2.4.4
+    - scipy >=1.17.1
+
+test:
+  imports:
+    - phonometry
+  commands:
+    - pip check
+    - python -c "import numpy as np; from phonometry import octavefilter; spl, freq = octavefilter(np.random.default_rng(0).standard_normal(48000), 48000, fraction=3); assert len(freq) == 33"
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/jmrplens/phonometry
+  summary: Acoustic measurement toolkit for Python (formerly PyOctaveBand).
+  description: |
+    Acoustic measurement toolkit (formerly PyOctaveBand): fractional octave
+    filter banks (ANSI S1.11 / IEC 61260-1), A/C/Z frequency weighting and
+    Fast/Slow/Impulse time weighting (IEC 61672-1), Leq/LAeq/LN/SEL/LCpeak
+    levels, IEC 61252 noise dose, SPL calibration with IEC 60942 validation,
+    and octave spectrograms.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://jmrplens.github.io/phonometry/
+  dev_url: https://github.com/jmrplens/phonometry
+
+extra:
+  recipe-maintainers:
+    - jmrplens

--- a/recipes/phonometry/meta.yaml
+++ b/recipes/phonometry/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.0.0" %}
+{% set version = "3.2.0" %}
 # The package requires Python >= 3.13.
 {% set python_min = "3.13" %}
 
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/p/phonometry/phonometry-{{ version }}.tar.gz
-  sha256: de5ddd172d8e1c4a8c823f585bf7c74f8d4bf71c4d9911f1b6a3ba1bb639b1f3
+  sha256: 28cd090e6dacb402db08c574ec6c96373490670045517de775c46443c7c83c2a
 
 build:
   noarch: python
@@ -24,7 +24,7 @@ requirements:
   run:
     - python >={{ python_min }}
     - numpy >=2.4.4
-    - scipy >=1.17.1
+    - scipy >=1.18.0
 
 test:
   imports:
@@ -38,13 +38,18 @@ test:
 
 about:
   home: https://github.com/jmrplens/phonometry
-  summary: Acoustic measurement toolkit for Python (formerly PyOctaveBand).
+  summary: Acoustic measurement, analysis and prediction for Python (formerly PyOctaveBand).
   description: |
-    Acoustic measurement toolkit (formerly PyOctaveBand): fractional octave
-    filter banks (ANSI S1.11 / IEC 61260-1), A/C/Z frequency weighting and
-    Fast/Slow/Impulse time weighting (IEC 61672-1), Leq/LAeq/LN/SEL/LCpeak
-    levels, IEC 61252 noise dose, SPL calibration with IEC 60942 validation,
-    and octave spectrograms.
+    Acoustic measurement, analysis and prediction (formerly PyOctaveBand).
+    Every metric is implemented from the text of its governing standard and
+    checked in CI against that standard's own tolerance tables and worked
+    examples. Covers sound level metrology (fractional octave filter banks per
+    ANSI S1.11 / IEC 61260-1, frequency and time weighting per IEC 61672-1,
+    Leq/LAeq/LN/SEL/LCpeak, IEC 61252 noise dose, IEC 60942 calibration),
+    psychoacoustics and hearing, speech intelligibility, room and building
+    acoustics, materials, vibration and structure-borne sound, environmental,
+    aircraft and underwater noise, electroacoustics and broadcast loudness,
+    and FDTD wave simulation.
   license: MIT
   license_file: LICENSE
   doc_url: https://jmrplens.github.io/phonometry/


### PR DESCRIPTION
## Add phonometry

Acoustic measurement toolkit for Python (formerly published on PyPI as `PyOctaveBand`; this is the renamed continuation, so no feedstock exists for the old name): fractional octave filter banks (ANSI S1.11 / IEC 61260-1), A/C/Z frequency weighting and Fast/Slow/Impulse time weighting (IEC 61672-1), Leq/LAeq/LN/SEL/LCpeak levels, IEC 61252 noise dose, SPL calibration with IEC 60942 validation, and octave spectrograms.

- Source: PyPI sdist `phonometry-3.0.0.tar.gz`
- noarch: python, Python >= 3.13
- License: MIT (license file included)
- Docs: https://jmrplens.github.io/phonometry/
- Repo: https://github.com/jmrplens/phonometry
- Built and tested locally with `build-locally.py` (linux64): package builds and both import and functional tests pass.

Note: an earlier submission for this package under its previous name (#34074) was closed by me pending the rename; this replaces it.

### Checklist
- [x] Title of this PR is meaningful
- [x] License file is packaged
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo is used
- [x] GitHub users listed in the maintainer section have commented on this PR that they are willing to be listed there

I am willing to be listed as maintainer (jmrplens).