### PR TITLE
Add types-boto3-secretsmanager

### DIFF
--- a/recipes/types-boto3-secretsmanager/recipe.yaml
+++ b/recipes/types-boto3-secretsmanager/recipe.yaml
@@ -1,7 +1,6 @@
 schema_version: 1
 
 context:
-  python_min: "3.9"
   version: "1.43.0"
 
 package:

--- a/recipes/types-boto3-secretsmanager/recipe.yaml
+++ b/recipes/types-boto3-secretsmanager/recipe.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "1.43.0"
+
+package:
+  name: types-boto3-secretsmanager
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/types-boto3-secretsmanager/types_boto3_secretsmanager-${{ version }}.tar.gz
+  sha256: 434a90cd08c4e5d25ca6139caa6a737454c62f95dfff924b00d951d4c6736706
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=60
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - botocore
+    - typing_extensions
+
+tests:
+  - python:
+      imports:
+        - types_boto3_secretsmanager
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  summary: Type annotations for boto3 SecretsManager 1.43.0 service generated with mypy-boto3-builder 8.12.0
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/youtype/mypy_boto3_builder
+  repository: https://github.com/youtype/mypy_boto3_builder
+  documentation: https://youtype.github.io/types_boto3_docs/types_boto3_secretsmanager/
+
+extra:
+  recipe-maintainers:
+    - ytausch


### PR DESCRIPTION
Adds a noarch Python recipe for `types-boto3-secretsmanager` 1.43.0 from PyPI.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

---

Note: The identical package [mypy-boto3-secretsmanager](https://prefix.dev/channels/conda-forge/packages/mypy-boto3-secretsmanager) is already on conda-forge, but because of https://github.com/youtype/mypy_boto3_builder/issues/364, both packages have to be maintained.