### PR TITLE
Add recipe for dinrail library

### DIFF
--- a/recipes/dinrail/build-dinrail-devices.bat
+++ b/recipes/dinrail/build-dinrail-devices.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\devices -B build-dinrail-devices -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-dinrail-devices
+if errorlevel 1 exit /b 1
+cmake --install build-dinrail-devices
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-dinrail-devices.sh
+++ b/recipes/dinrail/build-dinrail-devices.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/devices -B build-dinrail-devices -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-dinrail-devices -j "${CPU_COUNT}"
+cmake --install build-dinrail-devices

--- a/recipes/dinrail/build-dinrail-tools.bat
+++ b/recipes/dinrail/build-dinrail-tools.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\cli -B build-dinrail-tools -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-dinrail-tools
+if errorlevel 1 exit /b 1
+cmake --install build-dinrail-tools
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-dinrail-tools.bat
+++ b/recipes/dinrail/build-dinrail-tools.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\tools -B build-dinrail-tools -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-dinrail-tools
+if errorlevel 1 exit /b 1
+cmake --install build-dinrail-tools
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-dinrail-tools.sh
+++ b/recipes/dinrail/build-dinrail-tools.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/cli -B build-dinrail-tools -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-dinrail-tools -j "${CPU_COUNT}"
+cmake --install build-dinrail-tools

--- a/recipes/dinrail/build-dinrail-tools.sh
+++ b/recipes/dinrail/build-dinrail-tools.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/tools -B build-dinrail-tools -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-dinrail-tools -j "${CPU_COUNT}"
+cmake --install build-dinrail-tools

--- a/recipes/dinrail/build-dinrail-yarp-devices.bat
+++ b/recipes/dinrail/build-dinrail-yarp-devices.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\yarp-devices -B build-dinrail-yarp-devices -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-dinrail-yarp-devices
+if errorlevel 1 exit /b 1
+cmake --install build-dinrail-yarp-devices
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-dinrail-yarp-devices.sh
+++ b/recipes/dinrail/build-dinrail-yarp-devices.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/yarp-devices -B build-dinrail-yarp-devices -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-dinrail-yarp-devices -j "${CPU_COUNT}"
+cmake --install build-dinrail-yarp-devices

--- a/recipes/dinrail/build-dinrail-yarp-tools.bat
+++ b/recipes/dinrail/build-dinrail-yarp-tools.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\yarp-tools -B build-dinrail-yarp-tools -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-dinrail-yarp-tools
+if errorlevel 1 exit /b 1
+cmake --install build-dinrail-yarp-tools
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-dinrail-yarp-tools.sh
+++ b/recipes/dinrail/build-dinrail-yarp-tools.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/yarp-tools -B build-dinrail-yarp-tools -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-dinrail-yarp-tools -j "${CPU_COUNT}"
+cmake --install build-dinrail-yarp-tools

--- a/recipes/dinrail/build-libdinrail-yarp.bat
+++ b/recipes/dinrail/build-libdinrail-yarp.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\yarp -B build-libdinrail-yarp -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-libdinrail-yarp
+if errorlevel 1 exit /b 1
+cmake --install build-libdinrail-yarp
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-libdinrail-yarp.sh
+++ b/recipes/dinrail/build-libdinrail-yarp.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/yarp -B build-libdinrail-yarp -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-libdinrail-yarp -j "${CPU_COUNT}"
+cmake --install build-libdinrail-yarp

--- a/recipes/dinrail/build-libdinrail.bat
+++ b/recipes/dinrail/build-libdinrail.bat
@@ -1,0 +1,9 @@
+@echo on
+setlocal enabledelayedexpansion
+
+cmake -S src\core -B build-libdinrail -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=%PREFIX% %CMAKE_ARGS%
+if errorlevel 1 exit /b 1
+cmake --build build-libdinrail
+if errorlevel 1 exit /b 1
+cmake --install build-libdinrail
+if errorlevel 1 exit /b 1

--- a/recipes/dinrail/build-libdinrail.sh
+++ b/recipes/dinrail/build-libdinrail.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+cmake -S src/core -B build-libdinrail -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  ${CMAKE_ARGS}
+cmake --build build-libdinrail -j "${CPU_COUNT}"
+cmake --install build-libdinrail

--- a/recipes/dinrail/recipe.yaml
+++ b/recipes/dinrail/recipe.yaml
@@ -1,0 +1,191 @@
+schema_version: 1
+
+context:
+  version: "0.0.1"
+
+recipe:
+  name: dinrail-split
+  version: ${{ version }}
+
+source:
+  url: https://github.com/gbionics/dinrail/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 557062770312790c9ff3818265b375be6fa94c70e81423700f3f651ce20e54be
+
+outputs:
+  - package:
+      name: libdinrail
+    build:
+      number: 0
+      script:
+        file: build-libdinrail
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ycm-cmake-modules
+        - sharedlibpp
+      run_exports:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x') }}
+    tests:
+      - package_contents:
+          lib:
+            - dinrail
+      - package_contents:
+          include:
+            - dinrail/Device.h
+
+  - package:
+      name: dinrail-devices
+    build:
+      number: 0
+      script:
+        file: build-dinrail-devices
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+        - ycm-cmake-modules
+        - sharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+    tests:
+      - package_contents:
+          files:
+            - lib/*dinrail-device-fakeMotionControl*
+
+  - package:
+      name: dinrail-tools
+    build:
+      number: 0
+      script:
+        file: build-dinrail-tools
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+        - cli11
+        - ycm-cmake-modules
+        - sharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+    tests:
+      - script:
+          - dinrail --help
+
+  - package:
+      name: dinrail
+    requirements:
+      run:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+        - ${{ pin_subpackage('dinrail-devices', exact=True) }}
+        - ${{ pin_subpackage('dinrail-tools', exact=True) }}
+
+  - package:
+      name: libdinrail-yarp
+    build:
+      script:
+        file: build-libdinrail-yarp
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - libdinrail
+        - yarp
+        - ycm-cmake-modules
+        - sharedlibpp
+      run_exports:
+        - ${{ pin_subpackage('libdinrail-yarp', upper_bound='x.x') }}
+    tests:
+      - package_contents:
+          lib:
+            - dinrail-yarp-conversions
+      - package_contents:
+          include:
+            - dinrail/YarpPropertyConverter.h
+
+  - package:
+      name: dinrail-yarp-devices
+    build:
+      number: 0
+      script:
+        file: build-dinrail-yarp-devices
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+        - ${{ pin_subpackage('libdinrail-yarp', exact=True) }}
+        - libyarp
+        - ycm-cmake-modules
+        - sharedlibpp
+    tests:
+      - package_contents:
+          files:
+            - share/yarp/plugins/*
+
+  - package:
+      name: dinrail-yarp-tools
+    build:
+      number: 0
+      script:
+        file: build-dinrail-yarp-tools
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+        - libyarp
+        - ycm-cmake-modules
+        - sharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', exact=True) }}
+        - ${{ pin_subpackage('dinrail-tools', exact=True) }}
+    tests:
+      - package_contents:
+          files:
+            - bin/dinrail-runner*
+
+  - package:
+      name: dinrail-yarp
+    requirements:
+      run:
+        - ${{ pin_subpackage('libdinrail-yarp', exact=True) }}
+        - ${{ pin_subpackage('dinrail-yarp-devices', exact=True) }}
+        - ${{ pin_subpackage('dinrail-yarp-tools', exact=True) }}
+
+about:
+  homepage: https://github.com/gbionics/dinrail
+  summary: Lightweight robot device abstraction framework.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  repository: https://github.com/gbionics/dinrail
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/dinrail/recipe.yaml
+++ b/recipes/dinrail/recipe.yaml
@@ -101,6 +101,9 @@ outputs:
     requirements:
       build:
         - ${{ compiler('cxx') }}
+        # Workaround for https://github.com/conda-forge/clangdev-feedstock/issues/481
+        - if: osx
+          then: clang-tools
         - ${{ stdlib('c') }}
         - cmake
         - ninja
@@ -240,8 +243,9 @@ outputs:
         - ${{ pin_subpackage('dinrail-tools', upper_bound='x.x.x') }}
     tests:
       - package_contents:
-          files:
-            - bin/dinrail-runner*
+          bin:
+            - dinrail-runner
+            - dinrail-runner-rt
     about:
       summary: YARP-based executable tools for dinrail
       description: |

--- a/recipes/dinrail/recipe.yaml
+++ b/recipes/dinrail/recipe.yaml
@@ -29,6 +29,9 @@ outputs:
     requirements:
       build:
         - ${{ compiler('cxx') }}
+        # Workaround for https://github.com/conda-forge/clangdev-feedstock/issues/481
+        - if: osx
+          then: clang-tools
         - ${{ stdlib('c') }}
         - cmake
         - ninja
@@ -61,6 +64,9 @@ outputs:
     requirements:
       build:
         - ${{ compiler('cxx') }}
+        # Workaround for https://github.com/conda-forge/clangdev-feedstock/issues/481
+        - if: osx
+          then: clang-tools
         - ${{ stdlib('c') }}
         - cmake
         - ninja
@@ -140,6 +146,9 @@ outputs:
     requirements:
       build:
         - ${{ compiler('cxx') }}
+        # Workaround for https://github.com/conda-forge/clangdev-feedstock/issues/481
+        - if: osx
+          then: clang-tools
         - ${{ stdlib('c') }}
         - cmake
         - ninja
@@ -175,6 +184,9 @@ outputs:
     requirements:
       build:
         - ${{ compiler('cxx') }}
+        # Workaround for https://github.com/conda-forge/clangdev-feedstock/issues/481
+        - if: osx
+          then: clang-tools
         - ${{ stdlib('c') }}
         - cmake
         - ninja
@@ -190,7 +202,10 @@ outputs:
     tests:
       - package_contents:
           files:
-            - share/yarp/plugins/*
+            - if: win
+              then: Library/share/yarp/plugins/*
+              else: share/yarp/plugins/*
+
     about:
       summary: YARP device plugins for dinrail
       description: |
@@ -206,6 +221,9 @@ outputs:
     requirements:
       build:
         - ${{ compiler('cxx') }}
+        # Workaround for https://github.com/conda-forge/clangdev-feedstock/issues/481
+        - if: osx
+          then: clang-tools
         - ${{ stdlib('c') }}
         - cmake
         - ninja

--- a/recipes/dinrail/recipe.yaml
+++ b/recipes/dinrail/recipe.yaml
@@ -1,0 +1,272 @@
+schema_version: 1
+
+context:
+  version: "0.1.0"
+
+recipe:
+  name: dinrail-split
+  version: ${{ version }}
+
+source:
+  url: https://github.com/gbionics/dinrail/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 183c14c5013e9dde7ebffc416c00734a915286f721cab9ae591cbca3f3685a1f
+
+build:
+  number: 0
+
+# For what regards run_exports, we use x.x as that is the project policy,
+# see https://github.com/gbionics/dinrail#versioning-policy .
+# For all other pin_subpackage, we use x.x.x so that the users do not accidentally
+# mix different version of dinrail-* or libdinrail-* packages.
+
+outputs:
+  - package:
+      name: libdinrail
+    build:
+      number: 0
+      script:
+        file: build-libdinrail
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ycm-cmake-modules
+        - libsharedlibpp
+      run_exports:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x') }}
+    tests:
+      - package_contents:
+          lib:
+            - dinrail
+      - package_contents:
+          include:
+            - dinrail/Device.h
+    about:
+      summary: Core C++ shared library and headers for dinrail
+      description: |
+        `libdinrail` ships the core C++ shared library, public headers, and CMake
+        package files for dinrail. This output is intended for native consumers
+        that implement, load, or use dinrail device abstractions.
+
+  - package:
+      name: dinrail-devices
+    build:
+      number: 0
+      script:
+        file: build-dinrail-devices
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - ycm-cmake-modules
+        - libsharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+    tests:
+      - package_contents:
+          lib:
+            - if: linux or osx
+              then: dinrail-device-dr_controlboard_fake
+          files:
+            - if: win
+              then: Library/bin/dinrail-device-dr_controlboard_fake.dll
+    about:
+      summary: Built-in device plugins for dinrail
+      description: |
+        `dinrail-devices` ships the built-in runtime-loaded device plugins for
+        dinrail, including the fake control-board device used for development
+        and testing.
+
+  - package:
+      name: dinrail-tools
+    build:
+      number: 0
+      script:
+        file: build-dinrail-tools
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - cli11
+        - ycm-cmake-modules
+        - libsharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+    tests:
+      - script:
+          - dinrail --help
+    about:
+      summary: Command-line tools for dinrail
+      description: |
+        `dinrail-tools` ships the `dinrail` command-line application for working
+        with the core dinrail framework and its device abstractions.
+
+  - package:
+      name: dinrail
+    requirements:
+      run:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - ${{ pin_subpackage('dinrail-devices', upper_bound='x.x.x') }}
+        - ${{ pin_subpackage('dinrail-tools', upper_bound='x.x.x') }}
+    tests:
+      - script:
+          - dinrail --help
+    about:
+      summary: Metapackage for the complete core dinrail stack
+      description: |
+        `dinrail` is a convenience metapackage that depends on `libdinrail`,
+        `dinrail-devices`, and `dinrail-tools`.
+
+  - package:
+      name: libdinrail-yarp
+    build:
+      number: 0
+      script:
+        file: build-libdinrail-yarp
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - libyarp
+        - ycm-cmake-modules
+        - libsharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+      run_exports:
+        - ${{ pin_subpackage('libdinrail-yarp', upper_bound='x.x') }}
+    tests:
+      - package_contents:
+          lib:
+            - dinrail-yarp-conversions
+      - package_contents:
+          include:
+            - dinrail/YarpPropertyConverter.h
+    about:
+      summary: C++ conversion library for dinrail and YARP interoperability
+      description: |
+        `libdinrail-yarp` ships the C++ conversion library, public headers, and
+        CMake package files used to exchange properties between dinrail and YARP.
+
+  - package:
+      name: dinrail-yarp-devices
+    build:
+      number: 0
+      script:
+        file: build-dinrail-yarp-devices
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - ${{ pin_subpackage('libdinrail-yarp', upper_bound='x.x.x') }}
+        - libyarp
+        - fmt
+        - spdlog
+        - ycm-cmake-modules
+        - libsharedlibpp
+    tests:
+      - package_contents:
+          files:
+            - share/yarp/plugins/*
+    about:
+      summary: YARP device plugins for dinrail
+      description: |
+        `dinrail-yarp-devices` ships the runtime-loaded YARP device plugins that
+        connect dinrail control-board abstractions with YARP networks and devices.
+
+  - package:
+      name: dinrail-yarp-tools
+    build:
+      number: 0
+      script:
+        file: build-dinrail-yarp-tools
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      host:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - libyarp
+        - fmt
+        - spdlog
+        - ycm-cmake-modules
+        - libsharedlibpp
+      run:
+        - ${{ pin_subpackage('libdinrail', upper_bound='x.x.x') }}
+        - ${{ pin_subpackage('dinrail-tools', upper_bound='x.x.x') }}
+    tests:
+      - package_contents:
+          files:
+            - bin/dinrail-runner*
+    about:
+      summary: YARP-based executable tools for dinrail
+      description: |
+        `dinrail-yarp-tools` ships the YARP-based `dinrail-runner` executables for
+        launching and operating dinrail devices in a YARP environment.
+
+  - package:
+      name: dinrail-yarp
+    requirements:
+      run:
+        - ${{ pin_subpackage('libdinrail-yarp', upper_bound='x.x.x') }}
+        - ${{ pin_subpackage('dinrail-yarp-devices', upper_bound='x.x.x') }}
+        - ${{ pin_subpackage('dinrail-yarp-tools', upper_bound='x.x.x') }}
+    tests:
+      - script:
+          - dinrail --help
+    about:
+      summary: Metapackage for the complete dinrail YARP integration
+      description: |
+        `dinrail-yarp` is a convenience metapackage that depends on
+        `libdinrail-yarp`, `dinrail-yarp-devices`, and `dinrail-yarp-tools`.
+
+about:
+  homepage: https://github.com/gbionics/dinrail
+  summary: Lightweight robot device abstraction framework.
+  description: |
+    dinrail is a lightweight framework for defining, loading, and using robot
+    device abstractions, with optional tools and YARP integration.
+
+    The recipe provides the following outputs:
+
+    - `libdinrail`: core C++ shared library, public headers, and CMake package files.
+    - `dinrail-devices`: built-in runtime-loaded device plugins.
+    - `dinrail-tools`: command-line tools for the core dinrail framework.
+    - `dinrail`: convenience metapackage for the complete core dinrail stack.
+    - `libdinrail-yarp`: C++ conversion library and headers for YARP interoperability.
+    - `dinrail-yarp-devices`: runtime-loaded YARP device plugins for dinrail.
+    - `dinrail-yarp-tools`: YARP-based runner executables for dinrail devices.
+    - `dinrail-yarp`: convenience metapackage for the complete YARP integration.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  repository: https://github.com/gbionics/dinrail
+
+extra:
+  recipe-maintainers:
+    - traversaro

--- a/recipes/dinrail/recipe.yaml
+++ b/recipes/dinrail/recipe.yaml
@@ -134,6 +134,7 @@ outputs:
     tests:
       - script:
           - dinrail --help
+          - dinrail dev --list
     about:
       summary: Metapackage for the complete core dinrail stack
       description: |

--- a/recipes/dinrail/recipe.yaml
+++ b/recipes/dinrail/recipe.yaml
@@ -290,5 +290,6 @@ about:
   repository: https://github.com/gbionics/dinrail
 
 extra:
+  feedstock-name: dinrail
   recipe-maintainers:
     - traversaro


### PR DESCRIPTION
This PR adds a recipe for the `dinrail` C++ library, a lightweight framework for defining, loading and using robot device abstractions: https://github.com/gbionics/dinrail .

The proposed recipe follows a multiple-output structure, so that the core library does not depend on YARP and users can install only the components they need. In particular, the proposed recipe generates the following packages:

* `libdinrail`: the core C++ library, headers and CMake files. This package contains a `run_exports` section.
* `dinrail-devices`: the built-in dinrail device plugins.
* `dinrail-tools`: the command line tools that only depend on the core dinrail library.
* `dinrail`: an empty meta-package that depends on `libdinrail`, `dinrail-devices` and `dinrail-tools`, and can be used to install the complete core dinrail stack.
* `libdinrail-yarp`: the C++ library that provides interoperability between dinrail and YARP. This package contains a `run_exports` section.
* `dinrail-yarp-devices`: the YARP device plugins that expose dinrail devices through YARP.
* `dinrail-yarp-tools`: the YARP-based command line tools and runners.
* `dinrail-yarp`: an empty meta-package that depends on `libdinrail-yarp`, `dinrail-yarp-devices` and `dinrail-yarp-tools`, and can be used to install all the YARP-related components.

The different components are independently built from the corresponding upstream CMake projects, so this split also avoids introducing YARP dependencies in the basic `libdinrail`, `dinrail-devices` and `dinrail-tools` packages.

For what regards `run_exports`, both `libdinrail` and `libdinrail-yarp` use an `x.x` pin, following the upstream versioning policy documented in https://github.com/gbionics/dinrail#versioning-policy . Dependencies between the different outputs instead use an `x.x.x` pin, as mixing different versions of `dinrail-*` and `libdinrail-*` packages is not intended.


<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
