### PR TITLE
Add openamundsen-da

### DIFF
--- a/recipes/openamundsen-da/recipe.yaml
+++ b/recipes/openamundsen-da/recipe.yaml
@@ -1,0 +1,68 @@
+context:
+  version: "0.9.0"
+  python_min: "3.11"
+
+package:
+  name: openamundsen-da
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/c4/3d/c9d3559946a4e268260b5a40351681c26a6da6472776483bda9f6e8768a1/openamundsen_da-${{ version }}.tar.gz
+  sha256: 5a73ca4a404a33242a0f37fe67721c05473a0fda22ceb82d8f81fdf3b6a35e16
+
+build:
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77.0.3
+    - setuptools-scm >=8,<9
+    - wheel
+  run:
+    - python >=${{ python_min }},<3.15
+    - openamundsen >=1.1
+    - numpy >=1.24
+    - pandas >=1.5
+    - loguru >=0.7
+    - geopandas >=0.14
+    - rasterio >=1.3
+    - xarray >=2023.0
+    - netcdf4 >=1.6
+    - pyyaml >=6.0
+    - ruamel.yaml >=0.17
+    - matplotlib-base >=3.7
+    - psutil >=5.9
+
+tests:
+  - python:
+      imports:
+        - openamundsen_da
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - openamundsen-da --help
+      - openamundsen-da --version
+
+about:
+  homepage: https://github.com/franzwagner-uibk/openamundsen_da
+  summary: Data assimilation extension for openAMUNDSEN
+  description: |
+    openAMUNDSEN-DA assimilates satellite-based snow cover, wet snow extent
+    and station observations into the openAMUNDSEN snow-hydrological model.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://openamundsen-da.pages.dev/
+  repository: https://github.com/franzwagner-uibk/openamundsen_da
+
+extra:
+  recipe-maintainers:
+    - franzwagner-uibk

--- a/recipes/openamundsen-da/recipe.yaml
+++ b/recipes/openamundsen-da/recipe.yaml
@@ -14,6 +14,9 @@ build:
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  python:
+    entry_points:
+      - openamundsen-da = openamundsen_da.cli:main
 
 requirements:
   host:


### PR DESCRIPTION
Adds a v1 `recipe.yaml` for the stable openAMUNDSEN-DA v0.9.0 release from the verified PyPI source distribution.

The recipe is pure Python/noarch, supports Python 3.11 through 3.14, declares the full runtime dependency set, and tests import, CLI help/version, and `pip check`.

Checklist

- [x] Title of this PR is meaningful.
- [x] License file is packaged from the official source archive.
- [x] Source is the official PyPI 0.9.0 source distribution with verified SHA-256.
- [x] Package does not vendor other packages.
- [x] No static libraries are linked or shipped.
- [x] Build number is 0.
- [x] A source tarball is used.
- [x] The listed maintainer confirms willingness in a PR comment.

Validation before submission: source checksum and required sdist files verified; recipe YAML and declared contract validated. The official local Docker build was attempted, but Docker became unavailable before completion, so staged-recipes CI is the authoritative build check.
