### PR TITLE
Add pam-stubs: link-time PAM stub with system PAM at runtime

### DIFF
--- a/recipes/pam-stubs/build.sh
+++ b/recipes/pam-stubs/build.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# ---------------------------------------------------------------------------
+# pam-stubs: ship the Linux-PAM public headers plus a *link-time only* stub of
+# libpam so that conda packages (e.g. weston's VNC backend) can compile and
+# link against libpam, while the real authentication library is resolved from
+# the user's system PAM (/lib*/libpam.so.0, driven by /etc/pam.d) at runtime.
+#
+# The stub .so is deliberately installed into $PREFIX/lib/stubs (a NON-runtime
+# directory) and never into $PREFIX/lib, so it can never shadow the system
+# libpam via the conda $ORIGIN/../lib rpath.
+# ---------------------------------------------------------------------------
+
+# --- 1. Install the public headers -----------------------------------------
+mkdir -p "${PREFIX}/include/security"
+cp -p libpam/include/security/pam_appl.h      "${PREFIX}/include/security/"
+cp -p libpam/include/security/pam_modules.h   "${PREFIX}/include/security/"
+cp -p libpam/include/security/pam_ext.h       "${PREFIX}/include/security/"
+cp -p libpam/include/security/pam_modutil.h   "${PREFIX}/include/security/"
+cp -p libpam/include/security/_pam_types.h    "${PREFIX}/include/security/"
+cp -p libpam/include/security/_pam_compat.h   "${PREFIX}/include/security/"
+cp -p libpam/include/security/_pam_macros.h   "${PREFIX}/include/security/"
+# pam_misc.h is #included by weston's auth.c; it in turn pulls in pam_client.h.
+cp -p libpamc/include/security/pam_client.h   "${PREFIX}/include/security/"
+cp -p libpam_misc/include/security/pam_misc.h "${PREFIX}/include/security/"
+
+# --- 2. Generate the stub sources -------------------------------------------
+# Version script: reproduce the SONAME versions the real libpam exports so that
+# downstream binaries record exactly the versioned symbol requirements
+# (e.g. pam_start@LIBPAM_1.0) that the system libpam.so.0 satisfies.
+cat > libpam-stub.map <<'MAP'
+LIBPAM_1.0 {
+  global:
+    pam_start;
+    pam_end;
+    pam_authenticate;
+    pam_setcred;
+    pam_acct_mgmt;
+    pam_open_session;
+    pam_close_session;
+    pam_chauthtok;
+    pam_set_item;
+    pam_get_item;
+    pam_strerror;
+    pam_putenv;
+    pam_getenv;
+    pam_getenvlist;
+    pam_fail_delay;
+  local:
+    *;
+};
+LIBPAM_1.4 {
+  global:
+    pam_start_confdir;
+} LIBPAM_1.0;
+MAP
+
+# The bodies are NEVER executed; they only need correct, ABI-compatible
+# signatures (taken from the real headers) so downstreams link cleanly.
+cat > libpam-stub.c <<'STUB'
+#include <security/pam_appl.h>
+#include <stddef.h>
+
+int pam_start(const char *service_name, const char *user,
+              const struct pam_conv *pam_conversation, pam_handle_t **pamh)
+{ (void)service_name; (void)user; (void)pam_conversation; (void)pamh; return PAM_SYSTEM_ERR; }
+
+int pam_start_confdir(const char *service_name, const char *user,
+              const struct pam_conv *pam_conversation, const char *confdir,
+              pam_handle_t **pamh)
+{ (void)service_name; (void)user; (void)pam_conversation; (void)confdir; (void)pamh; return PAM_SYSTEM_ERR; }
+
+int pam_end(pam_handle_t *pamh, int pam_status)
+{ (void)pamh; (void)pam_status; return PAM_SYSTEM_ERR; }
+
+int pam_authenticate(pam_handle_t *pamh, int flags)
+{ (void)pamh; (void)flags; return PAM_SYSTEM_ERR; }
+
+int pam_setcred(pam_handle_t *pamh, int flags)
+{ (void)pamh; (void)flags; return PAM_SYSTEM_ERR; }
+
+int pam_acct_mgmt(pam_handle_t *pamh, int flags)
+{ (void)pamh; (void)flags; return PAM_SYSTEM_ERR; }
+
+int pam_open_session(pam_handle_t *pamh, int flags)
+{ (void)pamh; (void)flags; return PAM_SYSTEM_ERR; }
+
+int pam_close_session(pam_handle_t *pamh, int flags)
+{ (void)pamh; (void)flags; return PAM_SYSTEM_ERR; }
+
+int pam_chauthtok(pam_handle_t *pamh, int flags)
+{ (void)pamh; (void)flags; return PAM_SYSTEM_ERR; }
+
+int pam_set_item(pam_handle_t *pamh, int item_type, const void *item)
+{ (void)pamh; (void)item_type; (void)item; return PAM_SYSTEM_ERR; }
+
+int pam_get_item(const pam_handle_t *pamh, int item_type, const void **item)
+{ (void)pamh; (void)item_type; (void)item; return PAM_SYSTEM_ERR; }
+
+const char *pam_strerror(pam_handle_t *pamh, int errnum)
+{ (void)pamh; (void)errnum; return NULL; }
+
+int pam_putenv(pam_handle_t *pamh, const char *name_value)
+{ (void)pamh; (void)name_value; return PAM_SYSTEM_ERR; }
+
+const char *pam_getenv(pam_handle_t *pamh, const char *name)
+{ (void)pamh; (void)name; return NULL; }
+
+char **pam_getenvlist(pam_handle_t *pamh)
+{ (void)pamh; return NULL; }
+
+int pam_fail_delay(pam_handle_t *pamh, unsigned int musec_delay)
+{ (void)pamh; (void)musec_delay; return PAM_SYSTEM_ERR; }
+STUB
+
+# --- 3. Build the stub into the NON-runtime stubs/ directory ----------------
+# Compiling against the just-installed headers also validates that they are
+# self-consistent. SONAME is libpam.so.0 (matches the real library).
+mkdir -p "${PREFIX}/lib/stubs"
+${CC} ${CFLAGS} -shared -fPIC \
+  -I"${PREFIX}/include" \
+  -o "${PREFIX}/lib/stubs/libpam.so" \
+  libpam-stub.c \
+  -Wl,-soname,libpam.so.0 \
+  -Wl,--version-script=libpam-stub.map
+
+# --- 4. pkg-config file (meson's dependency('pam') finds this first) --------
+# Libs points at the stubs dir so linking picks up the stub, not $PREFIX/lib.
+mkdir -p "${PREFIX}/lib/pkgconfig"
+cat > "${PREFIX}/lib/pkgconfig/pam.pc" <<PC
+prefix=${PREFIX}
+exec_prefix=\${prefix}
+libdir=\${prefix}/lib
+includedir=\${prefix}/include
+
+Name: pam
+Description: Pluggable Authentication Modules (conda-forge link-time stub)
+Version: ${PKG_VERSION}
+Libs: -L\${libdir}/stubs -lpam
+Cflags: -I\${includedir}
+PC
+
+# --- 5. Activation: make bare `-lpam` / meson cc.find_library('pam') work ---
+# Add the stubs dir to LIBRARY_PATH, which gcc/clang consult ONLY at link time.
+# LIBRARY_PATH never affects the runtime dynamic loader, so this cannot shadow
+# the system libpam; it merely lets consumers that skip pkg-config still link.
+for CHANGE in activate deactivate; do
+  mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+done
+
+cat > "${PREFIX}/etc/conda/activate.d/pam-stubs.sh" <<'ACT'
+export LIBRARY_PATH="${CONDA_PREFIX}/lib/stubs${LIBRARY_PATH:+:${LIBRARY_PATH}}"
+ACT
+
+cat > "${PREFIX}/etc/conda/deactivate.d/pam-stubs.sh" <<'DEACT'
+if [ -n "${LIBRARY_PATH:-}" ]; then
+  _pam_entry="${CONDA_PREFIX}/lib/stubs"
+  _pam_wrapped=":${LIBRARY_PATH}:"
+  _pam_wrapped="${_pam_wrapped//:${_pam_entry}:/:}"
+  _pam_wrapped="${_pam_wrapped#:}"
+  _pam_wrapped="${_pam_wrapped%:}"
+  export LIBRARY_PATH="${_pam_wrapped}"
+  unset _pam_entry _pam_wrapped
+fi
+DEACT

--- a/recipes/pam-stubs/build.sh
+++ b/recipes/pam-stubs/build.sh
@@ -142,26 +142,9 @@ Libs: -L\${libdir}/stubs -lpam
 Cflags: -I\${includedir}
 PC
 
-# --- 5. Activation: make bare `-lpam` / meson cc.find_library('pam') work ---
-# Add the stubs dir to LIBRARY_PATH, which gcc/clang consult ONLY at link time.
-# LIBRARY_PATH never affects the runtime dynamic loader, so this cannot shadow
-# the system libpam; it merely lets consumers that skip pkg-config still link.
-for CHANGE in activate deactivate; do
-  mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
-done
-
-cat > "${PREFIX}/etc/conda/activate.d/pam-stubs.sh" <<'ACT'
-export LIBRARY_PATH="${CONDA_PREFIX}/lib/stubs${LIBRARY_PATH:+:${LIBRARY_PATH}}"
-ACT
-
-cat > "${PREFIX}/etc/conda/deactivate.d/pam-stubs.sh" <<'DEACT'
-if [ -n "${LIBRARY_PATH:-}" ]; then
-  _pam_entry="${CONDA_PREFIX}/lib/stubs"
-  _pam_wrapped=":${LIBRARY_PATH}:"
-  _pam_wrapped="${_pam_wrapped//:${_pam_entry}:/:}"
-  _pam_wrapped="${_pam_wrapped#:}"
-  _pam_wrapped="${_pam_wrapped%:}"
-  export LIBRARY_PATH="${_pam_wrapped}"
-  unset _pam_entry _pam_wrapped
-fi
-DEACT
+# NOTE: no activation scripts, following the cuda-driver-dev convention
+# (which ships lib/stubs/libcuda.so the same way). Consumers pick up the
+# stub either through pkg-config (pam.pc above points Libs at the stubs
+# dir, which satisfies meson's dependency('pam')), or by adding
+# -L$PREFIX/lib/stubs to LDFLAGS in their build script, exactly like CUDA
+# downstreams (e.g. pocl-feedstock) do for -lcuda.

--- a/recipes/pam-stubs/conda-forge.yml
+++ b/recipes/pam-stubs/conda-forge.yml
@@ -1,0 +1,7 @@
+build_platform:
+  linux_aarch64: linux_64
+  linux_ppc64le: linux_64
+provider:
+  linux_aarch64: default
+  linux_ppc64le: default
+test: native_and_emulated

--- a/recipes/pam-stubs/recipe.yaml
+++ b/recipes/pam-stubs/recipe.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+
+context:
+  version: "1.7.2"
+
+package:
+  name: pam-stubs
+  version: ${{ version }}
+
+source:
+  url: https://github.com/linux-pam/linux-pam/releases/download/v${{ version }}/Linux-PAM-${{ version }}.tar.xz
+  sha256: 3d86b6383fb5fd9eb9578d2cd47d92801191f4bf3f9bc61419bfefc8aa1e531a
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  # No host deps: we ship only the Linux-PAM public headers and a link-time
+  # stub generated from them.
+  #
+  # No run_exports on purpose. This is a build/host-time link stub. Downstreams
+  # must resolve the *real* libpam from the user's system at runtime (PAM does
+  # system auth via /etc/pam.d, and conda-forge deliberately ships no runtime
+  # PAM). Exporting a runtime dependency would be wrong; a runtime conda libpam
+  # would shadow the system one and break authentication.
+
+tests:
+  - package_contents:
+      include:
+        - security/pam_appl.h
+        - security/pam_modules.h
+      files:
+        exists:
+          - lib/stubs/libpam.so
+        # CRITICAL: nothing named libpam may live in lib/ itself, or the conda
+        # rpath would shadow the system libpam at runtime and break auth.
+        not_exists:
+          - lib/libpam.so
+          - lib/libpam.so.*
+  - script:
+      # pkg-config points -lpam at the stubs dir, not lib/.
+      - pkg-config --libs pam | grep -q stubs
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://github.com/linux-pam/linux-pam
+  license: BSD-3-Clause OR GPL-2.0-or-later
+  license_file: COPYING
+  summary: Link-time stub and headers for Linux-PAM (uses the system PAM at runtime)
+  description: |
+    pam-stubs provides the Linux-PAM public headers and a link-time-only stub
+    of libpam so that conda-forge packages (such as weston's VNC backend) can
+    compile and link against libpam.
+
+    conda-forge deliberately does not ship a runtime PAM: authentication is a
+    system concern driven by /etc/pam.d, and a conda libpam.so.0 placed on the
+    runtime search path would shadow the real one and break login/auth.
+
+    To square this, the stub is installed into $PREFIX/lib/stubs (used only at
+    link time via -L), never into $PREFIX/lib. Downstream binaries record
+    "NEEDED libpam.so.0" with the correct versioned symbols; at runtime the
+    dynamic loader finds no libpam inside the conda prefix and falls through to
+    the user's system /lib*/libpam.so.0. The stub function bodies merely return
+    PAM_SYSTEM_ERR and are never executed.
+
+extra:
+  recipe-maintainers:
+    - hmaarrfk

--- a/recipes/pam-stubs/recipe.yaml
+++ b/recipes/pam-stubs/recipe.yaml
@@ -38,6 +38,7 @@ tests:
       files:
         exists:
           - lib/stubs/libpam.so
+          - lib/pkgconfig/pam.pc
         # CRITICAL: nothing named libpam may live in lib/ itself, or the conda
         # rpath would shadow the system libpam at runtime and break auth.
         not_exists:
@@ -46,8 +47,23 @@ tests:
   - script:
       # pkg-config points -lpam at the stubs dir, not lib/.
       - pkg-config --libs pam | grep -q stubs
+      # Link a real consumer against the stub the same way meson's
+      # dependency('pam') would, then verify the binary records the
+      # system-resolvable versioned dependency — the same contract
+      # cuda-driver-dev consumers rely on for libcuda.
+      - $CC $CFLAGS test-link.c $(pkg-config --cflags --libs pam) -o test-pam
+      - $READELF -d test-pam | grep -q "NEEDED.*libpam\.so\.0"
+      - $READELF -V test-pam | grep -q "LIBPAM_1\.0"
+      # The binary must NOT carry an rpath/runpath to the stubs dir, or the
+      # stub would be found at runtime instead of the system libpam. (An
+      # rpath to $PREFIX/lib is fine: no libpam is ever installed there.)
+      - "! $READELF -d test-pam | grep -iE \"rpath|runpath\" | grep -q \"/lib/stubs\""
+    files:
+      recipe:
+        - test-link.c
     requirements:
       run:
+        - ${{ compiler('c') }}
         - pkg-config
 
 about:
@@ -65,11 +81,18 @@ about:
     runtime search path would shadow the real one and break login/auth.
 
     To square this, the stub is installed into $PREFIX/lib/stubs (used only at
-    link time via -L), never into $PREFIX/lib. Downstream binaries record
+    link time via -L), never into $PREFIX/lib, following the same convention as
+    conda-forge's cuda-driver-dev package (which ships lib/stubs/libcuda.so and
+    leaves the real driver to the system). Downstream binaries record
     "NEEDED libpam.so.0" with the correct versioned symbols; at runtime the
     dynamic loader finds no libpam inside the conda prefix and falls through to
     the user's system /lib*/libpam.so.0. The stub function bodies merely return
     PAM_SYSTEM_ERR and are never executed.
+
+    Consumers link against the stub via pkg-config (pam.pc points its Libs at
+    the stubs directory, satisfying meson's dependency('pam')), or by adding
+    -L$PREFIX/lib/stubs to LDFLAGS — just as CUDA downstream feedstocks do
+    for -lcuda. As with cuda-driver-dev, no activation scripts are shipped.
 
 extra:
   recipe-maintainers:

--- a/recipes/pam-stubs/test-link.c
+++ b/recipes/pam-stubs/test-link.c
@@ -1,0 +1,18 @@
+/* Link-time smoke test. Mirrors how weston's VNC backend consumes PAM
+ * (pam_appl.h + pam_misc.h). The binary is only linked and inspected,
+ * never executed: at runtime the real system libpam.so.0 would be used. */
+#include <security/pam_appl.h>
+#include <security/pam_misc.h>
+#include <security/pam_modules.h>
+
+int main(void)
+{
+    pam_handle_t *pamh = 0;
+    struct pam_conv conv = {0, 0};
+    int ret = pam_start("pam-stubs-test", "user", &conv, &pamh);
+    if (ret == PAM_SUCCESS) {
+        pam_authenticate(pamh, 0);
+        pam_end(pamh, ret);
+    }
+    return ret;
+}


### PR DESCRIPTION
I've found that for certain features of the weston compositor in https://github.com/conda-forge/staged-recipes/pull/34218 i needed the stubs to use the system PAM module.

I made it so that the neatvnc that needed this was an optional dependency. I can take on merging the rest, but I did want to discuss the appropriateness of having new STUB based dependencies at conda-forge.

<details><summary>more info from claude</summary>

Adds `pam-stubs`: a **link-time-only** PAM stub so conda-forge packages can compile and link against libpam while using the **user's system PAM at runtime**.

### Why

conda-forge deliberately ships no runtime PAM: authentication is a system concern driven by `/etc/pam.d`, and a conda `libpam.so.0` on the runtime search path would shadow the real one and break login/auth. But packages like Weston's VNC backend need to link `-lpam` at build time.

### How (the CUDA-stubs pattern)

This mirrors how conda-forge's CUDA packages ship `libcuda.so` (`cuda-driver-dev` → `lib/stubs/libcuda.so`):

- Ships the Linux-PAM public headers and a stub `libpam.so` (SONAME `libpam.so.0`) built from those headers, with exported symbols version-tagged (`@@LIBPAM_1.0`, `@@LIBPAM_1.4`) to match the real library.
- The stub is installed into **`$PREFIX/lib/stubs/`** (used only at link time via `-L`), **never** `$PREFIX/lib/`. Because nothing named `libpam` lives in `$PREFIX/lib`, the conda `$ORIGIN/../lib` rpath finds no libpam at runtime and the loader falls through to the system `/lib*/libpam.so.0`.
- **No `run_exports`** — downstreams get the headers + stub at build/host time only, never a runtime PAM dependency. The stub bodies just `return PAM_SYSTEM_ERR` and are never executed.

The packaged test asserts the stub is in `lib/stubs/` and — critically — that nothing named `libpam` exists in `lib/`.

### Notes for reviewers

This is novel and security-adjacent, so it is split into its own PR for focused review. It is the sole dependency I'd like scrutinised carefully; a larger Weston compositor stack builds on top of it. Source is Linux-PAM 1.7.2 (sha256 verified). Happy to adjust the naming or structure (e.g. a `pam` package with a stub-only output) if preferred.

</details>
Linux only. Built and tested on linux-64.
