### PR TITLE
Add openmassspec-io

### DIFF
--- a/recipes/openmassspec-io/meta.yaml
+++ b/recipes/openmassspec-io/meta.yaml
@@ -1,0 +1,56 @@
+{% set name = "openmassspec-io" %}
+{% set version = "1.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/f2/7e/cde0dbde2a3471b2d8cf44a578ac5795cf75307b44e72a45f985507c7d43/openmassspec_io-{{ version }}.tar.gz
+  sha256: 60fd50551d56c169b2c8628042deea2735fc1280b38a1694e09cd2621cb52342
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
+    - maturin >=1.5,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.5,<2.0
+    - numpy >=1.23
+  run:
+    - python
+    - {{ pin_compatible('numpy') }}
+
+test:
+  imports:
+    - openmassspec_io
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://sigilweaver.app/openmassspec/docs
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Vendor-neutral mass-spec I/O (Thermo / Bruker / Waters / Agilent / SCIEX to mzML) with Arrow streaming
+  description: |
+    openmassspec-io is the vendor-neutral I/O layer of the OpenMassSpec stack
+    (formerly OpenProteo). It detects Thermo .raw, Bruker .d / TDF, Waters
+    .raw, Agilent, and SCIEX acquisitions and converts them to mzML, or
+    streams spectra as Apache Arrow record batches, without requiring any
+    vendor SDK. This package provides the Python bindings to the
+    openmassspec-io Rust crate; peak arrays are returned as NumPy arrays.
+  doc_url: https://sigilweaver.app/openmassspec/docs
+  dev_url: https://github.com/Sigilweaver/OpenMassSpec
+
+extra:
+  recipe-maintainers:
+    - Nathan-D-R


### PR DESCRIPTION
Replaces #34069 (Add openproteo-io), which targeted the pre-rename package name. The upstream project (OpenProteo) was renamed to OpenMassSpec, and the PyPI package is now published as `openmassspec-io` (currently 1.1.0), covering Thermo, Bruker, Waters, Agilent, and SCIEX vendor formats via `detect_format`/`vendor2mzml`.

- Rust/maturin-built Python bindings, same build shape as the other Sigilweaver reader packages already in staged-recipes (e.g. opentfraw, dicom-map).
- `sha256` verified against the published sdist.