### PR TITLE
Add riftco-transformer 0.2.0

### DIFF
--- a/recipes/riftco-transformer/recipe.yaml
+++ b/recipes/riftco-transformer/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.1.0"
+  version: "0.2.0"
 
 package:
   name: riftco-transformer
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/quangng2000/riftco-transformer/releases/download/v${{ version }}/riftco_transformer-${{ version }}.tar.gz
-  sha256: bc93ca32680183a34c719c1767b6e2f159e1a95e78dadd500477d76b688ad420
+  sha256: cd6e964098ba637320c8a6a6a4d42d5dcd60ecf1b8460fc79d047fb4cd7fb453
 
 build:
   number: 0
@@ -43,15 +43,15 @@ requirements:
 tests:
   - python:
       imports:
-        - transformer_lab
-        - transformer_lab.artifacts
-        - transformer_lab.data
-        - transformer_lab.experiments
-        - transformer_lab.native
-        - transformer_lab.post_training
-        - transformer_lab.pretraining
-        - transformer_lab.serving
-        - transformer_lab.training
+        - riftco_transformer
+        - riftco_transformer.artifacts
+        - riftco_transformer.data
+        - riftco_transformer.experiments
+        - riftco_transformer.native
+        - riftco_transformer.post_training
+        - riftco_transformer.pretraining
+        - riftco_transformer.serving
+        - riftco_transformer.training
       pip_check: true
   - script:
       - python run_test.py

--- a/recipes/riftco-transformer/recipe.yaml
+++ b/recipes/riftco-transformer/recipe.yaml
@@ -8,7 +8,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/quangng2000/transformer-lab/releases/download/v${{ version }}/riftco_transformer-${{ version }}.tar.gz
+  url: https://github.com/quangng2000/riftco-transformer/releases/download/v${{ version }}/riftco_transformer-${{ version }}.tar.gz
   sha256: bc93ca32680183a34c719c1767b6e2f159e1a95e78dadd500477d76b688ad420
 
 build:
@@ -60,8 +60,8 @@ tests:
         - run_test.py
 
 about:
-  homepage: https://github.com/quangng2000/transformer-lab
-  repository: https://github.com/quangng2000/transformer-lab
+  homepage: https://github.com/quangng2000/riftco-transformer
+  repository: https://github.com/quangng2000/riftco-transformer
   summary: Auditable dependency-free transformer framework with a typed Python client
   description: |
     Riftco Transformer provides a dependency-free Python ctypes client backed by

--- a/recipes/riftco-transformer/recipe.yaml
+++ b/recipes/riftco-transformer/recipe.yaml
@@ -14,7 +14,12 @@ source:
 build:
   number: 0
   skip: match(python, "<3.10")
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    - if: unix
+      then: export CMAKE_GENERATOR=Ninja
+    - if: win
+      then: set "SKBUILD_CMAKE_ARGS=-G Ninja"
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:

--- a/recipes/riftco-transformer/recipe.yaml
+++ b/recipes/riftco-transformer/recipe.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+
+context:
+  version: "0.1.0"
+
+package:
+  name: riftco-transformer
+  version: ${{ version }}
+
+source:
+  url: https://github.com/quangng2000/transformer-lab/releases/download/v${{ version }}/riftco_transformer-${{ version }}.tar.gz
+  sha256: bc93ca32680183a34c719c1767b6e2f159e1a95e78dadd500477d76b688ad420
+
+build:
+  number: 0
+  skip: match(python, "<3.10")
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - scikit-build-core ==1.0.3
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake >=3.24
+    - ninja
+  host:
+    - python
+    - pip
+    - scikit-build-core ==1.0.3
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - transformer_lab
+        - transformer_lab.artifacts
+        - transformer_lab.data
+        - transformer_lab.experiments
+        - transformer_lab.native
+        - transformer_lab.post_training
+        - transformer_lab.pretraining
+        - transformer_lab.serving
+        - transformer_lab.training
+      pip_check: true
+  - script:
+      - python run_test.py
+    files:
+      recipe:
+        - run_test.py
+
+about:
+  homepage: https://github.com/quangng2000/transformer-lab
+  repository: https://github.com/quangng2000/transformer-lab
+  summary: Auditable dependency-free transformer framework with a typed Python client
+  description: |
+    Riftco Transformer provides a dependency-free Python ctypes client backed by
+    a native C++20 transformer runtime. It includes CPU execution on every
+    supported platform and a Metal backend on macOS.
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - quangng2000

--- a/recipes/riftco-transformer/run_test.py
+++ b/recipes/riftco-transformer/run_test.py
@@ -1,0 +1,68 @@
+"""Exercise the installed package and its bundled native runtime."""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from pathlib import Path
+
+from transformer_lab import Context, Tensor
+from transformer_lab.native import bindings
+
+
+def native_filename() -> str:
+    if sys.platform == "darwin":
+        return "libtransformer_lab_c.dylib"
+    if os.name == "nt":
+        return "transformer_lab_c.dll"
+    return "libtransformer_lab_c.so"
+
+
+def main() -> int:
+    if os.environ.get("TRANSFORMER_LAB_LIBRARY"):
+        raise RuntimeError(
+            "package smoke test must not use TRANSFORMER_LAB_LIBRARY"
+        )
+
+    package_directory = Path(bindings.__file__).resolve().parents[1]
+    bundled_library = package_directory / ".libs" / native_filename()
+    if not bundled_library.is_file():
+        raise RuntimeError(f"bundled native library is missing: {bundled_library}")
+
+    candidates = bindings._candidate_libraries()
+    if not candidates:
+        raise RuntimeError("native loader found no candidate libraries")
+    if Path(candidates[0]).resolve() != bundled_library.resolve():
+        raise RuntimeError(
+            "bundled library is not the loader's first candidate: "
+            f"{candidates[0]}"
+        )
+
+    with Context("cpu") as context:
+        if context.backend != "cpu":
+            raise RuntimeError(f"unexpected backend: {context.backend}")
+        with Tensor.from_data(context, (1, 2), (1.0, 2.0)) as left:
+            with Tensor.from_data(context, (2, 1), (3.0, 4.0)) as right:
+                with left.matmul(right) as product:
+                    if product.shape != (1, 1):
+                        raise RuntimeError(f"unexpected shape: {product.shape}")
+                    values = product.tolist()
+                    if len(values) != 1 or not math.isclose(values[0], 11.0):
+                        raise RuntimeError(f"unexpected matmul result: {values}")
+
+    library = bindings._native()
+    loaded_path = Path(str(library._name)).resolve()
+    if loaded_path != bundled_library.resolve():
+        raise RuntimeError(
+            f"loaded {loaded_path}, expected bundled {bundled_library.resolve()}"
+        )
+    if int(library.tl_abi_version()) != bindings.ABI_VERSION:
+        raise RuntimeError("bundled native ABI does not match the Python client")
+
+    print(f"package smoke test passed with {loaded_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/recipes/riftco-transformer/run_test.py
+++ b/recipes/riftco-transformer/run_test.py
@@ -7,22 +7,22 @@ import os
 import sys
 from pathlib import Path
 
-from transformer_lab import Context, Tensor
-from transformer_lab.native import bindings
+from riftco_transformer import Context, Tensor
+from riftco_transformer.native import bindings
 
 
 def native_filename() -> str:
     if sys.platform == "darwin":
-        return "libtransformer_lab_c.dylib"
+        return "libriftco_transformer_c.dylib"
     if os.name == "nt":
-        return "transformer_lab_c.dll"
-    return "libtransformer_lab_c.so"
+        return "riftco_transformer_c.dll"
+    return "libriftco_transformer_c.so"
 
 
 def main() -> int:
-    if os.environ.get("TRANSFORMER_LAB_LIBRARY"):
+    if os.environ.get("RIFTCO_TRANSFORMER_LIBRARY"):
         raise RuntimeError(
-            "package smoke test must not use TRANSFORMER_LAB_LIBRARY"
+            "package smoke test must not use RIFTCO_TRANSFORMER_LIBRARY"
         )
 
     package_directory = Path(bindings.__file__).resolve().parents[1]
@@ -57,7 +57,7 @@ def main() -> int:
         raise RuntimeError(
             f"loaded {loaded_path}, expected bundled {bundled_library.resolve()}"
         )
-    if int(library.tl_abi_version()) != bindings.ABI_VERSION:
+    if int(library.rt_abi_version()) != bindings.ABI_VERSION:
         raise RuntimeError("bundled native ABI does not match the Python client")
 
     print(f"package smoke test passed with {loaded_path}")


### PR DESCRIPTION
This adds Riftco Transformer 0.2.0 to conda-forge.

## Checklist

- [x] License file is packaged.
- [x] Source is the official v0.2.0 GitHub release sdist.
- [x] Source SHA-256 matches the GitHub asset digest and PyPI sdist.
- [x] Package does not vendor third-party packages.
- [x] The only statically linked code comes from this Apache-2.0 project.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] I am willing to be listed as maintainer (`quangng2000`).

## Package notes

- Distribution: `riftco-transformer`
- Python import: `riftco_transformer`
- Python requirement: 3.10 or newer
- Native C++20 runtime bundled in the Python package
- CPU backend on supported platforms; Metal backend on macOS
- No legacy `transformer_lab` import alias