### PR TITLE
Add ncarnate

### DIFF
--- a/recipes/ncarnate/recipe.yaml
+++ b/recipes/ncarnate/recipe.yaml
@@ -41,11 +41,7 @@ tests:
       python_version:
         - ${{ python_min }}.*
         - '*'
-  - requirements:
-      run:
-        - pip
-        - python ${{ python_min }}.*
-    script:
+  - script:
       - ncarnate --help
       - ncarnate --version
 

--- a/recipes/ncarnate/recipe.yaml
+++ b/recipes/ncarnate/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "2.0.0"
-  python_min: "3.10"
 
 package:
   name: ncarnate
@@ -39,7 +38,9 @@ tests:
         - ncarnate
         - ncarnate.eos
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - '*'
   - requirements:
       run:
         - pip

--- a/recipes/ncarnate/recipe.yaml
+++ b/recipes/ncarnate/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "2.0.0"
+  python_min: "3.10"
 
 package:
   name: ncarnate
@@ -21,11 +22,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python ${{ python_min }}.*
     - hatchling >=1.27
     - pip
   run:
-    - python >=3.10
+    - python >=${{ python_min }}
     - netcdf4 >=1.6
     - numpy >=1.26
     - pyhdf >=0.11.6
@@ -38,10 +39,11 @@ tests:
         - ncarnate
         - ncarnate.eos
       pip_check: true
+      python_version: ${{ python_min }}.*
   - requirements:
       run:
         - pip
-        - python
+        - python ${{ python_min }}.*
     script:
       - ncarnate --help
       - ncarnate --version

--- a/recipes/ncarnate/recipe.yaml
+++ b/recipes/ncarnate/recipe.yaml
@@ -1,0 +1,73 @@
+schema_version: 1
+
+context:
+  version: "2.0.0"
+
+package:
+  name: ncarnate
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/n/ncarnate/ncarnate-${{ version }}.tar.gz
+  sha256: 5d97943f26a7e8899301e16c79c9ae7571f5840abf7723ca7bd53a71fe32fbde
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - ncarnate = ncarnate.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - hatchling >=1.27
+    - pip
+  run:
+    - python >=3.10
+    - netcdf4 >=1.6
+    - numpy >=1.26
+    - pyhdf >=0.11.6
+    - pyproj >=3.6
+    - tqdm >=4.66
+
+tests:
+  - python:
+      imports:
+        - ncarnate
+        - ncarnate.eos
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+        - python
+    script:
+      - ncarnate --help
+      - ncarnate --version
+
+about:
+  summary: Losslessly recompress netCDF/HDF5 and convert HDF4/HDF-EOS2 granules to CF-annotated netCDF4 with reconstructed geolocation
+  description: |
+    ncarnate reads legacy scientific data — HDF4/HDF-EOS2 granules (AMSR-E,
+    MODIS) and netCDF3/netCDF4/HDF5 — and writes recompressed, CF-annotated
+    netCDF4. It does two jobs: losslessly recompress netCDF/HDF5 (change
+    compression, shuffle, or chunking without changing a stored value), and
+    convert HDF4/HDF-EOS2 to netCDF4 with the geographic coordinates
+    reconstructed so the output opens directly in modern tools (xarray, QGIS,
+    Panoply). For HDF-EOS2 it parses the StructMetadata layer and rebuilds
+    CF-standard coordinates: GCTP grid projections become CF grid mappings
+    with 1-D x/y and 2-D lat/lon via pyproj, and swath geolocation is attached
+    as CF coordinates with dimension-mapped geolocation interpolated through
+    ECEF space. The correctness contract is data fidelity — only storage
+    changes, never the science values, and every output is verified against
+    its source before it replaces anything.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/ErickShepherd/ncarnate
+  repository: https://github.com/ErickShepherd/ncarnate
+  documentation: https://github.com/ErickShepherd/ncarnate#readme
+
+extra:
+  recipe-maintainers:
+    - ErickShepherd


### PR DESCRIPTION
Adds a recipe for [ncarnate](https://pypi.org/project/ncarnate/) — losslessly recompress netCDF/HDF5 and convert HDF4/HDF-EOS2 granules (AMSR-E, MODIS) to CF-annotated netCDF4 with reconstructed geolocation.

Pure-Python `noarch`; all runtime dependencies (`netcdf4`, `numpy`, `pyhdf`, `pyproj`, `tqdm`) are already on conda-forge. A conda-forge build also gives Windows users a working HDF4 path, which the PyPI `pyhdf` wheel cannot (it ships no HDF4 runtime).

Verified locally before submitting: `rattler-build` builds the `noarch` package, resolves all deps from conda-forge, and passes the recipe tests (imports + `pip check` + `ncarnate --help`/`--version`); `conda-smithy recipe-lint` reports "in fine form".

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (`license_file: LICENSE`; the MIT `LICENSE` is included in the PyPI sdist).
- [x] Source is from official source (the PyPI sdist).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged. (N/A — pure-Python `noarch`.)
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (Sole maintainer @ErickShepherd is the author of this PR.)
- [x] When in trouble, please check our knowledge base documentation before pinging a team.
