### PR TITLE
Add r-californiaalw

### DIFF
--- a/recipes/r-californiaalw/bld.bat
+++ b/recipes/r-californiaalw/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipes/r-californiaalw/build.sh
+++ b/recipes/r-californiaalw/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-californiaalw/meta.yaml
+++ b/recipes/r-californiaalw/meta.yaml
@@ -1,0 +1,46 @@
+{% set version = "0.1.0" %}
+
+package:
+  name: r-californiaalw
+  version: {{ version }}
+
+source:
+  url: https://github.com/asafichaki/californiaalw/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: ea51e28555b0a9b5c1ecc6315721da7b5db122c37051a839393264666b2c8a50
+
+build:
+  noarch: generic
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+
+requirements:
+  host:
+    - r-base >=4.1
+  run:
+    - r-base >=4.1
+
+test:
+  commands:
+    - $R -e "library('californiaalw'); stopifnot(nrow(alw_facilities()) == 1224)"           # [not win]
+    - "\"%R%\" -e \"library('californiaalw'); stopifnot(nrow(alw_facilities()) == 1224)\""  # [win]
+
+about:
+  home: https://californiacarecompass.com/data/california-alw-county-tracker-2026
+  license: MIT AND CC-BY-4.0
+  license_file:
+    - LICENSE.md
+    - inst/extdata/LICENSE-data.md
+  summary: R access to California Assisted Living Waiver facility and county data from DHCS
+  description: |
+    californiaalw provides programmatic access to 1,224 California Assisted
+    Living Waiver facility records and county aggregates prepared from the
+    California Department of Health Care Services provider list. The package
+    includes source and access-date metadata and clearly separates statewide
+    enrollment and waitlist totals from county-level facility data.
+  dev_url: https://github.com/asafichaki/californiaalw
+
+extra:
+  recipe-maintainers:
+    - asafichaki


### PR DESCRIPTION
Adds the `californiaalw` R package, which provides programmatic access to California Assisted Living Waiver facility records and county aggregates prepared from the California Department of Health Care Services provider list.

- Upstream release: v0.1.0
- 1,224 facility records and 15 county aggregates
- MIT package code and CC BY 4.0 prepared data
- R CMD check status OK
- Recipe linter passed locally

The full local Linux conda build reached the recipe-build stage but the local Docker solver stopped producing output; this PR relies on conda-forge CI for the authoritative platform builds.