### PR TITLE
Adding fil-c

### DIFF
--- a/recipes/fil-c/build.sh
+++ b/recipes/fil-c/build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Keep the upstream release layout intact: the clang driver locates the Fil-C
+# runtime at <real-path-of-clang>/../../pizfix.
+DEST="${PREFIX}/lib/fil-c"
+mkdir -p "${DEST}"
+cp -a build pizfix README.md "${DEST}/"
+
+# Upstream's setup.sh sets these rpaths to absolute paths of the unpack
+# location; use $ORIGIN-relative rpaths instead so the tree is relocatable.
+patchelf --set-rpath '$ORIGIN' "${DEST}/pizfix/lib/libc.so"
+patchelf --set-rpath '$ORIGIN' "${DEST}/pizfix/lib/libpizlo.so"
+patchelf --set-rpath '$ORIGIN' "${DEST}/pizfix/lib/libc++.so.1.0"
+patchelf --set-rpath '$ORIGIN' "${DEST}/pizfix/lib/libc++abi.so.1.0"
+patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_test/libpizlo.so"
+patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_test_gcverify/libpizlo.so"
+patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_gcverify/libpizlo.so"
+
+# Upstream's setup.sh symlinks the system kernel headers (/usr/include/linux,
+# asm, asm-generic) into pizfix/os-include; point at the conda kernel headers
+# from kernel-headers_linux-64 instead.
+mkdir -p "${DEST}/pizfix/os-include"
+for dir in linux asm asm-generic; do
+  ln -s "../../../../x86_64-conda-linux-gnu/sysroot/usr/include/${dir}" \
+    "${DEST}/pizfix/os-include/${dir}"
+done
+
+# The clang driver needs a GNU ld for linking (upstream assumes system
+# binutils); the driver searches its own directory first, so link the conda
+# ld from ld_impl_linux-64 next to clang-20.
+ln -s ../../../../x86_64-conda-linux-gnu/bin/ld "${DEST}/build/bin/ld"
+
+# Expose the Fil-C driver names, but not the clang/clang++ symlinks, which
+# would collide with the clang packages.
+mkdir -p "${PREFIX}/bin"
+for tool in filcc fil++ filcpp; do
+  ln -s "../lib/fil-c/build/bin/${tool}" "${PREFIX}/bin/${tool}"
+done

--- a/recipes/fil-c/build.sh
+++ b/recipes/fil-c/build.sh
@@ -40,7 +40,13 @@ sed -i \
 # supported upstream (see the commented block in libpas/Makefile) and saves
 # ~1 GiB of build env.
 GCC_INTERNAL_INCLUDE="$(${CC} -print-file-name=include)"
-sed -i "s|^HOST_CLANG_EXTRA_FLAGS = .*|HOST_CLANG_EXTRA_FLAGS = -Wno-expansion-to-defined -Wno-pragmas -Wno-address-of-packed-member -Wno-missing-field-initializers -isystem ${GCC_INTERNAL_INCLUDE}|" libpas/Makefile
+# g++ is required (not gcc): the libpas C sources use compound-literal
+# static initializers that C-mode gcc rejects. -fpermissive covers the one
+# C-ism that is not valid C++, the -Wno flags silence gcc false positives
+# (atomic ops on GC object headers) that upstream's clang build never sees,
+# and -Werror goes so warning noise cannot fail the build.
+sed -i "s|^HOST_CLANG_EXTRA_FLAGS = .*|HOST_CLANG_EXTRA_FLAGS = -Wno-expansion-to-defined -Wno-pragmas -Wno-address-of-packed-member -Wno-missing-field-initializers -isystem ${GCC_INTERNAL_INCLUDE} -Wno-stringop-overflow -Wno-array-bounds -Wno-free-nonheap-object -fpermissive|" libpas/Makefile
+sed -i "s/ -Werror//g" libpas/Makefile libpas/common.mk
 export HOST_CLANG="${CXX}"
 sed -i "s|^\tclang |\t\$(CC) |" yolounwind/Makefile
 
@@ -72,9 +78,11 @@ EOF
 ./build_yolounwind.sh
 ./configure_llvm.sh
 ./build_clang.sh
+# from the host env's kernel-headers_linux-64: the gcc sysroot's own kernel
+# headers are too old for the Fil-C runtime (it needs e.g. linux/landlock.h)
 mkdir -p pizfix/os-include
 for dir in linux asm asm-generic; do
-  ln -s "${BUILD_PREFIX}/x86_64-conda-linux-gnu/sysroot/usr/include/${dir}" \
+  ln -s "${PREFIX}/x86_64-conda-linux-gnu/sysroot/usr/include/${dir}" \
     "pizfix/os-include/${dir}"
 done
 ./build_yolomusl.sh

--- a/recipes/fil-c/build.sh
+++ b/recipes/fil-c/build.sh
@@ -1,61 +1,11 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Reclaim disk space: the tarball carries benchmark data, LLVM subprojects
-# and ported-project sources that the base toolchain build does not need.
-# yolomusl/usermusl must stay: they are the Fil-C libc.
-rm -rf benchmarkData pizlix optfil bolt clang-tools-extra flang lldb mlir polly
-for d in projects/*; do
-  case "$d" in
-    projects/yolomusl | projects/usermusl) ;;
-    *) rm -rf "$d" ;;
-  esac
-done
-
-# CI has 2 cores / ~7 GB RAM: build Release instead of RelWithDebInfo and
-# serialize the large LLVM link steps to avoid running out of memory.
-sed -i 's/-DCMAKE_BUILD_TYPE=RelWithDebInfo/-DCMAKE_BUILD_TYPE=Release -DLLVM_PARALLEL_LINK_JOBS=1/' configure_llvm.sh
-
-# build_clang.sh/build_cxx.sh/build_compiler_rt.sh source this hook if present
-cat > clang-build-overrides.sh <<'EOF'
-NINJAFLAGS="-j 2"
-NINJARUNTIMEFLAGS="-j 2"
-EOF
-
-# The steps of upstream's build_base.sh, except build_os_include.sh, which
-# symlinks /usr/include kernel headers; use the conda sysroot ones instead.
-./build_compiler_rt.sh
-./build_yolounwind.sh
-./configure_llvm.sh
-./build_clang.sh
-mkdir -p pizfix/os-include
-for dir in linux asm asm-generic; do
-  ln -s "${BUILD_PREFIX}/x86_64-conda-linux-gnu/sysroot/usr/include/${dir}" \
-    "pizfix/os-include/${dir}"
-done
-./build_yolomusl.sh
-./build_runtime.sh
-./build_usermusl.sh
-./build_cxx.sh
-
-# Install, mirroring upstream's package-build.sh layout: the clang driver
-# locates the Fil-C runtime at <real-path-of-clang>/../../pizfix.
+# Keep the upstream release layout intact: the clang driver locates the Fil-C
+# runtime at <real-path-of-clang>/../../pizfix.
 DEST="${PREFIX}/lib/fil-c"
-mkdir -p "${DEST}/build/bin"
-cp build/bin/clang-20 "${DEST}/build/bin/"
-"${STRIP}" "${DEST}/build/bin/clang-20"
-(cd "${DEST}/build/bin" && ln -s clang-20 clang && ln -s clang-20 clang++ &&
-  ln -s clang-20 filcc && ln -s clang-20 fil++ && ln -s clang-20 filcpp)
-
-mkdir -p "${DEST}/build/include/x86_64-unknown-linux-gnu"
-cp -R build/include/c++ "${DEST}/build/include/"
-cp -R build/include/x86_64-unknown-linux-gnu/c++ "${DEST}/build/include/x86_64-unknown-linux-gnu/"
-mkdir -p "${DEST}/build/lib/clang/20"
-cp -R build/lib/clang/20/include "${DEST}/build/lib/clang/20/"
-
-cp -a pizfix "${DEST}/"
-rm -rf "${DEST}/pizfix/yolo-include" "${DEST}/pizfix/os-include"
-cp README.md "${DEST}/"
+mkdir -p "${DEST}"
+cp -a build pizfix README.md "${DEST}/"
 
 # Upstream's setup.sh sets these rpaths to absolute paths of the unpack
 # location; use $ORIGIN-relative rpaths instead so the tree is relocatable.
@@ -66,10 +16,6 @@ patchelf --set-rpath '$ORIGIN' "${DEST}/pizfix/lib/libc++abi.so.1.0"
 patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_test/libpizlo.so"
 patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_test_gcverify/libpizlo.so"
 patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_gcverify/libpizlo.so"
-
-# The dynamic loader for Fil-C programs is libyoloc.so itself.
-rm -f "${DEST}/pizfix/lib/ld-yolo-x86_64.so"
-ln -s libyoloc.so "${DEST}/pizfix/lib/ld-yolo-x86_64.so"
 
 # Upstream's setup.sh symlinks the system kernel headers (/usr/include/linux,
 # asm, asm-generic) into pizfix/os-include; point at the conda kernel headers

--- a/recipes/fil-c/build.sh
+++ b/recipes/fil-c/build.sh
@@ -4,9 +4,12 @@ set -euxo pipefail
 # ---- disk reclamation: CI agents have only ~7 GiB total for this build ----
 # Sources are fetched/extracted and envs installed by the time this script
 # runs: the 2 GiB cached source tarball and the package-cache archives
-# (already extracted into the envs) can go.
-find "${SRC_DIR}/../../../src_cache" -type f -size +100M -delete 2>/dev/null || true
-find "${SRC_DIR}/../../../pkg_cache" -type f \( -name "*.conda" -o -name "*.tar.bz2" \) -delete 2>/dev/null || true
+# (already extracted into the envs) can go. Set FILC_KEEP_CACHES for local
+# builds to keep iteration fast.
+if [ -z "${FILC_KEEP_CACHES:-}" ]; then
+  find "${SRC_DIR}/../../../src_cache" -type f -size +100M -delete 2>/dev/null || true
+  find "${SRC_DIR}/../../../pkg_cache" -type f \( -name "*.conda" -o -name "*.tar.bz2" \) -delete 2>/dev/null || true
+fi
 
 # The tarball carries benchmark data, LLVM subprojects and ported-project
 # sources that the base toolchain build does not need. yolomusl/usermusl
@@ -20,8 +23,9 @@ for d in projects/*; do
   esac
 done
 # Test suites are never built (LLVM_INCLUDE_TESTS=OFF below). The libcxx/
-# libcxxabi test dirs must stay: the runtimes configure includes them.
-rm -rf llvm/test llvm/unittests llvm/docs clang/test clang/unittests clang/docs
+# libcxxabi test dirs and the docs dirs must stay: cmake includes them
+# unconditionally.
+rm -rf llvm/test llvm/unittests clang/test clang/unittests
 
 # ---- adapt the upstream build to the conda toolchain and CI resources ----
 # Release instead of RelWithDebInfo and serialized link jobs: the 7 GiB RAM
@@ -41,8 +45,13 @@ export HOST_CLANG="${CXX}"
 sed -i "s|^\tclang |\t\$(CC) |" yolounwind/Makefile
 
 # The freshly built fil-c clang invokes plain `ld` when linking usermusl and
-# the runtimes; conda binutils only puts the triple-prefixed one on PATH.
-ln -sf "${BUILD_PREFIX}/x86_64-conda-linux-gnu/bin/ld" "${BUILD_PREFIX}/bin/ld"
+# the runtimes, and several upstream scripts use plain `ar`; conda binutils
+# only puts triple-prefixed names on PATH.
+for tool in ld ar ranlib nm strip objcopy as; do
+  if [ ! -e "${BUILD_PREFIX}/bin/${tool}" ]; then
+    ln -s "${BUILD_PREFIX}/x86_64-conda-linux-gnu/bin/${tool}" "${BUILD_PREFIX}/bin/${tool}"
+  fi
+done
 
 # Scale ninja parallelism to the machine, capped by available RAM (large
 # LLVM translation units need ~2 GiB each); CI agents resolve to -j 2.

--- a/recipes/fil-c/build.sh
+++ b/recipes/fil-c/build.sh
@@ -1,11 +1,61 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Keep the upstream release layout intact: the clang driver locates the Fil-C
-# runtime at <real-path-of-clang>/../../pizfix.
+# Reclaim disk space: the tarball carries benchmark data, LLVM subprojects
+# and ported-project sources that the base toolchain build does not need.
+# yolomusl/usermusl must stay: they are the Fil-C libc.
+rm -rf benchmarkData pizlix optfil bolt clang-tools-extra flang lldb mlir polly
+for d in projects/*; do
+  case "$d" in
+    projects/yolomusl | projects/usermusl) ;;
+    *) rm -rf "$d" ;;
+  esac
+done
+
+# CI has 2 cores / ~7 GB RAM: build Release instead of RelWithDebInfo and
+# serialize the large LLVM link steps to avoid running out of memory.
+sed -i 's/-DCMAKE_BUILD_TYPE=RelWithDebInfo/-DCMAKE_BUILD_TYPE=Release -DLLVM_PARALLEL_LINK_JOBS=1/' configure_llvm.sh
+
+# build_clang.sh/build_cxx.sh/build_compiler_rt.sh source this hook if present
+cat > clang-build-overrides.sh <<'EOF'
+NINJAFLAGS="-j 2"
+NINJARUNTIMEFLAGS="-j 2"
+EOF
+
+# The steps of upstream's build_base.sh, except build_os_include.sh, which
+# symlinks /usr/include kernel headers; use the conda sysroot ones instead.
+./build_compiler_rt.sh
+./build_yolounwind.sh
+./configure_llvm.sh
+./build_clang.sh
+mkdir -p pizfix/os-include
+for dir in linux asm asm-generic; do
+  ln -s "${BUILD_PREFIX}/x86_64-conda-linux-gnu/sysroot/usr/include/${dir}" \
+    "pizfix/os-include/${dir}"
+done
+./build_yolomusl.sh
+./build_runtime.sh
+./build_usermusl.sh
+./build_cxx.sh
+
+# Install, mirroring upstream's package-build.sh layout: the clang driver
+# locates the Fil-C runtime at <real-path-of-clang>/../../pizfix.
 DEST="${PREFIX}/lib/fil-c"
-mkdir -p "${DEST}"
-cp -a build pizfix README.md "${DEST}/"
+mkdir -p "${DEST}/build/bin"
+cp build/bin/clang-20 "${DEST}/build/bin/"
+"${STRIP}" "${DEST}/build/bin/clang-20"
+(cd "${DEST}/build/bin" && ln -s clang-20 clang && ln -s clang-20 clang++ &&
+  ln -s clang-20 filcc && ln -s clang-20 fil++ && ln -s clang-20 filcpp)
+
+mkdir -p "${DEST}/build/include/x86_64-unknown-linux-gnu"
+cp -R build/include/c++ "${DEST}/build/include/"
+cp -R build/include/x86_64-unknown-linux-gnu/c++ "${DEST}/build/include/x86_64-unknown-linux-gnu/"
+mkdir -p "${DEST}/build/lib/clang/20"
+cp -R build/lib/clang/20/include "${DEST}/build/lib/clang/20/"
+
+cp -a pizfix "${DEST}/"
+rm -rf "${DEST}/pizfix/yolo-include" "${DEST}/pizfix/os-include"
+cp README.md "${DEST}/"
 
 # Upstream's setup.sh sets these rpaths to absolute paths of the unpack
 # location; use $ORIGIN-relative rpaths instead so the tree is relocatable.
@@ -16,6 +66,10 @@ patchelf --set-rpath '$ORIGIN' "${DEST}/pizfix/lib/libc++abi.so.1.0"
 patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_test/libpizlo.so"
 patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_test_gcverify/libpizlo.so"
 patchelf --set-rpath '$ORIGIN/../lib' "${DEST}/pizfix/lib_gcverify/libpizlo.so"
+
+# The dynamic loader for Fil-C programs is libyoloc.so itself.
+rm -f "${DEST}/pizfix/lib/ld-yolo-x86_64.so"
+ln -s libyoloc.so "${DEST}/pizfix/lib/ld-yolo-x86_64.so"
 
 # Upstream's setup.sh symlinks the system kernel headers (/usr/include/linux,
 # asm, asm-generic) into pizfix/os-include; point at the conda kernel headers

--- a/recipes/fil-c/build.sh
+++ b/recipes/fil-c/build.sh
@@ -1,29 +1,64 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Reclaim disk space: the tarball carries benchmark data, LLVM subprojects
-# and ported-project sources that the base toolchain build does not need.
-# yolomusl/usermusl must stay: they are the Fil-C libc.
-rm -rf benchmarkData pizlix optfil bolt clang-tools-extra flang lldb mlir polly
+# ---- disk reclamation: CI agents have only ~7 GiB total for this build ----
+# Sources are fetched/extracted and envs installed by the time this script
+# runs: the 2 GiB cached source tarball and the package-cache archives
+# (already extracted into the envs) can go.
+find "${SRC_DIR}/../../../src_cache" -type f -size +100M -delete 2>/dev/null || true
+find "${SRC_DIR}/../../../pkg_cache" -type f \( -name "*.conda" -o -name "*.tar.bz2" \) -delete 2>/dev/null || true
+
+# The tarball carries benchmark data, LLVM subprojects and ported-project
+# sources that the base toolchain build does not need. yolomusl/usermusl
+# must stay: they are the Fil-C libc.
+rm -rf benchmarkData pizlix optfil bolt clang-tools-extra cross-project-tests \
+  flang libclc lldb llvm-libgcc mlir offload openmp polly pstl
 for d in projects/*; do
   case "$d" in
     projects/yolomusl | projects/usermusl) ;;
     *) rm -rf "$d" ;;
   esac
 done
+# Test suites are never built (LLVM_INCLUDE_TESTS=OFF below). The libcxx/
+# libcxxabi test dirs must stay: the runtimes configure includes them.
+rm -rf llvm/test llvm/unittests llvm/docs clang/test clang/unittests clang/docs
 
-# CI has 2 cores / ~7 GB RAM: build Release instead of RelWithDebInfo and
-# serialize the large LLVM link steps to avoid running out of memory.
-sed -i 's/-DCMAKE_BUILD_TYPE=RelWithDebInfo/-DCMAKE_BUILD_TYPE=Release -DLLVM_PARALLEL_LINK_JOBS=1/' configure_llvm.sh
+# ---- adapt the upstream build to the conda toolchain and CI resources ----
+# Release instead of RelWithDebInfo and serialized link jobs: the 7 GiB RAM
+# agents cannot link clang with debug info. No lld: GNU ld links fine and
+# keeps the clang+lld packages out of the disk budget.
+sed -i \
+  -e 's/-DCMAKE_BUILD_TYPE=RelWithDebInfo/-DCMAKE_BUILD_TYPE=Release -DLLVM_PARALLEL_LINK_JOBS=1 -DLLVM_INCLUDE_TESTS=OFF/' \
+  -e 's/-DLLVM_ENABLE_LLD=ON//' \
+  configure_llvm.sh
 
-# build_clang.sh/build_cxx.sh/build_compiler_rt.sh source this hook if present
-cat > clang-build-overrides.sh <<'EOF'
-NINJAFLAGS="-j 2"
-NINJARUNTIMEFLAGS="-j 2"
+# libpas and yolounwind default to a host clang; building with g++/gcc is
+# supported upstream (see the commented block in libpas/Makefile) and saves
+# ~1 GiB of build env.
+GCC_INTERNAL_INCLUDE="$(${CC} -print-file-name=include)"
+sed -i "s|^HOST_CLANG_EXTRA_FLAGS = .*|HOST_CLANG_EXTRA_FLAGS = -Wno-expansion-to-defined -Wno-pragmas -Wno-address-of-packed-member -Wno-missing-field-initializers -isystem ${GCC_INTERNAL_INCLUDE}|" libpas/Makefile
+export HOST_CLANG="${CXX}"
+sed -i "s|^\tclang |\t\$(CC) |" yolounwind/Makefile
+
+# The freshly built fil-c clang invokes plain `ld` when linking usermusl and
+# the runtimes; conda binutils only puts the triple-prefixed one on PATH.
+ln -sf "${BUILD_PREFIX}/x86_64-conda-linux-gnu/bin/ld" "${BUILD_PREFIX}/bin/ld"
+
+# Scale ninja parallelism to the machine, capped by available RAM (large
+# LLVM translation units need ~2 GiB each); CI agents resolve to -j 2.
+MEM_GB=$(awk '/MemTotal/ {print int($2/1048576)}' /proc/meminfo)
+JOBS=${CPU_COUNT:-2}
+if ((JOBS > MEM_GB / 2)); then JOBS=$((MEM_GB / 2)); fi
+((JOBS >= 1)) || JOBS=1
+# build_clang.sh/build_cxx.sh/build_compiler_rt.sh source this hook
+cat > clang-build-overrides.sh <<EOF
+NINJAFLAGS="-j ${JOBS}"
+NINJARUNTIMEFLAGS="-j ${JOBS}"
 EOF
 
-# The steps of upstream's build_base.sh, except build_os_include.sh, which
-# symlinks /usr/include kernel headers; use the conda sysroot ones instead.
+# ---- the steps of upstream's build_base.sh ----
+# build_os_include.sh is replaced: it symlinks /usr/include kernel headers,
+# which do not exist here; use the conda sysroot ones.
 ./build_compiler_rt.sh
 ./build_yolounwind.sh
 ./configure_llvm.sh
@@ -38,8 +73,8 @@ done
 ./build_usermusl.sh
 ./build_cxx.sh
 
-# Install, mirroring upstream's package-build.sh layout: the clang driver
-# locates the Fil-C runtime at <real-path-of-clang>/../../pizfix.
+# ---- install, mirroring upstream's package-build.sh layout ----
+# The clang driver locates the Fil-C runtime at <real-path-of-clang>/../../pizfix.
 DEST="${PREFIX}/lib/fil-c"
 mkdir -p "${DEST}/build/bin"
 cp build/bin/clang-20 "${DEST}/build/bin/"

--- a/recipes/fil-c/hello.c
+++ b/recipes/fil-c/hello.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(16);
+    if (p == NULL) {
+        return 1;
+    }
+    strcpy(p, "Fil-C");
+    printf("Hello from %s!\n", p);
+    free(p);
+    return 0;
+}

--- a/recipes/fil-c/hello.cpp
+++ b/recipes/fil-c/hello.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+int main() {
+    std::vector<std::string> words{"Hello", "from", "Fil-C++!"};
+    try {
+        throw std::runtime_error("exceptions work");
+    } catch (const std::exception &e) {
+        words.emplace_back(e.what());
+    }
+    for (const auto &w : words) {
+        std::cout << w << ' ';
+    }
+    std::cout << std::endl;
+    return 0;
+}

--- a/recipes/fil-c/recipe.yaml
+++ b/recipes/fil-c/recipe.yaml
@@ -6,26 +6,38 @@ package:
   version: ${{ version }}
 
 source:
-  # Fil-C only supports Linux/x86_64. This repackages the official upstream
-  # binary release: building from source means building a full LLVM/clang 20
-  # fork plus the Fil-C runtime, two musl builds and libc++/libc++abi, which
-  # does not fit within CI resource limits.
-  url: https://github.com/pizlonator/fil-c/releases/download/v${{ version }}/filc-${{ version }}-linux-x86_64.tar.xz
-  sha256: 84272acf017fe76bddb32bb3865f3d97ce332eb6e6a17fc1c07a8eb9ad777787
+  # Fil-C only supports Linux/x86_64. The tarball is the full fil-c monorepo:
+  # an LLVM/clang 20 fork plus the Fil-C runtime (libpas), musl, and the
+  # sources of many ported projects (~2 GiB).
+  url: https://github.com/pizlonator/fil-c/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 715387dd9ded5e4ee4561a14725312e2933d50856e7d59033e9fed1e838abd6c
 
 build:
   number: 0
   skip:
     - target_platform != "linux-64"
   dynamic_linking:
-    # Upstream prebuilt binaries; rpaths are set to $ORIGIN-relative paths in
-    # build.sh (mirroring upstream's setup.sh, which uses absolute paths).
+    # The pizfix tree is the Fil-C target runtime (its own musl-based libc,
+    # dynamic loader and libc++); rpaths are set to $ORIGIN-relative paths in
+    # build.sh (mirroring upstream's setup.sh) and must not be rewritten.
     binary_relocation: false
     missing_dso_allowlist:
       - "**"
 
 requirements:
   build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    # the Fil-C runtime (libpas) and yolounwind build with a host clang, and
+    # the LLVM build links with lld
+    - clang
+    - lld
+    - cmake
+    - ninja
+    - make
+    - python
+    - ruby
     - patchelf
   host:
     - kernel-headers_linux-64
@@ -35,8 +47,6 @@ requirements:
     - kernel-headers_linux-64
     # the clang driver invokes GNU ld for linking
     - ld_impl_linux-64
-    # the clang-20 host binary is linked against glibc >=2.34
-    - __glibc >=2.34
 
 tests:
   - script:
@@ -67,8 +77,8 @@ about:
   license: Apache-2.0 WITH LLVM-exception AND BSD-2-Clause AND MIT
   license_file:
     - LLVM-LICENSE.txt
-    - PAS-LICENSE.txt
-    - MUSL-LICENSE.txt
+    - libpas/LICENSE.txt
+    - projects/usermusl/COPYRIGHT
 
 extra:
   recipe-maintainers:

--- a/recipes/fil-c/recipe.yaml
+++ b/recipes/fil-c/recipe.yaml
@@ -6,38 +6,26 @@ package:
   version: ${{ version }}
 
 source:
-  # Fil-C only supports Linux/x86_64. The tarball is the full fil-c monorepo:
-  # an LLVM/clang 20 fork plus the Fil-C runtime (libpas), musl, and the
-  # sources of many ported projects (~2 GiB).
-  url: https://github.com/pizlonator/fil-c/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 715387dd9ded5e4ee4561a14725312e2933d50856e7d59033e9fed1e838abd6c
+  # Fil-C only supports Linux/x86_64. This repackages the official upstream
+  # binary release: building from source means building a full LLVM/clang 20
+  # fork plus the Fil-C runtime, two musl builds and libc++/libc++abi, which
+  # does not fit within CI resource limits.
+  url: https://github.com/pizlonator/fil-c/releases/download/v${{ version }}/filc-${{ version }}-linux-x86_64.tar.xz
+  sha256: 84272acf017fe76bddb32bb3865f3d97ce332eb6e6a17fc1c07a8eb9ad777787
 
 build:
   number: 0
   skip:
     - target_platform != "linux-64"
   dynamic_linking:
-    # The pizfix tree is the Fil-C target runtime (its own musl-based libc,
-    # dynamic loader and libc++); rpaths are set to $ORIGIN-relative paths in
-    # build.sh (mirroring upstream's setup.sh) and must not be rewritten.
+    # Upstream prebuilt binaries; rpaths are set to $ORIGIN-relative paths in
+    # build.sh (mirroring upstream's setup.sh, which uses absolute paths).
     binary_relocation: false
     missing_dso_allowlist:
       - "**"
 
 requirements:
   build:
-    - ${{ compiler('c') }}
-    - ${{ compiler('cxx') }}
-    - ${{ stdlib('c') }}
-    # the Fil-C runtime (libpas) and yolounwind build with a host clang, and
-    # the LLVM build links with lld
-    - clang
-    - lld
-    - cmake
-    - ninja
-    - make
-    - python
-    - ruby
     - patchelf
   host:
     - kernel-headers_linux-64
@@ -47,6 +35,8 @@ requirements:
     - kernel-headers_linux-64
     # the clang driver invokes GNU ld for linking
     - ld_impl_linux-64
+    # the clang-20 host binary is linked against glibc >=2.34
+    - __glibc >=2.34
 
 tests:
   - script:
@@ -77,8 +67,8 @@ about:
   license: Apache-2.0 WITH LLVM-exception AND BSD-2-Clause AND MIT
   license_file:
     - LLVM-LICENSE.txt
-    - libpas/LICENSE.txt
-    - projects/usermusl/COPYRIGHT
+    - PAS-LICENSE.txt
+    - MUSL-LICENSE.txt
 
 extra:
   recipe-maintainers:

--- a/recipes/fil-c/recipe.yaml
+++ b/recipes/fil-c/recipe.yaml
@@ -1,0 +1,75 @@
+context:
+  version: "0.681"
+
+package:
+  name: fil-c
+  version: ${{ version }}
+
+source:
+  # Fil-C only supports Linux/x86_64. This repackages the official upstream
+  # binary release: building from source means building a full LLVM/clang 20
+  # fork plus the Fil-C runtime, two musl builds and libc++/libc++abi, which
+  # does not fit within CI resource limits.
+  url: https://github.com/pizlonator/fil-c/releases/download/v${{ version }}/filc-${{ version }}-linux-x86_64.tar.xz
+  sha256: 84272acf017fe76bddb32bb3865f3d97ce332eb6e6a17fc1c07a8eb9ad777787
+
+build:
+  number: 0
+  skip:
+    - target_platform != "linux-64"
+  dynamic_linking:
+    # Upstream prebuilt binaries; rpaths are set to $ORIGIN-relative paths in
+    # build.sh (mirroring upstream's setup.sh, which uses absolute paths).
+    binary_relocation: false
+    missing_dso_allowlist:
+      - "**"
+
+requirements:
+  build:
+    - patchelf
+  host:
+    - kernel-headers_linux-64
+    - ld_impl_linux-64
+  run:
+    # pizfix/os-include symlinks resolve into the conda sysroot kernel headers
+    - kernel-headers_linux-64
+    # the clang driver invokes GNU ld for linking
+    - ld_impl_linux-64
+    # the clang-20 host binary is linked against glibc >=2.34
+    - __glibc >=2.34
+
+tests:
+  - script:
+      - filcc --version
+      - fil++ --version
+      - filcc -O2 -g -o hello_c hello.c
+      - ./hello_c
+      - fil++ -O2 -g -std=c++20 -o hello_cxx hello.cpp
+      - ./hello_cxx
+    files:
+      recipe:
+        - hello.c
+        - hello.cpp
+
+about:
+  homepage: https://fil-c.org
+  repository: https://github.com/pizlonator/fil-c
+  summary: A fanatically compatible memory-safe implementation of C and C++
+  description: |
+    Fil-C is a memory-safe implementation of C and C++, based on clang 20.
+    Lots of software compiles and runs with Fil-C with zero or minimal
+    changes. All memory safety errors are caught as Fil-C panics. Fil-C
+    achieves this using a combination of concurrent garbage collection and
+    invisible capabilities. Fil-C only works on Linux/x86_64.
+
+    The package installs the Fil-C toolchain under `lib/fil-c/` and exposes
+    the `filcc` (C) and `fil++` (C++) compiler drivers on `bin/`.
+  license: Apache-2.0 WITH LLVM-exception AND BSD-2-Clause AND MIT
+  license_file:
+    - LLVM-LICENSE.txt
+    - PAS-LICENSE.txt
+    - MUSL-LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - tdejager

--- a/recipes/fil-c/recipe.yaml
+++ b/recipes/fil-c/recipe.yaml
@@ -29,14 +29,11 @@ requirements:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
     - ${{ stdlib('c') }}
-    # the Fil-C runtime (libpas) and yolounwind build with a host clang, and
-    # the LLVM build links with lld
-    - clang
-    - lld
     - cmake
     - ninja
     - make
     - python
+    # libpas code generation scripts
     - ruby
     - patchelf
   host:


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

---

This adds [Fil-C](https://fil-c.org) ([GitHub](https://github.com/pizlonator/fil-c)), a memory-safe implementation of C and C++ based on clang 20, by Filip Pizlo.

Notes for reviewers:

- **This repackages the official upstream binary release** (like the `rust` feedstock does). Building from source means building a full LLVM/clang fork plus the Fil-C runtime (libpas), two musl builds, and libc++/libc++abi with a bespoke multi-stage bootstrap — that does not fit in staged-recipes CI limits. Happy to discuss if a source build is preferred once it has its own feedstock.
- Fil-C only supports Linux/x86_64, so all other platforms are skipped.
- The upstream `setup.sh` patches absolute rpaths and symlinks system kernel headers from `/usr/include`; the recipe instead sets `$ORIGIN`-relative rpaths and points `pizfix/os-include` at `kernel-headers_linux-64`, and provides `ld` via `ld_impl_linux-64` (upstream assumes system binutils).
- The upstream binaries require glibc >= 2.34, expressed as a `__glibc >=2.34` run dependency.
- The package ships the static variants of the Fil-C runtime libraries (musl-based libc, libpizlo, libc++) as upstream distributes them — these are the compiler's target runtime, not host libraries, so the static-library checkbox above is left unchecked; all corresponding licenses (Apache-2.0 WITH LLVM-exception, BSD-2-Clause, MIT) are packaged.
- `filcc`/`fil++` are exposed on `bin/`; the `clang`/`clang++` aliases are kept only inside `lib/fil-c/build/bin/` to avoid clobbering the `clang` packages.
- Tested locally (linux/amd64 container): compiles and runs C and C++ hello-world, C++ exceptions work, and an out-of-bounds write is trapped with a Fil-C panic as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)