### PR TITLE
Add nep 3.0.0

### DIFF
--- a/recipes/nep/build.sh
+++ b/recipes/nep/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -ex
+
+cmake -B build \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DNEP_BUILD_LZ4=ON \
+  -DNEP_BUILD_BZIP2=OFF \
+  -DNEP_ENABLE_FORTRAN=ON \
+  -DNEP_ENABLE_GEOTIFF=OFF \
+  -DNEP_ENABLE_GRIB2=OFF \
+  -DNEP_ENABLE_FITS=OFF \
+  -DNEP_ENABLE_PDS4=OFF \
+  -DNEP_ENABLE_CDF=OFF \
+  -DNEP_ENABLE_DICOM=OFF \
+  -DNEP_BUILD_DOCUMENTATION=OFF \
+  -DNEP_BUILD_EXAMPLES=OFF \
+  -DNEP_ENABLE_BENCHMARKS=OFF \
+  -DNEP_ENABLE_PARALLEL_TESTS=OFF
+
+cmake --build build -- -j${CPU_COUNT}
+ctest --test-dir build --output-on-failure
+cmake --install build
+install -m 644 build/fsrc/nep.mod "${PREFIX}/include/nep.mod"

--- a/recipes/nep/meta.yaml
+++ b/recipes/nep/meta.yaml
@@ -1,0 +1,54 @@
+{% set version = "3.0.0" %}
+
+package:
+  name: nep
+  version: {{ version }}
+
+source:
+  url: https://github.com/Intelligent-Data-Design-Inc/NEP/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: fda88f1b9c16864623a9c446b07396ab5cf9e3a579a44da8b616b6b606616bc6
+
+build:
+  number: 0
+  skip: true  # [win]
+  run_exports:
+    - {{ pin_subpackage('nep', max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('fortran') }}
+    - {{ stdlib('c') }}
+    - cmake >=3.9
+    - make
+    - pkg-config
+  host:
+    - hdf5
+    - libnetcdf >=4.10.1
+    - netcdf-fortran
+    - lz4-c
+  run:
+    - hdf5
+    - libnetcdf
+    - netcdf-fortran
+    - lz4-c
+
+test:
+  commands:
+    - test -f $PREFIX/lib/plugin/libh5lz4.so  # [linux]
+    - test -f $PREFIX/lib/plugin/libh5lz4.dylib  # [osx]
+    - test -f $PREFIX/include/nep.mod
+
+about:
+  home: https://github.com/Intelligent-Data-Design-Inc/NEP
+  license: Apache-2.0
+  license_file: LICENSE.txt
+  summary: NEP extends NetCDF-4 with an LZ4 compression filter and Fortran wrappers.
+  description: >
+    NEP (NetCDF Expansion Pack) provides an LZ4 compression filter and
+    Fortran wrappers for HDF5/NetCDF-4 files through the standard NetCDF API.
+  dev_url: https://github.com/Intelligent-Data-Design-Inc/NEP
+
+extra:
+  recipe-maintainers:
+    - edhartnett


### PR DESCRIPTION
## Package summary

NEP (NetCDF Expansion Pack) provides an LZ4 HDF5 compression filter and Fortran wrappers for NetCDF-4/HDF5 applications.

## Recipe scope

- Packages the upstream v3.0.0 GitHub tag with its verified SHA256 checksum.
- Builds LZ4 and Fortran wrappers.
- Disables BZIP2 and all UDF readers, including CDF, GeoTIFF, GRIB2, FITS, PDS4, and DICOM.
- Skips Windows because the upstream build uses a POSIX build script; Linux and macOS are supported.

## Validation

- The upstream repository Conda CI passed for this recipe.
- Local conda-build check and output-path validation completed for this staged recipe.

## Checklist

- [x] Title is meaningful.
- [x] License file is packaged.
- [x] Source is an official tarball.
- [x] Package does not vendor other packages.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] Maintainer confirmation is posted in a PR comment.