### PR TITLE
Add nika

### DIFF
--- a/recipes/nika/recipe.yaml
+++ b/recipes/nika/recipe.yaml
@@ -1,0 +1,62 @@
+context:
+  version: "0.99.0"
+
+package:
+  name: nika
+  version: ${{ version }}
+
+source:
+  url: https://github.com/supernovae-st/nika/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 4b0a59c74f522cb743760c7e4f41751064cd645eda41a4c70307a4ca8aea60dc
+
+build:
+  number: 0
+  # upstream ships macOS + Linux release binaries only; Windows is not a
+  # supported target yet (tracked upstream) — skip rather than ship untested
+  skip:
+    - win
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+    content:
+      # the workspace bin crate is `nika-cli`; the user-facing binary name is
+      # `nika` (upstream renames at packaging time — mirrored here)
+      - cargo install --locked --no-track --bin nika-cli --root ${{ PREFIX }} --path crates/nika-cli
+      - mv ${{ PREFIX }}/bin/nika-cli ${{ PREFIX }}/bin/nika
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+
+tests:
+  - script: nika --version
+  - package_contents:
+      bin:
+        - nika
+      strict: true
+
+about:
+  homepage: https://nika.sh
+  summary: Workflow engine for AI — reviewable YAML DAGs, statically checked before execution, tamper-evident traces after
+  description: |
+    Nika turns repeatable AI work into files you can run, review, diff
+    and share. A workflow is a plain .nika.yaml DAG — LLM steps, shell
+    steps, tool calls — statically checkable before a single token is
+    spent: `nika check` audits the schema, the DAG, the cost floor, the
+    permit boundary and secret flows. Runs are budget-cappable and leave
+    a tamper-evident, hash-chained trace. Local-first: the mock and
+    Ollama paths need no API key.
+  license: AGPL-3.0-or-later
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://docs.nika.sh
+  repository: https://github.com/supernovae-st/nika
+
+extra:
+  recipe-maintainers:
+    - ThibautMelen


### PR DESCRIPTION
Adds a recipe for **nika**, an open-source workflow engine for AI (Rust): workflows are plain `.nika.yaml` DAG files, statically checked before execution (schema, permits, cost floor) with tamper-evident traces after. Upstream: https://github.com/supernovae-st/nika (AGPL-3.0-or-later).

### Checklist
- [x] Title of this PR is meaningful (`Add nika`)
- [x] License (`AGPL-3.0-or-later`) and `license_file` (`LICENSE` + `THIRDPARTY.yml` via `cargo-bundle-licenses`) are specified and packaged
- [x] Source is the official GitHub release tag tarball, pinned with `sha256` (source build — not a binary repack)
- [x] Build is hermetic: pure-Rust build, `cargo install --locked`, no network beyond cargo's own vendored resolution, no system libraries beyond the C stdlib/compiler stack (upstream's Nix flake and release CI build with zero native inputs)
- [x] Tests included: `nika --version` + strict `package_contents` on the single binary
- [x] Maintainer listed (`@ThibautMelen`)

Notes for reviewers:
- v1 `recipe.yaml` (rattler-build) format, shape follows the recently merged `rust-analyzer` recipe (#33106).
- The workspace bin crate is `nika-cli`; the user-facing binary name is `nika` (upstream renames at packaging time — the recipe mirrors that with a `mv`).
- Windows is skipped: upstream does not ship or test Windows yet; will enable when upstream does.
- I am the upstream author (first-party submission).
