### PR TITLE
adds `r-mantar`

### DIFF
--- a/recipes/r-mantar/bld.bat
+++ b/recipes/r-mantar/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-mantar/build.sh
+++ b/recipes/r-mantar/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-mantar/meta.yaml
+++ b/recipes/r-mantar/meta.yaml
@@ -1,0 +1,87 @@
+{% set version = '0.3.1' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-mantar
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/mantar_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/mantar/mantar_{{ version }}.tar.gz
+  sha256: 4610d367325d7839954f2be22016ef91ee7ce927e37bb84ad3a07595fcf7e57b
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-matrix
+    - r-rdpack
+    - r-glassofast
+    - r-mathjaxr
+  run:
+    - r-base
+    - r-matrix
+    - r-rdpack
+    - r-glassofast
+    - r-mathjaxr
+
+test:
+  commands:
+    - $R -e "library('mantar')"           # [not win]
+    - "\"%R%\" -e \"library('mantar')\""  # [win]
+
+about:
+  home: https://github.com/kai-nehler/mantar
+  license: GPL-3.0-only
+  summary: Provides functionality for estimating cross-sectional network structures representing
+    partial correlations while accounting for missing data. Networks are estimated via
+    neighborhood selection or regularization, with model selection guided by information
+    criteria. Missing data can be handled primarily via multiple imputation or a maximum
+    likelihood-based approach, as demonstrated by Nehler and Schultze (2025) <doi:10.1080/00273171.2025.2503833>
+    and Nehler and Schultze (2026) <doi:10.1037/met0000828>. Deletion-based approaches
+    are also available but play a secondary role.
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: mantar
+# Title: Missingness Alleviation for Network Analysis
+# Version: 0.3.1
+# Authors@R: person("Kai Jannik", "Nehler", , "nehler@psych.uni-frankfurt.de", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3764-761X"))
+# Description: Provides functionality for estimating cross-sectional network structures representing partial correlations while accounting for missing data. Networks are estimated via neighborhood selection or regularization, with model selection guided by information criteria. Missing data can be handled primarily via multiple imputation or a maximum likelihood-based approach, as demonstrated by Nehler and Schultze (2025) <doi:10.1080/00273171.2025.2503833> and Nehler and Schultze (2026) <doi:10.1037/met0000828>. Deletion-based approaches are also available but play a secondary role.
+# License: GPL (>= 3)
+# Depends: R (>= 4.1.0)
+# Imports: Rdpack, mathjaxr, stats, Matrix, glassoFast
+# Suggests: numDeriv, mice, lavaan, qgraph, testthat (>= 3.0.0), knitr, rmarkdown
+# LazyData: true
+# Encoding: UTF-8
+# RdMacros: Rdpack, mathjaxr
+# Config/testthat/edition: 3
+# URL: https://github.com/kai-nehler/mantar
+# BugReports: https://github.com/kai-nehler/mantar/issues
+# VignetteBuilder: knitr
+# Config/roxygen2/version: 8.0.0
+# NeedsCompilation: no
+# Packaged: 2026-07-08 12:52:08 UTC; nehler
+# Author: Kai Jannik Nehler [aut, cre] (ORCID: <https://orcid.org/0000-0003-3764-761X>)
+# Maintainer: Kai Jannik Nehler <nehler@psych.uni-frankfurt.de>
+# Repository: CRAN
+# Date/Publication: 2026-07-08 13:40:09 UTC

--- a/recipes/r-mantar/meta.yaml
+++ b/recipes/r-mantar/meta.yaml
@@ -46,7 +46,7 @@ test:
 
 about:
   home: https://github.com/kai-nehler/mantar
-  license: GPL-3.0-only
+  license: GPL-3.0-or-later
   summary: Provides functionality for estimating cross-sectional network structures representing
     partial correlations while accounting for missing data. Networks are estimated via
     neighborhood selection or regularization, with model selection guided by information


### PR DESCRIPTION
Adds [CRAN package `mantar`](https://cran.r-project.org/package=mantar) as `r-mantar`. Recipe generated with `conda_r_skeleton_helper`.

Needed by https://github.com/conda-forge/r-bootnet-feedstock/pull/14.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
