### PR TITLE
Add sqlglot-mypy

### DIFF
--- a/recipes/sqlglot-mypy/conda-forge.yml
+++ b/recipes/sqlglot-mypy/conda-forge.yml
@@ -1,0 +1,5 @@
+provider:
+  # mypyc-compiled extensions, so build natively on Apple Silicon rather
+  # than cross-compiling from osx-64.
+  osx_arm64: azure
+  linux_64: github_actions

--- a/recipes/sqlglot-mypy/conda-forge.yml
+++ b/recipes/sqlglot-mypy/conda-forge.yml
@@ -2,4 +2,3 @@ provider:
   # mypyc-compiled extensions, so build natively on Apple Silicon rather
   # than cross-compiling from osx-64.
   osx_arm64: azure
-  linux_64: github_actions

--- a/recipes/sqlglot-mypy/recipe.yaml
+++ b/recipes/sqlglot-mypy/recipe.yaml
@@ -1,0 +1,96 @@
+schema_version: 1
+
+context:
+  version: "2.1.0.post3"
+  ast_serialize_min: "0.3.0"
+  ast_serialize_max: "1.0.0"
+  mypy_extensions_min: "1.0.0"
+  pathspec_min: "1.0.0"
+  pathspec_max: "1.1"
+  python_librt_min: "0.11.0"
+  tomli_min: "1.1.0"
+  typing_extensions_min: "4.6.0"
+
+package:
+  name: sqlglot-mypy
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/s/sqlglot-mypy/sqlglot_mypy-${{ version }}.tar.gz
+    sha256: 5574c67006fb259e05e5367a5537b756d02a34df959adc2883c49a5203a1ade4
+
+build:
+  number: 0
+  script:
+    env:
+      MYPY_USE_MYPYC: "1"
+    content:
+      - python -m pip install . --no-deps -vv --no-build-isolation --disable-pip-version-check
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+  host:
+    - ast-serialize >=${{ ast_serialize_min }},<${{ ast_serialize_max }}
+    - mypy_extensions >=${{ mypy_extensions_min }}
+    - pathspec >=${{ pathspec_min }},<${{ pathspec_max }}
+    - pip
+    - python
+    - python-librt >=${{ python_librt_min }}
+    - setuptools >=77.0.3
+    - types-psutil
+    - types-setuptools
+    - typing_extensions >=${{ typing_extensions_min }}
+    - if: match(python, "<3.11")
+      then:
+        - tomli >=${{ tomli_min }}
+  run:
+    - ast-serialize >=${{ ast_serialize_min }},<${{ ast_serialize_max }}
+    - mypy_extensions >=${{ mypy_extensions_min }}
+    - pathspec >=${{ pathspec_min }},<${{ pathspec_max }}
+    - python
+    - python-librt >=${{ python_librt_min }}
+    # mypyc.build (mypyc/build_setup.py) does `from distutils import
+    # ccompiler` at import time; on Python >=3.12, stdlib distutils is
+    # gone, so importing mypyc.build only works if setuptools (which
+    # ships its own vendored distutils and shims `import distutils` to
+    # it) is actually installed alongside this package at runtime, not
+    # just at build time.
+    - setuptools >=77.0.3
+    - typing_extensions >=${{ typing_extensions_min }}
+    - if: match(python, "<3.11")
+      then:
+        - tomli >=${{ tomli_min }}
+
+tests:
+  - python:
+      imports:
+        - mypy
+        - mypyc
+        - mypyc.build
+      pip_check: true
+
+about:
+  summary: Private mypyc-capable mypy build, used only to compile sqlglotc
+  description: |
+    sqlglot-mypy is tobymao/sqlglot's fork of mypy (same import names,
+    same CLI entry points), published under a separate PyPI name so the
+    mypyc toolchain used to compile the sqlglotc accelerator can move
+    independently of upstream mypy's release cadence. It is packaged
+    here solely to satisfy sqlglotc's `mypyc.build.mypycify` build-time
+    dependency. It is not intended to be installed in a
+    general-purpose environment: it installs files under the same
+    `mypy`/`mypyc` import names as the regular conda-forge `mypy`
+    package and will conflict with it if both are requested together.
+  license: MIT
+  license_file:
+    - LICENSE
+    - mypy/typeshed/LICENSE
+  homepage: https://github.com/vaggelisd/sqlglot-mypy
+  repository: https://github.com/vaggelisd/sqlglot-mypy
+  documentation: https://mypy.readthedocs.io/en/stable/index.html
+
+extra:
+  recipe-maintainers:
+    - pb01ka

--- a/recipes/sqlglot-mypy/recipe.yaml
+++ b/recipes/sqlglot-mypy/recipe.yaml
@@ -62,6 +62,13 @@ requirements:
     - if: match(python, "<3.11")
       then:
         - tomli >=1.1.0
+  run_constraints:
+    # This package installs files under the same `mypy`/`mypyc` import
+    # names as conda-forge's `mypy`, so the two would overwrite each
+    # other's files. Make that conflict explicit to the solver: no
+    # version of `mypy` can satisfy `<0.0.0a0`, so the two can never be
+    # installed into the same environment.
+    - mypy <0.0.0a0
 
 tests:
   - python:

--- a/recipes/sqlglot-mypy/recipe.yaml
+++ b/recipes/sqlglot-mypy/recipe.yaml
@@ -33,7 +33,11 @@ requirements:
     - setuptools >=77.0.3
     - types-psutil
     - types-setuptools
-    - typing_extensions >=4.6.0
+    - if: match(python, "<3.15")
+      then:
+        - typing_extensions >=4.6.0
+      else:
+        - typing_extensions >=4.14.0
     - if: match(python, "<3.11")
       then:
         - tomli >=1.1.0
@@ -50,7 +54,11 @@ requirements:
     # it) is actually installed alongside this package at runtime, not
     # just at build time.
     - setuptools >=77.0.3
-    - typing_extensions >=4.6.0
+    - if: match(python, "<3.15")
+      then:
+        - typing_extensions >=4.6.0
+      else:
+        - typing_extensions >=4.14.0
     - if: match(python, "<3.11")
       then:
         - tomli >=1.1.0

--- a/recipes/sqlglot-mypy/recipe.yaml
+++ b/recipes/sqlglot-mypy/recipe.yaml
@@ -2,14 +2,6 @@ schema_version: 1
 
 context:
   version: "2.1.0.post3"
-  ast_serialize_min: "0.3.0"
-  ast_serialize_max: "1.0.0"
-  mypy_extensions_min: "1.0.0"
-  pathspec_min: "1.0.0"
-  pathspec_max: "1.1"
-  python_librt_min: "0.11.0"
-  tomli_min: "1.1.0"
-  typing_extensions_min: "4.6.0"
 
 package:
   name: sqlglot-mypy
@@ -32,25 +24,25 @@ requirements:
     - ${{ compiler("c") }}
     - ${{ stdlib("c") }}
   host:
-    - ast-serialize >=${{ ast_serialize_min }},<${{ ast_serialize_max }}
-    - mypy_extensions >=${{ mypy_extensions_min }}
-    - pathspec >=${{ pathspec_min }},<${{ pathspec_max }}
+    - ast-serialize >=0.3.0,<1.0.0
+    - mypy_extensions >=1.0.0
+    - pathspec >=1.0.0,<1.1
     - pip
     - python
-    - python-librt >=${{ python_librt_min }}
+    - python-librt >=0.11.0
     - setuptools >=77.0.3
     - types-psutil
     - types-setuptools
-    - typing_extensions >=${{ typing_extensions_min }}
+    - typing_extensions >=4.6.0
     - if: match(python, "<3.11")
       then:
-        - tomli >=${{ tomli_min }}
+        - tomli >=1.1.0
   run:
-    - ast-serialize >=${{ ast_serialize_min }},<${{ ast_serialize_max }}
-    - mypy_extensions >=${{ mypy_extensions_min }}
-    - pathspec >=${{ pathspec_min }},<${{ pathspec_max }}
+    - ast-serialize >=0.3.0,<1.0.0
+    - mypy_extensions >=1.0.0
+    - pathspec >=1.0.0,<1.1
     - python
-    - python-librt >=${{ python_librt_min }}
+    - python-librt >=0.11.0
     # mypyc.build (mypyc/build_setup.py) does `from distutils import
     # ccompiler` at import time; on Python >=3.12, stdlib distutils is
     # gone, so importing mypyc.build only works if setuptools (which
@@ -58,10 +50,10 @@ requirements:
     # it) is actually installed alongside this package at runtime, not
     # just at build time.
     - setuptools >=77.0.3
-    - typing_extensions >=${{ typing_extensions_min }}
+    - typing_extensions >=4.6.0
     - if: match(python, "<3.11")
       then:
-        - tomli >=${{ tomli_min }}
+        - tomli >=1.1.0
 
 tests:
   - python:


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Adds a recipe for [`sqlglot-mypy`](https://github.com/vaggelisd/sqlglot-mypy) (v2.1.0.post3), using the v1 (`schema_version: 1`) recipe format.

## What this package is

`sqlglot-mypy` is the sqlglot project's fork of mypy, published to PyPI under a separate name so that the mypyc toolchain used to compile the `sqlglotc` accelerator can move independently of upstream mypy's release cadence. It ships the same `mypy`/`mypyc` import names and CLI entry points as upstream mypy.

It is packaged here for one purpose: to satisfy `sqlglotc`'s build-time dependency on `mypyc.build.mypycify`.

## Notes for reviewers

- **This package conflicts with conda-forge's `mypy` by design.** It installs files under the same `mypy`/`mypyc` import names, so the two cannot be co-installed. It is not meant for general-purpose environments - only as a build dependency of the forthcoming `sqlglotc` feedstock. This is called out explicitly in `about.description`.
- **Built with mypyc** (`MYPY_USE_MYPYC=1`), hence the C compiler/stdlib in `requirements.build` and the non-`noarch` build.
- **`setuptools` is a runtime dependency, not just a host one.** `mypyc.build` does `from distutils import ccompiler` at import time. Since stdlib `distutils` is gone on Python >= 3.12, importing `mypyc.build` only works when setuptools (which vendors distutils and shims the import) is installed alongside. There is a comment in the recipe explaining this.
- The test section imports `mypyc.build` specifically to exercise the point above, and runs `pip_check`.
- Two license files are included: the project's own `LICENSE` and the bundled `mypy/typeshed/LICENSE`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
