### PR TITLE
Add weston compositor (fully featured), Xwayland and their dependency stack

### DIFF
--- a/recipes/aml/build.sh
+++ b/recipes/aml/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# ${MESON_ARGS} comes from the compiler activation and already carries
+# --prefix, -Dlibdir=lib, -Dbuildtype=release, and --cross-file when cross
+# compiling, so it must be passed through verbatim.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Dexamples=false
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/aml/conda-forge.yml
+++ b/recipes/aml/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/aml/recipe.yaml
+++ b/recipes/aml/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+package:
+  name: aml
+  version: ${{ version }}
+
+source:
+  url: https://github.com/any1/aml/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: b2b8f743213af39f40e8bc611147d69e2ea9e010b9b19cb65246582338f28d96
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+  run_exports:
+    # library(version: '1.0.0') installs libaml.so.1: the soname tracks only
+    # the major version, so pin on the major.
+    - ${{ pin_subpackage('aml', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - aml
+      include:
+        - aml1/aml.h
+  - script:
+      - pkg-config --modversion aml1
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://github.com/any1/aml
+  license: ISC
+  license_file: COPYING
+  summary: Another main loop
+  description: |
+    aml is a general purpose event loop library for C. It abstracts over
+    epoll and kqueue and provides timers, signals, file descriptor events,
+    idle callbacks and a thread pool, and is used by wayvnc and Weston's VNC
+    backend by way of neatvnc.
+  repository: https://github.com/any1/aml
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/freerdp/build.sh
+++ b/recipes/freerdp/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# FreeRDP builds with CMake. ${CMAKE_ARGS} carries conda's cross toolchain
+# file and the usual install/rpath settings; the prefix and libdir are set
+# explicitly so everything lands in $PREFIX/lib rather than lib64.
+#
+# This build targets Weston's rdp backend, which needs the server libraries
+# (freerdp-server3.pc + winpr3.pc + freerdp3.pc). Everything Weston does not
+# need is turned off to keep the dependency surface small:
+#   * WITH_CLIENT / WITH_CLIENT_COMMON / WITH_CLIENT_SDL: the client binaries
+#     and the SDL GUI client are not used.
+#   * WITH_SAMPLE / WITH_SHADOW / WITH_PROXY / WITH_PLATFORM_SERVER: standalone
+#     server/proxy applications; Weston links the freerdp-server library itself.
+#   * WITH_X11 / WITH_WAYLAND: X11 and Wayland (wlfreerdp/uwac) clients.
+#   * WITH_FFMPEG / WITH_SWSCALE / WITH_CAIRO: optional codec/scaling backends.
+#   * WITH_ALSA / WITH_PULSE / WITH_OSS: sound backends.
+#   * WITH_MANPAGES: avoids the docs toolchain.
+#   * BUILD_TESTING: unit tests.
+# The core libraries and the virtual channel plugins (WITH_CHANNELS, on by
+# default) are kept. NLA authentication still works through NTLM.
+#
+# WITH_KRB5 is turned off: FreeRDP calls krb5_get_init_creds_opt_set_pac_request
+# unconditionally, but conda-forge's krb5 does not export that symbol, so a
+# Kerberos build cannot link. Weston's RDP backend does not require Kerberos
+# single sign-on.
+# FreeRDP forbids in-source builds, so configure from a dedicated directory.
+mkdir -p build
+cd build
+
+cmake -G Ninja ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=$PREFIX \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=ON \
+  -DWITH_LIBRARY_SOVERSIONING=ON \
+  -DWITH_SERVER=ON \
+  -DWITH_SERVER_INTERFACE=ON \
+  -DWITH_CLIENT=OFF \
+  -DWITH_CLIENT_COMMON=OFF \
+  -DWITH_CLIENT_SDL=OFF \
+  -DWITH_SAMPLE=OFF \
+  -DWITH_SHADOW=OFF \
+  -DWITH_PROXY=OFF \
+  -DWITH_PLATFORM_SERVER=OFF \
+  -DWITH_X11=OFF \
+  -DWITH_WAYLAND=OFF \
+  -DWITH_FFMPEG=OFF \
+  -DWITH_SWSCALE=OFF \
+  -DWITH_CAIRO=OFF \
+  -DWITH_ALSA=OFF \
+  -DWITH_PULSE=OFF \
+  -DWITH_OSS=OFF \
+  -DWITH_KRB5=OFF \
+  -DWITH_JSONC_REQUIRED=ON \
+  -DWITH_MANPAGES=OFF \
+  -DBUILD_TESTING=OFF \
+  $SRC_DIR
+
+cmake --build . -j ${CPU_COUNT}
+cmake --install .

--- a/recipes/freerdp/conda-forge.yml
+++ b/recipes/freerdp/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/freerdp/recipe.yaml
+++ b/recipes/freerdp/recipe.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+
+context:
+  version: "3.30.0"
+
+package:
+  name: freerdp
+  version: ${{ version }}
+
+source:
+  url: https://github.com/FreeRDP/FreeRDP/releases/download/${{ version }}/freerdp-${{ version }}.tar.gz
+  sha256: e2687d02dea6fede004d36391dac1a74ce57a210f8867fd95033171d4909590c
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - pkg-config
+  host:
+    - openssl
+    - zlib
+    # winpr's Unicode conversion uses ICU (WITH_UNICODE_BUILTIN is off), and
+    # winpr3.pc lists icu-uc/icu-io/icu-i18n under Requires.private.
+    - icu
+    # Optional JSON backend (used by winpr for Azure AD and timezone data).
+    # cJSON is not on conda-forge; FreeRDP also supports json-c.
+    - json-c
+  run_exports:
+    # The libraries carry an SOVERSION equal to the FreeRDP major version
+    # (libfreerdp3.so.3, libwinpr3.so.3, libfreerdp-server3.so.3), so the ABI
+    # only breaks at a new major release.
+    - ${{ pin_subpackage('freerdp', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - freerdp3
+        - freerdp-server3
+        - winpr3
+  - script:
+      - pkg-config --modversion freerdp3
+      - pkg-config --modversion freerdp-server3
+      - pkg-config --modversion winpr3
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://www.freerdp.com
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: A free implementation of the Remote Desktop Protocol (RDP)
+  description: |
+    FreeRDP is a free implementation of the Remote Desktop Protocol (RDP),
+    released under the Apache license. It provides the libfreerdp and WinPR
+    libraries as well as a server library (freerdp-server).
+
+    This build enables the server libraries so that compositors such as
+    Weston can offer an RDP backend. The standalone client and server
+    applications, the X11/Wayland/SDL clients, FFmpeg-based codecs and the
+    sound backends are disabled; only the shared core, WinPR and server
+    libraries with their virtual channel plugins are built.
+  repository: https://github.com/FreeRDP/FreeRDP
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/hwdata/build.sh
+++ b/recipes/hwdata/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# `configure` is a hand written script, not autoconf; it only generates
+# Makefile.inc. The Makefile refuses to run until that file exists.
+./configure \
+  --prefix="${PREFIX}" \
+  --datadir="${PREFIX}/share"
+
+make install -j"${CPU_COUNT}"

--- a/recipes/hwdata/recipe.yaml
+++ b/recipes/hwdata/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "0.409"
+
+package:
+  name: hwdata
+  version: ${{ version }}
+
+source:
+  url: https://github.com/vcrhonek/hwdata/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 23006accc0f931dd5187d0307a57d0744e2b8feb85e73c37bc0f5229fb31eadd
+
+build:
+  number: 0
+  # Pure data files (no compiled artifacts), but restricted to linux: the only
+  # consumer is libdisplay-info (linux only), and the POSIX shell/make build
+  # script does not run on the osx/win CI runners. Not marked noarch because a
+  # noarch package may not carry a platform skip.
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - make
+
+tests:
+  - package_contents:
+      files:
+        - share/hwdata/pnp.ids
+        - share/hwdata/pci.ids
+        - share/hwdata/usb.ids
+  - script:
+      - pkg-config --variable=pkgdatadir hwdata
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://github.com/vcrhonek/hwdata
+  # Upstream offers the data under either license and downstreams may pick
+  # either one. XFree86-1.0 predates the SPDX list (which only carries 1.1),
+  # hence the LicenseRef. The permissive option is what lets libdisplay-info
+  # compile pnp.ids into its MIT licensed library.
+  license: GPL-2.0-or-later OR LicenseRef-XFree86-1.0
+  license_file:
+    - LICENSE
+    - COPYING
+  summary: Hardware identification and configuration data
+  description: |
+    hwdata contains various hardware identification and configuration data,
+    such as the pci.ids, usb.ids and pnp.ids databases. These map numeric
+    vendor and device identifiers to human readable names.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libdisplay-info/build.sh
+++ b/recipes/libdisplay-info/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# libdisplay-info looks up hwdata with `dependency('hwdata', native: true)` to
+# locate pnp.ids. That lookup has to resolve against the build environment,
+# and meson reads the *_FOR_BUILD variables for the build machine when cross
+# compiling. Without this, meson falls back to a hardcoded
+# /usr/share/hwdata/pnp.ids and would either fail or silently bake in data
+# from the build image rather than from the hwdata package.
+export PKG_CONFIG_PATH_FOR_BUILD="${BUILD_PREFIX}/share/pkgconfig:${BUILD_PREFIX}/lib/pkgconfig"
+export PKG_CONFIG_PATH="${BUILD_PREFIX}/share/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload
+
+# Fail loudly rather than silently shipping a PNP table built from whatever
+# pnp.ids happened to be present on the build image.
+grep -qE "dependency hwdata found: YES" builddir/meson-logs/meson-log.txt
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/libdisplay-info/conda-forge.yml
+++ b/recipes/libdisplay-info/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/libdisplay-info/recipe.yaml
+++ b/recipes/libdisplay-info/recipe.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+
+context:
+  version: "0.3.0"
+
+package:
+  name: libdisplay-info
+  version: ${{ version }}
+
+source:
+  url: https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/${{ version }}/libdisplay-info-${{ version }}.tar.gz
+  sha256: 2b467e3336aec63819d6aca28d7310d3dc7415b2b3a3c3a5aec9d3727053c078
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+  variant:
+    # python only runs a build-time code generator and is not linked against,
+    # so it must not turn this C library into a python-versioned build matrix.
+    ignore_keys:
+      - python
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+    # gen-search-table.py generates pnp-id-table.c at build time.
+    - python
+    # pnp.ids is resolved through pkg-config with `native: true` and is
+    # compiled into the library, so hwdata is a build (not host) dependency.
+    - hwdata
+  run_exports:
+    # soversion is set to the minor version, so the soname bumps on every
+    # minor release: 0.3.0 installs libdisplay-info.so.3.
+    - ${{ pin_subpackage('libdisplay-info', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - display-info
+      include:
+        - libdisplay-info/info.h
+      bin:
+        - di-edid-decode
+  - script:
+      - pkg-config --modversion libdisplay-info
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://gitlab.freedesktop.org/emersion/libdisplay-info
+  license: MIT
+  license_file: LICENSE
+  summary: EDID and DisplayID library
+  description: |
+    libdisplay-info is a library to parse EDID and DisplayID metadata, as used
+    to describe the capabilities of computer displays. It provides a
+    high-level API on top of low-level parsing of the raw blobs, and is used
+    by Wayland compositors to identify monitors and their supported modes.
+  documentation: https://gitlab.freedesktop.org/emersion/libdisplay-info
+  repository: https://gitlab.freedesktop.org/emersion/libdisplay-info
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/libinput/build.sh
+++ b/recipes/libinput/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# ${MESON_ARGS} carries --prefix, -Dlibdir=lib, -Dbuildtype=release and, when
+# cross compiling, --cross-file. -Dlibdir=lib matters here: meson would
+# otherwise guess lib64 on the AlmaLinux build image and emit a libinput.pc
+# pointing at a directory conda does not use.
+#
+# lua-plugins is `auto`, so it is pinned explicitly to keep the build from
+# silently gaining a lua dependency if lua ever appears in the host env.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Ddocumentation=false \
+  -Dtests=false \
+  -Ddebug-gui=false \
+  -Dlibwacom=false \
+  -Dinstall-tests=false \
+  -Dlua-plugins=disabled \
+  -Dudev-dir="${PREFIX}/lib/udev" \
+  -Dzshcompletiondir=no
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/libinput/conda-forge.yml
+++ b/recipes/libinput/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/libinput/recipe.yaml
+++ b/recipes/libinput/recipe.yaml
@@ -1,0 +1,75 @@
+schema_version: 1
+
+context:
+  version: "1.31.3"
+
+package:
+  name: libinput
+  version: ${{ version }}
+
+source:
+  # Upstream stopped publishing release tarballs after 1.19.x and now ships
+  # signed git tags only, so the GitLab archive of the tag is the only tarball.
+  url: https://gitlab.freedesktop.org/libinput/libinput/-/archive/${{ version }}/libinput-${{ version }}.tar.gz
+  sha256: b6749bf6f1890f6631c0a70a027c35fec9d2e096a39f720548896e41474a9854
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+  host:
+    - libudev
+    - libevdev
+    - mtdev
+  run_exports:
+    # libinput installs libinput.so.10. The soname is decoupled from the
+    # release version and has been 10 since libinput 1.0; upstream bumps the
+    # libtool current/age fields together so that current-age stays at 10 for
+    # ABI compatible additions.
+    - ${{ pin_subpackage('libinput', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - input
+      include:
+        - libinput.h
+      bin:
+        - libinput
+  - script:
+      - pkg-config --atleast-version=1.2.0 libinput
+      - libinput --help
+    requirements:
+      run:
+        - pkg-config
+        # libinput.pc has Requires.private: libudev, which pkg-config resolves.
+        - libudev
+
+about:
+  homepage: https://gitlab.freedesktop.org/libinput/libinput
+  license: MIT
+  # COPYING also explains why the bundled (but not installed) GPL-2.0 kernel
+  # input headers do not affect libinput's own licensing.
+  license_file: COPYING
+  summary: Input device library for Wayland compositors and X.Org
+  description: |
+    libinput is a library that handles input devices for display servers and
+    other applications that need to directly deal with input devices. It
+    provides device detection, device handling, input device event processing
+    and abstraction to minimize the amount of custom input code needed by
+    compositors.
+  documentation: https://wayland.freedesktop.org/libinput/doc/latest/
+  repository: https://gitlab.freedesktop.org/libinput/libinput
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/mtdev/build.sh
+++ b/recipes/mtdev/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+./configure \
+  --prefix="${PREFIX}" \
+  --libdir="${PREFIX}/lib" \
+  --build="${BUILD}" \
+  --host="${HOST}" \
+  --disable-static \
+  --disable-dependency-tracking
+
+make -j"${CPU_COUNT}"
+make install -j"${CPU_COUNT}"
+
+# conda-forge does not ship libtool archives; they hardcode build paths.
+rm -f "${PREFIX}"/lib/*.la

--- a/recipes/mtdev/conda-forge.yml
+++ b/recipes/mtdev/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/mtdev/recipe.yaml
+++ b/recipes/mtdev/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: "1.1.7"
+
+package:
+  name: mtdev
+  version: ${{ version }}
+
+source:
+  url: http://bitmath.org/code/mtdev/mtdev-${{ version }}.tar.bz2
+  sha256: a107adad2101fecac54ac7f9f0e0a0dd155d954193da55c2340c97f2ff1d814e
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - make
+  run_exports:
+    # mtdev installs libmtdev.so.1; the soname tracks the libtool
+    # `current - age` field, so pinning on the major version is enough.
+    - ${{ pin_subpackage('mtdev', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - mtdev
+      include:
+        - mtdev.h
+  - script:
+      - pkg-config --modversion mtdev
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: http://bitmath.org/code/mtdev/
+  license: MIT
+  license_file: COPYING
+  summary: Multitouch Protocol Translation Library
+  description: |
+    mtdev is a stand-alone library which transforms all variants of kernel
+    multitouch events to the slotted type B protocol. The events put into
+    mtdev may be from any MT device, specifically type A without contact
+    tracking, type A with contact tracking, or type B with contact tracking.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/neatvnc/build.sh
+++ b/recipes/neatvnc/build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# ${MESON_ARGS} comes from the compiler activation and already carries
+# --prefix, -Dlibdir=lib, -Dbuildtype=release, and --cross-file when cross
+# compiling, so it must be passed through verbatim.
+#
+# Enabled features for a fully featured VNC backend:
+#   tls     -> gnutls: VeNCrypt encryption and authentication
+#   nettle  -> RSA-AES / DES / Apple-DH authentication and WebSocket transport
+# zlib and pixman are always required; libdrm headers are always pulled for
+# dmabuf pixel formats. jpeg, gbm and h264 are disabled: they are not needed by
+# Weston's VNC backend and would drag in turbojpeg/mesa/ffmpeg.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Dtls=enabled \
+  -Dnettle=enabled \
+  -Djpeg=disabled \
+  -Dgbm=disabled \
+  -Dh264=disabled \
+  -Dtests=false \
+  -Dexamples=false \
+  -Dbenchmarks=false
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/neatvnc/conda-forge.yml
+++ b/recipes/neatvnc/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/neatvnc/conda_build_config.yaml
+++ b/recipes/neatvnc/conda_build_config.yaml
@@ -1,0 +1,8 @@
+# Enabling nettle turns on the crypto code, which meson only accepts if a
+# random-number source is available. On the default sysroot (glibc 2.17) neither
+# getrandom() (needs sys/random.h from glibc 2.25) nor arc4random_buf() (glibc
+# 2.36) exists, so meson aborts with "No random generator available". The 2.34
+# sysroot provides getrandom(), which raises the runtime glibc floor to 2.34 --
+# the same floor Weston itself already requires.
+c_stdlib_version:   # [linux]
+  - "2.34"          # [linux]

--- a/recipes/neatvnc/recipe.yaml
+++ b/recipes/neatvnc/recipe.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+
+context:
+  version: "1.0.1"
+
+package:
+  name: neatvnc
+  version: ${{ version }}
+
+source:
+  url: https://github.com/any1/neatvnc/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: c37678fb1f9bbb8bd0932eb6dbd68bf10e937777c376c6c278ed37510b2cbd4b
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+  host:
+    - aml
+    - pixman
+    - zlib
+    # gnutls provides TLS (VeNCrypt encryption & authentication).
+    - gnutls
+    # nettle (with hogweed and gmp) enables the RSA-AES auth path, DES/Apple-DH
+    # authentication and the WebSocket transport.
+    - nettle
+    - gmp
+    # libdrm's headers are pulled unconditionally for dmabuf pixel formats.
+    - libdrm
+  run_exports:
+    # library(version: '1.0.1') installs libneatvnc.so.1: the soname tracks
+    # only the major version, so pin on the major.
+    - ${{ pin_subpackage('neatvnc', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - neatvnc
+      include:
+        - neatvnc.h
+  - script:
+      - pkg-config --modversion neatvnc
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://github.com/any1/neatvnc
+  license: ISC
+  license_file: COPYING
+  summary: A neat VNC server library
+  description: |
+    Neat VNC is a liberally licensed VNC server library written in C. It is
+    designed to be easy to use and integrate into applications, supports TLS
+    encryption, RSA-AES and VeNCrypt authentication, the Tight and ZRLE
+    encodings and dmabuf-backed framebuffers. It provides the VNC backend
+    used by Weston and wayvnc.
+  repository: https://github.com/any1/neatvnc
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/pipewire/build.sh
+++ b/recipes/pipewire/build.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Minimal PipeWire build: only the core client library (libpipewire-0.3) and
+# the SPA plugin API headers (libspa-0.2) are needed so that Weston's
+# backend-pipewire can be enabled. Everything that pulls a heavy or unpackaged
+# dependency, plus every session manager, example, test, doc and man page, is
+# turned off. dbus is kept because it is a genuine core dependency (the
+# spa-support dbus plugin), and it is available on conda-forge.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Dwerror=false \
+  -Ddocs=disabled \
+  -Dman=disabled \
+  -Dexamples=disabled \
+  -Dtests=disabled \
+  -Dinstalled_tests=disabled \
+  -Ddbus=enabled \
+  -Dpipewire-alsa=disabled \
+  -Dpipewire-jack=disabled \
+  -Dpipewire-v4l2=disabled \
+  -Djack=disabled \
+  -Djack-devel=false \
+  -Dalsa=disabled \
+  -Dbluez5=disabled \
+  -Dgstreamer=disabled \
+  -Dgstreamer-device-provider=disabled \
+  -Dffmpeg=disabled \
+  -Dpw-cat=disabled \
+  -Dpw-cat-ffmpeg=disabled \
+  -Dv4l2=disabled \
+  -Dlibcamera=disabled \
+  -Dvulkan=disabled \
+  -Dsdl2=disabled \
+  -Dsndfile=disabled \
+  -Dlibmysofa=disabled \
+  -Dlibpulse=disabled \
+  -Droc=disabled \
+  -Davahi=disabled \
+  -Decho-cancel-webrtc=disabled \
+  -Dlibusb=disabled \
+  -Dopus=disabled \
+  -Dfftw=disabled \
+  -Debur128=disabled \
+  -Dreadline=disabled \
+  -Dx11=disabled \
+  -Dx11-xfixes=disabled \
+  -Dlibcanberra=disabled \
+  -Draop=disabled \
+  -Dlv2=disabled \
+  -Davb=disabled \
+  -Dsnap=disabled \
+  -Dselinux=disabled \
+  -Dlibsystemd=disabled \
+  -Dlogind=disabled \
+  -Dsystemd-system-service=disabled \
+  -Dsystemd-user-service=disabled \
+  -Dflatpak=disabled \
+  -Dgsettings=disabled \
+  -Dgsettings-pulse-schema=disabled \
+  -Dlibffado=disabled \
+  -Dcompress-offload=disabled \
+  -Donnxruntime=disabled \
+  -Dudev=disabled \
+  -Dsession-managers=[]
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir
+
+# Ship dynamic libraries only; drop any libtool archives if present.
+rm -f "${PREFIX}"/lib/*.la

--- a/recipes/pipewire/conda-forge.yml
+++ b/recipes/pipewire/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/pipewire/recipe.yaml
+++ b/recipes/pipewire/recipe.yaml
@@ -1,0 +1,73 @@
+schema_version: 1
+
+context:
+  version: "1.6.8"
+
+package:
+  name: pipewire
+  version: ${{ version }}
+
+source:
+  url: https://gitlab.freedesktop.org/pipewire/pipewire/-/archive/${{ version }}/pipewire-${{ version }}.tar.gz
+  sha256: 8181172a1d95131f6af8bbc0b98f90b2a33349b042b84c3ce57dd5d11348cc58
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+    # i18n.gettext() in po/meson.build needs msgfmt to compile translations.
+    - gettext
+  host:
+    # dbus is the only genuine external dependency of this minimal build: the
+    # spa-support dbus plugin links libdbus-1. libpipewire-0.3 itself only
+    # needs libc, libdl, libm, libpthread and libatomic.
+    - dbus
+  run_exports:
+    # Installs libpipewire-0.3.so.0 (soversion 0). The "0.3" ABI marker in the
+    # library name is kept stable across the whole 1.x series -- only additive
+    # changes -- so a consumer built against 1.6.x keeps working with later
+    # 1.x. Bound at the next major to be safe.
+    - ${{ pin_subpackage('pipewire', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - pipewire-0.3
+  - script:
+      - pkg-config --modversion libpipewire-0.3
+      - pkg-config --modversion libspa-0.2
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://pipewire.org
+  license: MIT
+  license_file: COPYING
+  summary: Server and user space API to deal with multimedia pipelines
+  description: |
+    PipeWire is a server and user space API to deal with multimedia pipelines.
+    It provides a low-latency, graph-based processing engine on top of audio
+    and video devices that can be used to support the use cases currently
+    handled by both PulseAudio and JACK.
+
+    This is a minimal build providing only the core client library
+    (libpipewire-0.3) and the SPA plugin API headers (libspa-0.2), which is
+    what Weston's backend-pipewire links against. The session managers,
+    ALSA/JACK/V4L2 integrations, bluez5, gstreamer, ffmpeg and pulse support
+    are all disabled to keep the dependency footprint small.
+  repository: https://gitlab.freedesktop.org/pipewire/pipewire
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/seatd/build.sh
+++ b/recipes/seatd/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Upstream defaults to werror=true, which is not appropriate for a
+# distribution build.
+#
+# libseat-logind defaults to `auto`, which would silently vary with whatever
+# happens to be in the host environment, so both backends are pinned
+# explicitly. man-pages is disabled to avoid the scdoc build dependency.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Dwerror=false \
+  -Dlibseat-logind=systemd \
+  -Dlibseat-seatd=enabled \
+  -Dlibseat-builtin=disabled \
+  -Dserver=enabled \
+  -Dexamples=disabled \
+  -Dman-pages=disabled
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/seatd/conda-forge.yml
+++ b/recipes/seatd/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/seatd/patches/0001-define-EVIOCREVOKE-when-the-kernel-headers-predate-it.patch
+++ b/recipes/seatd/patches/0001-define-EVIOCREVOKE-when-the-kernel-headers-predate-it.patch
@@ -1,0 +1,24 @@
+From: conda-forge
+Subject: [PATCH] Define EVIOCREVOKE when the kernel headers predate it
+
+conda-forge builds against the default sysroot, whose kernel headers are
+older than Linux 3.12 and therefore do not define EVIOCREVOKE. The ioctl
+number is part of the stable kernel UAPI, so defining it when absent is safe
+and lets the seatd server build; on kernels that lack the ioctl the call
+simply fails with ENOTTY at runtime, which is already handled.
+
+--- a/common/evdev.c
++++ b/common/evdev.c
+@@ -13,6 +13,12 @@
+
+ #include "evdev.h"
+
++/* Added in Linux 3.12; may be missing from older kernel headers. */
++#if defined(__linux__) && !defined(EVIOCREVOKE)
++#include <linux/ioctl.h>
++#define EVIOCREVOKE _IOW('E', 0x91, int)
++#endif
++
+ #define STRLEN(s) ((sizeof(s) / sizeof(s[0])) - 1)
+
+ #if defined(__linux__) || defined(__FreeBSD__)

--- a/recipes/seatd/recipe.yaml
+++ b/recipes/seatd/recipe.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+
+context:
+  version: "0.9.3"
+
+package:
+  name: seatd
+  version: ${{ version }}
+
+source:
+  url: https://git.sr.ht/~kennylevinsen/seatd/archive/${{ version }}.tar.gz
+  sha256: 302564d54d8e28191fadfd734f2675ecb0c9e0615a58011b89ef15dfa4dbaa96
+  patches:
+    - patches/0001-define-EVIOCREVOKE-when-the-kernel-headers-predate-it.patch
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+  host:
+    - libsystemd
+  run_exports:
+    # Installs libseat.so.1. The soname is hardcoded to 1 and does not track
+    # the release version, so pin on the minor while seatd is still 0.x.
+    - ${{ pin_subpackage('seatd', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - seat
+      include:
+        - libseat.h
+      bin:
+        - seatd
+  - script:
+      - pkg-config --atleast-version=0.4 libseat
+      # Both backends must be compiled in, or libseat cannot open a session.
+      - test "$(pkg-config --variable=have_seatd libseat)" = "true"
+      - test "$(pkg-config --variable=have_logind libseat)" = "true"
+    requirements:
+      run:
+        - pkg-config
+        - libsystemd
+
+about:
+  homepage: https://git.sr.ht/~kennylevinsen/seatd
+  license: MIT
+  license_file: LICENSE
+  summary: Seat management daemon and libseat, a universal seat management library
+  description: |
+    seatd is a minimal seat management daemon, and libseat is a universal seat
+    management library allowing applications to use whatever seat management
+    is available.
+
+    Seat management takes care of mediating access to shared devices such as
+    graphics and input devices, without requiring the applications using them
+    to run as root.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/weston/build.sh
+++ b/recipes/weston/build.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# protocol/meson.build does `dependency('wayland-scanner', native: true)` and
+# then runs the binary named by the .pc file's wayland_scanner variable. That
+# variable resolves inside the prefix the .pc file came from, so a host-prefix
+# hit would hand meson a target-architecture binary that cannot execute on the
+# build machine. Meson reads the *_FOR_BUILD variables for the build machine,
+# so point them at $BUILD_PREFIX, where the `wayland` build dependency lives.
+export PKG_CONFIG_PATH_FOR_BUILD="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig"
+
+# The vulkan renderer compiles its GLSL shaders to SPIR-V at build time with
+# glslangValidator, which meson resolves from PATH and runs on the build
+# machine, so glslang is a build (not host) dependency.
+
+# Disabled features and why:
+#   deprecated-remoting  upstream-deprecated gstreamer remoting plugin,
+#                        superseded by the pipewire backend
+#   deprecated-pipewire  upstream-deprecated pipewire plugin, superseded by
+#                        the pipewire backend
+#   (nothing else: every backend, both renderers and every shell are enabled)
+# --wrap-mode=nodownload keeps meson from fetching the bundled aml, neatvnc,
+# display-info and perfetto subprojects over the network.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Dbackend-drm=true \
+  -Dbackend-headless=true \
+  -Dbackend-wayland=true \
+  -Dbackend-x11=true \
+  -Dbackend-rdp=true \
+  -Dbackend-vnc=true \
+  -Dbackend-pipewire=true \
+  -Dbackend-default=drm \
+  -Drenderer-gl=true \
+  -Drenderer-vulkan=true \
+  -Dxwayland=true \
+  -Dxwayland-path="${PREFIX}/bin/Xwayland" \
+  -Dsystemd=true \
+  -Dshell-desktop=true \
+  -Dshell-ivi=true \
+  -Dshell-kiosk=true \
+  -Dshell-lua=true \
+  -Dcolor-management-lcms=true \
+  -Dimage-jpeg=true \
+  -Dimage-webp=true \
+  -Ddemo-clients=true \
+  -Dsimple-clients=all \
+  -Dtools=calibrator,debug,info,terminal,touch-calibrator \
+  -Ddeprecated-remoting=false \
+  -Ddeprecated-pipewire=false \
+  -Dtests=false \
+  -Dtest-junit-xml=false \
+  -Ddoc=false
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/weston/conda-forge.yml
+++ b/recipes/weston/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/weston/conda_build_config.yaml
+++ b/recipes/weston/conda_build_config.yaml
@@ -1,0 +1,13 @@
+# Weston 16 needs kernel UAPI headers newer than conda-forge's default sysroot
+# (glibc 2.17 / CentOS 7 era, kernel 3.10) provides. shared/client-buffer-util.c
+# includes both of:
+#
+#   linux/dma-buf.h   (Linux 4.6)
+#   linux/udmabuf.h   (Linux 4.20, so the 2.28 sysroot's 4.18 headers are not
+#                      enough either)
+#
+# The 2.34 sysroot ships kernel 5.14 headers and has both. This raises weston's
+# runtime glibc floor to 2.34, which is reasonable for a compositor that needs a
+# modern kernel with DRM/KMS to be useful at all.
+c_stdlib_version:   # [linux]
+  - "2.34"          # [linux]

--- a/recipes/weston/recipe.yaml
+++ b/recipes/weston/recipe.yaml
@@ -1,0 +1,185 @@
+schema_version: 1
+
+context:
+  version: "16.0.0"
+
+package:
+  name: weston
+  version: ${{ version }}
+
+source:
+  url: https://gitlab.freedesktop.org/wayland/weston/-/releases/${{ version }}/downloads/weston-${{ version }}.tar.xz
+  sha256: dfb32e2bccabda957b94a8d0ec6075acd18c71c87ebc543ee3e618d294ca0f7f
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+  dynamic_linking:
+    missing_dso_allowlist:
+      # libpam is only linked through pam-stubs, whose stub lives in lib/stubs
+      # (off the runtime path), so the NEEDED libpam.so.0 on libweston-16.so has
+      # no conda provider and is treated as a missing DSO; allowlist it and let
+      # the SYSTEM pam resolve it at runtime.
+      #
+      # The soft rdp/vnc/pipewire backend libraries (freerdp/neatvnc/aml/
+      # pipewire) do NOT need to be listed here: they are present in host, so
+      # linking them from the backend modules is flagged as overlinking, which
+      # is a non-fatal warning in the rattler-build path, not a missing DSO.
+      - libpam.so.0
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+    # wayland-scanner has to run on the build machine, so wayland is needed
+    # in build as well as in host. See build.sh.
+    - wayland
+    # Provides glslangValidator, which compiles the vulkan renderer's shaders
+    # to SPIR-V on the build machine.
+    - glslang
+  host:
+    - wayland
+    - wayland-protocols
+    - pixman
+    - libxkbcommon
+    - libinput
+    - libevdev
+    - libdrm
+    - seatd
+    - libdisplay-info
+    - libudev
+    - libsystemd
+    - cairo
+    - libpng
+    - lcms2
+    - libjpeg-turbo
+    - libwebp
+    - libegl-devel
+    - libgles-devel
+    - libgbm
+    # The vulkan renderer needs both: libvulkan-loader ships vulkan.pc and
+    # libvulkan.so.1 but no headers at all, despite its .pc advertising
+    # -I${includedir}.
+    - libvulkan-headers
+    - libvulkan-loader
+    - libxcb
+    - xorg-libx11
+    # xwayland support needs xcursor and cairo-xcb at build time, and reads
+    # have_listenfd out of Xwayland's own xwayland.pc.
+    - xorg-libxcursor
+    - xwayland
+    # lua-shell. conda-forge's lua ships lua.pc, and 5.5 satisfies weston's
+    # `lua >= 5.4`.
+    - lua
+    - pango
+    # gobject-2.0 is used directly by the demo clients. This has to be `glib`
+    # rather than `libglib`: glib-2.0.pc advertises -I${libdir}/glib-2.0/include
+    # but glibconfig.h itself only ships in `glib`.
+    - glib
+    # Not used directly, but cairo.pc and libpng.pc name zlib and (via
+    # fontconfig) expat under Requires.private, and pkg-config has to resolve
+    # those before it will emit cflags for cairo/libpng/pango.
+    - zlib
+    - expat
+    # vnc/rdp/pipewire backends are built here (needed at build time to link
+    # the backend modules) but are OPTIONAL at runtime -- see run_constraints
+    # and ignore_run_exports below. Each backend is a separate dlopen'd module,
+    # so a plain `weston` install stays light and only pulls these heavy trees
+    # (freerdp -> openssl/json-c/icu, neatvnc -> gnutls/nettle, pipewire -> dbus)
+    # when the user opts into that backend.
+    # pam-stubs provides a link-only libpam.so stub so vnc-backend.so resolves
+    # at build time; the system pam takes over at runtime (see
+    # missing_dso_allowlist), so it is host-only and absent from run.
+    - neatvnc      # vnc backend (pulls aml)
+    - aml
+    - pam-stubs
+    - freerdp      # rdp backend
+    - pipewire     # pipewire backend
+  ignore_run_exports:
+    # Do not let the backend libraries' run_exports turn into hard runtime
+    # dependencies of the base weston package; they are declared as soft
+    # run_constraints instead.
+    by_name:
+      - neatvnc
+      - aml
+      - freerdp
+      - pipewire
+  run_constraints:
+    # weston execs Xwayland at the path baked in by -Dxwayland-path rather than
+    # linking to it (xwayland ships no shared library at all, so there is no
+    # run_export either). X11 support is only needed if it is actually used, so
+    # this is a constraint rather than a dependency -- a headless weston does
+    # not pull in an X server. It still has to be pinned: weston reads
+    # have_listenfd and friends out of xwayland.pc at build time and bakes the
+    # result into libexec_weston, so a mismatched Xwayland would misbehave.
+    - ${{ pin_compatible('xwayland') }}
+    # Optional backend dependencies. Not installed with weston, but if the user
+    # adds them (to enable that backend's dlopen'd module) they are pinned to a
+    # compatible version. neatvnc pulls aml via its own run_export, but aml is
+    # constrained too since vnc-backend.so links it directly.
+    - ${{ pin_compatible('neatvnc') }}
+    - ${{ pin_compatible('aml') }}
+    - ${{ pin_compatible('freerdp') }}
+    - ${{ pin_compatible('pipewire') }}
+
+tests:
+  - package_contents:
+      bin:
+        - weston
+        - weston-terminal
+        - weston-screenshooter
+      files:
+        - lib/libweston-16.so.0
+        - lib/libweston-16/drm-backend.so
+        - lib/libweston-16/headless-backend.so
+        - lib/libweston-16/wayland-backend.so
+        - lib/libweston-16/x11-backend.so
+        - lib/libweston-16/rdp-backend.so
+        - lib/libweston-16/vnc-backend.so
+        - lib/libweston-16/pipewire-backend.so
+        - lib/libweston-16/gl-renderer.so
+        - lib/libweston-16/vulkan-renderer.so
+        - lib/weston/desktop-shell.so
+        - lib/weston/lua-shell.so
+  - script:
+      - weston --version
+      - pkg-config --modversion libweston-16
+      # The baked-in Xwayland path must resolve to the packaged Xwayland.
+      - grep -q "${PREFIX}/bin/Xwayland" ${PREFIX}/lib/weston/libexec_weston.so.0.0.0
+    requirements:
+      run:
+        - pkg-config
+        - libegl-devel
+        - xwayland
+
+about:
+  homepage: https://wayland.freedesktop.org
+  license: MIT
+  license_file: COPYING
+  summary: The reference implementation of a Wayland compositor
+  description: |
+    Weston is the reference implementation of a Wayland compositor, and a
+    useful compositor in its own right. It has various backends that let it
+    run on Linux kernel modesetting and evdev input as well as nested under
+    another Wayland or X11 compositor, or headless for testing.
+
+    This build enables all seven backends (drm, headless, wayland, x11, rdp,
+    vnc and pipewire), the GL, Vulkan and pixman renderers, XWayland support,
+    and the desktop, ivi, kiosk and lua shells.
+
+    The rdp, vnc and pipewire backends are optional at runtime to keep a base
+    install light: install `freerdp` for the RDP backend, `neatvnc` for the
+    VNC backend, or `pipewire` for the PipeWire backend. The compositor and its
+    other backends work without them.
+  documentation: https://wayland.pages.freedesktop.org/weston/
+  repository: https://gitlab.freedesktop.org/wayland/weston
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/xwayland/build.sh
+++ b/recipes/xwayland/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Xwayland runs wayland-scanner for its protocol bindings, and meson resolves
+# it for the build machine. The .pc file points at a binary inside its own
+# prefix, so a host-prefix hit would hand meson a target-architecture binary.
+# Meson reads the *_FOR_BUILD variables for the build machine, so point them at
+# $BUILD_PREFIX, where the `wayland` build dependency lives.
+export PKG_CONFIG_PATH_FOR_BUILD="${BUILD_PREFIX}/lib/pkgconfig:${BUILD_PREFIX}/share/pkgconfig"
+
+# This tarball is Xwayland-only, so there are no -Dxorg/-Dxnest/-Dxephyr
+# options to turn off (passing them is a hard error). Xvfb is the exception:
+# it defaults to true and belongs to the xorg-server, not here.
+#
+# Disabled features and why:
+#   glx          needs dri.pc / dri_interface.h, which no conda-forge package
+#                ships since modern mesa dropped them. X11 clients under
+#                Xwayland therefore fall back to software GL.
+#   secure-rpc   would need libtirpc; SUN-DES-1 auth is useless for Xwayland
+#   xdmcp        Xwayland is not an XDMCP display
+#   xwayland_ei  libei is not packaged on conda-forge
+#
+# xkb_dir/xkb_bin_dir are left at their defaults: xkbcomp.pc already exports
+# xkbconfigdir and bindir inside $PREFIX, and meson.build prefers those.
+meson setup builddir \
+  ${MESON_ARGS} \
+  --wrap-mode=nodownload \
+  -Dxvfb=false \
+  -Dglamor=true \
+  -Ddri3=true \
+  -Dglx=false \
+  -Dsecure-rpc=false \
+  -Dxdmcp=false \
+  -Dxdm-auth-1=false \
+  -Dxwayland_ei=false \
+  -Dlibunwind=false \
+  -Dsha1=libnettle \
+  -Ddocs=false \
+  -Ddevel-docs=false
+
+meson compile -C builddir -j "${CPU_COUNT}" -v
+meson install -C builddir

--- a/recipes/xwayland/conda-forge.yml
+++ b/recipes/xwayland/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/xwayland/recipe.yaml
+++ b/recipes/xwayland/recipe.yaml
@@ -1,0 +1,86 @@
+schema_version: 1
+
+context:
+  version: "24.1.13"
+
+package:
+  name: xwayland
+  version: ${{ version }}
+
+source:
+  url: https://www.x.org/releases/individual/xserver/xwayland-${{ version }}.tar.xz
+  sha256: 173aea3d6f79609164c04528e1c8e4c9b60fcd59391c3c9dad4667297d727fb6
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+    # wayland-scanner has to run on the build machine. See build.sh.
+    - wayland
+  host:
+    - wayland
+    - wayland-protocols
+    - xorg-xorgproto
+    - xorg-libxcvt
+    - xorg-libx11
+    - xorg-libxau
+    - xorg-libxdmcp
+    - xorg-libxshmfence
+    - xorg-xtrans
+    - libxkbfile
+    - libxfont2
+    - libfontenc
+    - libxkbcommon
+    - libdrm
+    - pixman
+    - epoxy
+    - libgbm
+    - libegl-devel
+    - nettle
+    - xkbcomp
+  run:
+    # Xwayland shells out to xkbcomp to compile keymaps at runtime, and reads
+    # the keyboard data from xkeyboard-config.
+    - xkbcomp
+    - xkeyboard-config
+
+tests:
+  - package_contents:
+      bin:
+        - Xwayland
+  - script:
+      - Xwayland -version
+      - pkg-config --modversion xwayland
+      # weston reads the Xwayland path out of xwayland.pc.
+      - test "$(pkg-config --variable=xwayland xwayland)" = "${PREFIX}/bin/Xwayland"
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://www.x.org
+  license: MIT
+  license_file: COPYING
+  summary: Run X11 clients under a Wayland compositor
+  description: |
+    Xwayland is an X server that runs as a Wayland client, allowing X11
+    applications to display on a Wayland compositor without modification.
+
+    It is built here with glamor and DRI3 enabled. GLX is disabled because
+    conda-forge ships no dri.pc / dri_interface.h, so X11 clients under
+    Xwayland use software GL rather than hardware accelerated GLX.
+  documentation: https://wayland.freedesktop.org/xserver.html
+  repository: https://gitlab.freedesktop.org/xorg/xserver
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk


### PR DESCRIPTION
> **Stacked on #34232 (pam-stubs).** That recipe is the base commit of this branch and is proposed separately for focused review. This PR is the full Weston compositor stack on top of it; once #34232 merges, this PR's remaining diff is just the compositor and its other dependencies.

This adds [Weston](https://gitlab.freedesktop.org/wayland/weston) 16.0.0, the reference Wayland compositor, together with the dependency stack it needs. None of these packages exist on conda-forge today.

Weston is useful on conda-forge as a headless compositor for testing GUI/Wayland code in CI, and as a real compositor in its own right.

### Recipes added

Built in this order (resolved automatically from the dependencies):

| recipe | version | why |
| --- | --- | --- |
| `hwdata` | 0.409 | `noarch: generic`; supplies `pnp.ids` to libdisplay-info |
| `mtdev` | 1.1.7 | libinput dependency |
| `libevdev` | 1.13.6 | libinput + weston dependency |
| `libinput` | 1.31.3 | weston dependency (unconditional) |
| `seatd` | 0.9.3 | provides `libseat`, needed by the drm backend |
| `libdisplay-info` | 0.3.0 | weston dependency (unconditional) |
| `xwayland` | 24.1.13 | X11 clients under weston |
| `aml` | 1.0.0 | neatvnc's event loop |
| `neatvnc` | 1.0.1 | weston `backend-vnc` |
| `pam-stubs` | 1.7.2 | link-time PAM for `backend-vnc` (see below) |
| `freerdp` | 3.30.0 | weston `backend-rdp` (server libs) |
| `pipewire` | 1.6.8 | weston `backend-pipewire` |
| `weston` | 16.0.0 | the compositor |

All are v1 (`recipe.yaml`) recipes. Everything is dynamically linked and no static libraries are shipped (the weston package contains 0 `.a` files and 17 shared objects).

### Enabled / disabled weston features

Enabled: **all seven backends** — drm, headless, wayland, x11, **rdp, vnc, pipewire**; GL, Vulkan and pixman renderers; XWayland; desktop/ivi/kiosk/lua shells; lcms colour management; jpeg + webp; demo clients; all `simple-clients`; the `calibrator`/`debug`/`info`/`terminal`/`touch-calibrator` tools.

Disabled: only `deprecated-remoting` and `deprecated-pipewire`, which are marked deprecated upstream and superseded by `backend-pipewire`. Every non-deprecated feature weston offers is on.

`--wrap-mode=nodownload` is set so meson cannot fetch the bundled `aml`, `neatvnc`, `display-info` and `perfetto` subprojects over the network.

### aarch64 / ppc64le

Each recipe carries a `conda-forge.yml` requesting `linux_aarch64` and `linux_ppc64le` cross-compiled from `linux_64`, so the extra architectures build as soon as the feedstocks are created. (`build_platform` is what actually selects cross-compilation — `provider` alone gives emulated builds.)

Every existing dependency is available on all three platforms. In particular ppc64le is fine despite lagging: weston needs `pixman >= 0.25.2` and `libudev >= 136`, and ppc64le has pixman 0.44.2 and libudev 257.7.

Two cross-compilation details worth review attention:

- **weston**: `protocol/meson.build` does `dependency('wayland-scanner', native: true)` and then executes the binary named by the `.pc` file's `wayland_scanner` variable. That variable resolves inside whichever prefix the `.pc` came from, so a host-prefix hit would hand meson a target-architecture binary. `wayland` is therefore in `build:` as well as `host:`, and `build.sh` sets `PKG_CONFIG_PATH_FOR_BUILD` (which meson reads for the build machine) to `$BUILD_PREFIX`.
- **libdisplay-info**: resolves `hwdata` with `native: true` to find `pnp.ids`, which is compiled into the library, so `hwdata` is a `build:` dependency. Upstream marks the dependency `required: false` but then falls back to a hardcoded `/usr/share/hwdata/pnp.ids`; `build.sh` greps the meson log so a miss fails loudly rather than silently baking in data from the build image.

### Xwayland

Built with glamor and DRI3. **GLX is disabled**: `glx` requires `dri.pc` and `GL/internal/dri_interface.h`, and conda-forge ships neither — nor any `*_dri.so` driver modules for the resulting `DRI_DRIVER_PATH` to point at (mesalib explicitly disables egl/gbm/gles/glx). Vendoring the header would only make GLX compile and then bake in a path to an empty directory, so it is left off. glamor still gives Xwayland accelerated 2D through EGL via libglvnd; only the GLX extension for X11 OpenGL clients is missing. The real fix belongs in mesalib.

### Optional backends (soft dependencies)

The rdp, vnc and pipewire backends are separate `dlopen`'d modules, and each heavy library is isolated to exactly one module (`freerdp`/`winpr` → `rdp-backend.so`, `neatvnc`/`aml` → `vnc-backend.so`, `pipewire` → `pipewire-backend.so`). So the base compositor loads and runs without them, and a plain `weston` install stays light rather than pulling freerdp (openssl/json-c/icu), neatvnc (gnutls/nettle), aml and pipewire (dbus).

They are therefore soft: `ignore_run_exports` stops their run_exports becoming hard deps, they are declared as `run_constraints` (pinned if the user installs them, not installed by default), and the backend modules' now-dangling `NEEDED` entries are allowlisted via `build.dynamic_linking.missing_dso_allowlist` (the same mechanism as the PAM stub). To enable a backend, `conda install freerdp` / `neatvnc` / `pipewire`. Verified on the built package: `freerdp`/`neatvnc`/`aml`/`pipewire` are absent from weston's `run` deps and present under `constrains`, while all three backend modules still ship.

### The PAM stub (`pam-stubs`) — please read

weston's VNC backend links `-lpam`, but conda-forge deliberately ships no runtime PAM: authentication is a system concern driven by `/etc/pam.d`, and a conda `libpam.so.0` on the runtime search path would shadow the real one and break auth.

`pam-stubs` squares this with the same approach conda-forge's CUDA packages use for `libcuda.so` (`cuda-driver-dev` ships `lib/stubs/libcuda.so`):

- It ships the Linux-PAM public headers and a **link-time-only** stub `libpam.so.0` compiled from them, installed into `$PREFIX/lib/stubs/` — **never** `$PREFIX/lib/`. The stub's exported symbols are version-tagged (`@LIBPAM_1.0` etc.) to match the real library.
- weston links against it via `pam.pc` (`-L${libdir}/stubs`), producing `libweston-16.so` with `NEEDED libpam.so.0` and undefined `pam_start/authenticate/acct_mgmt/end@LIBPAM_1.0`.
- Because nothing named `libpam` lives in `$PREFIX/lib`, the conda `$ORIGIN/../lib` rpath finds no libpam at runtime and the loader falls through to the **system** `/lib*/libpam.so.0`, whose symbol versions match.
- weston allowlists the dangling `libpam.so.0` via `build.dynamic_linking.missing_dso_allowlist` and keeps `pam-stubs` in `host` only — it is deliberately **absent from `run`**, so no conda package ever provides a runtime libpam.

`pam-stubs` has no `run_exports` and its test asserts `$PREFIX/lib/libpam.so*` does not exist. This is novel for conda-forge and security-adjacent, so I'm flagging it explicitly — happy to adjust naming or structure (e.g. a `pam` package with a stub-only output) if the team prefers. If a user's system lacks libpam, only weston's VNC-with-auth path is affected, which is inherent.

### Notes for reviewers

- **`weston` pins `c_stdlib_version` to 2.34.** `shared/client-buffer-util.c` includes `linux/dma-buf.h` (Linux 4.6) and `linux/udmabuf.h` (Linux 4.20), so neither the default 2.17 sysroot nor 2.28 is sufficient. This raises weston's glibc floor to 2.34, which seems reasonable for a compositor that needs a modern kernel with DRM/KMS anyway. Happy to reconsider if there's a preferred approach.
- **`freerdp`** builds the server libraries (`freerdp3` + `freerdp-server3` + `winpr3`) only — no client/GUI/SDL/ffmpeg. `WITH_KRB5=OFF` because conda-forge's `krb5` lacks `krb5_get_init_creds_opt_set_pac_request()` (which FreeRDP calls unconditionally); NTLM auth, which weston's RDP backend uses, still works.
- **`pipewire`** is a minimal client build (`libpipewire-0.3` + `libspa-0.2`, `dbus` the only external dep); session managers, ALSA/JACK/V4L2, bluez5, gstreamer and pulse are all disabled.
- **`neatvnc`** enables gnutls (TLS) and nettle (RSA-AES auth) for full VNC crypto, and needs `c_stdlib_version` 2.34 for `getrandom()` — the same floor weston already uses.
- **`seatd` carries one patch** defining `EVIOCREVOKE` (Linux 3.12) when the kernel headers predate it, so the daemon builds against the default sysroot without raising its glibc floor.
- `libinput` upstream stopped publishing release tarballs after 1.19.x and now ships signed git tags only, so the recipe uses the GitLab archive of the tag rather than a release asset.
- `seatd` is packaged as a single output providing both `libseat` and the `seatd`/`seatd-launch` binaries. Distros usually split `libseat` out; happy to split if preferred.
- `hwdata` is dual licensed `GPL-2.0-or-later OR XFree86-1.0`. SPDX only carries `XFree86-1.1`, hence `LicenseRef-XFree86-1.0`. The permissive option is what allows `pnp.ids` to be compiled into libdisplay-info's MIT licensed library.
- `libdisplay-info`'s soversion tracks its **minor** version (0.3.0 installs `libdisplay-info.so.3`), so its `run_exports` pins on `x.x`. Weston 16 requires `>= 0.2.0, < 0.4.0`, which that pin satisfies exactly.
- **`xwayland` is a `run_constraints` entry, not a dependency.** weston execs `$PREFIX/bin/Xwayland` at a baked-in path rather than linking to it — xwayland ships no shared library, so nothing has it as a `NEEDED` entry and there is no run_export either. A headless weston therefore does not pull in an X server (plus xkeyboard-config, xkbcomp, libxfont2, libfontenc, epoxy, nettle and assorted xorg-*). It is still pinned via `pin_compatible` (`xwayland >=24.1.13,<25.0a0`) because weston reads `have_listenfd` and friends out of `xwayland.pc` at build time and bakes the result into `libexec_weston`. Every other run dependency is an ELF `NEEDED` entry arriving via run_exports and stays hard.
- `weston` needs both `libvulkan-headers` and `libvulkan-loader`: the loader ships `vulkan.pc` and `libvulkan.so.1` but no headers at all, despite its `.pc` advertising `-I${includedir}`. Note the live header package is `libvulkan-headers` — the similarly named `vulkan-headers` is linux-64 only and stuck at 1.3.231.1.
- `weston` lists `zlib` and `expat` in `host:` even though it does not use them directly: `cairo.pc` and `libpng.pc` name them (via `fontconfig`) under `Requires.private`, and pkg-config will not emit cflags for cairo/pango until they resolve. It also needs `glib` rather than `libglib`, because `glibconfig.h` only ships in `glib`.

### Testing

The whole stack was built and tested on linux-64 in `quay.io/condaforge/linux-anvil-x86_64:alma9` via `.scripts/run_docker_build.sh` before opening this. `weston --version` reports 16.0.0 and `weston --help` advertises exactly the drm/headless/wayland/x11 backends. The weston package ships all 11 libweston modules including `vnc-backend.so` (→ `libneatvnc.so.1`, `libaml.so.1`), `rdp-backend.so` (→ `libfreerdp3/-server3/winpr3.so.3`), `pipewire-backend.so` (→ `libpipewire-0.3.so.0`), `vulkan-renderer.so`, `xwayland.so`, `lua-shell.so`, and 0 static libraries. `libweston-16.so` imports `pam_start/authenticate/acct_mgmt/end@LIBPAM_1.0` with no conda provider (system PAM at runtime). `drm-backend.so` links dynamically against `libinput.so.10`, `libseat.so.1`, `libdisplay-info.so.3`, `libgbm.so.1`, `libudev.so.1` and `libdrm.so.2`. `Xwayland -version` reports 24.1.13.

The extra architectures are not exercised by staged-recipes CI (it only builds linux-64/osx/win), so they will first build on the feedstocks.
