### PR TITLE
adds `r-treesitter`

### DIFF
--- a/recipes/r-treesitter/bld.bat
+++ b/recipes/r-treesitter/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-treesitter/build.sh
+++ b/recipes/r-treesitter/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-treesitter/meta.yaml
+++ b/recipes/r-treesitter/meta.yaml
@@ -1,0 +1,92 @@
+{% set version = '0.3.2' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-treesitter
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/treesitter_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/treesitter/treesitter_{{ version }}.tar.gz
+  sha256: 3502fedfd6488a49808139437c3abd106fd2b6c92fc9e8e31f55c091508dbdb2
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-r6 >=2.5.1
+    - r-cli >=3.6.2
+    - r-rlang >=1.1.3
+    - r-vctrs >=0.6.5
+  run:
+    - r-base
+    - r-r6 >=2.5.1
+    - r-cli >=3.6.2
+    - r-rlang >=1.1.3
+    - r-vctrs >=0.6.5
+
+test:
+  commands:
+    - $R -e "library('treesitter')"           # [not win]
+    - "\"%R%\" -e \"library('treesitter')\""  # [win]
+
+about:
+  home: https://github.com/DavisVaughan/r-tree-sitter, https://davisvaughan.github.io/r-tree-sitter/
+  license: MIT
+  summary: Provides bindings to 'Tree-sitter', an incremental parsing system for programming
+    tools. 'Tree-sitter' builds concrete syntax trees for source files of any language,
+    and can efficiently update those syntax trees as the source file is edited. It also
+    includes a robust error recovery system that provides useful parse results even
+    in the presence of syntax errors.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: treesitter
+# Title: Bindings to 'Tree-Sitter'
+# Version: 0.3.2
+# Authors@R: c( person("Davis", "Vaughan", , "davis@posit.co", role = c("aut", "cre")), person("Posit Software, PBC", role = c("cph", "fnd")), person("Tree-sitter authors", role = "cph", comment = "Tree-sitter C library") )
+# Description: Provides bindings to 'Tree-sitter', an incremental parsing system for programming tools. 'Tree-sitter' builds concrete syntax trees for source files of any language, and can efficiently update those syntax trees as the source file is edited. It also includes a robust error recovery system that provides useful parse results even in the presence of syntax errors.
+# License: MIT + file LICENSE
+# URL: https://github.com/DavisVaughan/r-tree-sitter, https://davisvaughan.github.io/r-tree-sitter/
+# BugReports: https://github.com/DavisVaughan/r-tree-sitter/issues
+# Depends: R (>= 4.3.0)
+# Imports: cli (>= 3.6.2), R6 (>= 2.5.1), rlang (>= 1.1.3), vctrs (>= 0.6.5)
+# Suggests: testthat (>= 3.0.0), treesitter.r (>= 1.1.0)
+# Config/build/compilation-database: true
+# Config/Needs/website: tidyverse/tidytemplate
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# RoxygenNote: 7.3.3
+# NeedsCompilation: yes
+# Packaged: 2026-04-02 13:49:43 UTC; davis
+# Author: Davis Vaughan [aut, cre], Posit Software, PBC [cph, fnd], Tree-sitter authors [cph] (Tree-sitter C library)
+# Maintainer: Davis Vaughan <davis@posit.co>
+# Repository: CRAN
+# Date/Publication: 2026-04-03 06:50:02 UTC

--- a/recipes/r-treesitter/meta.yaml
+++ b/recipes/r-treesitter/meta.yaml
@@ -66,6 +66,7 @@ about:
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
     - LICENSE
+    - LICENSE.note
 
 extra:
   recipe-maintainers:

--- a/recipes/r-treesitter/meta.yaml
+++ b/recipes/r-treesitter/meta.yaml
@@ -23,10 +23,12 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ compiler('cxx') }}            # [not win]
-    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ compiler('c') }}          # [not win]
+    - {{ stdlib('c') }}            # [not win]
+    - {{ compiler('m2w64_c') }}    # [win]
+    - {{ stdlib('m2w64_c') }}      # [win]
+    - {{ compiler('cxx') }}        # [not win]
+    - {{ compiler('m2w64_cxx') }}  # [win]
     - {{ posix }}filesystem        # [win]
     - {{ posix }}make
     - {{ posix }}sed               # [win]
@@ -52,7 +54,8 @@ test:
     - "\"%R%\" -e \"library('treesitter')\""  # [win]
 
 about:
-  home: https://github.com/DavisVaughan/r-tree-sitter, https://davisvaughan.github.io/r-tree-sitter/
+  home: https://davisvaughan.github.io/r-tree-sitter/
+  dev_url: https://github.com/DavisVaughan/r-tree-sitter
   license: MIT
   summary: Provides bindings to 'Tree-sitter', an incremental parsing system for programming
     tools. 'Tree-sitter' builds concrete syntax trees for source files of any language,


### PR DESCRIPTION
Adds [CRAN package `treesitter`](https://cran.r-project.org/package=treesitter) as `r-treesitter`. Recipe generated with `conda_r_skeleton_helper`.

Default build vendors tree_sitter C library. For now, I'm opting to package the license (`LICENSE.note` in tarball); perhaps future recipe versions can try reworking to use [`libtree-sitter`](https://github.com/conda-forge/libtree-sitter-feedstock).

Needed by https://github.com/conda-forge/r-goodpractice-feedstock/pull/13.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does ~~not~~ vendor other packages, and their licenses are packaged.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
