### PR TITLE
Add mlflow-autogluon

### DIFF
--- a/recipes/mlflow-autogluon/meta.yaml
+++ b/recipes/mlflow-autogluon/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "mlflow-autogluon" %}
+{% set version = "0.2.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: e1c0e886146bf23722f407bfdaddc320a01b521fd92932a32405819c1ae7ea90
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=64
+    - wheel
+  run:
+    - python >=3.9
+    - mlflow >=2.15
+
+test:
+  imports:
+    - mlflow_autogluon
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/PhylaTech/mlflow-autogluon
+  summary: MLflow community model flavor and autologging for AutoGluon predictors
+  description: |
+    mlflow-autogluon is an MLflow community model flavor and autologging
+    integration for AutoGluon. It provides save_model, log_model, and
+    load_model for TabularPredictor, TimeSeriesPredictor, and
+    MultiModalPredictor with full round-trip fidelity, a python_function
+    flavor for generic inference and serving, and one-call autologging that
+    records parameters, leaderboard metrics, model signatures, dataset
+    lineage, and the fitted predictor.
+
+    The AutoGluon predictor packages (autogluon.tabular, autogluon.timeseries,
+    autogluon.multimodal) are imported lazily and are not hard runtime
+    dependencies of this package; install the ones you need alongside it.
+  license: Apache-2.0
+  license_file: LICENSE
+  doc_url: https://phylatech.github.io/mlflow-autogluon/
+  dev_url: https://github.com/PhylaTech/mlflow-autogluon
+
+extra:
+  recipe-maintainers:
+    - evanroyrees

--- a/recipes/mlflow-autogluon/meta.yaml
+++ b/recipes/mlflow-autogluon/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "mlflow-autogluon" %}
 {% set version = "0.2.0" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -16,18 +17,19 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools >=64
     - wheel
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - mlflow >=2.15
 
 test:
   imports:
     - mlflow_autogluon
   requires:
+    - python {{ python_min }}
     - pip
   commands:
     - pip check

--- a/recipes/mlflow-autogluon/meta.yaml
+++ b/recipes/mlflow-autogluon/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "mlflow-autogluon" %}
 {% set version = "0.2.0" %}
-{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Adds a recipe for [mlflow-autogluon](https://pypi.org/project/mlflow-autogluon/), an MLflow community model flavor and autologging integration for AutoGluon (Tabular, TimeSeries, and MultiModal predictors).

- Pure-Python, `noarch: python`.
- Single runtime dependency `mlflow >=2.15` (already on conda-forge). The AutoGluon predictor packages are imported lazily and are optional, so `import mlflow_autogluon` works without them.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.