### PR TITLE
Add pydata-wrangler

### DIFF
--- a/recipes/pydata-wrangler/meta.yaml
+++ b/recipes/pydata-wrangler/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "pydata-wrangler" %}
+{% set version = "0.5.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pydata_wrangler-{{ version }}.tar.gz
+  sha256: e716b4f2f8d794d082741e77287a0dc242f9ad87305ede1b40e4f4a001495147
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools
+  run:
+    - python >=3.9
+    - scikit-learn
+    - importlib-metadata
+    - pandas
+    - polars >=0.20.0
+    - pyarrow
+    - scipy
+    - numpy
+    - requests
+    - six
+    - setuptools
+    - tqdm
+    - dill
+    - pillow
+    - matplotlib-base
+
+test:
+  imports:
+    - datawrangler
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/ContextLab/data-wrangler
+  summary: 'Wrangle messy data into DataFrames (pandas or Polars), with a special focus on text data and natural language processing'
+  description: |
+    data-wrangler turns messy data (arrays, text, DataFrames, files, URLs,
+    null/empty values, and nested lists of these) into clean DataFrame
+    objects, with a special emphasis on text and natural language processing
+    embeddings. Every operation supports two backends: pandas (default) and
+    Polars. The package is published on PyPI as pydata-wrangler and imported
+    as datawrangler (or dw).
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://data-wrangler.readthedocs.io/
+  dev_url: https://github.com/ContextLab/data-wrangler
+
+extra:
+  recipe-maintainers:
+    - jeremymanning

--- a/recipes/pydata-wrangler/meta.yaml
+++ b/recipes/pydata-wrangler/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "pydata-wrangler" %}
 {% set version = "0.5.1" %}
+{% set python_min = "3.9" %}
 
 package:
   name: {{ name|lower }}
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python {{ python_min }}
     - pip
     - setuptools
   run:
-    - python >=3.9
+    - python >={{ python_min }}
     - scikit-learn
     - importlib-metadata
     - pandas
@@ -40,6 +41,7 @@ test:
   imports:
     - datawrangler
   requires:
+    - python {{ python_min }}
     - pip
   commands:
     - pip check

--- a/recipes/pydata-wrangler/recipe.yaml
+++ b/recipes/pydata-wrangler/recipe.yaml
@@ -1,15 +1,14 @@
 schema_version: 1
 
 context:
-  name: pydata-wrangler
   version: "0.5.1"
 
 package:
-  name: ${{ name }}
+  name: pydata-wrangler
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/p/${{ name }}/pydata_wrangler-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pydata-wrangler/pydata_wrangler-${{ version }}.tar.gz
   sha256: e716b4f2f8d794d082741e77287a0dc242f9ad87305ede1b40e4f4a001495147
 
 build:

--- a/recipes/pydata-wrangler/recipe.yaml
+++ b/recipes/pydata-wrangler/recipe.yaml
@@ -1,27 +1,29 @@
-{% set name = "pydata-wrangler" %}
-{% set version = "0.5.1" %}
-{% set python_min = "3.9" %}
+schema_version: 1
+
+context:
+  name: pydata-wrangler
+  version: "0.5.1"
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pydata_wrangler-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/${{ name }}/pydata_wrangler-${{ version }}.tar.gz
   sha256: e716b4f2f8d794d082741e77287a0dc242f9ad87305ede1b40e4f4a001495147
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - scikit-learn
     - importlib-metadata
     - pandas
@@ -37,18 +39,20 @@ requirements:
     - pillow
     - matplotlib-base
 
-test:
-  imports:
-    - datawrangler
-  requires:
-    - python {{ python_min }}
-    - pip
-  commands:
-    - pip check
+tests:
+  - python:
+      imports:
+        - datawrangler
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
 
 about:
-  home: https://github.com/ContextLab/data-wrangler
-  summary: 'Wrangle messy data into DataFrames (pandas or Polars), with a special focus on text data and natural language processing'
+  homepage: https://github.com/ContextLab/data-wrangler
+  license: MIT
+  license_file: LICENSE
+  summary: Wrangle messy data into DataFrames (pandas or Polars), with a special focus on text data and natural language processing
   description: |
     data-wrangler turns messy data (arrays, text, DataFrames, files, URLs,
     null/empty values, and nested lists of these) into clean DataFrame
@@ -56,11 +60,8 @@ about:
     embeddings. Every operation supports two backends: pandas (default) and
     Polars. The package is published on PyPI as pydata-wrangler and imported
     as datawrangler (or dw).
-  license: MIT
-  license_family: MIT
-  license_file: LICENSE
-  doc_url: https://data-wrangler.readthedocs.io/
-  dev_url: https://github.com/ContextLab/data-wrangler
+  repository: https://github.com/ContextLab/data-wrangler
+  documentation: https://data-wrangler.readthedocs.io/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds a recipe for [pydata-wrangler](https://pypi.org/project/pydata-wrangler/) — a pure-Python library that wrangles messy data (arrays, text, DataFrames, files, URLs, null/empty values, and nested lists of these) into clean **pandas** or **Polars** DataFrames, with an emphasis on text/NLP embeddings. Imported as `datawrangler` / `dw`.

- Source: official PyPI sdist.
- `noarch: python` — pure Python, no compiled extensions, no CLI entry points.
- Docs: https://data-wrangler.readthedocs.io/
- Upstream: https://github.com/ContextLab/data-wrangler
- Passes `conda-smithy recipe-lint` locally ("recipes/pydata-wrangler is in fine form").

I am the package author and the sole recipe maintainer (@jeremymanning), and I confirm I'm willing to be listed as maintainer.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (`license_file: LICENSE`, present in the sdist).
- [x] Source is from official source (PyPI sdist).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged. (N/A — pure Python.)
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
