### PR TITLE
Adding moonlight-qt

### DIFF
--- a/recipes/moonlight-qt/CC0-1.0.txt
+++ b/recipes/moonlight-qt/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/recipes/moonlight-qt/ModeSeven-LICENSE.txt
+++ b/recipes/moonlight-qt/ModeSeven-LICENSE.txt
@@ -1,0 +1,3 @@
+License notice for the ModeSeven font (app/ModeSeven.ttf, embedded into the moonlight binary), extracted from the font's name table:
+
+This rendition (C) 1998 Andrew C. Bul+hac?k. Freely distributable.

--- a/recipes/moonlight-qt/patches/0001-win-disable-prebuilts.patch
+++ b/recipes/moonlight-qt/patches/0001-win-disable-prebuilts.patch
@@ -1,5 +1,6 @@
---- a/app/app.pro	2026-07-23 09:19:00
-+++ b/app/app.pro	2026-07-23 09:19:00
+diff -ur a/app/app.pro b/app/app.pro
+--- a/app/app.pro	2026-07-23 10:57:11
++++ b/app/app.pro	2026-07-23 10:57:11
 @@ -36,20 +36,22 @@
  DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
  
@@ -56,3 +57,87 @@
  }
  macx {
      !disable-prebuilts {
+@@ -511,10 +518,11 @@
+ INCLUDEPATH += $$PWD/../h264bitstream/h264bitstream
+ DEPENDPATH += $$PWD/../h264bitstream/h264bitstream
+ 
+-!winrt {
++!winrt:!disable-prebuilts {
+     win32:CONFIG(release, debug|release): LIBS += -L$$OUT_PWD/../AntiHooking/release/ -lAntiHooking
+     else:win32:CONFIG(debug, debug|release): LIBS += -L$$OUT_PWD/../AntiHooking/debug/ -lAntiHooking
+ 
++    win32: DEFINES += HAVE_ANTIHOOKING
+     INCLUDEPATH += $$PWD/../AntiHooking
+     DEPENDPATH += $$PWD/../AntiHooking
+ }
+diff -ur a/app/main.cpp b/app/main.cpp
+--- a/app/main.cpp	2026-07-23 10:57:11
++++ b/app/main.cpp	2026-07-23 10:57:11
+@@ -24,7 +24,9 @@
+ #endif
+ 
+ #if defined(Q_OS_WIN32)
++#ifdef HAVE_ANTIHOOKING
+ #include "antihookingprotection.h"
++#endif
+ 
+ #define WIN32_LEAN_AND_MEAN
+ #include <Windows.h>
+@@ -366,7 +368,7 @@
+     }
+ #endif
+ 
+-#if defined(Q_OS_WIN32)
++#if defined(Q_OS_WIN32) && defined(HAVE_ANTIHOOKING)
+     // Force AntiHooking.dll to be statically imported and loaded
+     // by ntdll on Win32 platforms by calling a dummy function.
+     AntiHookingDummyImport();
+diff -ur a/moonlight-common-c/moonlight-common-c.pro b/moonlight-common-c/moonlight-common-c.pro
+--- a/moonlight-common-c/moonlight-common-c.pro	2026-07-23 10:57:11
++++ b/moonlight-common-c/moonlight-common-c.pro	2026-07-23 10:57:11
+@@ -16,20 +16,22 @@
+ include(../globaldefs.pri)
+ 
+ win32 {
+-    contains(QT_ARCH, i386) {
+-        INCLUDEPATH += $$PWD/../libs/windows/include/x86
+-    }
+-    contains(QT_ARCH, x86_64) {
+-        INCLUDEPATH += $$PWD/../libs/windows/include/x64
+-    }
+-    contains(QT_ARCH, arm64) {
+-        INCLUDEPATH += $$PWD/../libs/windows/include/arm64
+-    }
++    !disable-prebuilts {
++        contains(QT_ARCH, i386) {
++            INCLUDEPATH += $$PWD/../libs/windows/include/x86
++        }
++        contains(QT_ARCH, x86_64) {
++            INCLUDEPATH += $$PWD/../libs/windows/include/x64
++        }
++        contains(QT_ARCH, arm64) {
++            INCLUDEPATH += $$PWD/../libs/windows/include/arm64
++        }
+ 
+-    INCLUDEPATH += $$PWD/../libs/windows/include
++        INCLUDEPATH += $$PWD/../libs/windows/include
++    }
+     DEFINES += HAS_QOS_FLOWID=1 HAS_PQOS_FLOWID=1
+ }
+-macx {
++macx:!disable-prebuilts {
+     INCLUDEPATH += $$PWD/../libs/mac/include
+ }
+ unix:!macx {
+diff -ur a/moonlight-qt.pro b/moonlight-qt.pro
+--- a/moonlight-qt.pro	2026-07-23 10:57:11
++++ b/moonlight-qt.pro	2026-07-23 10:57:11
+@@ -7,7 +7,7 @@
+ 
+ # Build the dependencies in parallel before the final app
+ app.depends = qmdnsengine moonlight-common-c h264bitstream
+-win32:!winrt {
++win32:!winrt:!disable-prebuilts {
+     SUBDIRS += AntiHooking
+     app.depends += AntiHooking
+ }

--- a/recipes/moonlight-qt/patches/0001-win-disable-prebuilts.patch
+++ b/recipes/moonlight-qt/patches/0001-win-disable-prebuilts.patch
@@ -1,0 +1,58 @@
+--- a/app/app.pro	2026-07-23 09:19:00
++++ b/app/app.pro	2026-07-23 09:19:00
+@@ -36,20 +36,22 @@
+ DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+ 
+ win32 {
+-    contains(QT_ARCH, i386) {
+-        LIBS += -L$$PWD/../libs/windows/lib/x86
+-        INCLUDEPATH += $$PWD/../libs/windows/include/x86
+-    }
+-    contains(QT_ARCH, x86_64) {
+-        LIBS += -L$$PWD/../libs/windows/lib/x64
+-        INCLUDEPATH += $$PWD/../libs/windows/include/x64
+-    }
+-    contains(QT_ARCH, arm64) {
+-        LIBS += -L$$PWD/../libs/windows/lib/arm64
+-        INCLUDEPATH += $$PWD/../libs/windows/include/arm64
+-    }
++    !disable-prebuilts {
++        contains(QT_ARCH, i386) {
++            LIBS += -L$$PWD/../libs/windows/lib/x86
++            INCLUDEPATH += $$PWD/../libs/windows/include/x86
++        }
++        contains(QT_ARCH, x86_64) {
++            LIBS += -L$$PWD/../libs/windows/lib/x64
++            INCLUDEPATH += $$PWD/../libs/windows/include/x64
++        }
++        contains(QT_ARCH, arm64) {
++            LIBS += -L$$PWD/../libs/windows/lib/arm64
++            INCLUDEPATH += $$PWD/../libs/windows/include/arm64
++        }
+ 
+-    INCLUDEPATH += $$PWD/../libs/windows/include
++        INCLUDEPATH += $$PWD/../libs/windows/include
++    }
+     LIBS += ws2_32.lib winmm.lib dxva2.lib ole32.lib gdi32.lib user32.lib d3d9.lib dwmapi.lib dbghelp.lib
+ 
+     # Work around a conflict with math.h inclusion between SDL and Qt 6
+@@ -148,11 +150,16 @@
+     }
+ }
+ win32 {
+-    LIBS += -llibssl -llibcrypto -lSDL2 -lSDL2_ttf -lavcodec -lavutil -lswscale -lopus -ldxgi -ld3d11 -llibplacebo
+-    CONFIG += ffmpeg libplacebo
++    LIBS += -llibssl -llibcrypto -lSDL2 -lSDL2_ttf -lavcodec -lavutil -lswscale -lopus -ldxgi -ld3d11
++    CONFIG += ffmpeg
++    !disable-prebuilts {
++        LIBS += -llibplacebo
++        CONFIG += libplacebo
++    }
+ }
+ win32:!winrt {
+-    CONFIG += soundio discord-rpc
++    CONFIG += soundio
++    !disable-prebuilts: CONFIG += discord-rpc
+ }
+ macx {
+     !disable-prebuilts {

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -11,9 +11,12 @@ source:
   url: https://github.com/moonlight-stream/moonlight-qt/releases/download/v${{ version }}/MoonlightSrc-${{ version }}.tar.gz
   sha256: 696cc470a62e2f2e9b77739d400b389e7578c9510383c08614007c92be49d5b0
   patches:
-    # extend upstream's disable-prebuilts flag to windows so the build links
-    # conda libs instead of the vendored binaries (and skips libplacebo and
-    # the proprietary discord-rpc, which have no conda-forge packages there)
+    # extend upstream's disable-prebuilts flag to windows (and to the
+    # moonlight-common-c include paths) so the build uses conda headers and
+    # libs instead of the vendored ones, and skip the pieces that need
+    # vendored prebuilts: libplacebo and discord-rpc (not packaged on
+    # conda-forge for windows) and the AntiHooking shim (links Microsoft
+    # Detours, which is only present as a prebuilt static library)
     - patches/0001-win-disable-prebuilts.patch
 
 build:
@@ -48,7 +51,6 @@ build:
             moonlight-qt.pro
           jom
           cp app/release/Moonlight.exe "${LB}/"
-          cp AntiHooking/release/AntiHooking.dll "${LB}/"
           ;;
         *)
           case "${target_platform}" in
@@ -86,7 +88,7 @@ build:
       esac
       cat > "${P}/Menu/moonlight-qt.json" <<'EOF'
       {
-        "$schema": "https://schemas.conda.org/menuinst-1.schema.json",
+        "$schema": "https://schemas.conda.org/menuinst/menuinst-1-1-3.schema.json",
         "menu_name": "Moonlight",
         "menu_items": [
           {
@@ -104,7 +106,7 @@ build:
               "osx": {
                 "icon": "{{ MENU_DIR }}/moonlight.icns",
                 "CFBundleName": "Moonlight",
-                "CFBundleIdentifier": "com.moonlight_stream.Moonlight-conda"
+                "CFBundleIdentifier": "com.moonlight-stream.moonlight-conda"
               },
               "win": {
                 "command": ["{{ PREFIX }}/Library/bin/Moonlight.exe"],
@@ -183,7 +185,6 @@ tests:
           files:
             exists:
               - Library/bin/Moonlight.exe
-              - Library/bin/AntiHooking.dll
               - Menu/moonlight-qt.json
               - Menu/moonlight.ico
 
@@ -196,11 +197,13 @@ about:
     games and full desktops with hardware-accelerated video decoding,
     HDR support, and low-latency input forwarding for mouse, keyboard,
     and gamepads.
-  # GPL-3.0-or-later: moonlight-qt, moonlight-common-c; MIT: enet (patched
-  # fork), qmdnsengine (fork), libsoundio (modified copy); LGPL-2.1-or-later:
-  # h264bitstream; BSD-2-Clause: reedsolomon FEC in moonlight-common-c;
-  # Zlib: SDL_GameControllerDB
-  license: GPL-3.0-or-later AND MIT AND LGPL-2.1-or-later AND BSD-2-Clause AND Zlib
+  # GPL-3.0-or-later: moonlight-qt (per upstream's appdata project_license
+  # GPL-3.0+); GPL-3.0-only: moonlight-common-c (bare GPLv3 text, no or-later
+  # grant); MIT: enet (patched fork), qmdnsengine (fork), libsoundio
+  # (modified copy); LGPL-2.1-or-later: h264bitstream; BSD-2-Clause:
+  # reedsolomon FEC in moonlight-common-c; Zlib: SDL_GameControllerDB;
+  # CC0-1.0: AppStream metadata; LicenseRef-ModeSeven: embedded ModeSeven font
+  license: GPL-3.0-or-later AND GPL-3.0-only AND MIT AND LGPL-2.1-or-later AND BSD-2-Clause AND Zlib AND CC0-1.0 AND LicenseRef-ModeSeven
   license_file:
     - LICENSE
     - moonlight-common-c/moonlight-common-c/LICENSE.txt
@@ -211,6 +214,10 @@ about:
     - soundio/libsoundio/LICENSE
     # extracted from reedsolomon/rs.c, which has no standalone license file
     - reedsolomon-LICENSE.txt
+    # notice extracted from the embedded ModeSeven.ttf name table
+    - ModeSeven-LICENSE.txt
+    # covers the AppStream metadata file (metadata_license CC0-1.0)
+    - CC0-1.0.txt
   repository: https://github.com/moonlight-stream/moonlight-qt
   documentation: https://github.com/moonlight-stream/moonlight-docs/wiki
 

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -177,7 +177,11 @@ about:
     games and full desktops with hardware-accelerated video decoding,
     HDR support, and low-latency input forwarding for mouse, keyboard,
     and gamepads.
-  license: GPL-3.0-or-later
+  # GPL-3.0-or-later: moonlight-qt, moonlight-common-c; MIT: enet (patched
+  # fork), qmdnsengine (fork), libsoundio (modified copy); LGPL-2.1-or-later:
+  # h264bitstream; BSD-2-Clause: reedsolomon FEC in moonlight-common-c;
+  # Zlib: SDL_GameControllerDB
+  license: GPL-3.0-or-later AND MIT AND LGPL-2.1-or-later AND BSD-2-Clause AND Zlib
   license_file:
     - LICENSE
     - moonlight-common-c/moonlight-common-c/LICENSE.txt
@@ -186,6 +190,8 @@ about:
     - h264bitstream/h264bitstream/LICENSE
     - app/SDL_GameControllerDB/LICENSE
     - soundio/libsoundio/LICENSE
+    # extracted from reedsolomon/rs.c, which has no standalone license file
+    - reedsolomon-LICENSE.txt
   repository: https://github.com/moonlight-stream/moonlight-qt
   documentation: https://github.com/moonlight-stream/moonlight-docs/wiki
 

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -21,58 +21,69 @@ build:
   script:
     interpreter: brush
     content: |
+      # NOTE: platform dispatch uses case statements — brush 0.4.0 propagates
+      # a false [[ ]] if-condition's exit status as the if statement's status,
+      # which aborts the script under set -e
+
       # qmake's early config tests invoke the mkspec's plain compiler names
       # before command-line QMAKE_CC/CXX overrides take effect
-      if [[ "${target_platform}" == linux-* ]]; then
-        ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
-        ln -sf ${CXX} ${BUILD_PREFIX}/bin/g++
-      elif [[ "${target_platform}" == osx-* ]]; then
-        ln -sf ${CC} ${BUILD_PREFIX}/bin/clang
-        ln -sf ${CXX} ${BUILD_PREFIX}/bin/clang++
-      fi
+      case "${target_platform}" in
+        linux-*)
+          ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
+          ln -sf ${CXX} ${BUILD_PREFIX}/bin/g++
+          ;;
+        osx-*)
+          ln -sf ${CC} ${BUILD_PREFIX}/bin/clang
+          ln -sf ${CXX} ${BUILD_PREFIX}/bin/clang++
+          ;;
+      esac
 
-      if [[ "${target_platform}" == win-* ]]; then
-        LI="${LIBRARY_INC//\\//}"
-        LL="${LIBRARY_LIB//\\//}"
-        LB="${LIBRARY_BIN//\\//}"
-        qmake6 "CONFIG+=release" "CONFIG+=disable-prebuilts" \
-          "INCLUDEPATH+=${LI}" "INCLUDEPATH+=${LI}/SDL2" "LIBS+=-L${LL}" \
-          moonlight-qt.pro
-        jom
-        cp app/release/Moonlight.exe "${LB}/"
-        cp AntiHooking/release/AntiHooking.dll "${LB}/"
-      else
-        if [[ "${target_platform}" == osx-* ]]; then
-          # use pkg-config against conda libs instead of the vendored mac frameworks
-          EXTRA_CONFIG="CONFIG+=disable-prebuilts"
-        else
-          EXTRA_CONFIG=""
-        fi
-        qmake6 "CONFIG+=release" ${EXTRA_CONFIG} PREFIX=${PREFIX} \
-          QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
-          "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
-          moonlight-qt.pro
-        make -j${CPU_COUNT}
-        if [[ "${target_platform}" == osx-* ]]; then
-          # no qmake install target on macOS; ship the app bundle
-          mkdir -p ${PREFIX}/Applications ${PREFIX}/bin
-          cp -R app/Moonlight.app ${PREFIX}/Applications/
-          ln -s ../Applications/Moonlight.app/Contents/MacOS/Moonlight ${PREFIX}/bin/moonlight
-        else
-          make install
-        fi
-      fi
+      case "${target_platform}" in
+        win-*)
+          LI="${LIBRARY_INC//\\//}"
+          LL="${LIBRARY_LIB//\\//}"
+          LB="${LIBRARY_BIN//\\//}"
+          qmake6 "CONFIG+=release" "CONFIG+=disable-prebuilts" \
+            "INCLUDEPATH+=${LI}" "INCLUDEPATH+=${LI}/SDL2" "LIBS+=-L${LL}" \
+            moonlight-qt.pro
+          jom
+          cp app/release/Moonlight.exe "${LB}/"
+          cp AntiHooking/release/AntiHooking.dll "${LB}/"
+          ;;
+        *)
+          case "${target_platform}" in
+            # use pkg-config against conda libs instead of the vendored mac frameworks
+            osx-*) EXTRA_CONFIG="CONFIG+=disable-prebuilts" ;;
+            *) EXTRA_CONFIG="" ;;
+          esac
+          qmake6 "CONFIG+=release" ${EXTRA_CONFIG} PREFIX=${PREFIX} \
+            QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
+            "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
+            moonlight-qt.pro
+          make -j${CPU_COUNT}
+          case "${target_platform}" in
+            osx-*)
+              # no qmake install target on macOS; ship the app bundle
+              mkdir -p ${PREFIX}/Applications ${PREFIX}/bin
+              cp -R app/Moonlight.app ${PREFIX}/Applications/
+              ln -s ../Applications/Moonlight.app/Contents/MacOS/Moonlight ${PREFIX}/bin/moonlight
+              ;;
+            *)
+              make install
+              ;;
+          esac
+          ;;
+      esac
 
       # menuinst shortcut so conda/pixi create a desktop/start-menu/launcher
       # entry on install (the mac bundle in the prefix is not indexed by
       # Launchpad, so it needs one too)
       P="${PREFIX//\\//}"
       mkdir -p "${P}/Menu"
-      if [[ "${target_platform}" == win-* ]]; then
-        cp app/moonlight.ico "${P}/Menu/moonlight.ico"
-      elif [[ "${target_platform}" == osx-* ]]; then
-        cp app/moonlight.icns "${P}/Menu/moonlight.icns"
-      fi
+      case "${target_platform}" in
+        win-*) cp app/moonlight.ico "${P}/Menu/moonlight.ico" ;;
+        osx-*) cp app/moonlight.icns "${P}/Menu/moonlight.icns" ;;
+      esac
       cat > "${P}/Menu/moonlight-qt.json" <<'EOF'
       {
         "$schema": "https://schemas.conda.org/menuinst-1.schema.json",

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -44,7 +44,7 @@ build:
           LL="${LIBRARY_LIB//\\//}"
           LB="${LIBRARY_BIN//\\//}"
           qmake6 "CONFIG+=release" "CONFIG+=disable-prebuilts" \
-            "INCLUDEPATH+=${LI}" "INCLUDEPATH+=${LI}/SDL2" "LIBS+=-L${LL}" \
+            "INCLUDEPATH+=${LI}" "INCLUDEPATH+=${LI}/SDL2" "INCLUDEPATH+=${LI}/opus" "LIBS+=-L${LL}" \
             moonlight-qt.pro
           jom
           cp app/release/Moonlight.exe "${LB}/"

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -16,6 +16,10 @@ build:
   skip:
     - not linux
   script: |
+    # qmake's early config tests invoke the mkspec's plain gcc/g++ before
+    # command-line QMAKE_CC/CXX overrides take effect
+    ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
+    ln -sf ${CXX} ${BUILD_PREFIX}/bin/g++
     qmake6 "CONFIG+=release" PREFIX=${PREFIX} \
       QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
       "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -26,6 +26,30 @@ build:
       moonlight-qt.pro
     make -j${CPU_COUNT}
     make install
+    # menuinst shortcut so conda/pixi create a desktop entry on install
+    install -d ${PREFIX}/Menu
+    cat > ${PREFIX}/Menu/moonlight-qt.json <<'EOF'
+    {
+      "$schema": "https://schemas.conda.org/menuinst-1.schema.json",
+      "menu_name": "Moonlight",
+      "menu_items": [
+        {
+          "name": "Moonlight",
+          "description": "Stream games and other applications from another PC running Sunshine or GeForce Experience",
+          "command": ["{{ PREFIX }}/bin/moonlight"],
+          "icon": "{{ PREFIX }}/share/icons/hicolor/scalable/apps/moonlight.svg",
+          "activate": false,
+          "terminal": false,
+          "platforms": {
+            "linux": {
+              "Categories": ["Qt", "Game"],
+              "Keywords": ["nvidia", "gamestream", "stream", "sunshine", "remote play"]
+            }
+          }
+        }
+      ]
+    }
+    EOF
 
 requirements:
   build:
@@ -56,12 +80,15 @@ tests:
       content:
         - moonlight --version
   - package_contents:
+      strict: true
       bin:
         - moonlight
       files:
         exists:
           - share/applications/com.moonlight_stream.Moonlight.desktop
           - share/icons/hicolor/scalable/apps/moonlight.svg
+          - share/metainfo/com.moonlight_stream.Moonlight.appdata.xml
+          - Menu/moonlight-qt.json
 
 about:
   homepage: https://moonlight-stream.org

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -6,17 +6,15 @@ package:
   version: ${{ version }}
 
 source:
-  # official source tarball including the vendored submodules
-  # (moonlight-common-c, enet, qmdnsengine, h264bitstream, SDL_GameControllerDB)
+  # Official source archive, including the vendored submodules:
+  # moonlight-common-c, enet, qmdnsengine, h264bitstream, and SDL_GameControllerDB.
   url: https://github.com/moonlight-stream/moonlight-qt/releases/download/v${{ version }}/MoonlightSrc-${{ version }}.tar.gz
   sha256: 696cc470a62e2f2e9b77739d400b389e7578c9510383c08614007c92be49d5b0
   patches:
-    # extend upstream's disable-prebuilts flag to windows (and to the
-    # moonlight-common-c include paths) so the build uses conda headers and
-    # libs instead of the vendored ones, and skip the pieces that need
-    # vendored prebuilts: libplacebo and discord-rpc (not packaged on
-    # conda-forge for windows) and the AntiHooking shim (links Microsoft
-    # Detours, which is only present as a prebuilt static library)
+    # Use upstream's disable-prebuilts option on Windows too, including for
+    # moonlight-common-c. This keeps vendored headers and libraries out of the
+    # build. It also disables libplacebo, discord-rpc, and AntiHooking because
+    # their Windows dependencies are only available here as prebuilts.
     - patches/0001-win-disable-prebuilts.patch
 
 build:
@@ -24,12 +22,12 @@ build:
   script:
     interpreter: brush
     content: |
-      # NOTE: platform dispatch uses case statements — brush 0.4.0 propagates
-      # a false [[ ]] if-condition's exit status as the if statement's status,
-      # which aborts the script under set -e
+      # Keep the platform checks as case statements. brush 0.4.0 returns the
+      # status of a false [[ ]] condition from the whole if statement, so an
+      # if/else here can stop the script under set -e.
 
-      # qmake's early config tests invoke the mkspec's plain compiler names
-      # before command-line QMAKE_CC/CXX overrides take effect
+      # qmake's initial config tests use the compiler names from the mkspec
+      # before QMAKE_CC and QMAKE_CXX take effect.
       case "${target_platform}" in
         linux-*)
           ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
@@ -54,7 +52,7 @@ build:
           ;;
         *)
           case "${target_platform}" in
-            # use pkg-config against conda libs instead of the vendored mac frameworks
+            # Use pkg-config with conda libraries instead of the vendored macOS frameworks.
             osx-*) EXTRA_CONFIG="CONFIG+=disable-prebuilts" ;;
             *) EXTRA_CONFIG="" ;;
           esac
@@ -65,7 +63,7 @@ build:
           make -j${CPU_COUNT}
           case "${target_platform}" in
             osx-*)
-              # no qmake install target on macOS; ship the app bundle
+              # qmake has no macOS install target, so copy the app bundle directly.
               mkdir -p ${PREFIX}/Applications ${PREFIX}/bin
               cp -R app/Moonlight.app ${PREFIX}/Applications/
               ln -s ../Applications/Moonlight.app/Contents/MacOS/Moonlight ${PREFIX}/bin/moonlight
@@ -77,9 +75,8 @@ build:
           ;;
       esac
 
-      # menuinst shortcut so conda/pixi create a desktop/start-menu/launcher
-      # entry on install (the mac bundle in the prefix is not indexed by
-      # Launchpad, so it needs one too)
+      # Add a menuinst shortcut on each platform. The macOS bundle lives inside
+      # the prefix, where Launchpad does not index it.
       P="${PREFIX//\\//}"
       mkdir -p "${P}/Menu"
       case "${target_platform}" in
@@ -139,12 +136,12 @@ requirements:
     - ffmpeg
     - if: not win
       then:
-        # vulkan renderer via libplacebo (windows uses D3D11VA instead)
+        # libplacebo provides the Vulkan renderer. Windows uses D3D11VA instead.
         - libplacebo
         - libvulkan-headers
     - if: linux
       then:
-        # pkg-config-detected backends; presence here enables them
+        # qmake enables these backends when pkg-config finds them.
         - libva
         - libdrm
         - wayland
@@ -197,12 +194,10 @@ about:
     games and full desktops with hardware-accelerated video decoding,
     HDR support, and low-latency input forwarding for mouse, keyboard,
     and gamepads.
-  # GPL-3.0-or-later: moonlight-qt (per upstream's appdata project_license
-  # GPL-3.0+); GPL-3.0-only: moonlight-common-c (bare GPLv3 text, no or-later
-  # grant); MIT: enet (patched fork), qmdnsengine (fork), libsoundio
-  # (modified copy); LGPL-2.1-or-later: h264bitstream; BSD-2-Clause:
-  # reedsolomon FEC in moonlight-common-c; Zlib: SDL_GameControllerDB;
-  # CC0-1.0: AppStream metadata; LicenseRef-ModeSeven: embedded ModeSeven font
+  # moonlight-qt is GPL-3.0-or-later. moonlight-common-c only includes the
+  # GPLv3 text, so list it conservatively as GPL-3.0-only. The bundled code and
+  # data add MIT, LGPL-2.1-or-later, BSD-2-Clause, Zlib, CC0-1.0, and the
+  # ModeSeven font notice.
   license: GPL-3.0-or-later AND GPL-3.0-only AND MIT AND LGPL-2.1-or-later AND BSD-2-Clause AND Zlib AND CC0-1.0 AND LicenseRef-ModeSeven
   license_file:
     - LICENSE
@@ -212,11 +207,11 @@ about:
     - h264bitstream/h264bitstream/LICENSE
     - app/SDL_GameControllerDB/LICENSE
     - soundio/libsoundio/LICENSE
-    # extracted from reedsolomon/rs.c, which has no standalone license file
+    # reedsolomon/rs.c has no separate license file, so its notice is copied here.
     - reedsolomon-LICENSE.txt
-    # notice extracted from the embedded ModeSeven.ttf name table
+    # ModeSeven.ttf stores its license notice in the font name table.
     - ModeSeven-LICENSE.txt
-    # covers the AppStream metadata file (metadata_license CC0-1.0)
+    # The AppStream metadata declares CC0-1.0.
     - CC0-1.0.txt
   repository: https://github.com/moonlight-stream/moonlight-qt
   documentation: https://github.com/moonlight-stream/moonlight-docs/wiki

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -1,0 +1,81 @@
+context:
+  version: "6.1.0"
+
+package:
+  name: moonlight-qt
+  version: ${{ version }}
+
+source:
+  # official source tarball including the vendored submodules
+  # (moonlight-common-c, enet, qmdnsengine, h264bitstream, SDL_GameControllerDB)
+  url: https://github.com/moonlight-stream/moonlight-qt/releases/download/v${{ version }}/MoonlightSrc-${{ version }}.tar.gz
+  sha256: 696cc470a62e2f2e9b77739d400b389e7578c9510383c08614007c92be49d5b0
+
+build:
+  number: 0
+  skip:
+    - not linux
+  script: |
+    qmake6 "CONFIG+=release" PREFIX=${PREFIX} moonlight-qt.pro
+    make -j${CPU_COUNT}
+    make install
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - make
+    - pkg-config
+  host:
+    - qt6-main
+    - sdl2
+    - sdl2_ttf
+    - libopus
+    - openssl
+    - ffmpeg
+    # optional pkg-config-detected backends; presence here enables them
+    - libva
+    - libdrm
+    - libplacebo
+    - vulkan-headers
+    - wayland
+    - xorg-libx11
+
+tests:
+  - script:
+      env:
+        QT_QPA_PLATFORM: offscreen
+      content:
+        - moonlight --version
+  - package_contents:
+      bin:
+        - moonlight
+      files:
+        exists:
+          - share/applications/com.moonlight_stream.Moonlight.desktop
+          - share/icons/hicolor/scalable/apps/moonlight.svg
+
+about:
+  homepage: https://moonlight-stream.org
+  summary: GameStream client for streaming games from a remote host PC
+  description: |
+    Moonlight PC is an open source client for NVIDIA GameStream and
+    compatible hosts such as Sunshine, Apollo, and Moonshine. It streams
+    games and full desktops with hardware-accelerated video decoding,
+    HDR support, and low-latency input forwarding for mouse, keyboard,
+    and gamepads.
+  license: GPL-3.0-or-later
+  license_file:
+    - LICENSE
+    - moonlight-common-c/moonlight-common-c/LICENSE.txt
+    - moonlight-common-c/moonlight-common-c/enet/LICENSE
+    - qmdnsengine/qmdnsengine/LICENSE.txt
+    - h264bitstream/h264bitstream/LICENSE
+    - app/SDL_GameControllerDB/LICENSE
+  repository: https://github.com/moonlight-stream/moonlight-qt
+  documentation: https://github.com/moonlight-stream/moonlight-docs/wiki
+
+extra:
+  recipe-maintainers:
+    - tdejager

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -63,15 +63,17 @@ build:
         fi
       fi
 
-      # menuinst shortcut so conda/pixi create a desktop/start-menu entry on
-      # install (linux and windows; the mac bundle is discoverable as-is)
-      if [[ "${target_platform}" != osx-* ]]; then
-        P="${PREFIX//\\//}"
-        mkdir -p "${P}/Menu"
-        if [[ "${target_platform}" == win-* ]]; then
-          cp app/moonlight.ico "${P}/Menu/moonlight.ico"
-        fi
-        cat > "${P}/Menu/moonlight-qt.json" <<'EOF'
+      # menuinst shortcut so conda/pixi create a desktop/start-menu/launcher
+      # entry on install (the mac bundle in the prefix is not indexed by
+      # Launchpad, so it needs one too)
+      P="${PREFIX//\\//}"
+      mkdir -p "${P}/Menu"
+      if [[ "${target_platform}" == win-* ]]; then
+        cp app/moonlight.ico "${P}/Menu/moonlight.ico"
+      elif [[ "${target_platform}" == osx-* ]]; then
+        cp app/moonlight.icns "${P}/Menu/moonlight.icns"
+      fi
+      cat > "${P}/Menu/moonlight-qt.json" <<'EOF'
       {
         "$schema": "https://schemas.conda.org/menuinst-1.schema.json",
         "menu_name": "Moonlight",
@@ -88,6 +90,11 @@ build:
                 "Categories": ["Qt", "Game"],
                 "Keywords": ["nvidia", "gamestream", "stream", "sunshine", "remote play"]
               },
+              "osx": {
+                "icon": "{{ MENU_DIR }}/moonlight.icns",
+                "CFBundleName": "Moonlight",
+                "CFBundleIdentifier": "com.moonlight_stream.Moonlight-conda"
+              },
               "win": {
                 "command": ["{{ PREFIX }}/Library/bin/Moonlight.exe"],
                 "icon": "{{ MENU_DIR }}/moonlight.ico"
@@ -97,7 +104,6 @@ build:
         ]
       }
       EOF
-      fi
 
 requirements:
   build:
@@ -157,6 +163,8 @@ tests:
             exists:
               - Applications/Moonlight.app/**
               - bin/moonlight
+              - Menu/moonlight-qt.json
+              - Menu/moonlight.icns
   - if: win
     then:
       - package_contents:

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -14,48 +14,67 @@ source:
 build:
   number: 0
   skip:
-    - not linux
-  script: |
-    # qmake's early config tests invoke the mkspec's plain gcc/g++ before
-    # command-line QMAKE_CC/CXX overrides take effect
-    ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
-    ln -sf ${CXX} ${BUILD_PREFIX}/bin/g++
-    qmake6 "CONFIG+=release" PREFIX=${PREFIX} \
-      QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
-      "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
-      moonlight-qt.pro
-    make -j${CPU_COUNT}
-    make install
-    # menuinst shortcut so conda/pixi create a desktop entry on install
-    install -d ${PREFIX}/Menu
-    cat > ${PREFIX}/Menu/moonlight-qt.json <<'EOF'
-    {
-      "$schema": "https://schemas.conda.org/menuinst-1.schema.json",
-      "menu_name": "Moonlight",
-      "menu_items": [
-        {
-          "name": "Moonlight",
-          "description": "Stream games and other applications from another PC running Sunshine or GeForce Experience",
-          "command": ["{{ PREFIX }}/bin/moonlight"],
-          "icon": "{{ PREFIX }}/share/icons/hicolor/scalable/apps/moonlight.svg",
-          "activate": false,
-          "terminal": false,
-          "platforms": {
-            "linux": {
-              "Categories": ["Qt", "Game"],
-              "Keywords": ["nvidia", "gamestream", "stream", "sunshine", "remote play"]
+    # windows hardcodes prebuilt vendored libraries in the qmake project
+    - win
+  script:
+    interpreter: brush
+    content: |
+      # qmake's early config tests invoke the mkspec's plain compiler names
+      # before command-line QMAKE_CC/CXX overrides take effect
+      if [[ "${target_platform}" == linux-* ]]; then
+        ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
+        ln -sf ${CXX} ${BUILD_PREFIX}/bin/g++
+        EXTRA_CONFIG=""
+      else
+        ln -sf ${CC} ${BUILD_PREFIX}/bin/clang
+        ln -sf ${CXX} ${BUILD_PREFIX}/bin/clang++
+        # use pkg-config against conda libs instead of the vendored mac frameworks
+        EXTRA_CONFIG="CONFIG+=disable-prebuilts"
+      fi
+      qmake6 "CONFIG+=release" ${EXTRA_CONFIG} PREFIX=${PREFIX} \
+        QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
+        "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
+        moonlight-qt.pro
+      make -j${CPU_COUNT}
+      if [[ "${target_platform}" == osx-* ]]; then
+        # no qmake install target on macOS; ship the app bundle
+        mkdir -p ${PREFIX}/Applications ${PREFIX}/bin
+        cp -R app/Moonlight.app ${PREFIX}/Applications/
+        ln -s ../Applications/Moonlight.app/Contents/MacOS/Moonlight ${PREFIX}/bin/moonlight
+      else
+        make install
+        # menuinst shortcut so conda/pixi create a desktop entry on install
+        install -d ${PREFIX}/Menu
+        cat > ${PREFIX}/Menu/moonlight-qt.json <<'EOF'
+      {
+        "$schema": "https://schemas.conda.org/menuinst-1.schema.json",
+        "menu_name": "Moonlight",
+        "menu_items": [
+          {
+            "name": "Moonlight",
+            "description": "Stream games and other applications from another PC running Sunshine or GeForce Experience",
+            "command": ["{{ PREFIX }}/bin/moonlight"],
+            "icon": "{{ PREFIX }}/share/icons/hicolor/scalable/apps/moonlight.svg",
+            "activate": false,
+            "terminal": false,
+            "platforms": {
+              "linux": {
+                "Categories": ["Qt", "Game"],
+                "Keywords": ["nvidia", "gamestream", "stream", "sunshine", "remote play"]
+              }
             }
           }
-        }
-      ]
-    }
-    EOF
+        ]
+      }
+      EOF
+      fi
 
 requirements:
   build:
     - ${{ stdlib('c') }}
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
+    - brush
     - make
     - pkg-config
   host:
@@ -65,30 +84,42 @@ requirements:
     - libopus
     - openssl
     - ffmpeg
-    # optional pkg-config-detected backends; presence here enables them
-    - libva
-    - libdrm
     - libplacebo
     - libvulkan-headers
-    - wayland
-    - xorg-libx11
+    - if: linux
+      then:
+        # pkg-config-detected backends; presence here enables them
+        - libva
+        - libdrm
+        - wayland
+        - xorg-libx11
 
 tests:
-  - script:
-      env:
-        QT_QPA_PLATFORM: offscreen
-      content:
-        - moonlight --version
-  - package_contents:
-      strict: true
-      bin:
-        - moonlight
-      files:
-        exists:
-          - share/applications/com.moonlight_stream.Moonlight.desktop
-          - share/icons/hicolor/scalable/apps/moonlight.svg
-          - share/metainfo/com.moonlight_stream.Moonlight.appdata.xml
-          - Menu/moonlight-qt.json
+  - if: linux
+    then:
+      - script:
+          env:
+            QT_QPA_PLATFORM: offscreen
+          content:
+            - moonlight --version
+      - package_contents:
+          strict: true
+          bin:
+            - moonlight
+          files:
+            exists:
+              - share/applications/com.moonlight_stream.Moonlight.desktop
+              - share/icons/hicolor/scalable/apps/moonlight.svg
+              - share/metainfo/com.moonlight_stream.Moonlight.appdata.xml
+              - Menu/moonlight-qt.json
+  - if: osx
+    then:
+      - package_contents:
+          strict: true
+          files:
+            exists:
+              - Applications/Moonlight.app/**
+              - bin/moonlight
 
 about:
   homepage: https://moonlight-stream.org
@@ -107,6 +138,7 @@ about:
     - qmdnsengine/qmdnsengine/LICENSE.txt
     - h264bitstream/h264bitstream/LICENSE
     - app/SDL_GameControllerDB/LICENSE
+    - soundio/libsoundio/LICENSE
   repository: https://github.com/moonlight-stream/moonlight-qt
   documentation: https://github.com/moonlight-stream/moonlight-docs/wiki
 

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -10,12 +10,14 @@ source:
   # (moonlight-common-c, enet, qmdnsengine, h264bitstream, SDL_GameControllerDB)
   url: https://github.com/moonlight-stream/moonlight-qt/releases/download/v${{ version }}/MoonlightSrc-${{ version }}.tar.gz
   sha256: 696cc470a62e2f2e9b77739d400b389e7578c9510383c08614007c92be49d5b0
+  patches:
+    # extend upstream's disable-prebuilts flag to windows so the build links
+    # conda libs instead of the vendored binaries (and skips libplacebo and
+    # the proprietary discord-rpc, which have no conda-forge packages there)
+    - patches/0001-win-disable-prebuilts.patch
 
 build:
   number: 0
-  skip:
-    # windows hardcodes prebuilt vendored libraries in the qmake project
-    - win
   script:
     interpreter: brush
     content: |
@@ -24,28 +26,52 @@ build:
       if [[ "${target_platform}" == linux-* ]]; then
         ln -sf ${CC} ${BUILD_PREFIX}/bin/gcc
         ln -sf ${CXX} ${BUILD_PREFIX}/bin/g++
-        EXTRA_CONFIG=""
-      else
+      elif [[ "${target_platform}" == osx-* ]]; then
         ln -sf ${CC} ${BUILD_PREFIX}/bin/clang
         ln -sf ${CXX} ${BUILD_PREFIX}/bin/clang++
-        # use pkg-config against conda libs instead of the vendored mac frameworks
-        EXTRA_CONFIG="CONFIG+=disable-prebuilts"
       fi
-      qmake6 "CONFIG+=release" ${EXTRA_CONFIG} PREFIX=${PREFIX} \
-        QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
-        "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
-        moonlight-qt.pro
-      make -j${CPU_COUNT}
-      if [[ "${target_platform}" == osx-* ]]; then
-        # no qmake install target on macOS; ship the app bundle
-        mkdir -p ${PREFIX}/Applications ${PREFIX}/bin
-        cp -R app/Moonlight.app ${PREFIX}/Applications/
-        ln -s ../Applications/Moonlight.app/Contents/MacOS/Moonlight ${PREFIX}/bin/moonlight
+
+      if [[ "${target_platform}" == win-* ]]; then
+        LI="${LIBRARY_INC//\\//}"
+        LL="${LIBRARY_LIB//\\//}"
+        LB="${LIBRARY_BIN//\\//}"
+        qmake6 "CONFIG+=release" "CONFIG+=disable-prebuilts" \
+          "INCLUDEPATH+=${LI}" "INCLUDEPATH+=${LI}/SDL2" "LIBS+=-L${LL}" \
+          moonlight-qt.pro
+        jom
+        cp app/release/Moonlight.exe "${LB}/"
+        cp AntiHooking/release/AntiHooking.dll "${LB}/"
       else
-        make install
-        # menuinst shortcut so conda/pixi create a desktop entry on install
-        install -d ${PREFIX}/Menu
-        cat > ${PREFIX}/Menu/moonlight-qt.json <<'EOF'
+        if [[ "${target_platform}" == osx-* ]]; then
+          # use pkg-config against conda libs instead of the vendored mac frameworks
+          EXTRA_CONFIG="CONFIG+=disable-prebuilts"
+        else
+          EXTRA_CONFIG=""
+        fi
+        qmake6 "CONFIG+=release" ${EXTRA_CONFIG} PREFIX=${PREFIX} \
+          QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
+          "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
+          moonlight-qt.pro
+        make -j${CPU_COUNT}
+        if [[ "${target_platform}" == osx-* ]]; then
+          # no qmake install target on macOS; ship the app bundle
+          mkdir -p ${PREFIX}/Applications ${PREFIX}/bin
+          cp -R app/Moonlight.app ${PREFIX}/Applications/
+          ln -s ../Applications/Moonlight.app/Contents/MacOS/Moonlight ${PREFIX}/bin/moonlight
+        else
+          make install
+        fi
+      fi
+
+      # menuinst shortcut so conda/pixi create a desktop/start-menu entry on
+      # install (linux and windows; the mac bundle is discoverable as-is)
+      if [[ "${target_platform}" != osx-* ]]; then
+        P="${PREFIX//\\//}"
+        mkdir -p "${P}/Menu"
+        if [[ "${target_platform}" == win-* ]]; then
+          cp app/moonlight.ico "${P}/Menu/moonlight.ico"
+        fi
+        cat > "${P}/Menu/moonlight-qt.json" <<'EOF'
       {
         "$schema": "https://schemas.conda.org/menuinst-1.schema.json",
         "menu_name": "Moonlight",
@@ -54,13 +80,17 @@ build:
             "name": "Moonlight",
             "description": "Stream games and other applications from another PC running Sunshine or GeForce Experience",
             "command": ["{{ PREFIX }}/bin/moonlight"],
-            "icon": "{{ PREFIX }}/share/icons/hicolor/scalable/apps/moonlight.svg",
             "activate": false,
             "terminal": false,
             "platforms": {
               "linux": {
+                "icon": "{{ PREFIX }}/share/icons/hicolor/scalable/apps/moonlight.svg",
                 "Categories": ["Qt", "Game"],
                 "Keywords": ["nvidia", "gamestream", "stream", "sunshine", "remote play"]
+              },
+              "win": {
+                "command": ["{{ PREFIX }}/Library/bin/Moonlight.exe"],
+                "icon": "{{ MENU_DIR }}/moonlight.ico"
               }
             }
           }
@@ -75,8 +105,12 @@ requirements:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
     - brush
-    - make
-    - pkg-config
+    - if: unix
+      then:
+        - make
+        - pkg-config
+      else:
+        - jom
   host:
     - qt6-main
     - sdl2
@@ -84,8 +118,11 @@ requirements:
     - libopus
     - openssl
     - ffmpeg
-    - libplacebo
-    - libvulkan-headers
+    - if: not win
+      then:
+        # vulkan renderer via libplacebo (windows uses D3D11VA instead)
+        - libplacebo
+        - libvulkan-headers
     - if: linux
       then:
         # pkg-config-detected backends; presence here enables them
@@ -120,6 +157,16 @@ tests:
             exists:
               - Applications/Moonlight.app/**
               - bin/moonlight
+  - if: win
+    then:
+      - package_contents:
+          strict: true
+          files:
+            exists:
+              - Library/bin/Moonlight.exe
+              - Library/bin/AntiHooking.dll
+              - Menu/moonlight-qt.json
+              - Menu/moonlight.ico
 
 about:
   homepage: https://moonlight-stream.org

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -16,7 +16,10 @@ build:
   skip:
     - not linux
   script: |
-    qmake6 "CONFIG+=release" PREFIX=${PREFIX} moonlight-qt.pro
+    qmake6 "CONFIG+=release" PREFIX=${PREFIX} \
+      QMAKE_CC="${CC}" QMAKE_CXX="${CXX}" QMAKE_LINK="${CXX}" QMAKE_LINK_C="${CC}" \
+      "QMAKE_CFLAGS=${CFLAGS}" "QMAKE_CXXFLAGS=${CXXFLAGS}" "QMAKE_LFLAGS=${LDFLAGS}" \
+      moonlight-qt.pro
     make -j${CPU_COUNT}
     make install
 

--- a/recipes/moonlight-qt/recipe.yaml
+++ b/recipes/moonlight-qt/recipe.yaml
@@ -69,7 +69,7 @@ requirements:
     - libva
     - libdrm
     - libplacebo
-    - vulkan-headers
+    - libvulkan-headers
     - wayland
     - xorg-libx11
 

--- a/recipes/moonlight-qt/reedsolomon-LICENSE.txt
+++ b/recipes/moonlight-qt/reedsolomon-LICENSE.txt
@@ -1,0 +1,35 @@
+/*
+ * fec.c -- forward error correction based on Vandermonde matrices
+ *
+ * (C) 1997-98 Luigi Rizzo (luigi@iet.unipi.it)
+ * (C) 2001 Alain Knaff (alain@knaff.lu)
+ * (C) 2017 Iwan Timmer (irtimmer@gmail.com)
+ *
+ * Portions derived from code by Phil Karn (karn@ka9q.ampr.org),
+ * Robert Morelos-Zaragoza (robert@spectra.eng.hawaii.edu) and Hari
+ * Thirumoorthy (harit@spectra.eng.hawaii.edu), Aug 1995
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */

--- a/recipes/moonlight-qt/variants.yaml
+++ b/recipes/moonlight-qt/variants.yaml
@@ -1,5 +1,9 @@
-# the DRM renderer includes linux/dma-buf.h (kernel >= 4.6); the default
-# 2.17 sysroot ships 3.10 headers
+# linux: the DRM renderer includes linux/dma-buf.h (kernel >= 4.6); the
+# default 2.17 sysroot ships 3.10 headers.
+# osx: repeat the staged-recipes default — this file replaces the base
+# c_stdlib_version list wholesale, and an empty list on osx makes
+# rattler-build fall back to the runner's SDK version.
 c_stdlib_version:
   - if: linux
     then: "2.28"
+    else: "11.0"

--- a/recipes/moonlight-qt/variants.yaml
+++ b/recipes/moonlight-qt/variants.yaml
@@ -1,9 +1,8 @@
-# linux: the DRM renderer includes linux/dma-buf.h (kernel >= 4.6); the
-# default 2.17 sysroot ships 3.10 headers.
-# osx: repeat the staged-recipes default — this file replaces the base
-# c_stdlib_version list wholesale, and an empty list on osx makes
-# rattler-build fall back to the runner's SDK version.
-# win intentionally gets no entry: its stdlib (vs) is unversioned there.
+# The Linux DRM renderer needs linux/dma-buf.h, which is missing from the
+# default 2.17 sysroot and its 3.10 kernel headers.
+# Keep the staged-recipes macOS 11.0 default here because this file replaces
+# the full c_stdlib_version list. Without it, rattler-build uses the runner SDK.
+# Windows is omitted because its vs stdlib has no version.
 c_stdlib_version:
   - if: linux
     then: "2.28"

--- a/recipes/moonlight-qt/variants.yaml
+++ b/recipes/moonlight-qt/variants.yaml
@@ -3,7 +3,9 @@
 # osx: repeat the staged-recipes default — this file replaces the base
 # c_stdlib_version list wholesale, and an empty list on osx makes
 # rattler-build fall back to the runner's SDK version.
+# win intentionally gets no entry: its stdlib (vs) is unversioned there.
 c_stdlib_version:
   - if: linux
     then: "2.28"
-    else: "11.0"
+  - if: osx
+    then: "11.0"

--- a/recipes/moonlight-qt/variants.yaml
+++ b/recipes/moonlight-qt/variants.yaml
@@ -1,0 +1,5 @@
+# the DRM renderer includes linux/dma-buf.h (kernel >= 4.6); the default
+# 2.17 sysroot ships 3.10 headers
+c_stdlib_version:
+  - if: linux
+    then: "2.28"


### PR DESCRIPTION
This adds [moonlight-qt](https://github.com/moonlight-stream/moonlight-qt), the desktop Moonlight client for streaming games from GameStream-compatible hosts such as Sunshine, Apollo, and Moonshine. It pairs with the moonshine host in #34273. Having both on conda-forge gives me a complete setup on systems where the system package manager is not an option, such as SteamOS.

The recipe builds the official `MoonlightSrc` archive for **linux-64, osx-64, and win-64**. One `brush` script handles all three platforms.

A few notes for review:

- Windows uses `patches/0001-win-disable-prebuilts.patch`. It extends upstream's macOS `disable-prebuilts` option to Windows and moonlight-common-c, so the build uses conda-forge headers and libraries. It also disables libplacebo, discord-rpc, and AntiHooking because their Windows dependencies are only available here as prebuilts. D3D11VA covers HDR without libplacebo. I think this patch is suitable for upstream.
- Linux uses the 2.28 sysroot because the DRM renderer needs `linux/dma-buf.h`. The macOS 11.0 entry repeats the staged-recipes default because a local `variants.yaml` replaces the full base list.
- The source archive includes several bundled components. They stay bundled because enet and qmdnsengine are Moonlight forks, libsoundio is modified, and h264bitstream is pinned beyond its latest release. The recipe includes their licenses, plus extracted notices for Reed-Solomon and the embedded ModeSeven font. moonlight-common-c is listed as GPL-3.0-only because it does not include an or-later grant.
- menuinst v2 adds the desktop, Launchpad, or Start Menu entry for each platform.
- qmake has no macOS install target, so the recipe copies `Moonlight.app` to `$PREFIX/Applications` and adds a `bin/moonlight` symlink.
- Every platform has a strict `package_contents` test. Linux also runs `moonlight --version` with `QT_QPA_PLATFORM=offscreen`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
