### PR TITLE
Add qt6-wayland-adwaita-decoration

### DIFF
--- a/recipes/qt6-wayland-adwaita-decorations/adwaita_decoration_CMakeLists.txt
+++ b/recipes/qt6-wayland-adwaita-decorations/adwaita_decoration_CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(QtWaylandAdwaitaDecoration)
+
+set(QT_MIN_VERSION "6.11.0")
+set(QT_VERSION_MAJOR "6")
+
+# Guard these so that a -DCMAKE_CXX_STANDARD=... passed through CMAKE_ARGS is
+# honoured. A bare set() would create a normal variable that shadows the cache
+# entry for the rest of this directory scope, silently overriding CMAKE_ARGS.
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 17)
+endif()
+if (NOT DEFINED CMAKE_CXX_STANDARD_REQUIRED)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
+    Core
+    DBus
+    Gui
+    GuiPrivate
+    Svg
+    WaylandClient
+    WaylandClientPrivate
+)
+
+if (NOT QT_PLUGINS_DIR)
+    set(QT_PLUGINS_DIR ${QT6_INSTALL_PLUGINS})
+endif()
+
+# Qt6WaylandClientDependencies.cmake normally defines this for us.
+if (TARGET Wayland::Client)
+    set(WAYLAND_CLIENT_TARGET Wayland::Client)
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(WAYLAND_CLIENT REQUIRED IMPORTED_TARGET wayland-client)
+    set(WAYLAND_CLIENT_TARGET PkgConfig::WAYLAND_CLIENT)
+endif()
+
+set(adwaita_decoration_SRCS
+    main.cpp
+    qwaylandadwaitadecoration.cpp qwaylandadwaitadecoration_p.h
+)
+
+add_library(adwaita MODULE ${adwaita_decoration_SRCS})
+
+target_link_libraries(adwaita
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::DBus
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::GuiPrivate
+    Qt${QT_VERSION_MAJOR}::Svg
+    Qt${QT_VERSION_MAJOR}::WaylandClient
+    Qt${QT_VERSION_MAJOR}::WaylandClientPrivate
+    ${WAYLAND_CLIENT_TARGET}
+)
+
+set_property(TARGET adwaita PROPERTY AUTOMOC ON)
+
+install(TARGETS adwaita DESTINATION ${QT_PLUGINS_DIR}/wayland-decoration-client)

--- a/recipes/qt6-wayland-adwaita-decorations/build.sh
+++ b/recipes/qt6-wayland-adwaita-decorations/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+
+# The Adwaita client-side decoration plugin lives in the qtwayland module, but
+# it is the only part of that module we want here. As of Qt 6.11 the Wayland
+# *client* itself was merged into qtbase, and this decoration was left behind
+# in qtwayland only because it links against QtSvg, which qtbase is not allowed
+# to depend on:
+#   https://github.com/qt/qtwayland/blob/v6.11.1/src/client/configure.cmake
+#
+# Building it standalone, rather than turning on
+# FEATURE_wayland_decoration_adwaita in qt6-main, means qt6-main does not have
+# to build the whole qtwayland module (which would also drag in the Wayland
+# compositor). This mirrors what the qt-gtk-platformtheme feedstock does for
+# the GTK3 platform theme.
+#
+# This is the upstreamed version of https://github.com/FedoraQt/QAdwaitaDecorations
+
+cp -R src/plugins/decorations/adwaita/ adwaita_decoration
+cd adwaita_decoration
+cp "${RECIPE_DIR}/adwaita_decoration_CMakeLists.txt" CMakeLists.txt
+
+QT_HOST_PATH="${PREFIX}"
+if [[ "${build_platform}" != "${target_platform}" ]]; then
+    QT_HOST_PATH="${BUILD_PREFIX}"
+fi
+
+cmake ${CMAKE_ARGS} -G Ninja \
+    -B build -S . \
+    -DQT_HOST_PATH="${QT_HOST_PATH}" \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DQT_PLUGINS_DIR="${PREFIX}/lib/qt6/plugins"
+
+cmake --build build --parallel "${CPU_COUNT}"
+cmake --install build

--- a/recipes/qt6-wayland-adwaita-decorations/conda-forge.yml
+++ b/recipes/qt6-wayland-adwaita-decorations/conda-forge.yml
@@ -1,0 +1,7 @@
+# Cross-compile the aarch64 build on linux_64 rather than emulating it, so that
+# linux-aarch64 packages are available as soon as the feedstock is created.
+# The recipe already handles this: qt6-main is pulled into the build environment
+# when build_platform != target_platform, and build.sh points QT_HOST_PATH at
+# BUILD_PREFIX so that the host moc/tooling is used.
+build_platform:
+  linux_aarch64: linux_64

--- a/recipes/qt6-wayland-adwaita-decorations/recipe.yaml
+++ b/recipes/qt6-wayland-adwaita-decorations/recipe.yaml
@@ -1,0 +1,92 @@
+context:
+  version: "6.11.1"
+  maj_min: ${{ (version | split('.'))[:2] | join('.') }}
+
+package:
+  name: qt6-wayland-adwaita-decorations
+  version: ${{ version }}
+
+source:
+  # We only need the small qtwayland submodule, not all of qt-everywhere.
+  url: https://download.qt.io/official_releases/qt/${{ maj_min }}/${{ version }}/submodules/qtwayland-everywhere-src-${{ version }}.tar.xz
+  sha256: 95788aa502f75441d4edf65932b235f76523084e13dbbb7b9ee2d207b32bd9b3
+
+build:
+  number: 0
+  skip:
+    # Wayland is Linux only.
+    - not linux
+    # qt6-main is not built for ppc64le.
+    - target_platform == "linux-ppc64le"
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - pkg-config
+    - if: build_platform != target_platform
+      then:
+        - qt6-main ==${{ version }}
+  host:
+    - qt6-main ==${{ version }}
+    - wayland
+  run:
+    # The plugin is built against Qt's private headers, so it has to be used
+    # with the exact Qt version it was compiled against.
+    - qt6-main ==${{ version }}
+  ignore_run_exports:
+    by_name:
+      # wayland is needed at configure time, because Qt6WaylandClient's CMake
+      # config does find_dependency(Wayland), but the plugin only ever calls
+      # through QtWaylandClient's wrappers and so does not end up linking
+      # libwayland-client itself. qt6-main already depends on wayland at run
+      # time anyway.
+      - wayland
+
+tests:
+  - script:
+      - test -f ${PREFIX}/lib/qt6/plugins/wayland-decoration-client/libadwaita.so
+      # The plugin must advertise the "adwaita" and "gnome" decoration keys,
+      # otherwise QT_WAYLAND_DECORATION=adwaita silently falls back to bradient.
+      - ${PREFIX}/lib/qt6/bin/qtplugininfo --full-json ${PREFIX}/lib/qt6/plugins/wayland-decoration-client/libadwaita.so > metadata.json
+      - cat metadata.json
+      - grep -q '"adwaita"' metadata.json
+      - grep -q '"gnome"' metadata.json
+
+about:
+  homepage: https://doc.qt.io/qt-6/qtwayland-index.html
+  summary: Qt Wayland Adwaita client-side decoration plugin
+  description: |
+    QWaylandAdwaitaDecoration is Qt's Wayland decoration plugin implementing
+    Adwaita-like client-side decorations, so that Qt applications running on
+    Wayland get window decorations matching the GNOME Adwaita design language.
+
+    It is the upstreamed version of https://github.com/FedoraQt/QAdwaitaDecorations
+    and ships in the qtwayland module rather than in qtbase because it depends
+    on QtSvg. conda-forge's qt6-main does not build the qtwayland module, so
+    this recipe builds just this one plugin against it.
+
+    Enable it by setting QT_WAYLAND_DECORATION=adwaita.
+
+    This plugin uses private Qt headers and is therefore neither forward nor
+    backward compatible; it is pinned to, and must be rebuilt for, each
+    qt6-main version.
+  license: LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+  license_file:
+    - LICENSES/LGPL-3.0-only.txt
+    - LICENSES/GPL-2.0-only.txt
+    - LICENSES/GPL-3.0-only.txt
+  documentation: https://doc.qt.io/qt-6/qtwayland-index.html
+  repository: https://github.com/qt/qtwayland
+
+extra:
+  # Matches the sibling qt-gtk-platformtheme-feedstock, which likewise drops the
+  # major version from the feedstock name but keeps it in the package name.
+  feedstock-name: qt-wayland-adwaita-decoration
+  recipe-maintainers:
+    - hmaarrfk
+    - conda-forge/qt-main


### PR DESCRIPTION
<details><summary>Claude's draft</summary>

Adds a recipe for Qt's Adwaita Wayland client-side decoration plugin (QWaylandAdwaitaDecoration), the upstreamed version of FedoraQt/QAdwaitaDecorations.

As of Qt 6.11 the Wayland client itself was merged into qtbase, but this decoration stayed behind in the qtwayland module because it links against QtSvg, which qtbase is not allowed to depend on. conda-forge's qt6-main does not build the qtwayland module at all (QT_BUILD_SUBMODULES omits it), so it currently ships only libbradient.so.

Rather than have qt6-main build the whole qtwayland module (which would also pull in the Wayland compositor), this recipe builds just the one plugin out of the 900 KB qtwayland submodule tarball, using a standalone CMakeLists.txt. This mirrors what qt-gtk-platformtheme does for the GTK3 platform theme.

The plugin uses private Qt headers, so it is pinned to the exact qt6-main version and must be rebuilt for each Qt release.

Verified locally against conda-forge qt6-main 6.11.1: builds clean and qtplugininfo reports IID
org.qt-project.Qt.WaylandClient.QWaylandDecorationFactoryInterface.5.4 with keys ["adwaita", "gnome"].

Resume this Claude session:
```
cd /home/mark/git/feedstocks/qt-gtk-platformtheme-feedstock
claude --resume 57e6ba6f-2055-4b14-a2a9-8f4debd3f4d7
```
</details>

<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Checklist

- [ ] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [ ] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [ ] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [ ] Build number is 0.
- [ ] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [ ] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
