### PR TITLE
Add sar11-genome-atlas-tools

### DIFF
--- a/recipes/sar11-genome-atlas-tools/meta.yaml
+++ b/recipes/sar11-genome-atlas-tools/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "sar11-genome-atlas-tools" %}
+{% set version = "0.1.1" %}
+{% set python_min = "3.10" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/sar11-genome-atlas-tools/sar11_genome_atlas_tools-{{ version }}.tar.gz
+  sha256: 74a900e7de109e65af3d63d78cc0ab4fc7b9a9020a0511d14e6532d23b1a4fde
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68
+  run:
+    - python >={{ python_min }}
+    - biopython >=1.80
+    - pandas >=2.0
+    - pyyaml >=6.0
+    - rich >=13.7
+    - prodigal
+    - hmmer
+    - mafft
+    - epa-ng
+    - fastani
+
+test:
+  requires:
+    - python {{ python_min }}
+  commands:
+    - sga-mapper --version
+    - sga-classify --version
+    - sga-run --version
+
+about:
+  home: https://github.com/stsnsn/SAR11_Atlas
+  summary: SGAmapper and SGAclassifier for the SAR11 Genome Atlas
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - satoshinishino


### PR DESCRIPTION
This recipe packages the SAR11 Genome Atlas toolkit from PyPI.
EPA-ng is the only supported placement backend.
Runtime reference archives are downloaded from the configured Zenodo record.