### PR TITLE
Add voiage v1.0.0

### DIFF
--- a/recipes/voiage/meta.yaml
+++ b/recipes/voiage/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "voiage" %}
 {% set version = "0.2.1" %}
+{% set python_min = "3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -18,13 +19,13 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python {{ python_min }}
     - pip
     - setuptools >=69
     - setuptools_scm >=8
     - wheel
   run:
-    - python >=3.10
+    - python >= {{ python_min }}
     - defusedxml >=0.7.1
     - numpy >=1.22,<3.0
     - scipy >=1.7,<1.17
@@ -34,7 +35,7 @@ requirements:
     - jax >=0.4.33,<0.8
     - scikit-learn >=1.0,<2.0
     - statsmodels >=0.13,<1.0
-    - matplotlib >=3.4,<4.0
+    - matplotlib-base >=3.4,<4.0
     - seaborn >=0.13.2,<1.0
     - psutil >=5.9,<8.0
     - typing_extensions >=4.0
@@ -49,6 +50,7 @@ test:
     - pip check
     - voiage --help
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/voiage/meta.yaml
+++ b/recipes/voiage/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "voiage" %}
 {% set version = "1.0.0" %}
+{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,25 +8,22 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2cc57db154953af26b98918069275de0bca1fc9ffd7b49ad5089f3da1a88e30b
+  sha256: UPDATE_ON_RELEASE
 
 build:
   number: 0
-  skip: true  # [py<312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - voiage = voiage.cli:main
 
 requirements:
-  build:
-    - {{ compiler('rust') }}
-    - {{ stdlib("c") }}
   host:
-    - python
+    - {{ compiler('rust') }}
+    - python {{ python_min }}
     - pip
     - maturin >=1.9,<2.0
   run:
-    - python
+    - python >= {{ python_min }}
     - click >=8.3.3,<9
     - numpy >=2.2.6,<3.0
     - scipy >=1.16.3,<1.17
@@ -46,9 +44,8 @@ test:
   commands:
     - pip check
     - voiage --help
-    - python -c "from voiage import _core"
   requires:
-    - python
+    - python {{ python_min }}
     - pip
 
 about:
@@ -68,4 +65,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - edithatogo
+    - doughnut

--- a/recipes/voiage/meta.yaml
+++ b/recipes/voiage/meta.yaml
@@ -1,0 +1,71 @@
+{% set name = "voiage" %}
+{% set version = "0.2.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: eedf952ffd1b0eae1e7aef8d17983f7da7f4dbf5d290796453c5e8e22b8dac5e
+
+build:
+  number: 0
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  entry_points:
+    - voiage = voiage.cli:main
+
+requirements:
+  host:
+    - python >=3.10
+    - pip
+    - setuptools >=69
+    - setuptools_scm >=8
+    - wheel
+  run:
+    - python >=3.10
+    - defusedxml >=0.7.1
+    - numpy >=1.22,<3.0
+    - scipy >=1.7,<1.17
+    - pandas >=1.3,<3.0
+    - xarray >=0.19,<2025.0
+    - numpyro >=0.14,<0.22
+    - jax >=0.4.33,<0.8
+    - scikit-learn >=1.0,<2.0
+    - statsmodels >=0.13,<1.0
+    - matplotlib >=3.4,<4.0
+    - seaborn >=0.13.2,<1.0
+    - psutil >=5.9,<8.0
+    - typing_extensions >=4.0
+    - typer >=0.9,<1.0
+
+test:
+  imports:
+    - voiage
+    - voiage.analysis
+    - voiage.schema
+  commands:
+    - pip check
+    - voiage --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/edithatogo/voiage
+  summary: A Python library for Value of Information analysis
+  description: |
+    voiage is a Python library for Value of Information (VOI) analysis, 
+    designed to provide a comprehensive, open-source toolkit for researchers 
+    and decision-makers. It implements core VOI methods including EVPI, EVPPI, 
+    and EVSI, as well as advanced methods for adaptive trial designs, network 
+    meta-analyses, and structural uncertainty.
+  dev_url: https://github.com/edithatogo/voiage
+  doc_url: https://edithatogo.github.io/voiage
+  license: Apache-2.0
+  license_file: LICENSE
+  license_family: Apache
+
+extra:
+  recipe-maintainers:
+    - doughnut

--- a/recipes/voiage/meta.yaml
+++ b/recipes/voiage/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "voiage" %}
-{% set version = "0.2.1" %}
-{% set python_min = "3.10" %}
+{% set version = "1.0.0" %}
+{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -8,37 +8,34 @@ package:
 
 source:
   url: https://files.pythonhosted.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: eedf952ffd1b0eae1e7aef8d17983f7da7f4dbf5d290796453c5e8e22b8dac5e
+  sha256: 2cc57db154953af26b98918069275de0bca1fc9ffd7b49ad5089f3da1a88e30b
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - voiage = voiage.cli:main
 
 requirements:
+  build:
+    - {{ compiler('rust') }}
+    - {{ stdlib("c") }}
   host:
     - python {{ python_min }}
     - pip
-    - setuptools >=69
-    - setuptools_scm >=8
-    - wheel
+    - maturin >=1.9,<2.0
   run:
-    - python >= {{ python_min }}
-    - defusedxml >=0.7.1
-    - numpy >=1.22,<3.0
-    - scipy >=1.7,<1.17
+    - python >={{ python_min }}
+    - click >=8.3.3,<9
+    - numpy >=2.2.6,<3.0
+    - scipy >=1.16.3,<1.17
     - pandas >=1.3,<3.0
     - xarray >=0.19,<2025.0
-    - numpyro >=0.14,<0.22
-    - jax >=0.4.33,<0.8
-    - scikit-learn >=1.0,<2.0
-    - statsmodels >=0.13,<1.0
-    - matplotlib-base >=3.4,<4.0
-    - seaborn >=0.13.2,<1.0
-    - psutil >=5.9,<8.0
-    - typing_extensions >=4.0
+    - scikit-learn >=1.7.2,<2.0
+    - pyarrow >=25.0.0,<26
+    - polars >=1.42.1,<2
+    - pydantic >=2.13.4,<3
+    - typing_extensions >=4.16.0
     - typer >=0.9,<1.0
 
 test:
@@ -49,6 +46,7 @@ test:
   commands:
     - pip check
     - voiage --help
+    - python -c "from voiage import _core"
   requires:
     - python {{ python_min }}
     - pip
@@ -70,4 +68,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - doughnut
+    - edithatogo

--- a/recipes/voiage/meta.yaml
+++ b/recipes/voiage/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "voiage" %}
 {% set version = "1.0.0" %}
-{% set python_min = "3.12" %}
 
 package:
   name: {{ name|lower }}
@@ -12,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: true  # [py<312]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - voiage = voiage.cli:main
@@ -21,11 +21,11 @@ requirements:
     - {{ compiler('rust') }}
     - {{ stdlib("c") }}
   host:
-    - python {{ python_min }}
+    - python
     - pip
     - maturin >=1.9,<2.0
   run:
-    - python >={{ python_min }}
+    - python
     - click >=8.3.3,<9
     - numpy >=2.2.6,<3.0
     - scipy >=1.16.3,<1.17
@@ -48,7 +48,7 @@ test:
     - voiage --help
     - python -c "from voiage import _core"
   requires:
-    - python {{ python_min }}
+    - python
     - pip
 
 about:


### PR DESCRIPTION
Update voiage to the signed v1.0.0 release.

- Source SHA256: 2cc57db154953af26b98918069275de0bca1fc9ffd7b49ad5089f3da1a88e30b
- Native Rust/PyO3 build with Python >=3.12.
- Recipe linted locally with conda-smithy.