### PR TITLE
Add cooling-tower-chem

### DIFF
--- a/recipes/cooling-tower-chem/recipe.yaml
+++ b/recipes/cooling-tower-chem/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  name: cooling-tower-chem
+  version: "0.1.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name | replace('-', '_') }}-${{ version }}.tar.gz
+  sha256: 125fcfb84976447098c3194097a8715cf7f2a202b80d683a1651ba7bf16b81b5
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - cooling_tower_chem
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - ctchem --help
+
+about:
+  summary: Water-stability and corrosion indices (LSI, RSI, PSI, Larson-Skold) and water-balance math for cooling towers.
+  description: |
+    cooling-tower-chem is a small, dependency-free (standard-library only)
+    Python library for the classical water-stability and corrosion indices
+    used in cooling-tower and process-water treatment: the Langelier (LSI),
+    Ryznar (RSI), Puckorius (PSI), Larson-Skold, aggressiveness, and
+    Stiff-Davis indices, calcium-carbonate precipitation potential (CCPP),
+    plus the evaporation / blowdown / makeup water-balance math that sets
+    cycles of concentration. A ctchem command-line interface is included.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/Madhvansh/cooling-tower-chem
+  repository: https://github.com/Madhvansh/cooling-tower-chem
+  documentation: https://madhvansh.github.io/cooling-tower-chem/
+
+extra:
+  recipe-maintainers:
+    - Madhvansh

--- a/recipes/cooling-tower-chem/recipe.yaml
+++ b/recipes/cooling-tower-chem/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: cooling-tower-chem
-  version: "0.1.0"
+  version: "0.1.1"
 
 package:
   name: ${{ name }}
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name | replace('-', '_') }}-${{ version }}.tar.gz
-  sha256: 125fcfb84976447098c3194097a8715cf7f2a202b80d683a1651ba7bf16b81b5
+  sha256: edd81f68c0cd4601116aabe896d723b3bee0798a2a70635225a3b93fb8e8d62a
 
 build:
   noarch: python
@@ -35,7 +35,7 @@ tests:
       run:
         - python ${{ python_min }}.*
     script:
-      - ctchem --help
+      - python -m cooling_tower_chem --version
 
 about:
   summary: Water-stability and corrosion indices (LSI, RSI, PSI, Larson-Skold) and water-balance math for cooling towers.

--- a/recipes/cooling-tower-chem/recipe.yaml
+++ b/recipes/cooling-tower-chem/recipe.yaml
@@ -30,7 +30,9 @@ tests:
       imports:
         - cooling_tower_chem
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - requirements:
       run:
         - python ${{ python_min }}.*


### PR DESCRIPTION
Adds a recipe for **cooling-tower-chem**, a small, dependency-free (Python standard-library only) library of the classical water-stability and corrosion indices used in cooling-tower and process-water treatment: Langelier (LSI), Ryznar (RSI), Puckorius (PSI), Larson-Skold, aggressiveness, and Stiff-Davis, plus calcium-carbonate precipitation potential (CCPP) and the evaporation/blowdown/makeup water-balance math for cycles of concentration. Ships a `ctchem` CLI. The interpretation bands are the conventional screening thresholds cited to the original AWWA/Corrosion literature. MIT licensed, `noarch: python`.

- PyPI: https://pypi.org/project/cooling-tower-chem/ (v0.1.0)
- Source: https://github.com/Madhvansh/cooling-tower-chem
- Docs: https://madhvansh.github.io/cooling-tower-chem/

The submitter (@Madhvansh) is the package's author and the sole recipe maintainer.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (`license_file: LICENSE`; LICENSE is included in the PyPI sdist).
- [x] Source is from official source (PyPI sdist tarball).
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged. (N/A — pure-Python, no linking.)
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (Sole maintainer @Madhvansh is the submitter and package author.)
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
