### PR TITLE
Adding griffe2md

### DIFF
--- a/recipes/griffe2md/recipe.yaml
+++ b/recipes/griffe2md/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "1.5.0"
-  python_min: "3.10"
 
 package:
   name: griffe2md

--- a/recipes/griffe2md/recipe.yaml
+++ b/recipes/griffe2md/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  version: "1.5.0"
+  python_min: "3.10"
+
+package:
+  name: griffe2md
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/g/griffe2md/griffe2md-${{ version }}.tar.gz
+  sha256: 58e184dffcd506ca97f54516dc07dd41f98ddc76eb17ba30518cf3dda18f6a51
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - griffe2md = griffe2md:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pdm-backend
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - griffelib >=2.0
+    - jinja2 >=3.1.2
+    - mdformat >=0.7.16
+    - tomli >=2.0
+
+tests:
+  - python:
+      imports:
+        - griffe2md
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - griffe2md --help
+
+about:
+  summary: Output API docs to Markdown using Griffe.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://mkdocstrings.github.io/griffe2md
+  documentation: https://mkdocstrings.github.io/griffe2md
+  repository: https://github.com/mkdocstrings/griffe2md
+
+extra:
+  recipe-maintainers:
+    - JakobKlaushoferQC
+    - ytausch
+    - jakobkla

--- a/recipes/griffe2md/recipe.yaml
+++ b/recipes/griffe2md/recipe.yaml
@@ -36,10 +36,11 @@ tests:
       imports:
         - griffe2md
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version: 
+        - ${{ python_min }}.*
+        - '*'
   - requirements:
       run:
-        - pip
         - python ${{ python_min }}.*
     script:
       - griffe2md --help


### PR DESCRIPTION
Adds a recipe for [griffe2md](https://github.com/mkdocstrings/griffe2md) — output API docs to Markdown using Griffe.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
