### PR TITLE
Create recipe.yaml for traceml-ai package

### DIFF
--- a/recipes/traceml-ai/recipe.yaml
+++ b/recipes/traceml-ai/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: "0.3.5"
+  version: "0.3.5.1"
 
 package:
   name: traceml-ai
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/t/traceml-ai/traceml_ai-${{ version }}.tar.gz
-  sha256: 6d2d91fb4df4de29db624f424aa6959e7cc174a08fe9a6bb81c7c513ee1aba5d
+  sha256: 019b86705954db88ca9fc797721cb307c819cd354705e2aa3699044bfe7071b9
 
 build:
   number: 0
@@ -28,11 +28,10 @@ requirements:
     - rich >=12.0.0
     - psutil >=5.0.0
     - nvidia-ml-py
-    - numpy <2
+    - numpy >=1.26
     - msgspec
     - pyyaml >=6.0
-    - nicegui
-    - plotly
+    - nicegui >=1.4.23
 
 tests:
   - python:

--- a/recipes/traceml-ai/recipe.yaml
+++ b/recipes/traceml-ai/recipe.yaml
@@ -22,13 +22,21 @@ build:
   python:
     entry_points:
       - traceml = traceml_ai.launcher.cli:main
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  # setuptools-scm derives the version from a git tag. The PyPI sdist has no
+  # .git, and --no-build-isolation means the build-system requires are not
+  # installed for us, so without the host dependency and this pretend version
+  # the package builds as 0.0.0.
+  script:
+    env:
+      SETUPTOOLS_SCM_PRETEND_VERSION: ${{ version }}
+    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python ${{ python_min }}.*
     - pip
-    - setuptools
+    - setuptools >=64
+    - setuptools-scm >=8
     - wheel
   run:
     - python >=${{ python_min }}

--- a/recipes/traceml-ai/recipe.yaml
+++ b/recipes/traceml-ai/recipe.yaml
@@ -15,6 +15,13 @@ source:
 build:
   number: 0
   noarch: python
+  # Declared so the console script is regenerated for the target platform at
+  # install time. Without this the noarch package carries whatever launcher
+  # the build machine produced, which on a win-64 build is a Scripts/*.exe
+  # that cannot start anywhere else.
+  python:
+    entry_points:
+      - traceml = traceml_ai.launcher.cli:main
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -41,13 +48,8 @@ tests:
       python_version:
         - ${{ python_min }}.*
         - "*"
-  # CLI check is unix-only: traceml --help exits 1 on Windows, tracked
-  # upstream at https://github.com/traceopt-ai/traceml/issues/281.
-  # Imports and pip_check above still run on all platforms.
-  - if: unix
-    then:
-      - script:
-          - traceml --help
+  - script:
+      - traceml --help
 
 about:
   homepage: https://github.com/traceopt-ai/traceml

--- a/recipes/traceml-ai/recipe.yaml
+++ b/recipes/traceml-ai/recipe.yaml
@@ -1,0 +1,64 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  version: "0.3.4"
+
+package:
+  name: traceml-ai
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/traceml-ai/traceml_ai-${{ version }}.tar.gz
+  sha256: ac85f9df9c37309319040ffee4632b6ea8b27af00f0ebfe040eb5765f6ddaccf
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - rich >=12.0.0
+    - psutil >=5.0.0
+    - nvidia-ml-py
+    - numpy <2
+    - msgspec
+    - pyyaml >=6.0
+    - nicegui
+    - plotly
+
+tests:
+  - python:
+      imports:
+        - traceml_ai
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - traceml --help
+
+about:
+  homepage: https://github.com/traceopt-ai/traceml
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Lightweight runtime bottleneck diagnostics for PyTorch training.
+  description: |
+    TraceML is open-source, real-time bottleneck diagnostics for PyTorch
+    training runs. It auto-instruments the training loop (dataloader,
+    forward, backward, optimizer, H2D transfer) with no manual logging,
+    and reports where step time and GPU hours are actually going.
+  repository: https://github.com/traceopt-ai/traceml
+  documentation: https://github.com/traceopt-ai/traceml/tree/main/docs
+
+extra:
+  recipe-maintainers:
+    - Pendu
+    - abhinavsriva

--- a/recipes/traceml-ai/recipe.yaml
+++ b/recipes/traceml-ai/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: "0.3.4"
+  version: "0.3.5"
 
 package:
   name: traceml-ai
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/t/traceml-ai/traceml_ai-${{ version }}.tar.gz
-  sha256: ac85f9df9c37309319040ffee4632b6ea8b27af00f0ebfe040eb5765f6ddaccf
+  sha256: 6d2d91fb4df4de29db624f424aa6959e7cc174a08fe9a6bb81c7c513ee1aba5d
 
 build:
   number: 0
@@ -42,8 +42,13 @@ tests:
       python_version:
         - ${{ python_min }}.*
         - "*"
-  - script:
-      - traceml --help
+  # CLI check is unix-only: traceml --help exits 1 on Windows, tracked
+  # upstream at https://github.com/traceopt-ai/traceml/issues/281.
+  # Imports and pip_check above still run on all platforms.
+  - if: unix
+    then:
+      - script:
+          - traceml --help
 
 about:
   homepage: https://github.com/traceopt-ai/traceml


### PR DESCRIPTION
### Checklist

- [x] Followed the recipe review checklist below.
- [x] License file is packaged (`LICENSE`, present in the sdist).
- [x] Source is the PyPI sdist; sha256 verified against the file downloaded from PyPI.
- [x] `recipe.yaml` validates cleanly against the official rattler-build JSON schema.
- [x] Runtime and build requirements match the package's own published metadata exactly (`pip install traceml-ai==0.3.4`, PyPI `requires_dist`), not inferred from the repo's newer, unreleased branch.

### About traceml-ai

TraceML is an open-source, real-time bottleneck diagnostics library for PyTorch training runs. It auto-instruments the training loop (dataloader, forward, backward, optimizer, H2D transfer) and reports where step time and GPU hours are going, with no manual logging required.

- PyPI: https://pypi.org/project/traceml-ai/
- Repository: https://github.com/traceopt-ai/traceml
- License: Apache-2.0

`noarch: python`, pure-Python package, no compiled extensions. All eight runtime dependencies (`rich`, `psutil`, `nvidia-ml-py`, `numpy`, `msgspec`, `pyyaml`, `nicegui`, `plotly`) are already on conda-forge.

