### PR TITLE
Add cellpycore

### DIFF
--- a/recipes/cellpycore/meta.yaml
+++ b/recipes/cellpycore/meta.yaml
@@ -1,0 +1,43 @@
+{% set name = "cellpycore" %}
+{% set version = "0.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/cellpycore-{{ version }}.tar.gz
+  sha256: 2624033e47fdc51bc9fa8d644ba6bf7ca8d69ee66f88ffbd922a819f5504843a
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.13
+    - pip
+    - hatchling >=1.27
+  run:
+    - python >=3.13
+    - pandas >=2.2.3
+    - polars >=1.29.0
+    - pyarrow >=20.0.0
+
+test:
+  imports:
+    - cellpycore
+
+about:
+  home: https://github.com/cellpy/cellpy-core
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Core engine for cellpy — step and cycle summarization of battery-cycling data
+  doc_url: https://github.com/cellpy/cellpy-core
+  dev_url: https://github.com/cellpy/cellpy-core
+
+extra:
+  recipe-maintainers:
+    - jepegit

--- a/recipes/cellpycore/meta.yaml
+++ b/recipes/cellpycore/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "cellpycore" %}
 {% set version = "0.2.1" %}
+{% set python_min = "3.13" %}
 
 package:
   name: {{ name|lower }}
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.13
+    - python {{ python_min }}
     - pip
     - hatchling >=1.27
   run:
-    - python >=3.13
+    - python >={{ python_min }}
     - pandas >=2.2.3
     - polars >=1.29.0
     - pyarrow >=20.0.0
@@ -28,6 +29,8 @@ requirements:
 test:
   imports:
     - cellpycore
+  requires:
+    - python {{ python_min }}
 
 about:
   home: https://github.com/cellpy/cellpy-core


### PR DESCRIPTION
## Package
- **Name:** cellpycore
- **Version:** 0.2.1
- **PyPI:** https://pypi.org/project/cellpycore/
- **Repo:** https://github.com/cellpy/cellpy-core
- **License:** MIT

## Notes
Pure-Python (`noarch: python`), requires Python >=3.13.
Needed as a run dependency for cellpy 1.1.x on conda-forge
(see conda-forge/cellpy-feedstock#55).

Maintainer: @jepegit

Made with [Cursor](https://cursor.com)