### PR TITLE
Add polars-config-meta

### DIFF
--- a/recipes/polars-config-meta/meta.yaml
+++ b/recipes/polars-config-meta/meta.yaml
@@ -1,0 +1,57 @@
+{% set name = "polars-config-meta" %}
+{% set version = "0.3.4" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  # The PyPI sdist omits the LICENSE file, which conda-forge requires, so the
+  # GitHub tag archive is used instead.
+  url: https://github.com/lmmx/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 175f3b981eb0ed1d9f387e811628f24edc6dbdc67aedf9e5fa7e4f160523771c
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - uv-build >=0.11.6,<0.12
+    - pip
+  run:
+    - python >={{ python_min }}
+    # Upstream lists polars only as an optional extra, but
+    # polars_config_meta/__init__.py imports it unconditionally, so it is a
+    # hard runtime requirement in practice. The lower bound matches the
+    # `polars` extra in pyproject.toml.
+    - polars >=1.30
+
+test:
+  imports:
+    - polars_config_meta
+  commands:
+    - pip check
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/lmmx/polars-config-meta
+  summary: A Polars plugin for persistent DataFrame-level metadata
+  description: |
+    polars-config-meta is a Polars plugin that attaches persistent,
+    DataFrame-level metadata to Polars DataFrames and LazyFrames. Metadata
+    survives operations that return new frames, which plain attribute
+    assignment cannot do.
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  doc_url: https://github.com/lmmx/polars-config-meta
+  dev_url: https://github.com/lmmx/polars-config-meta
+
+extra:
+  recipe-maintainers:
+    - mwiewior

--- a/recipes/polars-config-meta/recipe.yaml
+++ b/recipes/polars-config-meta/recipe.yaml
@@ -3,7 +3,6 @@ schema_version: 1
 context:
   name: polars-config-meta
   version: "0.3.4"
-  python_min: "3.10"
 
 package:
   name: ${{ name|lower }}

--- a/recipes/polars-config-meta/recipe.yaml
+++ b/recipes/polars-config-meta/recipe.yaml
@@ -8,10 +8,14 @@ package:
   version: ${{ version }}
 
 source:
-  # The PyPI sdist omits the LICENSE file, which conda-forge requires, so the
-  # GitHub tag archive is used instead.
-  url: https://github.com/lmmx/polars-config-meta/archive/refs/tags/${{ version }}.tar.gz
-  sha256: 175f3b981eb0ed1d9f387e811628f24edc6dbdc67aedf9e5fa7e4f160523771c
+  - url: https://pypi.org/packages/source/p/polars-config-meta/polars_config_meta-${{ version }}.tar.gz
+    sha256: 5ca11dac1e61cbb0cbecd5928e37b96c728cb416cddf9b5efd949ca060864c25
+  # The sdist omits the LICENSE file, which conda-forge requires, so it is
+  # fetched from the matching git tag. Reported upstream so a future release
+  # can ship it in the sdist.
+  - url: https://raw.githubusercontent.com/lmmx/polars-config-meta/${{ version }}/LICENSE
+    sha256: dcf4cfd0dfab62ae09eb54a50e7a052536bc535f81a8e4e6fb5c4151d7789487
+    file_name: LICENSE
 
 build:
   noarch: python

--- a/recipes/polars-config-meta/recipe.yaml
+++ b/recipes/polars-config-meta/recipe.yaml
@@ -1,17 +1,16 @@
 schema_version: 1
 
 context:
-  name: polars-config-meta
   version: "0.3.4"
 
 package:
-  name: ${{ name|lower }}
+  name: polars-config-meta
   version: ${{ version }}
 
 source:
   # The PyPI sdist omits the LICENSE file, which conda-forge requires, so the
   # GitHub tag archive is used instead.
-  url: https://github.com/lmmx/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
+  url: https://github.com/lmmx/polars-config-meta/archive/refs/tags/${{ version }}.tar.gz
   sha256: 175f3b981eb0ed1d9f387e811628f24edc6dbdc67aedf9e5fa7e4f160523771c
 
 build:

--- a/recipes/polars-config-meta/recipe.yaml
+++ b/recipes/polars-config-meta/recipe.yaml
@@ -1,45 +1,51 @@
-{% set name = "polars-config-meta" %}
-{% set version = "0.3.4" %}
+schema_version: 1
+
+context:
+  name: polars-config-meta
+  version: "0.3.4"
+  python_min: "3.10"
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
   # The PyPI sdist omits the LICENSE file, which conda-forge requires, so the
   # GitHub tag archive is used instead.
-  url: https://github.com/lmmx/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/lmmx/${{ name }}/archive/refs/tags/${{ version }}.tar.gz
   sha256: 175f3b981eb0ed1d9f387e811628f24edc6dbdc67aedf9e5fa7e4f160523771c
 
 build:
   noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - uv-build >=0.11.6,<0.12
     - pip
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     # Upstream lists polars only as an optional extra, but
     # polars_config_meta/__init__.py imports it unconditionally, so it is a
     # hard runtime requirement in practice. The lower bound matches the
     # `polars` extra in pyproject.toml.
     - polars >=1.30
 
-test:
-  imports:
-    - polars_config_meta
-  commands:
-    - pip check
-  requires:
-    - pip
-    - python {{ python_min }}
+tests:
+  - python:
+      imports:
+        - polars_config_meta
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
-  home: https://github.com/lmmx/polars-config-meta
+  homepage: https://github.com/lmmx/polars-config-meta
+  repository: https://github.com/lmmx/polars-config-meta
+  documentation: https://github.com/lmmx/polars-config-meta
   summary: A Polars plugin for persistent DataFrame-level metadata
   description: |
     polars-config-meta is a Polars plugin that attaches persistent,
@@ -47,10 +53,7 @@ about:
     survives operations that return new frames, which plain attribute
     assignment cannot do.
   license: MIT
-  license_family: MIT
   license_file: LICENSE
-  doc_url: https://github.com/lmmx/polars-config-meta
-  dev_url: https://github.com/lmmx/polars-config-meta
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Adds a recipe for [polars-config-meta](https://github.com/lmmx/polars-config-meta), a small pure-Python Polars plugin that attaches persistent DataFrame-level metadata to Polars frames.

### Why

It is a runtime dependency of [polars-bio](https://github.com/biodatageeks/polars-bio), which is being submitted to bioconda. polars-bio imports it unconditionally, so the bioconda recipe cannot build until this package exists on conda-forge. polars-config-meta is a general-purpose Polars plugin rather than a bioinformatics tool, so conda-forge is the appropriate channel for it.

### Notes for reviewers

- **Source is the GitHub tag archive, not the PyPI sdist.** The 0.3.4 sdist ships only `PKG-INFO`, `README.md`, `pyproject.toml` and `src/`; it omits `LICENSE`, so `license_file` cannot be satisfied from it.
- **`polars` is declared as a run dependency even though upstream lists it as optional.** `pyproject.toml` has `dependencies = []` and exposes polars via an optional `polars` extra, but `src/polars_config_meta/__init__.py` does `import polars as pl` at module scope. Without the run dependency the package installs and then fails on import — I hit exactly this on a local build before adding it. The `>=1.30` bound matches the extra.
- Build backend is `uv_build>=0.11.6,<0.12`, available on conda-forge as `uv-build`.
- `noarch: python`, no compiled components.

### Checklist

- [x] Title of this PR is short and descriptive.
- [x] license_file is packaged.
- [x] Source is from a tagged release with a pinned sha256.
- [x] Built and tested locally with `conda-build` (`polars-config-meta-0.3.4-py_0.conda`, import and `pip check` pass).