### PR TITLE
Add recipe for gb-robot-models

### DIFF
--- a/recipes/gb-robot-models/build.bat
+++ b/recipes/gb-robot-models/build.bat
@@ -1,0 +1,6 @@
+# CMAKE_ARGS env variable is not used as it is defined by
+# compiler activation scripts
+cmake -G Ninja -S %SRC_DIR% -B build -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%
+if errorlevel 1 exit 1
+cmake --build build --parallel %CPU_COUNT% --target install
+if errorlevel 1 exit 1

--- a/recipes/gb-robot-models/build.sh
+++ b/recipes/gb-robot-models/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+cmake -G Ninja -S ${SRC_DIR} -B build -DCMAKE_INSTALL_PREFIX=${PREFIX}
+cmake --build build --parallel ${CPU_COUNT} --target install

--- a/recipes/gb-robot-models/conda-forge.yml
+++ b/recipes/gb-robot-models/conda-forge.yml
@@ -1,0 +1,3 @@
+noarch_platforms:
+  - linux_64
+  - win_64

--- a/recipes/gb-robot-models/recipe.yaml
+++ b/recipes/gb-robot-models/recipe.yaml
@@ -1,0 +1,44 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: gb-robot-models
+  version: ${{ version }}
+
+source:
+  url: https://github.com/gbionics/gb-robot-models/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 416eaf2b75531e28e97cbfc214f26b0baf28044800612adbad570f4f24edafe9
+
+build:
+  # See https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-packages-with-os-specific-dependencies
+  noarch: generic
+  number: 0
+
+requirements:
+  build:
+    - cmake
+    - ninja
+  run:
+    - if: unix
+      then: __unix
+      else: __win
+
+tests:
+  - package_contents:
+      files:
+        - ${{ "Library/" if win else "" }}share/gb_robot_models/package.xml
+        - ${{ "Library/" if win else "" }}share/gb_robot_models/robots/gene01_0/model.urdf
+        - ${{ "Library/" if win else "" }}share/ament_index/resource_index/packages/gb_robot_models
+
+about:
+  homepage: https://github.com/gbionics/gb-robot-models
+  summary: Public robot models from Generative Bionics
+  description: |
+    This package includes models for robots created by Generative Bionics.
+  license: CC-BY-NC-4.0
+  license_file: LICENSE
+  repository: https://github.com/gbionics/gb-robot-models
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
This PR adds a recipe for the `gb-robot-models` library, a library of URDF assets to use and simulate [Generative Bionics](https://gbionics.ai/) robots.

The library is installed with CMake, but it only installs data files (mainly `.urdf` and `.obj` mesh files) in a way that they can easily found by ROS's style resource system, so it is modeled as `noarch: generic` with system-specific dependencies (see https://conda-forge.org/docs/maintainer/knowledge_base/#noarch-packages-with-os-specific-dependencies). As the package does not contain a C/C++ library, it does not contain the `lib` prefix, but it is directly called `gb-robot-models`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
