### PR TITLE
Add dbt-core-experimental-parser recipe

### DIFF
--- a/recipes/dbt-core-experimental-parser/recipe.yaml
+++ b/recipes/dbt-core-experimental-parser/recipe.yaml
@@ -1,0 +1,90 @@
+# This package is a new dependency of dbt-core >=1.12.0 (see dbt-core-feedstock PR
+# https://github.com/conda-forge/dbt-feedstock/pull/171), so it needs to land on
+# conda-forge before that PR can pass its dependency resolution / build.
+#
+# Upstream (dbt-labs/dbt-core, on the branch developing the Rust-based dbt v2.0/Fusion
+# rewrite) does not currently publish anything buildable from source for this package:
+# the PyPI sdist for versions >=2.0.0a5 is not real source at all -- it is a PEP 517
+# build backend that reaches out over the network at install time to download a
+# prebuilt wheel from a GitHub Release and hand it back unmodified. That approach
+# can't work in conda-forge's network-isolated build containers, and isn't a real
+# "build from source" path regardless. The underlying Rust source lives in a ~60-crate
+# workspace in the dbt-core repo (crates/) that isn't set up to be built standalone by
+# downstream packagers.
+#
+# So this recipe repackages the last upstream release that still published real,
+# directly-installable wheels straight to PyPI (2.0.0a4, one per OS/arch, tagged
+# `py3-none` since there's no Python C-ABI involved -- the wheel just carries a
+# prebuilt native CLI binary via `.data/scripts/`). No license file ships inside the
+# wheel, so it's fetched separately from the matching upstream release tag.
+#
+# This is a first attempt to unblock dbt-feedstock#171 quickly and demonstrate good
+# faith effort to the dbt-core maintainers -- feedback on a better packaging approach
+# (e.g. if/when upstream ships a real source release, or if there's a preferred way to
+# track the alpha/Fusion release cadence) is very welcome.
+
+context:
+  version: "2.0.0a4"
+  upstream_tag: v2.0.0-alpha.4
+
+package:
+  name: dbt-core-experimental-parser
+  version: ${{ version }}
+
+source:
+  - if: linux and x86_64
+    then:
+      url: https://files.pythonhosted.org/packages/f8/ca/5b7b7d0934b1cdcc76dbeb14f88d0794446e1e8ab593ba767932da845a6b/dbt_core_experimental_parser-${{ version }}-py3-none-manylinux_2_28_x86_64.whl
+      sha256: 07649f912a7eb9fb54b9cfd1a63747020c88977d8050a1a29445966012c09b9a
+  - if: linux and aarch64
+    then:
+      url: https://files.pythonhosted.org/packages/05/46/545a2a6fdd5943888d4f6c26db2ba0b1837f4e1ce08daa34a7c3b689d943/dbt_core_experimental_parser-${{ version }}-py3-none-manylinux_2_28_aarch64.whl
+      sha256: 2bd6245abed8e1f48aa7cdbd4170a6fb3605fd763657440d36bbf90c8d989731
+  - if: osx and x86_64
+    then:
+      url: https://files.pythonhosted.org/packages/01/65/33390a43639b5903efe407850deef642a417014853ffdba7b70874b44c8e/dbt_core_experimental_parser-${{ version }}-py3-none-macosx_10_12_x86_64.whl
+      sha256: 244f18a1eaf67cde836344c551368cc25e10c22f0158fafbbc9d950693e75a0d
+  - if: osx and arm64
+    then:
+      url: https://files.pythonhosted.org/packages/ab/d0/9b47b20d8dc45532ddb9d608d31e724bee0434ad831808daac79c853be12/dbt_core_experimental_parser-${{ version }}-py3-none-macosx_11_0_arm64.whl
+      sha256: 02109d850288009a85f58095774c2d32f73d77174e2c6aec129d2944b0e8ecb4
+  - if: win
+    then:
+      url: https://files.pythonhosted.org/packages/0f/01/9fa6693d919a9a602110eb177552c1e9d5bd7dc6a4e369a94e79ffc75a6e/dbt_core_experimental_parser-${{ version }}-py3-none-win_amd64.whl
+      sha256: c6b5d1f0b8271a29a70094c40e75be8de6dfe2234e5258ad63601693ef6d4225
+  # No LICENSE ships inside the wheel; pull it from the matching upstream release tag.
+  - url: https://raw.githubusercontent.com/dbt-labs/dbt-core/${{ upstream_tag }}/LICENSE
+    sha256: aaec0fc491a8093b76b7301f6168b9ac05b0fd20e8ea717f7d90691b3b7d8772
+    target_directory: license-src
+
+build:
+  number: 0
+  # Nothing is compiled -- this just unpacks a prebuilt wheel into the environment.
+  script: pip install ./*.whl --no-deps -vv
+  noarch: false
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python >=3.9
+
+tests:
+  - script:
+      - dbt-core-experimental-parser --help
+
+about:
+  homepage: https://github.com/dbt-labs/dbt-core
+  repository: https://github.com/dbt-labs/dbt-core
+  documentation: https://docs.getdbt.com
+  summary: Experimental parser preview for the Rust-based dbt Core v2.0 (Fusion) rewrite
+  description: |
+    Prebuilt binary preview of the parser component from dbt Core v2.0 (Fusion), the
+    Rust-based rewrite of dbt-core. Packaged as a dependency of dbt-core >=1.12.0.
+  license: Apache-2.0
+  license_file: license-src/LICENSE
+
+extra:
+  recipe-maintainers:
+    - zaneselvans

--- a/recipes/dbt-core-experimental-parser/recipe.yaml
+++ b/recipes/dbt-core-experimental-parser/recipe.yaml
@@ -31,23 +31,23 @@ package:
 source:
   - if: linux and x86_64
     then:
-      url: https://files.pythonhosted.org/packages/f8/ca/5b7b7d0934b1cdcc76dbeb14f88d0794446e1e8ab593ba767932da845a6b/dbt_core_experimental_parser-${{ version }}-py3-none-manylinux_2_28_x86_64.whl
+      url: https://pypi.org/packages/py3/d/dbt-core-experimental-parser/dbt_core_experimental_parser-${{ version }}-py3-none-manylinux_2_28_x86_64.whl
       sha256: 07649f912a7eb9fb54b9cfd1a63747020c88977d8050a1a29445966012c09b9a
   - if: linux and aarch64
     then:
-      url: https://files.pythonhosted.org/packages/05/46/545a2a6fdd5943888d4f6c26db2ba0b1837f4e1ce08daa34a7c3b689d943/dbt_core_experimental_parser-${{ version }}-py3-none-manylinux_2_28_aarch64.whl
+      url: https://pypi.org/packages/py3/d/dbt-core-experimental-parser/dbt_core_experimental_parser-${{ version }}-py3-none-manylinux_2_28_aarch64.whl
       sha256: 2bd6245abed8e1f48aa7cdbd4170a6fb3605fd763657440d36bbf90c8d989731
   - if: osx and x86_64
     then:
-      url: https://files.pythonhosted.org/packages/01/65/33390a43639b5903efe407850deef642a417014853ffdba7b70874b44c8e/dbt_core_experimental_parser-${{ version }}-py3-none-macosx_10_12_x86_64.whl
+      url: https://pypi.org/packages/py3/d/dbt-core-experimental-parser/dbt_core_experimental_parser-${{ version }}-py3-none-macosx_10_12_x86_64.whl
       sha256: 244f18a1eaf67cde836344c551368cc25e10c22f0158fafbbc9d950693e75a0d
   - if: osx and arm64
     then:
-      url: https://files.pythonhosted.org/packages/ab/d0/9b47b20d8dc45532ddb9d608d31e724bee0434ad831808daac79c853be12/dbt_core_experimental_parser-${{ version }}-py3-none-macosx_11_0_arm64.whl
+      url: https://pypi.org/packages/py3/d/dbt-core-experimental-parser/dbt_core_experimental_parser-${{ version }}-py3-none-macosx_11_0_arm64.whl
       sha256: 02109d850288009a85f58095774c2d32f73d77174e2c6aec129d2944b0e8ecb4
   - if: win
     then:
-      url: https://files.pythonhosted.org/packages/0f/01/9fa6693d919a9a602110eb177552c1e9d5bd7dc6a4e369a94e79ffc75a6e/dbt_core_experimental_parser-${{ version }}-py3-none-win_amd64.whl
+      url: https://pypi.org/packages/py3/d/dbt-core-experimental-parser/dbt_core_experimental_parser-${{ version }}-py3-none-win_amd64.whl
       sha256: c6b5d1f0b8271a29a70094c40e75be8de6dfe2234e5258ad63601693ef6d4225
   # No LICENSE ships inside the wheel; pull it from the matching upstream release tag.
   - url: https://raw.githubusercontent.com/dbt-labs/dbt-core/${{ upstream_tag }}/LICENSE

--- a/recipes/dbt-core-experimental-parser/recipe.yaml
+++ b/recipes/dbt-core-experimental-parser/recipe.yaml
@@ -6,22 +6,19 @@
 # rewrite) does not currently publish anything buildable from source for this package:
 # the PyPI sdist for versions >=2.0.0a5 is not real source at all -- it is a PEP 517
 # build backend that reaches out over the network at install time to download a
-# prebuilt wheel from a GitHub Release and hand it back unmodified. That approach
-# can't work in conda-forge's network-isolated build containers, and isn't a real
-# "build from source" path regardless. The underlying Rust source lives in a ~60-crate
-# workspace in the dbt-core repo (crates/) that isn't set up to be built standalone by
-# downstream packagers.
+# prebuilt wheel from a GitHub Release and hand it back unmodified. The underlying Rust
+# source lives in a ~60-crate workspace in the dbt-core repo (crates/) that isn't set up
+# to be built standalone by downstream packagers.
 #
 # So this recipe repackages the last upstream release that still published real,
 # directly-installable wheels straight to PyPI (2.0.0a4, one per OS/arch, tagged
-# `py3-none` since there's no Python C-ABI involved -- the wheel just carries a
-# prebuilt native CLI binary via `.data/scripts/`). No license file ships inside the
-# wheel, so it's fetched separately from the matching upstream release tag.
+# `py3-none` since there's no Python C-ABI involved -- the wheel just carries a prebuilt
+# native CLI binary via `.data/scripts/`). No license file ships inside the wheel, so
+# it's fetched separately from the matching upstream release tag.
 #
-# This is a first attempt to unblock dbt-feedstock#171 quickly and demonstrate good
-# faith effort to the dbt-core maintainers -- feedback on a better packaging approach
-# (e.g. if/when upstream ships a real source release, or if there's a preferred way to
-# track the alpha/Fusion release cadence) is very welcome.
+# This is a first attempt to unblock dbt-feedstock#171 -- feedback on a better packaging
+# approach (e.g. if/when upstream ships a real source release, or if there's a preferred
+# way to track the alpha/Fusion release) is very welcome.
 
 context:
   version: "2.0.0a4"

--- a/recipes/dbt-core-experimental-parser/recipe.yaml
+++ b/recipes/dbt-core-experimental-parser/recipe.yaml
@@ -60,15 +60,24 @@ source:
 build:
   number: 0
   # Nothing is compiled -- this just unpacks a prebuilt wheel into the environment.
+  # Not noarch: the wheel payload differs per platform/arch.
   script: pip install ./*.whl --no-deps -vv
-  noarch: false
 
 requirements:
+  # python/pip must stay in `host` so the wheel installs into $PREFIX (not the
+  # build prefix). But the resulting package doesn't need to match a specific
+  # python ABI -- it's a prebuilt native binary, not a compiled extension -- so
+  # `ignore_run_exports` suppresses python's normal strong `python_abi` pin.
+  # Otherwise conda-forge would rebuild this identical package once per
+  # supported Python version for no reason.
   host:
     - python
     - pip
   run:
     - python >=3.9
+  ignore_run_exports:
+    by_name:
+      - python_abi
 
 tests:
   - script:

--- a/recipes/dbt-core-experimental-parser/recipe.yaml
+++ b/recipes/dbt-core-experimental-parser/recipe.yaml
@@ -57,8 +57,16 @@ source:
 build:
   number: 0
   # Nothing is compiled -- this just unpacks a prebuilt wheel into the environment.
-  # Not noarch: the wheel payload differs per platform/arch.
-  script: pip install ./*.whl --no-deps -vv
+  # Not noarch: the wheel payload differs per platform/arch. The one .whl in
+  # $SRC_DIR is found with Python's own glob rather than a shell wildcard,
+  # since cmd.exe (used on win-64) doesn't glob-expand `*.whl` the way bash
+  # does -- a shell wildcard here broke the Windows build (pip received the
+  # literal, un-expanded string `*.whl`), and renaming to a fixed filename
+  # doesn't work either since pip validates wheel filenames strictly on
+  # install and rejects anything that isn't the real 5-part wheel name.
+  script: >-
+    python -c "import glob, subprocess, sys;
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--no-deps', '-vv', glob.glob('*.whl')[0]])"
 
 requirements:
   # python/pip must stay in `host` so the wheel installs into $PREFIX (not the

--- a/recipes/dbt-core-experimental-parser/recipe.yaml
+++ b/recipes/dbt-core-experimental-parser/recipe.yaml
@@ -71,7 +71,7 @@ requirements:
     - python
     - pip
   run:
-    - python >=3.9
+    - python
   ignore_run_exports:
     by_name:
       - python_abi


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

# Overview

I understand that this isn't the way feedstocks are supposed to work, with the pre-compiled wheels, and I'm not sure if this is a case in which an exception makes sense, but the new upstream `dbt-core` version 1.12.0 depends on an alpha version of the rust-based re-write of dbt, which is currently only being distributed as compiled wheels. The most recent alpha version 2.0.0a5 on PyPI (which this is not attempting to package) actually downloads the wheels from GitHub at install time. I'm primarily trying to unblock the release of  https://github.com/conda-forge/dbt-feedstock/pull/171 but the rust package for the alpha release looks like a lot, and doesn't seem to be ready for packaging (but I also don't really know the rust ecosystem).

Is there a better way to go about doing this packaging given the state of the rust package? Or maybe there's a clean way to leave this optional, alpha release package out of the mature, production conda-forge distribution for dbt 1.12?

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
