### PR TITLE
Add dcifer

### DIFF
--- a/recipes/dcifer/meta.yaml
+++ b/recipes/dcifer/meta.yaml
@@ -48,7 +48,7 @@ test:
 about:
   home: https://github.com/EPPIcenter/dcifer
   doc_url: https://eppicenter.github.io/dcifer/
-  summary: An implementation of Dcifer (Distance for complex infections: fast estimation of relatedness), an identity by descent (IBD)-based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data.
+  summary: An identity by descent (IBD)-based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data.
   license: MIT
   license_file: LICENSE
 

--- a/recipes/dcifer/meta.yaml
+++ b/recipes/dcifer/meta.yaml
@@ -1,0 +1,52 @@
+{% set posix = "m2-" if win else "" %}
+{% set native = "m2w64-" if win else "" %}
+
+package:
+  name: r-dcifer
+  version: '{{ version }}'
+
+source:
+  url: https://cran.r-project.org/src/contrib/dcifer_{{ version }}.tar.gz
+  sha256: 24d5dddf19aad9d071a1306b06d5e007e51935bbadebe72a4c0cc4340236dac5
+
+build:
+  number: 0
+  merge_build_host: true
+  script: R CMD INSTALL --build .
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  build:
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+    - autoconf  # [unix]
+    - "{{ compiler('c') }}"  # [unix]
+    - "{{ compiler('m2w64_c') }}"  # [win]
+    - "{{ compiler('cxx') }}"  # [unix]
+    - "{{ compiler('m2w64_cxx') }}"  # [win]
+    - posix  # [win]
+  host:
+    - r-base
+    - r-graphics
+    - r-stats
+    - r-utils
+  run:
+    - r-base
+    - r-graphics
+    - r-stats
+    - r-utils
+
+test:
+  commands:
+    - $R -e "library('dcifer')"  # [not win]
+    - "\"%R%\" -e \"library('dcifer')\""  # [win]
+
+about:
+  home: https://github.com/EPPIcenter/dcifer, https://eppicenter.github.io/dcifer/
+  summary: 'An implementation of Dcifer (Distance for complex infections: fast estimation of relatedness), an identity by descent (IBD) based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data. The package includes functions that format and preprocess the data, implement the method, and visualize the results. Gerlovina et al. (2022) <doi:10.1093/genetics/iyac126>.'
+  license: MIT
+
+extra:
+  recipe-maintainers:
+    - AddYourGitHubIdHere

--- a/recipes/dcifer/meta.yaml
+++ b/recipes/dcifer/meta.yaml
@@ -49,4 +49,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - AddYourGitHubIdHere
+    - kathrynmurie
+    - innager

--- a/recipes/dcifer/meta.yaml
+++ b/recipes/dcifer/meta.yaml
@@ -1,9 +1,10 @@
+{% set version = "1.5.2" %}
 {% set posix = "m2-" if win else "" %}
 {% set native = "m2w64-" if win else "" %}
 
 package:
   name: r-dcifer
-  version: '{{ version }}'
+  version: {{ version }}
 
 source:
   url: https://cran.r-project.org/src/contrib/dcifer_{{ version }}.tar.gz
@@ -26,11 +27,13 @@ requirements:
     - "{{ compiler('cxx') }}"  # [unix]
     - "{{ compiler('m2w64_cxx') }}"  # [win]
     - posix  # [win]
+
   host:
     - r-base
     - r-graphics
     - r-stats
     - r-utils
+
   run:
     - r-base
     - r-graphics
@@ -43,9 +46,11 @@ test:
     - "\"%R%\" -e \"library('dcifer')\""  # [win]
 
 about:
-  home: https://github.com/EPPIcenter/dcifer, https://eppicenter.github.io/dcifer/
-  summary: 'An implementation of Dcifer (Distance for complex infections: fast estimation of relatedness), an identity by descent (IBD) based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data. The package includes functions that format and preprocess the data, implement the method, and visualize the results. Gerlovina et al. (2022) <doi:10.1093/genetics/iyac126>.'
+  home: https://github.com/EPPIcenter/dcifer
+  doc_url: https://eppicenter.github.io/dcifer/
+  summary: An implementation of Dcifer (Distance for complex infections: fast estimation of relatedness), an identity by descent (IBD)-based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data.
   license: MIT
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipes/r-dcifer/bld.bat
+++ b/recipes/r-dcifer/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dcifer/build.sh
+++ b/recipes/r-dcifer/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -49,6 +49,7 @@ about:
   license: MIT
   license_family: MIT
   license_file:
+    - {{ environ["PREFIX"] }}/lib/R/share/licenses/MIT
     - LICENSE
 
 extra:

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -55,6 +55,7 @@ extra:
   recipe-maintainers:
     - kathrynmurie
     - innager
+    - conda-forge/r
 
 # Package: dcifer
 # Type: Package

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -23,10 +23,11 @@ requirements:
     - cross-r-base {{ r_base }}  # [build_platform != target_platform]
     - autoconf  # [unix]
     - "{{ compiler('c') }}"  # [unix]
+    - "{{ stdlib('c') }}"  # [unix]
     - "{{ compiler('m2w64_c') }}"  # [win]
     - "{{ compiler('cxx') }}"  # [unix]
     - "{{ compiler('m2w64_cxx') }}"  # [win]
-    - posix  # [win]
+    - m2-base  # [win]
 
   host:
     - r-base

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -1,6 +1,4 @@
 {% set version = "1.5.2" %}
-{% set posix = "m2-" if win else "" %}
-{% set native = "m2w64-" if win else "" %}
 
 package:
   name: r-dcifer
@@ -31,15 +29,9 @@ requirements:
 
   host:
     - r-base
-    - r-graphics
-    - r-stats
-    - r-utils
 
   run:
     - r-base
-    - r-graphics
-    - r-stats
-    - r-utils
 
 test:
   commands:

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: r-dcifer
-  version: {{ version|replace("-", "_") }}
+  version: {{ version }}
 
 source:
   url:
@@ -50,7 +50,6 @@ about:
   license: MIT
   license_family: MIT
   license_file:
-    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
     - LICENSE
 
 extra:

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -1,51 +1,81 @@
-{% set version = "1.5.2" %}
+{% set version = '1.5.2' %}
+{% set posix = 'm2-' if win else '' %}
 
 package:
   name: r-dcifer
-  version: {{ version }}
+  version: {{ version|replace("-", "_") }}
 
 source:
-  url: https://cran.r-project.org/src/contrib/dcifer_{{ version }}.tar.gz
+  url:
+    - {{ cran_mirror }}/src/contrib/dcifer_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/dcifer/dcifer_{{ version }}.tar.gz
   sha256: 24d5dddf19aad9d071a1306b06d5e007e51935bbadebe72a4c0cc4340236dac5
 
 build:
   number: 0
-  merge_build_host: true
-  script: R CMD INSTALL --build .
   rpaths:
     - lib/R/lib/
     - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
 
 requirements:
   build:
-    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
-    - autoconf  # [unix]
-    - "{{ compiler('c') }}"  # [unix]
-    - "{{ stdlib('c') }}"  # [unix]
-    - "{{ compiler('m2w64_c') }}"  # [win]
-    - "{{ compiler('cxx') }}"  # [unix]
-    - "{{ compiler('m2w64_cxx') }}"  # [win]
-    - m2-base  # [win]
-
+    - {{ compiler('c') }}              # [not win]
+    - {{ stdlib('c') }}                # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-
   run:
     - r-base
 
 test:
   commands:
-    - $R -e "library('dcifer')"  # [not win]
+    - $R -e "library('dcifer')"           # [not win]
     - "\"%R%\" -e \"library('dcifer')\""  # [win]
 
 about:
   home: https://github.com/EPPIcenter/dcifer
   doc_url: https://eppicenter.github.io/dcifer/
-  summary: An identity by descent (IBD)-based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data.
   license: MIT
-  license_file: LICENSE
+  summary: 'An identity by descent (IBD) based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data'
+  license: MIT
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
 
 extra:
   recipe-maintainers:
     - kathrynmurie
     - innager
+
+# Package: dcifer
+# Type: Package
+# Title: Genetic Relatedness Between Polyclonal Infections
+# Version: 1.5.2
+# Authors@R: person("Inna", "Gerlovina", role = c("aut", "cre"), email = "innager@berkeley.edu", comment = c(ORCID = "0000-0002-7772-7473"))
+# Description: An implementation of Dcifer (Distance for complex infections: fast estimation of relatedness), an identity by descent (IBD) based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data. The package includes functions that format and preprocess the data, implement the method, and visualize the results. Gerlovina et al. (2022) <doi:10.1093/genetics/iyac126>.
+# Imports: stats, utils, graphics
+# License: MIT + file LICENSE
+# Encoding: UTF-8
+# LazyData: true
+# RoxygenNote: 7.3.2
+# URL: https://github.com/EPPIcenter/dcifer, https://eppicenter.github.io/dcifer/
+# Suggests: knitr, rmarkdown
+# VignetteBuilder: knitr
+# Depends: R (>= 4.4.0)
+# NeedsCompilation: yes
+# Packaged: 2026-05-06 22:25:49 UTC; igerlovina
+# Author: Inna Gerlovina [aut, cre] (ORCID: <https://orcid.org/0000-0002-7772-7473>)
+# Maintainer: Inna Gerlovina <innager@berkeley.edu>
+# Repository: CRAN
+# Date/Publication: 2026-05-07 07:20:02 UTC

--- a/recipes/r-dcifer/meta.yaml
+++ b/recipes/r-dcifer/meta.yaml
@@ -45,7 +45,6 @@ test:
 about:
   home: https://github.com/EPPIcenter/dcifer
   doc_url: https://eppicenter.github.io/dcifer/
-  license: MIT
   summary: 'An identity by descent (IBD) based method to calculate genetic relatedness between polyclonal infections from biallelic and multiallelic data'
   license: MIT
   license_family: MIT


### PR DESCRIPTION
This PR adds the CRAN R package dcifer.

Package information

CRAN: https://cran.r-project.org/package=dcifer
Source: https://github.com/EPPIcenter/dcifer
Documentation: https://eppicenter.github.io/dcifer/
License: MIT

dcifer implements an identity-by-descent (IBD)-based method for estimating genetic relatedness between polyclonal infections from biallelic and multiallelic data.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
