### PR TITLE
Adding moonshine (and libevdev)

### DIFF
--- a/recipes/libevdev/recipe.yaml
+++ b/recipes/libevdev/recipe.yaml
@@ -33,10 +33,19 @@ requirements:
 
 tests:
   - package_contents:
-      lib:
-        - evdev
+      strict: true
+      bin:
+        - libevdev-tweak-device
+        - mouse-dpi-tool
+        - touchpad-edge-detector
       include:
-        - libevdev-1.0/libevdev/libevdev.h
+        - libevdev-1.0/libevdev/*.h
+      files:
+        exists:
+          - lib/libevdev.so*
+          - lib/pkgconfig/libevdev.pc
+          - share/man/man1/*.1
+          - share/man/man3/*.3
   - script:
       - pkg-config --exists libevdev
     requirements:

--- a/recipes/libevdev/recipe.yaml
+++ b/recipes/libevdev/recipe.yaml
@@ -1,0 +1,56 @@
+context:
+  version: "1.13.6"
+
+package:
+  name: libevdev
+  version: ${{ version }}
+
+source:
+  url: https://www.freedesktop.org/software/libevdev/libevdev-${{ version }}.tar.xz
+  sha256: 73f215eccbd8233f414737ac06bca2687e67c44b97d2d7576091aa9718551110
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script:
+    - ./configure --prefix=$PREFIX --disable-static
+    - make -j${CPU_COUNT}
+    - make install
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - make
+    - pkg-config
+  run_exports:
+    - ${{ pin_subpackage('libevdev', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - evdev
+      include:
+        - libevdev-1.0/libevdev/libevdev.h
+  - script:
+      - pkg-config --exists libevdev
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://www.freedesktop.org/wiki/Software/libevdev/
+  summary: Wrapper library for evdev devices
+  description: |
+    libevdev is a wrapper library for evdev devices. It moves the common
+    tasks when dealing with evdev devices into a library and provides a
+    library interface to the callers, thus avoiding erroneous ioctl calls.
+  license: MIT
+  license_file: COPYING
+  documentation: https://www.freedesktop.org/software/libevdev/doc/latest/
+  repository: https://gitlab.freedesktop.org/libevdev/libevdev
+
+extra:
+  recipe-maintainers:
+    - tdejager

--- a/recipes/libevdev/recipe.yaml
+++ b/recipes/libevdev/recipe.yaml
@@ -14,6 +14,9 @@ build:
   skip:
     - not linux
   script:
+    # make-event-names.py runs at build time; point configure at the build
+    # prefix python instead of the (nonexistent) $PREFIX/bin/python
+    - export PYTHON=${BUILD_PREFIX}/bin/python3
     - ./configure --prefix=$PREFIX --disable-static
     - make -j${CPU_COUNT}
     - make install
@@ -24,6 +27,7 @@ requirements:
     - ${{ compiler('c') }}
     - make
     - pkg-config
+    - python
   run_exports:
     - ${{ pin_subpackage('libevdev', upper_bound='x.x') }}
 

--- a/recipes/moonshine/recipe.yaml
+++ b/recipes/moonshine/recipe.yaml
@@ -19,6 +19,8 @@ build:
       CARGO_PROFILE_RELEASE_STRIP: symbols
     content: |
       export LIBCLANG_PATH=${BUILD_PREFIX}/lib
+      # bindgen needs clang's builtin headers (stdbool.h etc.)
+      export BINDGEN_EXTRA_CLANG_ARGS="-resource-dir=$(${BUILD_PREFIX}/bin/clang -print-resource-dir)"
       cargo auditable build --release --locked -p moonshine -p moonshine-wsi
       install -Dm755 target/release/moonshine ${PREFIX}/bin/moonshine
       install -Dm755 target/release/libmoonshine_wsi.so ${PREFIX}/lib/moonshine/vulkan-layers/libmoonshine_wsi.so
@@ -43,6 +45,8 @@ requirements:
     - make
     - pkg-config
     - git
+    - clang
+    - clangdev
     - libclang
   host:
     - libevdev

--- a/recipes/moonshine/recipe.yaml
+++ b/recipes/moonshine/recipe.yaml
@@ -1,0 +1,86 @@
+context:
+  version: "0.12.0"
+
+package:
+  name: moonshine
+  version: ${{ version }}
+
+source:
+  url: https://github.com/hgaiser/moonshine/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 3358beafdbeff78f155a0e161468838a683fd6bec03824147ae16986be6bfd56
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script:
+    env:
+      # LTO is disabled upstream (see the AUR PKGBUILD's !lto option)
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+    content: |
+      export LIBCLANG_PATH=${BUILD_PREFIX}/lib
+      cargo auditable build --release --locked -p moonshine -p moonshine-wsi
+      install -Dm755 target/release/moonshine ${PREFIX}/bin/moonshine
+      install -Dm755 target/release/libmoonshine_wsi.so ${PREFIX}/lib/moonshine/vulkan-layers/libmoonshine_wsi.so
+      # The Vulkan loader resolves relative library_path entries relative to the manifest location
+      sed 's|/usr/lib/moonshine/vulkan-layers/libmoonshine_wsi.so|../../../lib/moonshine/vulkan-layers/libmoonshine_wsi.so|' \
+        dist/VkLayer_moonshine_wsi.json > VkLayer_moonshine_wsi.json
+      install -Dm644 VkLayer_moonshine_wsi.json ${PREFIX}/share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+      install -Dm644 dist/moonshine@.service ${PREFIX}/share/moonshine/moonshine@.service
+      install -Dm644 dist/60-moonshine.rules ${PREFIX}/share/moonshine/60-moonshine.rules
+      install -Dm644 dist/moonshine-modules.conf ${PREFIX}/share/moonshine/moonshine-modules.conf
+      cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ compiler('rust') }}
+    - cargo-auditable
+    - cargo-bundle-licenses
+    - cmake
+    - make
+    - pkg-config
+    - git
+    - libclang
+  host:
+    - libevdev
+    - libopus
+    - libdrm
+    - libgbm
+    - wayland
+    - libxkbcommon
+
+tests:
+  - script: moonshine --help
+  - package_contents:
+      bin:
+        - moonshine
+      files:
+        exists:
+          - lib/moonshine/vulkan-layers/libmoonshine_wsi.so
+          - share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+
+about:
+  homepage: https://github.com/hgaiser/moonshine
+  summary: Headless streaming server for Moonlight clients, written in Rust
+  description: |
+    Moonshine lets you stream games from a Linux PC to any device running
+    Moonlight. Each stream runs in its own isolated compositor, separate
+    from the desktop environment, so no monitor or active desktop session
+    is required. It supports hardware H.264/H.265/AV1 encoding via Vulkan,
+    HDR, surround-sound audio, and full mouse, keyboard, and gamepad input.
+
+    The package also ships the Moonshine Vulkan WSI layer
+    (share/vulkan/implicit_layer.d) and reference systemd/udev integration
+    files (share/moonshine).
+  license: BSD-2-Clause
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  repository: https://github.com/hgaiser/moonshine
+
+extra:
+  recipe-maintainers:
+    - tdejager

--- a/recipes/moonshine/recipe.yaml
+++ b/recipes/moonshine/recipe.yaml
@@ -49,6 +49,9 @@ requirements:
     - clangdev
     - libclang
   host:
+    # inputtino-sys emits link-lib=c++ unconditionally; --as-needed drops it
+    # again at runtime since no libc++ symbols are used
+    - libcxx-devel
     - libevdev
     - libopus
     - libdrm

--- a/recipes/moonshine/recipe.yaml
+++ b/recipes/moonshine/recipe.yaml
@@ -63,12 +63,16 @@ requirements:
 tests:
   - script: moonshine --help
   - package_contents:
+      strict: true
       bin:
         - moonshine
       files:
         exists:
           - lib/moonshine/vulkan-layers/libmoonshine_wsi.so
           - share/vulkan/implicit_layer.d/VkLayer_moonshine_wsi.json
+          - share/moonshine/60-moonshine.rules
+          - share/moonshine/moonshine-modules.conf
+          - share/moonshine/moonshine@.service
 
 about:
   homepage: https://github.com/hgaiser/moonshine

--- a/recipes/moonshine/recipe.yaml
+++ b/recipes/moonshine/recipe.yaml
@@ -22,8 +22,9 @@ build:
       # bindgen needs clang's builtin headers (stdbool.h etc.)
       export BINDGEN_EXTRA_CLANG_ARGS="-resource-dir=$(${BUILD_PREFIX}/bin/clang -print-resource-dir)"
       cargo auditable build --release --locked -p moonshine -p moonshine-wsi
-      install -Dm755 target/release/moonshine ${PREFIX}/bin/moonshine
-      install -Dm755 target/release/libmoonshine_wsi.so ${PREFIX}/lib/moonshine/vulkan-layers/libmoonshine_wsi.so
+      RELEASE_DIR="target/${CARGO_BUILD_TARGET:+${CARGO_BUILD_TARGET}/}release"
+      install -Dm755 ${RELEASE_DIR}/moonshine ${PREFIX}/bin/moonshine
+      install -Dm755 ${RELEASE_DIR}/libmoonshine_wsi.so ${PREFIX}/lib/moonshine/vulkan-layers/libmoonshine_wsi.so
       # The Vulkan loader resolves relative library_path entries relative to the manifest location
       sed 's|/usr/lib/moonshine/vulkan-layers/libmoonshine_wsi.so|../../../lib/moonshine/vulkan-layers/libmoonshine_wsi.so|' \
         dist/VkLayer_moonshine_wsi.json > VkLayer_moonshine_wsi.json

--- a/recipes/moonshine/variants.yaml
+++ b/recipes/moonshine/variants.yaml
@@ -1,4 +1,5 @@
 # inputtino uses gamepad button codes (BTN_SOUTH etc.) that need kernel
 # headers >= 4.3; the default 2.17 sysroot ships 3.10 headers
 c_stdlib_version:
-  - "2.28"
+  - if: linux
+    then: "2.28"

--- a/recipes/moonshine/variants.yaml
+++ b/recipes/moonshine/variants.yaml
@@ -1,0 +1,4 @@
+# inputtino uses gamepad button codes (BTN_SOUTH etc.) that need kernel
+# headers >= 4.3; the default 2.17 sysroot ships 3.10 headers
+c_stdlib_version:
+  - "2.28"


### PR DESCRIPTION
This adds [moonshine](https://github.com/hgaiser/moonshine), a headless game-streaming server for Moonlight clients written in Rust. I want to run it on a Steam Machine, and SteamOS's immutable root filesystem makes a conda package a nice fit: it installs into the user's home directory and survives OS updates, no pacman involved.

It also adds **libevdev** as a new package. Moonshine's input stack ([inputtino](https://github.com/games-on-whales/inputtino)) needs it via pkg-config, and conda-forge only had the Python `evdev` bindings so far.

A few notes for review:

- Both packages are Linux-only.
- Built with `cargo auditable build --locked`; licenses of all Rust dependencies (including the statically linked inputtino and aws-lc code) are bundled into `THIRDPARTY.yml` via cargo-bundle-licenses.
- moonshine needs the 2.28 sysroot because inputtino uses gamepad button codes that only exist in kernel headers >= 4.3 — that's what `variants.yaml` is for.
- LTO is off because upstream disables it as well (`!lto` in their PKGBUILD).
- Besides the binary, the package ships moonshine's Vulkan WSI implicit layer. The manifest's `library_path` is rewritten to a relative path so the loader resolves it from within a conda prefix. The systemd/udev integration files land in `share/moonshine` as a reference, since conda can't install those system-wide.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.