### PR TITLE
Add py-lets-be-rational

### DIFF
--- a/recipes/py-lets-be-rational/LICENSE
+++ b/recipes/py-lets-be-rational/LICENSE
@@ -1,0 +1,19 @@
+:copyright: © 2017 Gammon Capital LLC
+:license: MIT, see LICENSE for more details.
+
+About LetsBeRational:
+~~~~~~~~~~~~~~~~~~~~~
+
+The source code of LetsBeRational resides at www.jaeckel.org/LetsBeRational.7z .
+
+======================================================================================
+Copyright © 2013-2014 Peter Jäckel.
+
+Permission to use, copy, modify, and distribute this software is freely granted,
+provided that this notice is preserved.
+
+WARRANTY DISCLAIMER
+The Software is provided "as is" without warranty of any kind, either express or implied,
+including without limitation any implied warranties of condition, uninterrupted use,
+merchantability, fitness for a particular purpose, or non-infringement.
+======================================================================================

--- a/recipes/py-lets-be-rational/recipe.yaml
+++ b/recipes/py-lets-be-rational/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: "1.1.2"
+
+package:
+  name: py-lets-be-rational
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/py-lets-be-rational/py_lets_be_rational-${{ version }}.tar.gz
+  sha256: 2c4980eb7df97023c8b9918e8086d7d39a33304962e121212c580322cc7f4553
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - poetry-core
+  run:
+    - python >=${{ python_min }}
+    - cody-special >=1.0.0,<2.0.0
+    - numpy >=1.20
+    - piecewise-rational >=1.0.0,<2.0.0
+
+tests:
+  - python:
+      imports:
+        - py_lets_be_rational
+        - lets_be_rational
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/vollib/py_lets_be_rational
+  repository: https://github.com/vollib/py_lets_be_rational
+  summary: Pure python implementation of Peter Jaeckel's LetsBeRational
+  license: MIT
+  # Upstream ships no LICENSE file in the sdist or the repository, reported in
+  # https://github.com/vollib/py_lets_be_rational/issues/9 . The LICENSE here is
+  # the copyright and license statement copied verbatim from the docstring of
+  # py_lets_be_rational/__init__.py, which also carries Peter Jaeckel's notice
+  # for the LetsBeRational code this package is a port of.
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - killua156
+    - mgorny

--- a/recipes/py-lets-be-rational/recipe.yaml
+++ b/recipes/py-lets-be-rational/recipe.yaml
@@ -52,4 +52,3 @@ about:
 extra:
   recipe-maintainers:
     - killua156
-    - mgorny


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Note on the license file: upstream ships no LICENSE in the sdist or the repository, reported in https://github.com/vollib/py_lets_be_rational/issues/9 . The `LICENSE` in this recipe is the copyright and license statement copied verbatim from the docstring of `py_lets_be_rational/__init__.py`.