### PR TITLE
Add ssqueezepy, a synchrosqueezing package for Python

### DIFF
--- a/recipes/ssqueezepy/meta.yaml
+++ b/recipes/ssqueezepy/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "ssqueezepy" %}
+{% set version = "0.6.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1c6e4417db1623e26d1264a6b89e5ca212cea24b2c9de9002c3ea13c791ba625
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >={{ python_min }}
+    - numpy
+    - numba
+    - scipy
+
+test:
+  imports:
+    - ssqueezepy
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/OverLordGoldDragon/ssqueezepy
+  summary: Synchrosqueezing, wavelet transforms, and time-frequency analysis in Python
+  license: MIT
+  license_file: LICENSE
+  dev_url: https://github.com/OverLordGoldDragon/ssqueezepy
+
+extra:
+  recipe-maintainers:
+    - nup002


### PR DESCRIPTION
Adds a recipe for [ssqueezepy](https://github.com/OverLordGoldDragon/ssqueezepy). Synchrosqueezing, wavelet transforms, and time-frequency analysis in Python (v0.6.6).

Purely Python `noarch` package, sourced from the official pypi sdist.

**Checklist**
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
