### PR TITLE
Add qadwaitadecorations recipe (Qt6)

### DIFF
--- a/recipes/qadwaitadecorations/0001-Fix-build-with-Qt-6.10.patch
+++ b/recipes/qadwaitadecorations/0001-Fix-build-with-Qt-6.10.patch
@@ -1,0 +1,125 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f50ebf7..d8b23d1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,6 +24,10 @@ include(FeatureSummary)
+ 
+ if (USE_QT6)
+     find_package(QT NAMES Qt6 COMPONENTS Core Gui Svg Wayland Widgets REQUIRED)
++    if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
++        find_package(Qt6GuiPrivate REQUIRED)
++        find_package(Qt6WaylandClientPrivate REQUIRED)
++    endif()
+ else()
+     find_package(QT NAMES Qt5 COMPONENTS Core Gui Svg Wayland Widgets REQUIRED)
+ endif()
+@@ -35,6 +39,12 @@ find_package(Qt${QT_VERSION_MAJOR} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
+     WaylandClient
+     Widgets
+ )
++if (Qt6Gui_VERSION VERSION_GREATER_EQUAL "6.10.0")
++    find_package(Qt6 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
++        GuiPrivate
++        WaylandClientPrivate
++    )
++endif()
+ 
+ find_package(Qt${QT_VERSION_MAJOR}Gui ${QT_MIN_VERSION} CONFIG REQUIRED Private)
+ if (NOT USE_QT6)
+@@ -68,4 +78,3 @@ endif()
+ add_subdirectory(src)
+ 
+ feature_summary(WHAT ALL INCLUDE_QUIET_PACKAGES FATAL_ON_MISSING_REQUIRED_PACKAGES)
+-
+diff --git a/src/qadwaitadecorations.cpp b/src/qadwaitadecorations.cpp
+index 4189fa3..6619e1e 100644
+--- a/src/qadwaitadecorations.cpp
++++ b/src/qadwaitadecorations.cpp
+@@ -798,19 +798,31 @@ void QAdwaitaDecorations::processMouseTop(QWaylandInputDevice *inputDevice, cons
+         if (local.x() <= margins().left()) {
+             // top left bit
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++            waylandWindow()->applyCursor(inputDevice, Qt::SizeFDiagCursor);
++#  else
+             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeFDiagCursor);
++#  endif
+ #endif
+             startResize(inputDevice, Qt::TopEdge | Qt::LeftEdge, b);
+         } else if (local.x() > surfaceRect.right() - margins().left()) {
+             // top right bit
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++            waylandWindow()->applyCursor(inputDevice, Qt::SizeBDiagCursor);
++#  else
+             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeBDiagCursor);
++#  endif
+ #endif
+             startResize(inputDevice, Qt::TopEdge | Qt::RightEdge, b);
+         } else {
+             // top resize bit
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++            waylandWindow()->applyCursor(inputDevice, Qt::SizeVerCursor);
++#  else
+             waylandWindow()->setMouseCursor(inputDevice, Qt::SizeVerCursor);
++#  endif
+ #endif
+             startResize(inputDevice, Qt::TopEdge, b);
+         }
+@@ -857,19 +869,31 @@ void QAdwaitaDecorations::processMouseBottom(QWaylandInputDevice *inputDevice, c
+     if (local.x() <= margins().left()) {
+         // bottom left bit
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++        waylandWindow()->applyCursor(inputDevice, Qt::SizeBDiagCursor);
++#  else
+         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeBDiagCursor);
++#  endif
+ #endif
+         startResize(inputDevice, Qt::BottomEdge | Qt::LeftEdge, b);
+     } else if (local.x() > window()->width() + margins().right()) {
+         // bottom right bit
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++        waylandWindow()->applyCursor(inputDevice, Qt::SizeFDiagCursor);
++#  else
+         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeFDiagCursor);
++#  endif
+ #endif
+         startResize(inputDevice, Qt::BottomEdge | Qt::RightEdge, b);
+     } else {
+         // bottom bit
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++        waylandWindow()->applyCursor(inputDevice, Qt::SizeVerCursor);
++#  else
+         waylandWindow()->setMouseCursor(inputDevice, Qt::SizeVerCursor);
++#  endif
+ #endif
+         startResize(inputDevice, Qt::BottomEdge, b);
+     }
+@@ -881,7 +905,11 @@ void QAdwaitaDecorations::processMouseLeft(QWaylandInputDevice *inputDevice, con
+     Q_UNUSED(local)
+     Q_UNUSED(mods)
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++    waylandWindow()->applyCursor(inputDevice, Qt::SizeHorCursor);
++#  else
+     waylandWindow()->setMouseCursor(inputDevice, Qt::SizeHorCursor);
++#  endif
+ #endif
+     startResize(inputDevice, Qt::LeftEdge, b);
+ }
+@@ -892,7 +920,11 @@ void QAdwaitaDecorations::processMouseRight(QWaylandInputDevice *inputDevice, co
+     Q_UNUSED(local)
+     Q_UNUSED(mods)
+ #if QT_CONFIG(cursor)
++#  if QT_VERSION >= QT_VERSION_CHECK(6, 10, 0)
++    waylandWindow()->applyCursor(inputDevice, Qt::SizeHorCursor);
++#  else
+     waylandWindow()->setMouseCursor(inputDevice, Qt::SizeHorCursor);
++#  endif
+ #endif
+     startResize(inputDevice, Qt::RightEdge, b);
+ }

--- a/recipes/qadwaitadecorations/build.sh
+++ b/recipes/qadwaitadecorations/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+
+cmake -GNinja -B build -S . ${CMAKE_ARGS} \
+    -DUSE_QT6=ON \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DQT_PLUGINS_DIR=$PREFIX/lib/qt6/plugins
+
+cmake --build build --parallel
+cmake --install build

--- a/recipes/qadwaitadecorations/recipe.yaml
+++ b/recipes/qadwaitadecorations/recipe.yaml
@@ -15,13 +15,7 @@ source:
 build:
   number: 0
   skip: not linux
-  script:
-    - cmake -GNinja -B build -S . ${CMAKE_ARGS}
-      -DUSE_QT6=ON
-      -DCMAKE_INSTALL_PREFIX=$PREFIX
-      -DQT_PLUGINS_DIR=$PREFIX/lib/qt6/plugins
-    - cmake --build build --parallel
-    - cmake --install build
+  script: build.sh
 
 requirements:
   build:

--- a/recipes/qadwaitadecorations/recipe.yaml
+++ b/recipes/qadwaitadecorations/recipe.yaml
@@ -37,9 +37,11 @@ requirements:
     - ninja
   host:
     # qt6-main provides Core, Gui, Svg, WaylandClient and Widgets, along with
-    # the private headers this plugin links against. Its run_exports pins the
-    # exact Qt version, which is required because private Qt APIs are used.
-    - qt6-main
+    # the private headers this plugin links against. Build against >=6.11,
+    # whose run_exports use a loose >=6.11,<7 pin, so the resulting plugin
+    # stays compatible with future Qt 6.x (6.12, ...) rather than being locked
+    # to a single minor release as with the tighter 6.10 pin.
+    - qt6-main >=6.11
     # Qt6 Gui's CMake config requires OpenGL/EGL to be discoverable, otherwise
     # find_package(Qt6 COMPONENTS Gui) fails with "Could NOT find WrapOpenGL".
     - libgl-devel

--- a/recipes/qadwaitadecorations/recipe.yaml
+++ b/recipes/qadwaitadecorations/recipe.yaml
@@ -8,6 +8,12 @@ package:
 source:
   url: https://github.com/FedoraQt/QAdwaitaDecorations/archive/refs/tags/${{ version }}.tar.gz
   sha256: 6cd96efca241a4b60fb6bf449c64dbad713b223c36e003ae89f45e34739d56d1
+  patches:
+    # Upstream commit e6da80a (released after 0.1.7) "Fix build with Qt >= 6.10".
+    # conda-forge ships Qt >= 6.10, where the private QWaylandWindow cursor API
+    # changed (setMouseCursor -> applyCursor) and the private Qt targets must be
+    # requested explicitly. Drop this patch once a release > 0.1.7 is available.
+    - 0001-Fix-build-with-Qt-6.10.patch
 
 build:
   number: 0
@@ -34,6 +40,10 @@ requirements:
     # the private headers this plugin links against. Its run_exports pins the
     # exact Qt version, which is required because private Qt APIs are used.
     - qt6-main
+    # Qt6 Gui's CMake config requires OpenGL/EGL to be discoverable, otherwise
+    # find_package(Qt6 COMPONENTS Gui) fails with "Could NOT find WrapOpenGL".
+    - libgl-devel
+    - libegl-devel
 
 tests:
   - script:

--- a/recipes/qadwaitadecorations/recipe.yaml
+++ b/recipes/qadwaitadecorations/recipe.yaml
@@ -9,16 +9,11 @@ source:
   url: https://github.com/FedoraQt/QAdwaitaDecorations/archive/refs/tags/${{ version }}.tar.gz
   sha256: 6cd96efca241a4b60fb6bf449c64dbad713b223c36e003ae89f45e34739d56d1
   patches:
-    # Upstream commit e6da80a (released after 0.1.7) "Fix build with Qt >= 6.10".
-    # conda-forge ships Qt >= 6.10, where the private QWaylandWindow cursor API
-    # changed (setMouseCursor -> applyCursor) and the private Qt targets must be
-    # requested explicitly. Drop this patch once a release > 0.1.7 is available.
+    # Upstream commit e6da80a, released after 0.1.7; drop once a newer release exists.
     - 0001-Fix-build-with-Qt-6.10.patch
 
 build:
   number: 0
-  # QAdwaitaDecorations is a Qt Wayland client-side decoration plugin,
-  # which is only meaningful (and only builds) on Linux.
   skip: not linux
   script:
     - cmake -GNinja -B build -S . ${CMAKE_ARGS}
@@ -36,14 +31,7 @@ requirements:
     - cmake
     - ninja
   host:
-    # qt6-main provides Core, Gui, Svg, WaylandClient and Widgets, along with
-    # the private headers this plugin links against. Build against >=6.11,
-    # whose run_exports use a loose >=6.11,<7 pin, so the resulting plugin
-    # stays compatible with future Qt 6.x (6.12, ...) rather than being locked
-    # to a single minor release as with the tighter 6.10 pin.
-    - qt6-main >=6.11
-    # Qt6 Gui's CMake config requires OpenGL/EGL to be discoverable, otherwise
-    # find_package(Qt6 COMPONENTS Gui) fails with "Could NOT find WrapOpenGL".
+    - qt6-main
     - libgl-devel
     - libegl-devel
 

--- a/recipes/qadwaitadecorations/recipe.yaml
+++ b/recipes/qadwaitadecorations/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.1.7"
+
+package:
+  name: qadwaitadecorations
+  version: ${{ version }}
+
+source:
+  url: https://github.com/FedoraQt/QAdwaitaDecorations/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 6cd96efca241a4b60fb6bf449c64dbad713b223c36e003ae89f45e34739d56d1
+
+build:
+  number: 0
+  # QAdwaitaDecorations is a Qt Wayland client-side decoration plugin,
+  # which is only meaningful (and only builds) on Linux.
+  skip: not linux
+  script:
+    - cmake -GNinja -B build -S . ${CMAKE_ARGS}
+      -DUSE_QT6=ON
+      -DCMAKE_INSTALL_PREFIX=$PREFIX
+      -DQT_PLUGINS_DIR=$PREFIX/lib/qt6/plugins
+    - cmake --build build --parallel
+    - cmake --install build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  host:
+    # qt6-main provides Core, Gui, Svg, WaylandClient and Widgets, along with
+    # the private headers this plugin links against. Its run_exports pins the
+    # exact Qt version, which is required because private Qt APIs are used.
+    - qt6-main
+
+tests:
+  - script:
+      - test -f $PREFIX/lib/qt6/plugins/wayland-decoration-client/libqadwaitadecorations.so
+
+about:
+  homepage: https://github.com/FedoraQt/QAdwaitaDecorations
+  summary: Qt decoration plugin implementing Adwaita-like client-side decorations
+  description: |
+    QAdwaitaDecorations is a Qt Wayland decoration plugin implementing
+    Adwaita-like client-side decorations. It makes Qt applications running
+    on Wayland use window decorations that match the GNOME Adwaita design
+    language.
+
+    This library uses private Qt headers and will likely not be forward nor
+    backward compatible, so it needs to be recompiled with each Qt update.
+  license: LGPL-2.1-or-later
+  license_file: LICENSE
+  repository: https://github.com/FedoraQt/QAdwaitaDecorations
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk


### PR DESCRIPTION
Adds a v1 (rattler-build) recipe for [QAdwaitaDecorations](https://github.com/FedoraQt/QAdwaitaDecorations) 0.1.7, a Qt Wayland client-side decoration plugin implementing Adwaita-like decorations. Inspired by the [adwaita-qt-feedstock](https://github.com/conda-forge/adwaita-qt-feedstock).

- **Qt6 only** — builds with `-DUSE_QT6=ON` (upstream defaults to Qt5).
- **Linux only** — it is a Qt Wayland decoration plugin.
- Single host dep `qt6-main`, whose `run_exports` pins the exact Qt version (required because the plugin links private Qt APIs and must be rebuilt with each Qt update).
- Installs the plugin to `lib/qt6/plugins/wayland-decoration-client` and tests that `libqadwaitadecorations.so` is present.
- License `LGPL-2.1-or-later`.

### Checklist
- [x] Title of this PR is meaningful, e.g. "Adding my_nifty_package".
- [x] License file is packaged (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#packaging-the-license-manually) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.