### PR TITLE
Add libqglviewer

### DIFF
--- a/recipes/libqglviewer/patches/0001-make-examples-optional.patch
+++ b/recipes/libqglviewer/patches/0001-make-examples-optional.patch
@@ -1,0 +1,23 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7738d19..4904ae4 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,6 +57,9 @@ add_library(QGLViewer SHARED ${QGLViewer_SRC})
+ target_include_directories(QGLViewer INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+ target_link_libraries(QGLViewer PRIVATE ${QtLibs} OpenGL::GL OpenGL::GLU)
+ 
++option(LIBQGLVIEWER_BUILD_EXAMPLES "Build libQGLViewer examples" ON)
++if(LIBQGLVIEWER_BUILD_EXAMPLES)
++
+ # Example: animation.
+ set(animation_SRC
+     "${PROJECT_SOURCE_DIR}/examples/animation/animation.cpp"
+@@ -259,6 +262,8 @@ set(stereoViewer_SRC
+ target_include_directories(stereoViewer PRIVATE QGLViewer ${QtLibs} OpenGL::GL OpenGL::GLU)
+ target_link_libraries(stereoViewer QGLViewer ${QtLibs} OpenGL::GL OpenGL::GLU)
+ 
++endif()
++
+ # Install.
+ include(GNUInstallDirs)
+ install(TARGETS QGLViewer

--- a/recipes/libqglviewer/recipe.yaml
+++ b/recipes/libqglviewer/recipe.yaml
@@ -1,0 +1,91 @@
+schema_version: 1
+
+context:
+  version: "2.9.1"
+
+package:
+  name: libqglviewer
+  version: ${{ version }}
+
+source:
+  url: https://github.com/GillesDebunne/libQGLViewer/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: ea4f9ac627c136a6851ffd3763b154f21c87a58bcec4e5d5b2d07e65a403096b
+  patches:
+    - patches/0001-make-examples-optional.patch
+
+build:
+  number: 0
+  script:
+    - if: win
+      then: |
+        cmake -G Ninja ^
+          %CMAKE_ARGS% ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+          -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON ^
+          -DLIBQGLVIEWER_BUILD_EXAMPLES=OFF ^
+          -S %SRC_DIR% -B build
+        cmake --build build --config Release
+        cmake --install build --config Release
+      else: |
+        cmake -G Ninja \
+          ${CMAKE_ARGS} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DCMAKE_DISABLE_FIND_PACKAGE_Qt6=ON \
+          -DLIBQGLVIEWER_BUILD_EXAMPLES=OFF \
+          -S ${SRC_DIR} -B build
+        cmake --build build --config Release
+        cmake --install build --config Release
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  host:
+    - qt-main
+    - if: linux
+      then:
+        - libgl-devel
+        - libglu
+  run_exports:
+    - ${{ pin_subpackage('libqglviewer', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      include:
+        - QGLViewer/qglviewer.h
+      lib:
+        - QGLViewer
+      files:
+        - lib/pkgconfig/libQGLViewer.pc
+  - script:
+      - if: unix
+        then:
+          - test "$(pkg-config --modversion libQGLViewer)" = "${PKG_VERSION}"
+      - if: win
+        then:
+          - if not exist %LIBRARY_PREFIX%\lib\pkgconfig\libQGLViewer.pc exit 1
+    requirements:
+      run:
+        - pkg-config
+
+about:
+  homepage: https://libqglviewer.com/
+  repository: https://github.com/GillesDebunne/libQGLViewer
+  documentation: https://libqglviewer.com/refManual/
+  license: GPL-2.0-or-later
+  license_file:
+    - LICENCE
+    - GPL_EXCEPTION
+  summary: Qt-based C++ library for the creation of OpenGL 3D viewers
+  description: >-
+    libQGLViewer provides camera, trackball, object manipulation, snapshot, and
+    other common facilities for creating interactive OpenGL 3D viewers with Qt.
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/main/README.md#license)).
- [x] Source is from an official source.
- [x] Package does not vendor dependencies.
- [x] Recipe uses a stable release.
- [x] Recipe has been linted locally.

This adds libQGLViewer 2.9.1, a Qt-based library for building interactive OpenGL 3D viewers. It builds the library against Qt 5.15 while disabling upstream's example applications. Qt 5 is selected intentionally because the initial downstream consumer, g2o's `g2o_viewer`, currently discovers QGLViewer together with Qt 5.

A small patch adds an option to avoid compiling the examples; it does not alter the installed library. The recipe packages the upstream GPL license and its additional exception.

Validated locally on Linux x86_64 with rattler-build, including package-content and pkg-config tests.
