### PR TITLE
Add package cvise

### DIFF
--- a/recipes/cvise/recipe.yaml
+++ b/recipes/cvise/recipe.yaml
@@ -1,0 +1,64 @@
+context:
+  version: "2.12.0"
+
+package:
+  name: cvise
+  version: ${{ version }}
+
+source:
+  url: https://github.com/marxin/cvise/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d015050cfc4015460ca5793378c4899a36104ddcf084f29f0f5f6233f6187cb1
+
+build:
+  number: 0
+  skip:
+    - win
+  script:
+    - cmake -S . -B build -G Ninja ${CMAKE_ARGS}
+    - cmake --build build
+    - cmake --install build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - flex
+    - ninja
+  host:
+    - python
+    - llvmdev 20.*
+    - clangdev 20.*
+  run:
+    - python
+    - chardet
+    - pebble
+    - psutil
+    - libclang-cpp20.1
+    - clang-format
+    - unifdef
+
+tests:
+  - script:
+    - printf '%s\n' 'static int nextHi = 1;' 'static int junk(void) { return 0; }' 'int main(void) { return nextHi + junk(); }' > test.c
+    - printf '%s\n' '#!/bin/sh' 'set -eu' 'clang -c test.c >/dev/null 2>&1 && grep -q nextHi test.c' > interesting.sh
+    - chmod +x interesting.sh
+    - cvise ./interesting.sh test.c
+    - grep -q nextHi test.c
+    - test "$(wc -c < test.c)" -lt 80
+    - cvise-delta --help
+
+about:
+  homepage: https://github.com/marxin/cvise
+  repository: https://github.com/marxin/cvise
+  summary: Super-parallel Python port of C-Reduce
+  description: |
+    C-Vise is a super-parallel Python port of C-Reduce. The port is fully compatible to C-Reduce and
+    uses the same efficient LLVM-based C/C++ reduction tool named `clang_delta`.
+  license: NCSA
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - user202729

--- a/recipes/cvise/recipe.yaml
+++ b/recipes/cvise/recipe.yaml
@@ -1,0 +1,69 @@
+context:
+  version: "2.12.0"
+
+package:
+  name: cvise
+  version: ${{ version }}
+
+source:
+  url: https://github.com/marxin/cvise/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d015050cfc4015460ca5793378c4899a36104ddcf084f29f0f5f6233f6187cb1
+
+build:
+  number: 0
+  skip:
+    - win
+  script:
+    - cmake -S . -B build -G Ninja ${CMAKE_ARGS}
+    - cmake --build build
+    - cmake --install build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - flex
+    - ninja
+  host:
+    - python
+    - llvmdev 20.*
+    - clangdev 20.*
+  run:
+    - python
+    - chardet
+    - pebble
+    - psutil
+    - libclang-cpp20.1
+    - clang-format
+    - unifdef
+
+tests:
+  - requirements:
+      run:
+        - clang 20.*
+    script:
+    - printf '%s\n' 'static int nextHi = 1;' 'static int junk(void) { return 0; }' 'int main(void) { return nextHi + junk(); }' > test.c
+    - printf '%s\n' '#!/bin/sh' 'set -eu' 'clang -c test.c >/dev/null 2>&1 && grep -q nextHi test.c' > interesting.sh
+    - chmod +x interesting.sh
+    - cvise ./interesting.sh test.c
+    - grep -q nextHi test.c
+    - test "$(wc -c < test.c)" -lt 80
+    - cvise-delta --help
+
+about:
+  homepage: https://github.com/marxin/cvise
+  repository: https://github.com/marxin/cvise
+  summary: Super-parallel Python port of C-Reduce
+  description: |
+    C-Vise is a super-parallel Python port of C-Reduce. The port is fully compatible to C-Reduce and
+    uses the same efficient LLVM-based C/C++ reduction tool named `clang_delta`.
+  license: NCSA AND BSD-3-Clause
+  license_file:
+    - COPYING
+    - delta/License.txt
+
+extra:
+  recipe-maintainers:
+    - user202729


### PR DESCRIPTION
This is a Python port of creduce. Both C-Vise and C-Reduce are used to minimize C/C++ programs that has a property, usually useful for finding a minimal example that trigger a compiler bug.

The package description in the recipe is taken from the README of the project, but I change `the C-Reduce` to `C-Reduce`. (The `the` doesn't feel grammatically correct.)

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
