### PR TITLE
Add recipe for libstatgrab

### DIFF
--- a/recipes/libstatgrab/recipe.yaml
+++ b/recipes/libstatgrab/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: "0.92.1"
+  tag: "LIBSTATGRAB_${{ version | replace('.', '_') }}"
+
+package:
+  name: libstatgrab
+  version: ${{ version }}
+
+source:
+  url: https://github.com/libstatgrab/libstatgrab/releases/download/${{ tag }}/libstatgrab-${{ version }}.tar.gz
+  sha256: 5688aa4a685547d7174a8a373ea9d8ee927e766e3cc302bdee34523c2c5d6c11
+
+build:
+  skip: win  # does support mingw32
+  script:
+    - ./configure --prefix="${PREFIX}" --disable-static --disable-saidar
+    - make
+    - make check || (cat tests/test-suite.log && exit 1)
+    - make install
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - make
+    - file
+  host:
+  run:
+
+tests:
+  - package_contents:
+      bin:
+        - statgrab
+      include:
+        - statgrab.h
+      lib:
+        - statgrab
+
+about:
+  homepage: https://libstatgrab.org/
+  summary: 'Provides cross-platform access to statistics about the system'
+  description: |
+    libstatgrab is a library that provides cross platform access to statistics
+    about the system on which it’s run. It’s written in C and presents a
+    selection of useful interfaces which can be used to access key system
+    statistics. The current list of statistics includes CPU usage, memory
+    utilisation, disk usage, process counts, network traffic, disk I/O, and
+    more.
+  license: GPL-2.0-or-later AND LGPL-2.1-or-later
+  license_file:
+    - COPYING
+    - COPYING.LGPL
+  documentation: https://libstatgrab.org/#documentation
+  repository: https://github.com/libstatgrab/libstatgrab
+
+extra:
+  recipe-maintainers:
+    - embray
+    - jhunkeler

--- a/recipes/libstatgrab/recipe.yaml
+++ b/recipes/libstatgrab/recipe.yaml
@@ -27,6 +27,8 @@ requirements:
     - file
   host:
   run:
+  run_exports:
+    - ${{ pin_subpackage('libstatgrab', upper_bound='x.x') }}
 
 tests:
   - package_contents:


### PR DESCRIPTION
libstatgrab is a library that provides cross platform access to statistics about the system on which it’s run. It’s written in C and presents a selection of useful interfaces which can be used to access key system statistics. The current list of statistics includes CPU usage, memory utilisation, disk usage, process counts, network traffic, disk I/O, and more.

I'm requesting to add it as it is a dependency of libasdf ( being added in #31639 which is quite stale; I intend to refresh it and get it up to snuff).


Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged. (N/A)
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team. (Noted)
