### PR TITLE
Add recipe for scrubadub

### DIFF
--- a/recipes/scrubadub/recipe.yaml
+++ b/recipes/scrubadub/recipe.yaml
@@ -1,0 +1,51 @@
+context:
+  version: 2.0.1
+
+package:
+  name: scrubadub
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/scrubadub/scrubadub-${{ version }}.tar.gz
+  sha256: 52a1fb8aa9bc0226043e02c3ec22d450bd4ebeede9e7e8db2def7c89b37c5aad
+
+build:
+  number: 0 
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  noarch: python
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - textblob ==0.15.3
+    - phonenumbers
+    - python-stdnum
+    - dateparser
+    - catalogue
+    - scikit-learn
+    - typing-extensions
+    - faker
+
+tests:
+  - python:
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      imports:
+        - scrubadub
+      pip_check: true
+
+about:
+  homepage: https://github.com/LeapBeyond/scrubadub
+  summary: Clean personally identifiable information from dirty dirty text.
+  license: MIT
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - soapy1


### PR DESCRIPTION
Adds a recipe for scrubadub v2.0.1.

Project homepage: https://github.com/LeapBeyond/scrubadub/tree/master
pypi project: https://pypi.org/project/scrubadub/

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.

