### PR TITLE
Add r-tigerr

### DIFF
--- a/recipes/r-tigerr/bld.bat
+++ b/recipes/r-tigerr/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-tigerr/build.sh
+++ b/recipes/r-tigerr/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-tigerr/meta.yaml
+++ b/recipes/r-tigerr/meta.yaml
@@ -54,3 +54,4 @@ about:
 extra:
   recipe-maintainers:
     - VinzentRisch
+    - conda-forge/r

--- a/recipes/r-tigerr/meta.yaml
+++ b/recipes/r-tigerr/meta.yaml
@@ -1,0 +1,56 @@
+{% set version = "1.0.0" %}
+{% set posix = "m2-" if win else "" %}
+
+package:
+  name: r-tigerr
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/TIGERr_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/TIGERr/TIGERr_{{ version }}.tar.gz
+  sha256: edd09c4f21b2e044ea8f5a57d76a0f32ad5994c06a46a1ce7e4b03d714a8d612
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - "*/R.dll"        # [win]
+    - "*/Rblas.dll"    # [win]
+    - "*/Rlapack.dll"  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip  # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+  host:
+    - r-base >=3.5.0
+    - r-pbapply >=1.4_3
+    - r-ppcor >=1.1
+    - r-randomforest >=4.6_14
+  run:
+    - r-base >=3.5.0
+    - r-pbapply >=1.4_3
+    - r-ppcor >=1.1
+    - r-randomforest >=4.6_14
+
+test:
+  commands:
+    - $R -e "library('TIGERr')"  # [not win]
+    - "\"%R%\" -e \"library('TIGERr')\""  # [win]
+
+about:
+  home: https://cran.r-project.org/package=TIGERr
+  dev_url: https://github.com/HAN-Siyu/TIGER
+  summary: Technical variation elimination with ensemble learning architecture
+  license: GPL-3.0-or-later
+  license_family: GPL3
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
+
+extra:
+  recipe-maintainers:
+    - VinzentRisch

--- a/recipes/r-tigerr/meta.yaml
+++ b/recipes/r-tigerr/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - {{ posix }}zip  # [win]
     - cross-r-base {{ r_base }}  # [build_platform != target_platform]
   host:
-    - r-base >=3.5.0
+    - r-base
     - r-pbapply >=1.4_3
     - r-ppcor >=1.1
     - r-randomforest >=4.6_14

--- a/recipes/r-tigerr/meta.yaml
+++ b/recipes/r-tigerr/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - r-ppcor >=1.1
     - r-randomforest >=4.6_14
   run:
-    - r-base >=3.5.0
+    - r-base
     - r-pbapply >=1.4_3
     - r-ppcor >=1.1
     - r-randomforest >=4.6_14


### PR DESCRIPTION
## Checklist

- [x] Recipe builds and tests locally with conda-build.
- [x] Recipe lints cleanly with conda-smithy.
- [x] Source checksum is verified against the CRAN release.

This adds `r-tigerr` 1.0.0, the R implementation of TIGER for metabolomics technical-variation correction.

`grayskull cran` was used to retrieve and parse the CRAN metadata, but its current generator fails for this package because the DESCRIPTION file omits the optional `URL` field; the resulting v0 recipe follows the staged-recipes R-package conventions.
