### PR TITLE
Add TRIQS 4.0 application recipes

### DIFF
--- a/recipes/triqs_ctint/build.sh
+++ b/recipes/triqs_ctint/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+mkdir build
+cd build
+
+export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
+source $PREFIX/share/triqs/triqsvars.sh
+
+# Override the default Build_Deps=Always so that triqs_hartree_fock is taken from the host
+# environment rather than cloned. finufft is BUILD_ALWAYS in ctint's deps/, so it builds from
+# the tarball unpacked under deps/ regardless of this setting.
+cmake ${CMAKE_ARGS} \
+    -DCMAKE_CXX_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CXX}) \
+    -DCMAKE_C_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CC}) \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBuild_Deps=IfNotFound \
+    ..
+
+make -j${CPU_COUNT} VERBOSE=1
+CTEST_OUTPUT_ON_FAILURE=1 ctest
+make install
+
+# Rewrite any build-prefix path leaked into the installed CMake targets file.
+tgt="${PREFIX}/lib/cmake/${PKG_NAME}/${PKG_NAME}-targets.cmake"
+if [[ -f "$tgt" ]]; then
+  sed "s|$BUILD_PREFIX|$PREFIX|g" "$tgt" > tmp_file
+  cp tmp_file "$tgt"
+fi

--- a/recipes/triqs_ctint/conda-forge.yml
+++ b/recipes/triqs_ctint/conda-forge.yml
@@ -1,0 +1,3 @@
+provider:
+  osx_arm64: native
+test: native_and_emulated

--- a/recipes/triqs_ctint/conda_build_config.yaml
+++ b/recipes/triqs_ctint/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - mpich
+  - openmpi
+# Force MPI 5: TRIQS 4.0 requires openmpi>=5 / mpich>=5, but staged-recipes' base pinning is still 4.
+openmpi:
+  - '5'
+mpich:
+  - '5'

--- a/recipes/triqs_ctint/meta.yaml
+++ b/recipes/triqs_ctint/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = "4.0.2" %}
+
+package:
+  name: triqs_ctint
+  version: {{ version }}
+
+source:
+  - url: https://github.com/TRIQS/ctint/releases/download/{{ version }}/ctint-{{ version }}.tar.gz
+    sha256: 182ea83fc317b0210b787f37f7d535c1f9c63722cba978a8cab8259b1eddb300
+  # conda-forge provides no C++ finufft package (the finufft output is the Python bindings only),
+  # so build it from source. Placed under deps/ so that the ctint build picks it up from there.
+  - url: https://github.com/flatironinstitute/finufft/archive/v2.5.1.tar.gz
+    sha256: 809aa60ea4bf11a9976642d30d6bd2634da0083bdebd580d64705bc4aecfcd0e
+    folder: deps/finufft
+
+build:
+  number: 0
+  skip: true  # [win]
+  # Boost is header-only here; libboost-devel provides BoostConfig.cmake for
+  # find_package(Boost) under CMP0167, but its compiled-lib run_export is not needed.
+  ignore_run_exports:
+    - libboost
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - cmake
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - {{ mpi }}                              # [mpi == 'openmpi' and build_platform != target_platform]
+  host:
+    - triqs {{ '.'.join(version.split('.')[:2]) }}
+    - triqs_hartree_fock {{ '.'.join(version.split('.')[:2]) }}
+    - libboost-devel
+    - fftw
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - numpy
+    - python
+  run:
+    - {{ pin_compatible("triqs", max_pin="x.x") }}
+    - {{ pin_compatible("triqs_hartree_fock", max_pin="x.x") }}
+    - fftw
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - python
+
+test:
+  commands:
+    - export OMPI_MCA_btl=self,tcp
+    - export OMPI_MCA_plm=isolated
+    - export OMPI_MCA_rmaps_base_oversubscribe=yes
+    - export OMPI_MCA_btl_vader_single_copy_mechanism=none
+    - export mpiexec="mpiexec --allow-run-as-root"
+    - python -c "import triqs_ctint"
+
+about:
+  home: https://triqs.github.io/ctint
+  # finufft is built from the deps/finufft source above and linked in statically
+  # (libfinufft.a), so its Apache-2.0 terms cover the shipped binaries. Apache-2.0
+  # section 4(d) also requires the NOTICE file to be redistributed.
+  license: GPL-3.0-or-later AND Apache-2.0
+  license_family: GPL
+  license_file:
+    - LICENSE
+    - deps/finufft/LICENSE
+    - deps/finufft/NOTICE
+  summary: A continuous-time interaction-expansion impurity solver for TRIQS
+
+extra:
+  recipe-maintainers:
+    - wentzell

--- a/recipes/triqs_dftkit/build.sh
+++ b/recipes/triqs_dftkit/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+mkdir build
+cd build
+
+export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
+source $PREFIX/share/triqs/triqsvars.sh
+
+cmake ${CMAKE_ARGS} \
+    -DCMAKE_CXX_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CXX}) \
+    -DCMAKE_C_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CC}) \
+    -DCMAKE_Fortran_COMPILER=${BUILD_PREFIX}/bin/$(basename ${FC}) \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBuild_Deps=Never \
+    ..
+
+make -j${CPU_COUNT} VERBOSE=1
+CTEST_OUTPUT_ON_FAILURE=1 ctest
+make install
+
+# Rewrite any build-prefix path leaked into the installed CMake targets file.
+tgt="${PREFIX}/lib/cmake/${PKG_NAME}/${PKG_NAME}-targets.cmake"
+if [[ -f "$tgt" ]]; then
+  sed "s|$BUILD_PREFIX|$PREFIX|g" "$tgt" > tmp_file
+  cp tmp_file "$tgt"
+fi

--- a/recipes/triqs_dftkit/conda-forge.yml
+++ b/recipes/triqs_dftkit/conda-forge.yml
@@ -1,0 +1,3 @@
+provider:
+  osx_arm64: native
+test: native_and_emulated

--- a/recipes/triqs_dftkit/conda_build_config.yaml
+++ b/recipes/triqs_dftkit/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - mpich
+  - openmpi
+# Force MPI 5: TRIQS 4.0 requires openmpi>=5 / mpich>=5, but staged-recipes' base pinning is still 4.
+openmpi:
+  - '5'
+mpich:
+  - '5'

--- a/recipes/triqs_dftkit/meta.yaml
+++ b/recipes/triqs_dftkit/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = "4.0.0" %}
+
+package:
+  name: triqs_dftkit
+  version: {{ version }}
+
+source:
+  url: https://github.com/TRIQS/dftkit/releases/download/{{ version }}/dftkit-{{ version }}.tar.gz
+  sha256: 97b01d61af8132dde0e280ae4a872eec29908d7eb4b03fb649f848af83ae6bf7
+
+build:
+  number: 0
+  skip: true  # [win]
+  # Boost is header-only here; libboost-devel provides BoostConfig.cmake for
+  # find_package(Boost) under CMP0167, but its compiled-lib run_export is not needed.
+  ignore_run_exports:
+    - libboost
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - cmake
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
+    - {{ stdlib("c") }}
+    - {{ mpi }}                              # [mpi == 'openmpi' and build_platform != target_platform]
+  host:
+    - triqs {{ '.'.join(version.split('.')[:2]) }}
+    - libboost-devel
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - numpy
+    - python
+  run:
+    - {{ pin_compatible("triqs", max_pin="x.x") }}
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - python
+    - libgcc  # [osx]   # dmftproj (Fortran) links libgcc_s.1.1.dylib; osx run-export omits it
+
+test:
+  commands:
+    - export OMPI_MCA_btl=self,tcp
+    - export OMPI_MCA_plm=isolated
+    - export OMPI_MCA_rmaps_base_oversubscribe=yes
+    - export OMPI_MCA_btl_vader_single_copy_mechanism=none
+    - export mpiexec="mpiexec --allow-run-as-root"
+    - test -x "$PREFIX/bin/dmftproj"
+    - python -c "import triqs_dftkit"
+
+about:
+  home: https://triqs.github.io/dftkit
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE.txt
+  summary: DFT converters for TRIQS-based DFT+DMFT calculations
+
+extra:
+  recipe-maintainers:
+    - wentzell

--- a/recipes/triqs_hartree_fock/build.sh
+++ b/recipes/triqs_hartree_fock/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+mkdir build
+cd build
+
+export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
+source $PREFIX/share/triqs/triqsvars.sh
+
+cmake ${CMAKE_ARGS} \
+    -DCMAKE_CXX_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CXX}) \
+    -DCMAKE_C_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CC}) \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBuild_Deps=Never \
+    ..
+
+make -j${CPU_COUNT} VERBOSE=1
+CTEST_OUTPUT_ON_FAILURE=1 ctest
+make install
+
+# Rewrite any build-prefix path leaked into the installed CMake targets file.
+tgt="${PREFIX}/lib/cmake/${PKG_NAME}/${PKG_NAME}-targets.cmake"
+if [[ -f "$tgt" ]]; then
+  sed "s|$BUILD_PREFIX|$PREFIX|g" "$tgt" > tmp_file
+  cp tmp_file "$tgt"
+fi

--- a/recipes/triqs_hartree_fock/conda-forge.yml
+++ b/recipes/triqs_hartree_fock/conda-forge.yml
@@ -1,0 +1,3 @@
+provider:
+  osx_arm64: native
+test: native_and_emulated

--- a/recipes/triqs_hartree_fock/conda_build_config.yaml
+++ b/recipes/triqs_hartree_fock/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - mpich
+  - openmpi
+# Force MPI 5: TRIQS 4.0 requires openmpi>=5 / mpich>=5, but staged-recipes' base pinning is still 4.
+openmpi:
+  - '5'
+mpich:
+  - '5'

--- a/recipes/triqs_hartree_fock/meta.yaml
+++ b/recipes/triqs_hartree_fock/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = "4.0.0" %}
+
+package:
+  name: triqs_hartree_fock
+  version: {{ version }}
+
+source:
+  url: https://github.com/TRIQS/hartree_fock/releases/download/{{ version }}/hartree_fock-{{ version }}.tar.gz
+  sha256: 27c9ed1f2ee745058d8ed05626ef0994a35c5f45d9319f0cf2c93ce226c719e2
+
+build:
+  number: 0
+  skip: true  # [win]
+  # triqs_hartree_fock is pure Python, but it is built through the app4triqs
+  # CMake flow (find_package(TRIQS), project(... CXX)), so a C++ compiler and the
+  # TRIQS CMake dependencies are still needed at configure time.
+  # Boost is header-only here; libboost-devel provides BoostConfig.cmake for
+  # find_package(Boost) under CMP0167, but its compiled-lib run_export is not needed.
+  ignore_run_exports:
+    - libboost
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - cmake
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - {{ mpi }}                              # [mpi == 'openmpi' and build_platform != target_platform]
+  host:
+    - triqs {{ '.'.join(version.split('.')[:2]) }}
+    - libboost-devel
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - numpy
+    - scipy
+    - python
+  run:
+    - {{ pin_compatible("triqs", max_pin="x.x") }}
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - numpy
+    - scipy
+    - python
+
+test:
+  commands:
+    - export OMPI_MCA_btl=self,tcp
+    - export OMPI_MCA_plm=isolated
+    - export OMPI_MCA_rmaps_base_oversubscribe=yes
+    - export OMPI_MCA_btl_vader_single_copy_mechanism=none
+    - export mpiexec="mpiexec --allow-run-as-root"
+    - python -c "import triqs_hartree_fock"
+
+about:
+  home: https://triqs.github.io/hartree_fock
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE.txt
+  summary: Hartree-Fock lattice and impurity solvers based on the TRIQS library
+
+extra:
+  recipe-maintainers:
+    - wentzell

--- a/recipes/triqs_modest/build.sh
+++ b/recipes/triqs_modest/build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+mkdir build
+cd build
+
+export CXXFLAGS="$CXXFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
+source $PREFIX/share/triqs/triqsvars.sh
+
+cmake ${CMAKE_ARGS} \
+    -DCMAKE_CXX_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CXX}) \
+    -DCMAKE_C_COMPILER=${BUILD_PREFIX}/bin/$(basename ${CC}) \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBuild_Deps=Never \
+    ..
+
+make -j${CPU_COUNT} VERBOSE=1
+CTEST_OUTPUT_ON_FAILURE=1 ctest
+make install
+
+# Rewrite any build-prefix path leaked into the installed CMake targets file.
+tgt="${PREFIX}/lib/cmake/${PKG_NAME}/${PKG_NAME}-targets.cmake"
+if [[ -f "$tgt" ]]; then
+  sed "s|$BUILD_PREFIX|$PREFIX|g" "$tgt" > tmp_file
+  cp tmp_file "$tgt"
+fi

--- a/recipes/triqs_modest/conda-forge.yml
+++ b/recipes/triqs_modest/conda-forge.yml
@@ -1,0 +1,3 @@
+provider:
+  osx_arm64: native
+test: native_and_emulated

--- a/recipes/triqs_modest/conda_build_config.yaml
+++ b/recipes/triqs_modest/conda_build_config.yaml
@@ -1,0 +1,8 @@
+mpi:
+  - mpich
+  - openmpi
+# Force MPI 5: TRIQS 4.0 requires openmpi>=5 / mpich>=5, but staged-recipes' base pinning is still 4.
+openmpi:
+  - '5'
+mpich:
+  - '5'

--- a/recipes/triqs_modest/meta.yaml
+++ b/recipes/triqs_modest/meta.yaml
@@ -1,0 +1,68 @@
+{% set version = "4.0.0" %}
+
+package:
+  name: triqs_modest
+  version: {{ version }}
+
+source:
+  url: https://github.com/TRIQS/modest/releases/download/{{ version }}/modest-{{ version }}.tar.gz
+  sha256: 1db680581a2bb537e5afeb12b5692357cde871aaa14ff4921d5ca075affcf6e0
+
+build:
+  number: 0
+  skip: true  # [win]
+  # Boost is header-only here; libboost-devel provides BoostConfig.cmake for
+  # find_package(Boost) under CMP0167, but its compiled-lib run_export is not needed.
+  ignore_run_exports:
+    - libboost
+
+requirements:
+  build:
+    - python                                 # [build_platform != target_platform]
+    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
+    - cmake
+    - make
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ stdlib("c") }}
+    - {{ mpi }}                              # [mpi == 'openmpi' and build_platform != target_platform]
+  host:
+    - triqs {{ '.'.join(version.split('.')[:2]) }}
+    - libboost-devel
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    # modest compiles its own OpenMP regions; host run-exports credit the runtime (_openmp_mutex/llvm-openmp).
+    - libgomp      # [linux]
+    - llvm-openmp  # [osx]
+    - numpy
+    - python
+  run:
+    - {{ pin_compatible("triqs", max_pin="x.x") }}
+    - hdf5
+    - {{ mpi }}
+    - libblas
+    - liblapack
+    - python
+
+test:
+  commands:
+    - export OMPI_MCA_btl=self,tcp
+    - export OMPI_MCA_plm=isolated
+    - export OMPI_MCA_rmaps_base_oversubscribe=yes
+    - export OMPI_MCA_btl_vader_single_copy_mechanism=none
+    - export mpiexec="mpiexec --allow-run-as-root"
+    - python -c "import triqs_modest"
+
+about:
+  home: https://triqs.github.io/modest
+  license: GPL-3.0-or-later
+  license_family: GPL
+  license_file: LICENSE
+  summary: Modular Electronic Structure Toolkit based on TRIQS
+
+extra:
+  recipe-maintainers:
+    - wentzell

--- a/recipes/triqs_modest/meta.yaml
+++ b/recipes/triqs_modest/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0" %}
+{% set version = "4.0.1" %}
 
 package:
   name: triqs_modest
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/TRIQS/modest/releases/download/{{ version }}/modest-{{ version }}.tar.gz
-  sha256: 1db680581a2bb537e5afeb12b5692357cde871aaa14ff4921d5ca075affcf6e0
+  sha256: 9854e00b946ab8cf9a900bb13a8d99cab083168a183abf37f518c833dfe49b0c
 
 build:
   number: 0


### PR DESCRIPTION
This adds initial conda-forge recipes for four TRIQS 4.0 applications

- `triqs_hartree_fock` 4.0.0
- `triqs_dftkit` 4.0.0
- `triqs_modest` 4.0.0
- `triqs_ctint` 4.0.2

C.f. respective documentation pages at

- [triqs.github.io/hartree_fock](https://triqs.github.io/hartree_fock)
- [triqs.github.io/dftkit](https://triqs.github.io/dftkit)
- [triqs.github.io/modest](https://triqs.github.io/modest)
- [triqs.github.io/ctint](https://triqs.github.io/ctint)

`triqs_ctint` depends on `triqs_hartree_fock` at host, so it has to build after it.
