### PR TITLE
Add bioformats2raw

### DIFF
--- a/recipes/bioformats2raw/0001-conda-build.patch
+++ b/recipes/bioformats2raw/0001-conda-build.patch
@@ -1,0 +1,45 @@
+diff --git a/build.gradle b/build.gradle
+index b3a7535..223ace0 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -1,5 +1,6 @@
+ plugins {
+     id 'application'
++    id 'com.github.jk1.dependency-license-report' version '3.1.4'
+     id 'eclipse'
+     id 'maven-publish'
+     id 'checkstyle'
+@@ -12,9 +13,12 @@ application {
+   mainClass = 'com.glencoesoftware.bioformats2raw.Converter'
+ }
+ java {
+-  toolchain {
+-    languageVersion = JavaLanguageVersion.of(11)
+-  }
++  sourceCompatibility = JavaVersion.VERSION_11
++  targetCompatibility = JavaVersion.VERSION_11
++}
++
++tasks.withType(JavaCompile).configureEach {
++    options.release = 11
+ }
+ 
+ repositories {
+@@ -71,10 +75,5 @@ jar {
+     manifest {
+         attributes(
+-            "Created-By": "Gradle ${gradle.gradleVersion}",
+-            "Build-Jdk": "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+-            "Built-By": System.properties['user.name'],
+-            "Built-On": new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").format(new Date()),
+-            "Implementation-Build": "git rev-parse --verify HEAD".execute().getText().trim(),
+             "Implementation-Title": "bioformats2raw converter",
+             "Implementation-Version": archiveVersion,
+             "Implementation-Vendor": "Glencoe Software Inc.",
+diff --git a/settings.gradle b/settings.gradle
+new file mode 100644
+index 0000000..cfc6e41
+--- /dev/null
++++ b/settings.gradle
+@@ -0,0 +1 @@
++rootProject.name = 'bioformats2raw'

--- a/recipes/bioformats2raw/build.bat
+++ b/recipes/bioformats2raw/build.bat
@@ -1,0 +1,17 @@
+@echo on
+setlocal EnableExtensions
+
+rem Dependencies and the pinned license-report plugin are intentionally
+rem resolved over the network. Gradle itself is supplied by conda-forge.
+set "GRADLE_USER_HOME=%SRC_DIR%\.gradle-conda"
+if not exist "%BUILD_PREFIX%\bioformats2raw-tmp" mkdir "%BUILD_PREFIX%\bioformats2raw-tmp"
+set "JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=%BUILD_PREFIX%\bioformats2raw-tmp"
+call gradle.bat --no-daemon --stacktrace clean test installDist generateLicenseReport
+if errorlevel 1 exit /b 1
+
+if not exist "%PREFIX%\share\bioformats2raw" mkdir "%PREFIX%\share\bioformats2raw"
+xcopy /E /I /Y "build\install\bioformats2raw\*" "%PREFIX%\share\bioformats2raw\"
+if errorlevel 1 exit /b 1
+
+if not exist "%SCRIPTS%" mkdir "%SCRIPTS%"
+echo @call "%%~dp0..\share\bioformats2raw\bin\bioformats2raw.bat" %%* > "%SCRIPTS%\bioformats2raw.bat"

--- a/recipes/bioformats2raw/build.bat
+++ b/recipes/bioformats2raw/build.bat
@@ -14,4 +14,7 @@ xcopy /E /I /Y "build\install\bioformats2raw\*" "%PREFIX%\share\bioformats2raw\"
 if errorlevel 1 exit /b 1
 
 if not exist "%SCRIPTS%" mkdir "%SCRIPTS%"
+if errorlevel 1 exit /b 1
 echo @call "%%~dp0..\share\bioformats2raw\bin\bioformats2raw.bat" %%* > "%SCRIPTS%\bioformats2raw.bat"
+if errorlevel 1 exit /b 1
+if not exist "%SCRIPTS%\bioformats2raw.bat" exit /b 1

--- a/recipes/bioformats2raw/build.sh
+++ b/recipes/bioformats2raw/build.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+# Dependencies and the pinned license-report plugin are intentionally resolved
+# over the network. Gradle itself is supplied by conda-forge.
+export GRADLE_USER_HOME="${SRC_DIR}/.gradle-conda"
+install -d "${BUILD_PREFIX}/bioformats2raw-tmp"
+export JAVA_TOOL_OPTIONS="-Djava.io.tmpdir=${BUILD_PREFIX}/bioformats2raw-tmp"
+gradle --no-daemon --stacktrace clean test installDist generateLicenseReport
+
+install -d "${PREFIX}/share/bioformats2raw" "${PREFIX}/bin"
+cp -R build/install/bioformats2raw/. "${PREFIX}/share/bioformats2raw/"
+ln -s ../share/bioformats2raw/bin/bioformats2raw "${PREFIX}/bin/bioformats2raw"

--- a/recipes/bioformats2raw/recipe.yaml
+++ b/recipes/bioformats2raw/recipe.yaml
@@ -33,10 +33,16 @@ tests:
         then:
           - if not exist "%CONDA_PREFIX%\bioformats2raw-tmp" mkdir "%CONDA_PREFIX%\bioformats2raw-tmp"
           - set "JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=%CONDA_PREFIX%\bioformats2raw-tmp"
+      # bioformats2raw 0.12.1 prints the correct version but exits with status 255,
+      # so capture its output and validate that separately from the exit status.
       - if: unix
-        then: bioformats2raw --version 2>&1 | grep -F "Version = ${PKG_VERSION}"
+        then:
+          - bioformats2raw --version > bioformats2raw-version.txt 2>&1 || true
+          - grep -F "Version = ${PKG_VERSION}" bioformats2raw-version.txt
       - if: win
-        then: bioformats2raw --version 2>&1 | findstr /C:"Version = %PKG_VERSION%"
+        then:
+          - bioformats2raw --version > bioformats2raw-version.txt 2>&1 || cmd /c exit 0
+          - findstr /C:"Version = %PKG_VERSION%" bioformats2raw-version.txt
       - bioformats2raw --help
       - bioformats2raw "test&sizeX=16&sizeY=16.fake" output.zarr --resolutions 1
       - if: unix

--- a/recipes/bioformats2raw/recipe.yaml
+++ b/recipes/bioformats2raw/recipe.yaml
@@ -57,3 +57,4 @@ about:
 extra:
   recipe-maintainers:
     - Darlokt
+    - Tom-TBT 

--- a/recipes/bioformats2raw/recipe.yaml
+++ b/recipes/bioformats2raw/recipe.yaml
@@ -16,28 +16,32 @@ build:
       then:
         - mkdir -p "$PREFIX/share/bioformats2raw" "$PREFIX/bin"
         - cp -R bin lib "$PREFIX/share/bioformats2raw/"
+        - chmod +x "$PREFIX/share/bioformats2raw/bin/bioformats2raw"
         - ln -s ../share/bioformats2raw/bin/bioformats2raw "$PREFIX/bin/bioformats2raw"
     - if: win
       then:
         - mkdir "%PREFIX%\share\bioformats2raw\bin"
         - mkdir "%PREFIX%\share\bioformats2raw\lib"
-        - xcopy /E /I /Y bin "%PREFIX%\share\bioformats2raw\bin"
-        - xcopy /E /I /Y lib "%PREFIX%\share\bioformats2raw\lib"
-        - mkdir "%PREFIX%\bin"
-        - echo %%~dp0..\share\bioformats2raw\bin\bioformats2raw %%* > "%PREFIX%\bin\bioformats2raw.bat"
+        - xcopy /E /I /Y "bin" "%PREFIX%\share\bioformats2raw\bin"
+        - xcopy /E /I /Y "lib" "%PREFIX%\share\bioformats2raw\lib"
+        - echo @call "%%~dp0..\share\bioformats2raw\bin\bioformats2raw.bat" %%* > "%SCRIPTS%\bioformats2raw.bat"
 
 requirements:
   run:
-    - openjdk >=11,<22
+    - openjdk >=11
 
 tests:
   - script:
       - if: unix
-        then: bioformats2raw --version 2>&1 | grep "Version = 0.12.1"
+        then: bioformats2raw --version 2>&1 | grep -F "Version = ${{ version }}"
       - if: win
-        then: bioformats2raw --version 2>&1 | findstr /C:"Version = 0.12.1"
+        then: bioformats2raw --version 2>&1 | findstr /C:"Version = ${{ version }}"
       - bioformats2raw --help
       - bioformats2raw "test&sizeX=16&sizeY=16.fake" output.zarr --resolutions 1
+      - if: unix
+        then: test -d output.zarr
+      - if: win
+        then: if not exist output.zarr\NUL exit /b 1
 
 about:
   homepage: https://github.com/glencoesoftware/bioformats2raw
@@ -45,9 +49,9 @@ about:
   description: |
     bioformats2raw converts image file formats supported by Bio-Formats into
     a Zarr structure compatible with the OME-NGFF specification.
-  license: GPL-2.0-or-later
+  license: GPL-2.0-only
   license_file: LICENSE.txt
-  documentation: https://github.com/glencoesoftware/bioformats2raw/blob/master/README.md
+  documentation: https://github.com/glencoesoftware/bioformats2raw/blob/v${{ version }}/README.md
   repository: https://github.com/glencoesoftware/bioformats2raw
 
 extra:

--- a/recipes/bioformats2raw/recipe.yaml
+++ b/recipes/bioformats2raw/recipe.yaml
@@ -1,3 +1,5 @@
+schema_version: 1
+
 context:
   version: "0.12.1"
 
@@ -6,42 +8,48 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/glencoesoftware/bioformats2raw/releases/download/v${{ version }}/bioformats2raw-${{ version }}.zip
-  sha256: 51fbbf04a83c2042b707fce016ad0c8260d37194ff8fe7d986d53f4ebee116a6
+  url: https://github.com/glencoesoftware/bioformats2raw/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 3447cd42ce53bd761e7f273a0abc26bfbc9c954e7d5243cb7f01debeadbebecd
+  patches:
+    - 0001-conda-build.patch
 
 build:
   number: 0
-  script:
-    - if: unix
-      then:
-        - mkdir -p "$PREFIX/share/bioformats2raw" "$PREFIX/bin"
-        - cp -R bin lib "$PREFIX/share/bioformats2raw/"
-        - chmod +x "$PREFIX/share/bioformats2raw/bin/bioformats2raw"
-        - ln -s ../share/bioformats2raw/bin/bioformats2raw "$PREFIX/bin/bioformats2raw"
-    - if: win
-      then:
-        - mkdir "%PREFIX%\share\bioformats2raw\bin"
-        - mkdir "%PREFIX%\share\bioformats2raw\lib"
-        - xcopy /E /I /Y "bin" "%PREFIX%\share\bioformats2raw\bin"
-        - xcopy /E /I /Y "lib" "%PREFIX%\share\bioformats2raw\lib"
-        - echo @call "%%~dp0..\share\bioformats2raw\bin\bioformats2raw.bat" %%* > "%SCRIPTS%\bioformats2raw.bat"
 
 requirements:
+  build:
+    - gradle =9.3.1
+    - openjdk =21
   run:
-    - openjdk >=11,<26  # in line with bioformats2raw testing
+    - openjdk >=11,<26
 
 tests:
   - script:
       - if: unix
-        then: bioformats2raw --version 2>&1 | grep -F "Version = ${{ version }}"
+        then:
+          - mkdir -p "$CONDA_PREFIX/bioformats2raw-tmp"
+          - export JAVA_TOOL_OPTIONS="-Djava.io.tmpdir=$CONDA_PREFIX/bioformats2raw-tmp"
       - if: win
-        then: bioformats2raw --version 2>&1 | findstr /C:"Version = ${{ version }}"
+        then:
+          - if not exist "%CONDA_PREFIX%\bioformats2raw-tmp" mkdir "%CONDA_PREFIX%\bioformats2raw-tmp"
+          - set "JAVA_TOOL_OPTIONS=-Djava.io.tmpdir=%CONDA_PREFIX%\bioformats2raw-tmp"
+      - if: unix
+        then: bioformats2raw --version 2>&1 | grep -F "Version = ${PKG_VERSION}"
+      - if: win
+        then: bioformats2raw --version 2>&1 | findstr /C:"Version = %PKG_VERSION%"
       - bioformats2raw --help
       - bioformats2raw "test&sizeX=16&sizeY=16.fake" output.zarr --resolutions 1
       - if: unix
-        then: test -d output.zarr
-      - if: win
-        then: if not exist output.zarr\NUL exit /b 1
+        then:
+          - test -f output.zarr/.zgroup
+          - test -f output.zarr/.zattrs
+          - test -f output.zarr/0/0/.zarray
+          - test -f output.zarr/OME/METADATA.ome.xml
+        else:
+          - if not exist output.zarr\.zgroup exit /b 1
+          - if not exist output.zarr\.zattrs exit /b 1
+          - if not exist output.zarr\0\0\.zarray exit /b 1
+          - if not exist output.zarr\OME\METADATA.ome.xml exit /b 1
 
 about:
   homepage: https://github.com/glencoesoftware/bioformats2raw
@@ -50,7 +58,9 @@ about:
     bioformats2raw converts image file formats supported by Bio-Formats into
     a Zarr structure compatible with the OME-NGFF specification.
   license: GPL-2.0-only
-  license_file: LICENSE.txt
+  license_file:
+    - LICENSE.txt
+    - build/reports/dependency-license/
   documentation: https://github.com/glencoesoftware/bioformats2raw/blob/v${{ version }}/README.md
   repository: https://github.com/glencoesoftware/bioformats2raw
 

--- a/recipes/bioformats2raw/recipe.yaml
+++ b/recipes/bioformats2raw/recipe.yaml
@@ -1,0 +1,55 @@
+context:
+  version: "0.12.1"
+
+package:
+  name: bioformats2raw
+  version: ${{ version }}
+
+source:
+  url: https://github.com/glencoesoftware/bioformats2raw/releases/download/v${{ version }}/bioformats2raw-${{ version }}.zip
+  sha256: 51fbbf04a83c2042b707fce016ad0c8260d37194ff8fe7d986d53f4ebee116a6
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - mkdir -p "$PREFIX/share/bioformats2raw" "$PREFIX/bin"
+        - cp -R bin lib "$PREFIX/share/bioformats2raw/"
+        - ln -s ../share/bioformats2raw/bin/bioformats2raw "$PREFIX/bin/bioformats2raw"
+    - if: win
+      then:
+        - mkdir "%PREFIX%\share\bioformats2raw\bin"
+        - mkdir "%PREFIX%\share\bioformats2raw\lib"
+        - xcopy /E /I /Y bin "%PREFIX%\share\bioformats2raw\bin"
+        - xcopy /E /I /Y lib "%PREFIX%\share\bioformats2raw\lib"
+        - mkdir "%PREFIX%\bin"
+        - echo %%~dp0..\share\bioformats2raw\bin\bioformats2raw %%* > "%PREFIX%\bin\bioformats2raw.bat"
+
+requirements:
+  run:
+    - openjdk >=11,<22
+
+tests:
+  - script:
+      - if: unix
+        then: bioformats2raw --version 2>&1 | grep "Version = 0.12.1"
+      - if: win
+        then: bioformats2raw --version 2>&1 | findstr /C:"Version = 0.12.1"
+      - bioformats2raw --help
+      - bioformats2raw "test&sizeX=16&sizeY=16.fake" output.zarr --resolutions 1
+
+about:
+  homepage: https://github.com/glencoesoftware/bioformats2raw
+  summary: Bio-Formats image file format to OME-NGFF format converter
+  description: |
+    bioformats2raw converts image file formats supported by Bio-Formats into
+    a Zarr structure compatible with the OME-NGFF specification.
+  license: GPL-2.0-or-later
+  license_file: LICENSE.txt
+  documentation: https://github.com/glencoesoftware/bioformats2raw/blob/master/README.md
+  repository: https://github.com/glencoesoftware/bioformats2raw
+
+extra:
+  recipe-maintainers:
+    - Darlokt

--- a/recipes/bioformats2raw/recipe.yaml
+++ b/recipes/bioformats2raw/recipe.yaml
@@ -28,7 +28,7 @@ build:
 
 requirements:
   run:
-    - openjdk >=11
+    - openjdk >=11,<26  # in line with bioformats2raw testing
 
 tests:
   - script:
@@ -57,4 +57,4 @@ about:
 extra:
   recipe-maintainers:
     - Darlokt
-    - Tom-TBT 
+    - Tom-TBT


### PR DESCRIPTION
# Adds a v1 recipe for bioformats2raw 0.12.1, a command-line tool that converts Bio-Formats-supported images to OME-NGFF/Zarr.

The recipe builds from the checksummed upstream source tag with Gradle and
OpenJDK from conda-forge. It runs the upstream tests, creates the application
distribution, installs the Unix and Windows launchers, and generates the
third-party dependency license report. The package tests check the version and
help output, then convert a small synthetic image and verify the resulting Zarr
and OME-XML files.

The source-build and patching approach is inspired by the `apache-solr` recipe,
adapted here as a v1 recipe. The patch is applied by `source.patches` after the
source archive is downloaded and verified. It pins the Gradle license-report
plugin, builds Java 11-compatible bytecode with OpenJDK 21, sets a stable
project name, and removes environment-specific fields from the JAR manifest.

The installed Gradle distribution includes its resolved runtime JARs. The
package is platform-specific because some of those JARs include native
libraries.

Gradle needs to resolve the pinned plugin and project dependencies from the
configured Maven repositories. For this recipe, we would therefore request
online access during the sandboxed build (rattler-build `--allow-network`).

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
