### PR TITLE
add `r-smooth`

### DIFF
--- a/recipes/r-smooth/bld.bat
+++ b/recipes/r-smooth/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-smooth/build.sh
+++ b/recipes/r-smooth/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-smooth/meta.yaml
+++ b/recipes/r-smooth/meta.yaml
@@ -1,0 +1,108 @@
+{% set version = '4.5.0' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-smooth
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/smooth_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/smooth/smooth_{{ version }}.tar.gz
+  sha256: 7ab0e1cec1129d3add7f2b604f544ecca414cc9f87350b01058c907558d47be6
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-mass
+    - r-rcpp >=0.12.3
+    - r-rcpparmadillo >=0.8.100.0.0
+    - r-generics >=0.1.2
+    - r-greybox >=2.0.2
+    - r-nloptr
+    - r-statmod
+    - r-xtable
+    - r-zoo
+  run:
+    - r-base
+    - r-mass
+    - r-rcpp >=0.12.3
+    - r-rcpparmadillo >=0.8.100.0.0
+    - r-generics >=0.1.2
+    - r-greybox >=2.0.2
+    - r-nloptr
+    - r-statmod
+    - r-xtable
+    - r-zoo
+
+test:
+  commands:
+    - $R -e "library('smooth')"           # [not win]
+    - "\"%R%\" -e \"library('smooth')\""  # [win]
+
+about:
+  home: https://github.com/config-i1/smooth
+  license: LGPL-2.1
+  summary: 'Functions implementing Single Source of Error state space models for purposes of
+    time series analysis and forecasting. The package includes ADAM (Svetunkov, 2023,
+    <https://openforecast.org/adam/>), Exponential Smoothing (Hyndman et al., 2008,
+    <doi:10.1007/978-3-540-71918-2>), SARIMA (Svetunkov & Boylan, 2019 <doi: 10.1080/00207543.2019.1600764>),
+    Complex Exponential Smoothing (Svetunkov & Kourentzes, 2018, <doi:10.13140/RG.2.2.24986.29123>),
+    Simple Moving Average (Svetunkov & Petropoulos, 2018 <doi:10.1080/00207543.2017.1380326>)
+    and several simulation functions. It also allows dealing with intermittent demand
+    based on the iETS framework (Svetunkov & Boylan, 2019, <doi:10.13140/RG.2.2.35897.06242>).'
+  license_family: LGPL
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/LGPL-2.1'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: smooth
+# Type: Package
+# Title: Forecasting Using State Space Models
+# Version: 4.5.0
+# Date: 2026-06-19
+# Authors@R: person("Ivan", "Svetunkov", email = "ivan@svetunkov.com", role = c("aut", "cre"), comment="Senior Lecturer at Centre for Marketing Analytics and Forecasting, Lancaster University, UK")
+# URL: https://github.com/config-i1/smooth
+# BugReports: https://github.com/config-i1/smooth/issues
+# Language: en-GB
+# Description: Functions implementing Single Source of Error state space models for purposes of time series analysis and forecasting. The package includes ADAM (Svetunkov, 2023, <https://openforecast.org/adam/>), Exponential Smoothing (Hyndman et al., 2008, <doi:10.1007/978-3-540-71918-2>), SARIMA (Svetunkov & Boylan, 2019 <doi: 10.1080/00207543.2019.1600764>), Complex Exponential Smoothing (Svetunkov & Kourentzes, 2018, <doi:10.13140/RG.2.2.24986.29123>), Simple Moving Average (Svetunkov & Petropoulos, 2018 <doi:10.1080/00207543.2017.1380326>) and several simulation functions. It also allows dealing with intermittent demand based on the iETS framework (Svetunkov & Boylan, 2019, <doi:10.13140/RG.2.2.35897.06242>).
+# License: LGPL-2.1
+# Depends: R (>= 3.0.2), greybox (>= 2.0.2)
+# Imports: Rcpp (>= 0.12.3), stats, generics (>= 0.1.2), graphics, grDevices, methods, statmod, MASS, nloptr, utils, xtable, zoo
+# LinkingTo: Rcpp, RcppArmadillo (>= 0.8.100.0.0)
+# Suggests: legion, numDeriv, testthat, knitr, rmarkdown, doMC, doParallel, foreach
+# VignetteBuilder: knitr
+# Encoding: UTF-8
+# ByteCompile: true
+# Config/roxygen2/version: 8.0.0
+# RoxygenNote: 8.0.0
+# NeedsCompilation: yes
+# Packaged: 2026-06-20 21:10:18 UTC; config
+# Author: Ivan Svetunkov [aut, cre] (Senior Lecturer at Centre for Marketing Analytics and Forecasting, Lancaster University, UK)
+# Maintainer: Ivan Svetunkov <ivan@svetunkov.com>
+# Repository: CRAN
+# Date/Publication: 2026-06-21 05:10:02 UTC

--- a/recipes/r-smooth/meta.yaml
+++ b/recipes/r-smooth/meta.yaml
@@ -60,6 +60,8 @@ requirements:
     - r-zoo
 
 test:
+  requires:
+    - r-codetools
   commands:
     - $R -e "library('smooth')"           # [not win]
     - "\"%R%\" -e \"library('smooth')\""  # [win]

--- a/recipes/r-smooth/meta.yaml
+++ b/recipes/r-smooth/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: r-smooth
-  version: "{{ version|replace('-'', '_') }}"
+  version: "{{ version|replace('-', '_') }}"
 
 source:
   url:

--- a/recipes/r-smooth/meta.yaml
+++ b/recipes/r-smooth/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: r-smooth
-  version: {{ version|replace("-", "_") }}
+  version: "{{ version|replace('-'', '_') }}"
 
 source:
   url:
@@ -23,10 +23,12 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -35,23 +37,24 @@ requirements:
     - cross-r-base {{ r_base }}    # [build_platform != target_platform]
   host:
     - r-base
-    - r-mass
-    - r-rcpp >=0.12.3
-    - r-rcpparmadillo >=0.8.100.0.0
     - r-generics >=0.1.2
     - r-greybox >=2.0.2
+    - r-mass
     - r-nloptr
+    - r-rcpp >=0.12.3
+    - r-rcpparmadillo >=0.8.100.0.0
     - r-statmod
     - r-xtable
     - r-zoo
+    - libblas
+    - liblapack
   run:
     - r-base
-    - r-mass
-    - r-rcpp >=0.12.3
-    - r-rcpparmadillo >=0.8.100.0.0
     - r-generics >=0.1.2
     - r-greybox >=2.0.2
+    - r-mass
     - r-nloptr
+    - r-rcpp >=0.12.3
     - r-statmod
     - r-xtable
     - r-zoo
@@ -63,7 +66,7 @@ test:
 
 about:
   home: https://github.com/config-i1/smooth
-  license: LGPL-2.1
+  license: LGPL-2.1-only
   summary: 'Functions implementing Single Source of Error state space models for purposes of
     time series analysis and forecasting. The package includes ADAM (Svetunkov, 2023,
     <https://openforecast.org/adam/>), Exponential Smoothing (Hyndman et al., 2008,


### PR DESCRIPTION
Adds [CRAN package `smooth`](https://cran.r-project.org/package=smooth) as `r-smooth`. Recipe generated with `conda_r_skeleton_helper`.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
