### PR TITLE
Add spineprep

### DIFF
--- a/recipes/spineprep/meta.yaml
+++ b/recipes/spineprep/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "spineprep" %}
 {% set version = "26.0.0" %}
+{% set python_min = "3.10" %}
 
 # conda-forge recipe for the SpinePrep Python orchestration layer.
 #
@@ -13,8 +14,7 @@ package:
   version: {{ version }}
 
 source:
-  # After the PyPI release exists, point at its sdist and fill in the sha256:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 04fecd0d6778637ca84d60006304d7164b78ec771b403604863c7b8b7900ea88
 
 build:
@@ -26,11 +26,11 @@ build:
 
 requirements:
   host:
-    - python >=3.10,<3.13
+    - python {{ python_min }}
     - poetry-core >=1.7.0
     - pip
   run:
-    - python >=3.10,<3.13
+    - python >={{ python_min }}
     - pyyaml >=6.0.1
     - jsonschema >=4.23.0
     - nibabel >=5.2.1
@@ -43,6 +43,8 @@ requirements:
     - nilearn >=0.10
 
 test:
+  requires:
+    - python {{ python_min }}
   imports:
     - spineprep
   commands:

--- a/recipes/spineprep/meta.yaml
+++ b/recipes/spineprep/meta.yaml
@@ -1,0 +1,67 @@
+{% set name = "spineprep" %}
+{% set version = "26.0.0" %}
+
+# conda-forge recipe for the SpinePrep Python orchestration layer.
+#
+# NOTE: like the PyPI package, this installs only the pure-Python layer. The full
+# pipeline additionally needs SCT, FSL and ANTs, which are NOT provided here — use
+# the container recipe for a complete environment. See recipe/README.md for how
+# to submit this to conda-forge/staged-recipes.
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # After the PyPI release exists, point at its sdist and fill in the sha256:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 04fecd0d6778637ca84d60006304d7164b78ec771b403604863c7b8b7900ea88
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - spineprep = spineprep.cli:main
+
+requirements:
+  host:
+    - python >=3.10,<3.13
+    - poetry-core >=1.7.0
+    - pip
+  run:
+    - python >=3.10,<3.13
+    - pyyaml >=6.0.1
+    - jsonschema >=4.23.0
+    - nibabel >=5.2.1
+    - pillow >=12.0.0
+    - matplotlib-base >=3.10
+    - scipy <1.15
+    - pandas <2.2
+    - scikit-image <0.24.0
+    - numpy <2.0.0
+    - nilearn >=0.10
+
+test:
+  imports:
+    - spineprep
+  commands:
+    - spineprep --version
+
+about:
+  home: https://spineprep.com
+  license: Apache-2.0
+  license_family: APACHE
+  license_file: LICENSE
+  summary: A containerised BIDS-App for reproducible spinal-cord fMRI preprocessing
+  description: >-
+    SpinePrep is an open-source BIDS-App that preprocesses human spinal-cord
+    functional MRI into GLM-ready derivatives with per-vertebral-level quality
+    control. This conda package provides the Python orchestration layer only;
+    the full pipeline also needs the Spinal Cord Toolbox, FSL and ANTs.
+  dev_url: https://github.com/SpinePrep/SpinePrep
+  doc_url: https://spineprep.com
+
+extra:
+  recipe-maintainers:
+    - kiomarssharifi


### PR DESCRIPTION
Adds a recipe for [spineprep](https://pypi.org/project/spineprep/) — an open, containerised BIDS-App for reproducible, QC-first preprocessing of human spinal-cord fMRI (docs: https://spineprep.com, repo: https://github.com/SpinePrep/SpinePrep). This packages the pure-Python orchestration layer (noarch); the full pipeline additionally uses SCT/FSL/ANTs via the project's container recipe, out of scope here. Source: PyPI sdist spineprep-26.0.0, sha256 verified; License Apache-2.0 (LICENSE in the sdist); smoke test is spineprep --version. I am the package author.