### PR TITLE
Add agentsor-file

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,3 +3,6 @@ azure:
   settings_win:
     pool:
       vmImage: windows-2022
+noarch_platforms:
+  - linux_64
+  - osx_64

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,6 +3,3 @@ azure:
   settings_win:
     pool:
       vmImage: windows-2022
-noarch_platforms:
-  - linux_64
-  - osx_64

--- a/recipes/agentsor-file/conda-forge.yml
+++ b/recipes/agentsor-file/conda-forge.yml
@@ -1,0 +1,3 @@
+noarch_platforms:
+  - linux_64
+  - osx_64

--- a/recipes/agentsor-file/recipe.yaml
+++ b/recipes/agentsor-file/recipe.yaml
@@ -1,0 +1,72 @@
+schema_version: 1
+
+context:
+  version: "0.2.3"
+  python_min: "3.11"
+
+package:
+  name: agentsor-file
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/agentsor-file/agentsor_file-${{ version }}.tar.gz
+  sha256: e2e2337f8ec701a6582de76590eb5b337df7f97e25f2b1eb55dc000393496151
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - agentsor-file = parquet_guard.file_cli:main
+      - parquet-guard = parquet_guard.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+  run:
+    - python >=${{ python_min }}
+    - pyarrow >=16
+    - __unix
+
+tests:
+  - python:
+      imports:
+        - parquet_guard
+        - parquet_guard.file_cli
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+  - files:
+      source:
+        - tests/
+        - examples/
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+        - pytest >=8,<10
+        - jsonschema >=4.23,<5
+    script:
+      - agentsor-file --help
+      - parquet-guard --help
+      - agentsor-file schema
+      - pytest -q tests
+
+about:
+  homepage: https://agentsor.ai/file-contracts
+  repository: https://github.com/linkoinsight/agentsor-file
+  documentation: https://agentsor.ai/file-contracts/guides/validate-parquet-schema-cron
+  summary: Validate local CSV and Parquet schemas and monitor scheduled outputs
+  description: |
+    agentsor-file validates local CSV and Parquet files against declared
+    schemas, freshness rules, and row or byte limits. Its optional reporting
+    command sends a content-free result envelope for missed-run monitoring.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - linkoinsight

--- a/recipes/agentsor-file/recipe.yaml
+++ b/recipes/agentsor-file/recipe.yaml
@@ -32,28 +32,34 @@ requirements:
     - __unix
 
 tests:
-  - python:
-      imports:
-        - parquet_guard
-        - parquet_guard.file_cli
-      python_version:
-        - ${{ python_min }}.*
-        - "*"
-      pip_check: true
-  - files:
-      source:
-        - tests/
-        - examples/
-    requirements:
-      run:
-        - python ${{ python_min }}.*
-        - pytest >=8,<10
-        - jsonschema >=4.23,<5
-    script:
-      - agentsor-file --help
-      - parquet-guard --help
-      - agentsor-file schema
-      - pytest -q tests
+  # The package is intentionally unavailable when the __unix virtual package
+  # is absent, so its install-time and functional tests only apply on Unix.
+  - if: unix
+    then:
+      python:
+        imports:
+          - parquet_guard
+          - parquet_guard.file_cli
+        python_version:
+          - ${{ python_min }}.*
+          - "*"
+        pip_check: true
+  - if: unix
+    then:
+      files:
+        source:
+          - tests/
+          - examples/
+      requirements:
+        run:
+          - python ${{ python_min }}.*
+          - pytest >=8,<10
+          - jsonschema >=4.23,<5
+      script:
+        - agentsor-file --help
+        - parquet-guard --help
+        - agentsor-file schema
+        - pytest -q tests
 
 about:
   homepage: https://agentsor.ai/file-contracts

--- a/recipes/agentsor-file/recipe.yaml
+++ b/recipes/agentsor-file/recipe.yaml
@@ -32,34 +32,28 @@ requirements:
     - __unix
 
 tests:
-  # The package is intentionally unavailable when the __unix virtual package
-  # is absent, so its install-time and functional tests only apply on Unix.
-  - if: unix
-    then:
-      python:
-        imports:
-          - parquet_guard
-          - parquet_guard.file_cli
-        python_version:
-          - ${{ python_min }}.*
-          - "*"
-        pip_check: true
-  - if: unix
-    then:
-      files:
-        source:
-          - tests/
-          - examples/
-      requirements:
-        run:
-          - python ${{ python_min }}.*
-          - pytest >=8,<10
-          - jsonschema >=4.23,<5
-      script:
-        - agentsor-file --help
-        - parquet-guard --help
-        - agentsor-file schema
-        - pytest -q tests
+  - python:
+      imports:
+        - parquet_guard
+        - parquet_guard.file_cli
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+  - files:
+      source:
+        - tests/
+        - examples/
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+        - pytest >=8,<10
+        - jsonschema >=4.23,<5
+    script:
+      - agentsor-file --help
+      - parquet-guard --help
+      - agentsor-file schema
+      - pytest -q tests
 
 about:
   homepage: https://agentsor.ai/file-contracts


### PR DESCRIPTION
Adds `agentsor-file` 0.2.3 from its official PyPI sdist.

`agentsor-file` validates local CSV and Parquet outputs against declared schemas, freshness rules, and row or byte limits. The Python package is noarch but intentionally constrained to Unix because its credential and state-file safety relies on POSIX owner-only permission semantics.

Validation completed before submission:

- `conda-smithy recipe-lint --conda-forge recipes/agentsor-file`: in fine form
- `python3 build-locally.py linux64`: passed
- Packaged test suite: 69 passed
- Both CLI entry points, schema output, minimum/latest Python import tests, and `pip check`: passed

Checklist

- [x] Title of this PR is meaningful.
- [x] License file is packaged.
- [x] Source is from the official PyPI release.
- [x] Package does not vendor other packages.
- [x] No static libraries are linked in.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A release tarball URL is used.
- [x] The listed GitHub maintainer will post a separate consent comment.
- [x] The conda-forge knowledge base was checked.
