### PR TITLE
Add bashkit recipe

### DIFF
--- a/recipes/bashkit/LICENSE
+++ b/recipes/bashkit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Everruns
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/recipes/bashkit/cargo-auditable-wrapper.bat
+++ b/recipes/bashkit/cargo-auditable-wrapper.bat
@@ -1,0 +1,1 @@
+cargo auditable %*

--- a/recipes/bashkit/cargo-auditable-wrapper.sh
+++ b/recipes/bashkit/cargo-auditable-wrapper.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec cargo auditable $*

--- a/recipes/bashkit/recipe.yaml
+++ b/recipes/bashkit/recipe.yaml
@@ -23,6 +23,10 @@ build:
           - chmod +x ${BUILD_PREFIX}/bin/cargo-auditable-wrapper
         else:
           - copy %RECIPE_DIR%\cargo-auditable-wrapper.bat %BUILD_PREFIX%\Library\bin\cargo-auditable-wrapper.bat
+          # The monty (-> ruff) git dependencies check out snapshot files
+          # whose paths exceed Windows' 260-char MAX_PATH under the long build
+          # prefix; a short CARGO_HOME keeps the checkout paths within limit.
+          - set CARGO_HOME=C:\.cargo
       - python -m pip install . -vv --no-deps --no-build-isolation
       # Bundle the licenses of all vendored Rust dependencies.
       - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml

--- a/recipes/bashkit/recipe.yaml
+++ b/recipes/bashkit/recipe.yaml
@@ -1,0 +1,72 @@
+context:
+  version: "0.13.0"
+
+package:
+  name: bashkit
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/b/bashkit/bashkit-${{ version }}.tar.gz
+  sha256: 1045d75b38e51becde4ef552fb73785cf58d22e259bb77cd7185bc0b2d561511
+
+build:
+  number: 0
+  script:
+    env:
+      # Route maturin's cargo invocations through cargo-auditable so the
+      # compiled extension embeds a dependency audit trail (SBOM).
+      CARGO: cargo-auditable-wrapper${{ '' if unix else '.bat' }}
+    content:
+      - if: unix
+        then:
+          - cp ${RECIPE_DIR}/cargo-auditable-wrapper.sh ${BUILD_PREFIX}/bin/cargo-auditable-wrapper
+          - chmod +x ${BUILD_PREFIX}/bin/cargo-auditable-wrapper
+        else:
+          - copy %RECIPE_DIR%\cargo-auditable-wrapper.bat %BUILD_PREFIX%\Library\bin\cargo-auditable-wrapper.bat
+      - python -m pip install . -vv --no-deps --no-build-isolation
+      # Bundle the licenses of all vendored Rust dependencies.
+      - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - crossenv
+        - maturin >=1.4,<2.0
+  host:
+    - python
+    - pip
+    - maturin >=1.4,<2.0
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - bashkit
+      pip_check: true
+
+about:
+  homepage: https://github.com/everruns/bashkit
+  summary: A sandboxed bash interpreter for AI agents
+  description: |
+    Bashkit is a virtual Bash interpreter with an embedded filesystem
+    designed for secure, sandboxed script execution in multi-tenant
+    environments. It reimplements many Bash commands in Rust without
+    process spawning or host filesystem access.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  repository: https://github.com/everruns/bashkit
+
+extra:
+  recipe-maintainers:
+    - RogerHYang


### PR DESCRIPTION
Adds a recipe for [**bashkit**](https://github.com/everruns/bashkit) — a sandboxed bash interpreter for AI agents, distributed on PyPI as a PyO3/maturin Rust extension (MIT).

### Notes for reviewers
- **Not `noarch`**: it's a compiled Rust extension module, so it builds per-platform with `{{ compiler('rust') }}` + `{{ compiler('c') }}` + `{{ stdlib('c') }}` and cross-python entries.
- **Rust supply-chain**: builds through `cargo-auditable` (embeds a dependency SBOM into the artifact) and runs `cargo-bundle-licenses` to ship the vendored crate licenses as `THIRDPARTY.yml`, following the [conda-forge Rust guidelines](https://conda-forge.org/docs/maintainer/example_recipes/rust/). Patterned on the `pydantic-monty` feedstock.
- **License**: upstream sdist doesn't include the MIT `LICENSE`, so it's vendored into the recipe directory.
- Uses the v1 `recipe.yaml` format.

### Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7d9d1c9e923e6c81a30ba6d1a2e6fef7c8/recipes/example/meta.yaml#L54) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)