### PR TITLE
Add scrollcase-consumer

### DIFF
--- a/recipes/scrollcase-consumer/recipe.yaml
+++ b/recipes/scrollcase-consumer/recipe.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  version: "0.1.0"
+  python_min: "3.10"
+  python_check_max: "3.14"
+
+package:
+  name: scrollcase-consumer
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/scrollcase-consumer/scrollcase_consumer-${{ version }}.tar.gz
+  sha256: f9a9d95617416fb5e97ae8413921f50684340279afa2322ccf5e84d2b62cf40b
+
+build:
+  number: 0
+  noarch: python
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  host:
+    - pip
+    - python ${{ python_min }}.*
+    - setuptools >=77
+  run:
+    - cryptography >=42,<47
+    - jsonschema >=4.21,<5
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - scrollcase_consumer
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - ${{ python_check_max }}.*
+
+about:
+  homepage: https://scrollcase.dev
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Verify, prepare, and run caller-supplied local Scrollcase boxes
+  repository: https://github.com/suffro/scrollcase
+  documentation: https://scrollcase.dev/reference/api
+
+extra:
+  recipe-maintainers:
+    - suffro

--- a/recipes/scrollcase-consumer/recipe.yaml
+++ b/recipes/scrollcase-consumer/recipe.yaml
@@ -2,7 +2,7 @@
 schema_version: 1
 
 context:
-  version: "0.1.0"
+  version: "0.4.1"
   python_min: "3.10"
   python_check_max: "3.14"
 
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/s/scrollcase-consumer/scrollcase_consumer-${{ version }}.tar.gz
-  sha256: f9a9d95617416fb5e97ae8413921f50684340279afa2322ccf5e84d2b62cf40b
+  sha256: 93bb30b8ac761825e515aaed9bba4f3ee402e78255bac32f3af9e1055ab8c25e
 
 build:
   number: 0
@@ -28,6 +28,7 @@ requirements:
   run:
     - cryptography >=42,<47
     - jsonschema >=4.21,<5
+    - referencing >=0.28.4,<1
     - python >=${{ python_min }}
 
 tests:

--- a/recipes/scrollcase-consumer/recipe.yaml
+++ b/recipes/scrollcase-consumer/recipe.yaml
@@ -3,8 +3,6 @@ schema_version: 1
 
 context:
   version: "0.4.1"
-  python_min: "3.10"
-  python_check_max: "3.14"
 
 package:
   name: scrollcase-consumer
@@ -38,7 +36,7 @@ tests:
       pip_check: true
       python_version:
         - ${{ python_min }}.*
-        - ${{ python_check_max }}.*
+        - "*"
 
 about:
   homepage: https://scrollcase.dev


### PR DESCRIPTION
Adds scrollcase-consumer 0.1.0 from the published PyPI sdist as a noarch Python package.\n\nThe recipe uses the exact sdist SHA-256, tests imports on Python 3.10 and 3.14, and runs pip check. conda-smithy lint passes locally.\n\nChecklist\n\n- [x] License file is packaged.\n- [x] Source is the official PyPI sdist.\n- [x] Package does not vendor other packages.\n- [x] Package does not ship static libraries.\n- [x] Build number is 0.\n- [x] The source is a tarball.\n- [x] I am willing to be listed as a recipe maintainer.