### PR TITLE
Add dash-seqviz

### DIFF
--- a/recipes/dash-seqviz/meta.yaml
+++ b/recipes/dash-seqviz/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "dash-seqviz" %}
 {% set version = "0.3.0" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - dash >=3.0.0
 
 test:
@@ -30,6 +31,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/dash-seqviz/meta.yaml
+++ b/recipes/dash-seqviz/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - python >=3.9
     - pip
     - setuptools
+    - wheel
   run:
     - python >=3.9
     - dash >=3.0.0

--- a/recipes/dash-seqviz/meta.yaml
+++ b/recipes/dash-seqviz/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "dash-seqviz" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/dash_seqviz-{{ version }}.tar.gz
+  sha256: 01179f2d4197ab1451b3f88f604e9c7b80d81fb078ab9327eb1dcc401dd5479c
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - dash >=3.0.0
+
+test:
+  imports:
+    - dash_seqviz
+    - dash_seqviz.integrations
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://dash-seqviz.com
+  summary: A Dash component for DNA, RNA and protein sequence visualization
+  description: |
+    dash-seqviz is a Dash component library wrapping the seqviz JavaScript
+    viewer for interactive DNA, RNA, and protein sequence visualization:
+    circular and linear viewers, annotations, primers, restriction enzymes,
+    motif search, theming, and figure export. It also ships Python helpers
+    for parsing FASTA/GenBank files and NCBI accessions into component props.
+  license: MIT
+  license_file: LICENSE
+  doc_url: https://dash-seqviz.com
+  dev_url: https://github.com/Full-Spectrum-Analytics/dash-seqviz
+
+extra:
+  recipe-maintainers:
+    - evanroyrees

--- a/recipes/dash-seqviz/meta.yaml
+++ b/recipes/dash-seqviz/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "dash-seqviz" %}
 {% set version = "0.3.0" %}
-{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}

--- a/recipes/dash-seqviz/meta.yaml
+++ b/recipes/dash-seqviz/meta.yaml
@@ -27,7 +27,6 @@ requirements:
 test:
   imports:
     - dash_seqviz
-    - dash_seqviz.integrations
   commands:
     - pip check
   requires:


### PR DESCRIPTION
Adds a recipe for [**dash-seqviz**](https://pypi.org/project/dash-seqviz/) — a Dash component library wrapping the [seqviz](https://github.com/Lattice-Automation/seqviz) JavaScript viewer for interactive DNA/RNA/protein sequence visualization.

- Source: PyPI sdist (v0.3.0), MIT licensed.
- `noarch: python`; single runtime dependency `dash >=3.0.0` (already on conda-forge).
- Homepage / docs: https://dash-seqviz.com
- Repo: https://github.com/Full-Spectrum-Analytics/dash-seqviz

Checklist:
- [x] Title of this PR is meaningful.
- [x] License file is packaged (`license_file: LICENSE`).
- [x] Source is from a stable release (PyPI sdist with sha256).
- [x] Recipe maintainer listed (`evanroyrees`).
- [x] Package is `noarch: python` (pure Python + bundled JS/CSS assets).