### PR TITLE
Add vaping and its dependencies (pid, pluginmgr, confu, python-munge)

### DIFF
--- a/recipes/confu/recipe.yaml
+++ b/recipes/confu/recipe.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "1.9.0"
+
+package:
+  name: confu
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/confu/confu-${{ version }}.tar.gz
+  sha256: bc921d2cf14eccbffca131e7514985d5d320187565afe731c87a367d29cd2b87
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - poetry-core
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - python-munge >=1.2.1,<2.0.0
+
+tests:
+  - python:
+      imports:
+        - confu
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: Configuration file validation and generation
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://github.com/20c/confu
+  repository: https://github.com/20c/confu
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/pid/recipe.yaml
+++ b/recipes/pid/recipe.yaml
@@ -24,8 +24,7 @@ requirements:
     - pip
   run:
     - python >=${{ python_min }}
-    - if: win
-      then: psutil >=5.4.8
+    - psutil >=5.4.8
 
 tests:
   - python:

--- a/recipes/pid/recipe.yaml
+++ b/recipes/pid/recipe.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "3.0.4"
+
+package:
+  name: pid
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pid/pid-${{ version }}.tar.gz
+  sha256: 0e33670e83f6a33ebb0822e43a609c3247178d4a375ff50a4689e266d853eb66
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - if: win
+      then: psutil >=5.4.8
+
+tests:
+  - python:
+      imports:
+        - pid
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: Pidfile featuring stale detection and file-locking, can also be used as context-manager or decorator
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://github.com/trbs/pid/
+  repository: https://github.com/trbs/pid/
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/pluginmgr/recipe.yaml
+++ b/recipes/pluginmgr/recipe.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "1.2.1"
+
+package:
+  name: pluginmgr
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pluginmgr/pluginmgr-${{ version }}.tar.gz
+  sha256: eb4f78521861224e79ce045e6f97ffa06a347b955e6e69e44716acda4ca024d4
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - python-munge >=1
+    - importlib-metadata >=1
+
+tests:
+  - python:
+      imports:
+        - pluginmgr
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: lightweight python plugin system supporting config inheritance
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://github.com/20c/pluginmgr
+  repository: https://github.com/20c/pluginmgr
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/python-munge/recipe.yaml
+++ b/recipes/python-munge/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "1.4.0"
+
+package:
+  name: python-munge
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/munge/munge-${{ version }}.tar.gz
+  sha256: 2f8c156e624fcc993fce1bfee5b9739f11b505c7f581562bd6bb46615c1f356a
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - munge = munge.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - requests >=2.32.0
+    - click >=8.0.1
+    - toml >=0.10.2
+    - tomlkit >=0.11.6
+    - pyyaml >=6.0.1
+    - urllib3 >=2.0.0
+    - charset-normalizer >=3.3.0
+
+tests:
+  - python:
+      imports:
+        - munge
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - munge --help
+
+about:
+  summary: data manipulation library and client
+  license: Apache-2.0
+  license_file: LICENSE.txt
+  homepage: https://github.com/20c/munge
+  repository: https://github.com/20c/munge
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/vaping/recipe.yaml
+++ b/recipes/vaping/recipe.yaml
@@ -1,7 +1,6 @@
 schema_version: 1
 
 context:
-  python_min: "3.9"
   version: "1.5.4"
 
 package:
@@ -14,7 +13,8 @@ source:
 
 build:
   number: 0
-  noarch: python
+  # vaping is a daemon tool that depends on python-daemon (Unix-only: pwd, fcntl)
+  skip: win
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   python:
     entry_points:
@@ -22,11 +22,11 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}.*
+    - python
     - poetry-core
     - pip
   run:
-    - python >=${{ python_min }}
+    - python
     - pid >=3
     - pluginmgr >=1.2
     - python-daemon >=2
@@ -39,11 +39,9 @@ tests:
       imports:
         - vaping
       pip_check: true
-      python_version: ${{ python_min }}.*
   - requirements:
       run:
         - pip
-        - python ${{ python_min }}.*
     script:
       - vaping --help
 

--- a/recipes/vaping/recipe.yaml
+++ b/recipes/vaping/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "1.5.4"
+
+package:
+  name: vaping
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/v/vaping/vaping-${{ version }}.tar.gz
+  sha256: 5b733ce5c7490a758ef678734258b312e7257ef83700086452da982efb419d49
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - vaping = vaping.cli:cli
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - poetry-core
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pid >=3
+    - pluginmgr >=1.2
+    - python-daemon >=2
+    - docutils <=0.21
+    - python-munge >=1.2.0
+    - confu >=1.7.1
+
+tests:
+  - python:
+      imports:
+        - vaping
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - vaping --help
+
+about:
+  summary: vaping is a healthy alternative to smokeping!
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://github.com/20c/vaping
+  repository: https://github.com/20c/vaping
+  documentation: https://vaping.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds [vaping](https://github.com/20c/vaping) (a healthy alternative to smokeping!) along with its four dependencies that are not yet on conda-forge, all in dependency order:

- **python-munge** — the [20c `munge`](https://github.com/20c/munge) data-manipulation library. Named `python-munge` because the name `munge` is already taken on conda-forge by the unrelated C MUNGE authentication library.
- **pid** — pidfile with stale detection and file-locking
- **pluginmgr** — lightweight plugin system (depends on `python-munge`)
- **confu** — config validation/generation (depends on `python-munge`)
- **vaping** — depends on `pid`, `pluginmgr`, `confu`, `python-munge`, `python-daemon`, `docutils`

All five build cleanly and pass tests locally (import + CLI `--help`) on osx-arm64.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our knowledge base documentation before pinging a team.
