### PR TITLE
Add bargo-congress

### DIFF
--- a/recipes/bargo-congress/recipe.yaml
+++ b/recipes/bargo-congress/recipe.yaml
@@ -1,0 +1,45 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: bargo-congress
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/33/1e/379f299e362bf7daeb527cce5224133ce500363e57ac8d69ea89e903e4ff/bargo_congress-${{ version }}.tar.gz
+  sha256: 8f4a3592d9fff9d47308a8531ecd5fee70a201ffe63c69884641d54e27bf9ee5
+
+build:
+  noarch: python
+  script: python -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.9
+
+tests:
+  - python:
+      imports:
+        - bargo_congress
+      pip_check: true
+
+about:
+  homepage: https://www.bargo.ai/free-apis/congress
+  summary: Official Python client for the Bargo Congress Trades API
+  description: |
+    bargo-congress is the lightweight official Python client for querying
+    U.S. House and Senate STOCK Act disclosures through the Bargo Congress
+    Trades API.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://www.bargo.ai/free-apis/congress
+  repository: https://github.com/bargo-ai/bargo-free-api-packages
+
+extra:
+  recipe-maintainers:
+    - bargo-ai

--- a/recipes/bargo-congress/recipe.yaml
+++ b/recipes/bargo-congress/recipe.yaml
@@ -16,17 +16,20 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68
   run:
-    - python >=3.9
+    - python >=${{ python_min }}
 
 tests:
   - python:
       imports:
         - bargo_congress
       pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://www.bargo.ai/free-apis/congress


### PR DESCRIPTION
Adds bargo-congress 0.1.0, the lightweight Python client for the Bargo Congress Trades API. The recipe uses the published PyPI source distribution and SHA256, builds as noarch Python, imports bargo_congress, and runs pip check. I maintain the upstream package as bargo-ai and can handle feedstock updates after review.