### PR TITLE
Add emdash

### DIFF
--- a/recipes/emdash/build.sh
+++ b/recipes/emdash/build.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail -o xtrace
+
+case "${target_platform}" in
+  linux-64)
+    electron_platform="linux"
+    electron_arch="x64"
+    ;;
+  osx-64)
+    electron_platform="mac"
+    electron_arch="x64"
+    ;;
+  osx-arm64)
+    electron_platform="mac"
+    electron_arch="arm64"
+    ;;
+  *)
+    echo "Unsupported target platform: ${target_platform}" >&2
+    exit 1
+    ;;
+esac
+
+export CI=1
+export EMDASH_SKIP_ELECTRON_REBUILD=1
+export npm_config_build_from_source=true
+export npm_config_manage_package_manager_versions=false
+
+pnpm config set manage-package-manager-versions false
+pnpm install --frozen-lockfile
+pnpm run build
+
+pnpm --filter @emdash/emdash-desktop licenses list --json --prod \
+  > third-party-licenses.json
+node "${RECIPE_DIR}/generate-third-party-licenses.mjs" \
+  third-party-licenses.json \
+  third-party-licenses.txt \
+  node_modules/electron/dist/LICENSE \
+  node_modules/electron/dist/LICENSES.chromium.html
+test "$(wc -c < third-party-licenses.txt)" -gt 10000
+
+deploy_dir="${SRC_DIR}/.emdash-conda-deploy"
+mkdir -p "${deploy_dir}"
+pnpm --filter @emdash/emdash-desktop deploy --legacy --prod "${deploy_dir}"
+cp -R apps/emdash-desktop/out "${deploy_dir}/out"
+cp -R apps/emdash-desktop/drizzle "${deploy_dir}/drizzle"
+mkdir -p "${deploy_dir}/icons"
+cp apps/emdash-desktop/src/assets/images/emdash/emdash.icns "${deploy_dir}/icons/emdash.icns"
+cp apps/emdash-desktop/src/assets/images/emdash/emdash.png "${deploy_dir}/icons/emdash.png"
+
+node --experimental-strip-types \
+  apps/emdash-desktop/scripts/release/rebuild-native.ts \
+  --arch "${electron_arch}" \
+  --deploy-dir "${deploy_dir}"
+
+electron_version="$(node -p "require('./node_modules/electron/package.json').version")"
+pnpm --dir apps/emdash-desktop exec electron-builder \
+  "--${electron_platform}" \
+  --dir \
+  "--${electron_arch}" \
+  --publish never \
+  --projectDir "${deploy_dir}" \
+  --config "${RECIPE_DIR}/electron-builder.json" \
+  --config.electronVersion="${electron_version}" \
+  --config.electronDist="${SRC_DIR}/node_modules/electron/dist"
+
+mkdir -p "${PREFIX}/bin"
+
+if [[ "${electron_platform}" == "linux" ]]; then
+  test -d "${deploy_dir}/release/linux-unpacked"
+  mkdir -p "${PREFIX}/libexec"
+  cp -R "${deploy_dir}/release/linux-unpacked" "${PREFIX}/libexec/emdash"
+  ln -s ../libexec/emdash/emdash "${PREFIX}/bin/emdash"
+else
+  app_bundles=("${deploy_dir}"/release/mac*/Emdash.app)
+  test "${#app_bundles[@]}" -eq 1
+  codesign --force --deep --sign - --timestamp=none "${app_bundles[0]}"
+  mkdir -p "${PREFIX}/Applications"
+  cp -R "${app_bundles[0]}" "${PREFIX}/Applications/Emdash.app"
+  ln -s ../Applications/Emdash.app/Contents/MacOS/emdash "${PREFIX}/bin/emdash"
+fi

--- a/recipes/emdash/electron-builder.json
+++ b/recipes/emdash/electron-builder.json
@@ -1,0 +1,37 @@
+{
+  "appId": "com.emdash.stable",
+  "productName": "Emdash",
+  "executableName": "emdash",
+  "directories": {
+    "output": "release"
+  },
+  "files": [
+    "out/**/*",
+    "node_modules/**/*",
+    "drizzle/**/*"
+  ],
+  "asarUnpack": [
+    "node_modules/better-sqlite3/**",
+    "node_modules/node-pty/**",
+    "node_modules/@parcel/watcher/**",
+    "**/*.node"
+  ],
+  "npmRebuild": false,
+  "electronFuses": {
+    "enableCookieEncryption": true
+  },
+  "mac": {
+    "category": "public.app-category.developer-tools",
+    "icon": "icons/emdash.icns",
+    "target": [
+      "dir"
+    ]
+  },
+  "linux": {
+    "category": "Development",
+    "icon": "icons/emdash.png",
+    "target": [
+      "dir"
+    ]
+  }
+}

--- a/recipes/emdash/generate-third-party-licenses.mjs
+++ b/recipes/emdash/generate-third-party-licenses.mjs
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const [inputPath, outputPath, ...extraLicensePaths] = process.argv.slice(2);
+
+if (!inputPath || !outputPath) {
+  throw new Error(
+    "Usage: generate-third-party-licenses.mjs INPUT OUTPUT [EXTRA_LICENSE ...]",
+  );
+}
+
+const groupedDependencies = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+const dependencies = Object.entries(groupedDependencies)
+  .flatMap(([license, packages]) =>
+    packages.map((pkg) => ({ ...pkg, license: pkg.license || license })),
+  )
+  .sort((left, right) => {
+    const byName = left.name.localeCompare(right.name);
+    return byName || left.versions.join(",").localeCompare(right.versions.join(","));
+  });
+
+if (dependencies.length === 0) {
+  throw new Error("pnpm returned no production dependencies");
+}
+
+const licenseNamePattern =
+  /^(license|licence|copying|notice|copyright|ofl)([-._].*)?$/i;
+const licenseGroups = new Map();
+const dependenciesWithoutLicenseText = [];
+
+for (const dependency of dependencies) {
+  const label = `${dependency.name}@${dependency.versions.join(", ")}`;
+  let licenseFiles = [];
+
+  const packagePaths = [
+    ...dependency.paths,
+    path.resolve("node_modules", dependency.name),
+  ];
+
+  for (const packagePath of packagePaths) {
+    if (!fs.existsSync(packagePath)) {
+      continue;
+    }
+
+    licenseFiles = fs
+      .readdirSync(packagePath, { withFileTypes: true })
+      .filter(
+        (entry) =>
+          (entry.isFile() || entry.isSymbolicLink()) &&
+          licenseNamePattern.test(entry.name),
+      )
+      .map((entry) => path.join(packagePath, entry.name))
+      .sort();
+
+    if (licenseFiles.length > 0) {
+      break;
+    }
+  }
+
+  if (licenseFiles.length === 0) {
+    dependenciesWithoutLicenseText.push(label);
+    continue;
+  }
+
+  const licenseText = licenseFiles
+    .map((licensePath) => fs.readFileSync(licensePath, "utf8").trim())
+    .filter(Boolean)
+    .join("\n\n");
+
+  if (!licenseText) {
+    dependenciesWithoutLicenseText.push(label);
+    continue;
+  }
+
+  const existing = licenseGroups.get(licenseText) ?? [];
+  existing.push(label);
+  licenseGroups.set(licenseText, existing);
+}
+
+const lines = [
+  "THIRD-PARTY SOFTWARE NOTICES",
+  "============================",
+  "",
+  "Production dependencies bundled with Emdash:",
+  "",
+  ...dependencies.map(
+    (dependency) =>
+      `- ${dependency.name}@${dependency.versions.join(", ")} — ${dependency.license}`,
+  ),
+  "",
+  "LICENSE TEXTS",
+  "=============",
+  "",
+];
+
+for (const [licenseText, packages] of licenseGroups) {
+  lines.push(
+    `Applies to: ${packages.join(", ")}`,
+    "-".repeat(80),
+    licenseText,
+    "",
+  );
+}
+
+if (dependenciesWithoutLicenseText.length > 0) {
+  lines.push(
+    "DEPENDENCIES WITHOUT A DISTRIBUTED LICENSE FILE",
+    "===============================================",
+    "",
+    "Their declared license identifiers are recorded in the dependency list above.",
+    "",
+    ...dependenciesWithoutLicenseText.map((dependency) => `- ${dependency}`),
+    "",
+  );
+}
+
+for (const extraLicensePath of extraLicensePaths) {
+  lines.push(
+    `BUNDLED RUNTIME NOTICE: ${path.basename(extraLicensePath)}`,
+    "=".repeat(80),
+    "",
+    fs.readFileSync(extraLicensePath, "utf8").trim(),
+    "",
+  );
+}
+
+if (licenseGroups.size === 0) {
+  throw new Error("No dependency license texts were found");
+}
+
+fs.writeFileSync(outputPath, `${lines.join("\n")}\n`);

--- a/recipes/emdash/recipe.yaml
+++ b/recipes/emdash/recipe.yaml
@@ -1,0 +1,112 @@
+context:
+  version: "1.1.40"
+
+package:
+  name: emdash
+  version: ${{ version }}
+
+source:
+  url: https://github.com/generalaction/emdash/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: fecca3121fe40784aa25f9d64dce9c6e3264711645c7aa6ff695a6358a459e57
+
+build:
+  number: 0
+  skip: win or (linux and not x86_64)
+  dynamic_linking:
+    binary_relocation: ${{ false if osx else true }}
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - git
+    - make
+    - nodejs 24.*
+    - pkg-config
+    - pnpm ==10.28.2
+    - python
+  host:
+    - if: linux
+      then:
+        - alsa-lib
+        - atk
+        - cairo
+        - dbus
+        - glib
+        - gtk3
+        - libdrm
+        - libegl
+        - libgles
+        - libglvnd
+        - libsecret
+        - libudev
+        - libxcrypt1
+        - mesalib
+        - nss
+        - pango
+        - xorg-libx11
+        - xorg-libxcomposite
+        - xorg-libxdamage
+        - xorg-libxext
+        - xorg-libxfixes
+        - xorg-libxrandr
+  run:
+    - if: linux
+      then:
+        - alsa-lib
+        - atk
+        - cairo
+        - dbus
+        - glib
+        - gtk3
+        - libdrm
+        - libegl
+        - libgles
+        - libglvnd
+        - libsecret
+        - libudev
+        - libxcrypt1
+        - mesalib
+        - nss
+        - pango
+        - xorg-libx11
+        - xorg-libxcomposite
+        - xorg-libxdamage
+        - xorg-libxext
+        - xorg-libxfixes
+        - xorg-libxrandr
+
+tests:
+  - package_contents:
+      bin:
+        - emdash
+      files:
+        - if: linux
+          then:
+            - libexec/emdash/emdash
+            - libexec/emdash/resources/app.asar
+        - if: osx
+          then:
+            - Applications/Emdash.app/Contents/MacOS/emdash
+            - Applications/Emdash.app/Contents/Resources/app.asar
+  - script:
+      - ELECTRON_RUN_AS_NODE=1 emdash --version
+
+about:
+  homepage: https://emdash.sh
+  summary: Open-source agentic development environment
+  description: |
+    Emdash is a desktop application for running AI coding agents in parallel.
+    Each task runs in an isolated Git worktree, and local and remote projects
+    can be used with multiple agent providers.
+  license: Apache-2.0
+  license_file:
+    - LICENSE.md
+    - third-party-licenses.txt
+  documentation: https://emdash.sh/docs
+  repository: https://github.com/generalaction/emdash
+
+extra:
+  recipe-maintainers:
+    - ytausch

--- a/recipes/emdash/recipe.yaml
+++ b/recipes/emdash/recipe.yaml
@@ -37,6 +37,7 @@ requirements:
         - gtk3
         - libdrm
         - libegl
+        - libgbm
         - libgles
         - libglvnd
         - libsecret
@@ -62,6 +63,7 @@ requirements:
         - gtk3
         - libdrm
         - libegl
+        - libgbm
         - libgles
         - libglvnd
         - libsecret


### PR DESCRIPTION
(AI-generated, WIP)

This adds Emdash, an Apache-2.0 Electron desktop application for running AI coding agents in parallel.

The recipe builds the application from the upstream source tarball, rebuilds its native Node modules from source for the target architecture, and packages the unpacked desktop application for Linux x86_64 and macOS x86_64/arm64. Windows is skipped because its native-module and application packaging path requires a separate MSVC build that has not been validated here.

Important packaging note: the upstream lockfile pins Electron 40.10.2, whose runtime binary is downloaded by Electron's npm installer. The application JavaScript and native addons (`better-sqlite3`, `node-pty`, and `@parcel/watcher`) are built or rebuilt from source. This follows the practical pattern used by existing Electron application feedstocks such as `pgadmin4-desktop`; reviewer confirmation of the compiled-object exception is requested. macOS binary relocation is disabled because rewriting Electron frameworks invalidates the app bundle, which is ad-hoc signed after Electron fuse changes.

Third-party production dependencies and the full Electron/Chromium notices are packaged in `third-party-licenses.txt`. The built artifact was also checked and does not ship `.a`, `.o`, or `.obj` files.

Local validation:

- `conda-smithy recipe-lint --conda-forge recipes/emdash`
- `rattler-build build --recipe recipes/emdash -m .ci_support/osx_arm64.yaml`
- Package contents test
- `ELECTRON_RUN_AS_NODE=1 emdash --version`

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
  - As an Electron application, Emdash bundles its npm runtime dependencies. Their licenses and notices are packaged as described above.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
