### PR TITLE
Add sshtunnel2

### DIFF
--- a/recipes/sshtunnel2/recipe.yaml
+++ b/recipes/sshtunnel2/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  name: sshtunnel2
+  version: "0.4.1"
+  python_min: "3.9"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 2309d07ba9622bfa0c1d81e6888269b4782764d06a751eae5c7d36739b834691
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - paramiko >=3,<6
+
+tests:
+  - python:
+      imports:
+        - sshtunnel
+      python_version: ${{ python_min }}.*
+      pip_check: true
+
+about:
+  homepage: https://github.com/andyxuanq110/sshtunnel2
+  summary: Maintained drop-in fork of sshtunnel for Paramiko 3, 4, and 5
+  description: |
+    sshtunnel2 is a maintained drop-in fork of the sshtunnel library
+    (SSH port forwarding / SSHTunnelForwarder). It keeps the original
+    public API and the `sshtunnel` import name, and fixes compatibility
+    with modern Paramiko releases (including the removal of DSSKey in
+    Paramiko 4.0), listener cleanup on failed startup, and shutdown
+    deadlock scenarios. Because it installs the same top-level module,
+    it must not be co-installed with the original `sshtunnel` package.
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/andyxuanq110/sshtunnel2
+  documentation: https://github.com/andyxuanq110/sshtunnel2#readme
+
+extra:
+  recipe-maintainers:
+    - andyxuanq110


### PR DESCRIPTION
### Add `sshtunnel2`

`sshtunnel2` is a **maintained drop-in fork** of [`sshtunnel`](https://github.com/pahaz/sshtunnel) (SSH port forwarding / `SSHTunnelForwarder`). The upstream project has had no releases or maintainer activity for about five years, while the last release (0.4.0) now crashes on import against current Paramiko.

Release 0.4.1 is deliberately maintenance-only:

- **Paramiko 3/4/5 compatibility** — `DSSKey` was removed in Paramiko 4.0 and upstream references it unconditionally (upstream [#302](https://github.com/pahaz/sshtunnel/issues/302), [#299](https://github.com/pahaz/sshtunnel/issues/299)); DSS support is now discovered only when Paramiko actually exposes it.
- **Listener cleanup when startup fails** (upstream [#288](https://github.com/pahaz/sshtunnel/issues/288)).
- Shutdown / force-close behavior covered by regression tests; CI across Python 3.9–3.13.
- MIT, original copyright and NOTICE preserved. No new public APIs.

### ⚠️ Intentional name collision with the existing `sshtunnel` feedstock — please read

I want to flag this up front rather than have a reviewer discover it:

`sshtunnel2` **installs the same top-level module `sshtunnel/` and the same console script `sshtunnel`** as the existing conda-forge [`sshtunnel`](https://github.com/conda-forge/sshtunnel-feedstock) package. This is **by design** — it is a drop-in replacement, so that `from sshtunnel import SSHTunnelForwarder` keeps working for existing users and only the dependency name changes. Users install **one or the other, never both**; the two packages are not intended to be co-installed, and the `description` field says so explicitly.

conda has no `conflicts:` mechanism to express this, but there is precedent on conda-forge for packages that provide the same importable name:

- `pillow` installs `PIL` (the `PIL`/Pillow lineage)
- `pycryptodome` and `pycrypto` both provide `Crypto`

If the maintainers would prefer a different arrangement (e.g. a `run_constrained` entry against `sshtunnel`, dropping the console script, or renaming the module), I'm happy to adjust the recipe — just tell me which you prefer.

### Checklist

- [x] Title of this PR is "Add sshtunnel2"
- [x] `recipe.yaml` (v1 format) placed in `recipes/sshtunnel2/`
- [x] License is MIT, and `LICENSE` is verified to ship inside the PyPI sdist
- [x] `sha256` verified against the PyPI sdist
- [x] Source is a tagged/versioned PyPI release (0.4.1)
- [x] I am the package author and the listed recipe maintainer (@andyxuanq110)
