### PR TITLE
Add figure-gate

### DIFF
--- a/recipes/figure-gate/recipe.yaml
+++ b/recipes/figure-gate/recipe.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+
+context:
+  name: figure-gate
+  version: "0.4.0"
+  python_min: "3.11"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/figure-gate/figure_gate-${{ version }}.tar.gz
+  sha256: 23b095cc976551d91565bb4fbc23b9a375c385f0f33863b33b08e551f9188a5a
+
+build:
+  # Three unnamespaced entries in site-packages, deliberately: the scripts are
+  # meant to be vendored as single files and the sheet is found beside them.
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - check-palette = check_palette:main
+      - check-figure = check_figure:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling >=1.26
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - matplotlib-base >=3.8
+
+tests:
+  - python:
+      imports:
+        - check_palette
+        - check_figure
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - check-palette --help
+      # Takes no arguments; runs a self-test that exits 0 only on a correct FAIL.
+      - check-figure
+
+about:
+  homepage: https://github.com/narenp12/figure-gate
+  repository: https://github.com/narenp12/figure-gate
+  documentation: https://narenp12.github.io/figure-gate/
+  summary: "Mechanical gates for publication figures: colorblind-safe color, composition, and type legibility at print size."
+  description: |
+    figure-gate audits a matplotlib figure before it goes into a paper, a
+    slide deck or a thesis, and fails it on defects that survive a look at the
+    screen: a hue pair a colour-blind reader cannot tell apart, a colormap
+    whose lightness reverses on itself instead of ordering the data, axis
+    labels that fall below a legible point size once the figure is scaled to
+    its column width, clipped text, and Type 3 fonts, which IEEE PDF eXpress
+    refuses at upload.
+
+    Two scripts, check-palette and check-figure. check_palette.py imports
+    nothing outside the standard library, and both are meant to be run in CI or
+    copied into a project outright. Every gate has a test that proves it can
+    fail.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - narenp12


### PR DESCRIPTION
figure-gate is a pure-Python matplotlib checker: it audits a figure for colorblind-unsafe colour, composition problems, and type too small to read at the size it prints, then fails the build. `noarch: python`, no compiled components.

One thing worth flagging up front, because it looks wrong: the package installs three unnamespaced entries into `site-packages` -- `check_palette.py`, `check_figure.py` and `figure.mplstyle`. That is deliberate. The scripts are designed to be vendored into a project as single files (`check_palette.py` imports nothing outside the standard library), and the style-sheet check locates the sheet by looking beside `check_figure.py`, so wrapping either in a package would break the tool's main use. Happy to restructure if that is a problem.

The script test runs `check-figure` with no arguments rather than `--help`, which it does not take. Bare, it runs a self-test that exits 0 only when the gate correctly rejects a deliberately bad figure, so it verifies matplotlib resolves and the style sheet is found on the install path.

`matplotlib-base` rather than `matplotlib`, since these render on Agg and never open a window.

Built and linted locally through the repo's own tasks:

- `pixi run lint` -> `recipes/figure-gate is in fine form`
- `pixi run build-osx osx_arm64` -> exit 0, all packaged tests pass

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.