### PR TITLE
Update examples to use files.pythonhosted.org instead of pypi.org

### DIFF
--- a/recipes/example-v1/recipe.yaml
+++ b/recipes/example-v1/recipe.yaml
@@ -21,7 +21,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/s/simplejson/simplejson-${{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/s/simplejson/simplejson-${{ version }}.tar.gz
   # If getting the source from GitHub, remove the line above,
   # uncomment the line below, and modify as needed. Use releases if available:
   # url: https://github.com/simplejson/simplejson/releases/download/${{ version }}/simplejson-${{ version }}.tar.gz

--- a/recipes/example/meta.yaml
+++ b/recipes/example/meta.yaml
@@ -11,7 +11,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/s/simplejson/simplejson-{{ version }}.tar.gz
+  url: https://files.pythonhosted.org.org/packages/source/s/simplejson/simplejson-{{ version }}.tar.gz
   # If getting the source from GitHub, remove the line above,
   # uncomment the line below, and modify as needed. Use releases if available:
   # url: https://github.com/simplejson/simplejson/releases/download/{{ version }}/simplejson-{{ version }}.tar.gz


### PR DESCRIPTION
Part of https://github.com/conda-forge/conda-forge.github.io/issues/2878