### PR TITLE
Add lean4

### DIFF
--- a/recipes/lean4/Main.lean
+++ b/recipes/lean4/Main.lean
@@ -1,0 +1,5 @@
+def main : IO Unit :=
+  IO.println "Lean 4 works"
+
+example (n : Nat) : n + 0 = n := by
+  simp

--- a/recipes/lean4/build.sh
+++ b/recipes/lean4/build.sh
@@ -5,7 +5,7 @@ set -euxo pipefail
 # Lean's configure-time download of a prebuilt leantar executable.
 pushd leangz
 cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-cargo install \
+cargo auditable install \
   --force \
   --locked \
   --no-track \

--- a/recipes/lean4/build.sh
+++ b/recipes/lean4/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Build Lake's archive helper from source. Installing it ourselves also avoids
+# Lean's configure-time download of a prebuilt leantar executable.
+pushd leangz
+cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+cargo install \
+  --force \
+  --locked \
+  --no-track \
+  --root "${PREFIX}" \
+  --path . \
+  --bin leantar
+popd
+
+# The top-level project bootstraps stage1 from the checked-in stage0 sources.
+# It only supports Makefile generators. Use conda-forge's libraries, CaDiCaL,
+# and compiler rather than allowing any configure-time downloads.
+cmake ${CMAKE_ARGS} \
+  -G "Unix Makefiles" \
+  -S . \
+  -B build/release \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCADICAL="${BUILD_PREFIX}/bin/cadical" \
+  -DLEANTAR="${PREFIX}/bin/leantar" \
+  -DINSTALL_CADICAL=OFF \
+  -DINSTALL_LEANTAR=OFF \
+  -DSTAGE0_INSTALL_CADICAL=OFF \
+  -DSTAGE0_INSTALL_LEANTAR=OFF \
+  -DLEANC_CC="$(basename "${CC}")" \
+  -DLEAN_EXTRA_LINKER_FLAGS="${LDFLAGS}" \
+  -DUSE_MIMALLOC=OFF
+
+cmake --build build/release --parallel "${CPU_COUNT}"
+cmake --build build/release/stage1 --target install

--- a/recipes/lean4/lakefile.toml
+++ b/recipes/lean4/lakefile.toml
@@ -1,0 +1,7 @@
+name = "lean4-conda-smoke-test"
+version = "0.1.0"
+defaultTargets = ["smoke"]
+
+[[lean_exe]]
+name = "smoke"
+root = "Main"

--- a/recipes/lean4/no-sys-random.patch
+++ b/recipes/lean4/no-sys-random.patch
@@ -1,0 +1,30 @@
+From: conda-forge <conda-forge@users.noreply.github.com>
+Subject: Do not include sys/random.h
+
+Lean reads random bytes from /dev/urandom and does not use any declarations
+from sys/random.h. The header is unavailable in conda-forge's glibc 2.17
+sysroot.
+--- a/src/runtime/io.cpp
++++ b/src/runtime/io.cpp
+@@ -22,9 +22,6 @@
+ #include <unistd.h> // NOLINT
+ #include <sys/mman.h>
+ #include <sys/file.h>
+-#ifndef LEAN_EMSCRIPTEN
+-#include <sys/random.h>
+-#endif
+ #endif
+ #ifndef LEAN_WINDOWS
+ #include <csignal>
+--- a/stage0/src/runtime/io.cpp
++++ b/stage0/src/runtime/io.cpp
+@@ -22,9 +22,6 @@
+ #include <unistd.h> // NOLINT
+ #include <sys/mman.h>
+ #include <sys/file.h>
+-#ifndef LEAN_EMSCRIPTEN
+-#include <sys/random.h>
+-#endif
+ #endif
+ #ifndef LEAN_WINDOWS
+ #include <csignal>

--- a/recipes/lean4/recipe.yaml
+++ b/recipes/lean4/recipe.yaml
@@ -1,0 +1,91 @@
+context:
+  version: "4.32.2"
+  leangz_version: "0.1.19"
+
+package:
+  name: lean4
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/leanprover/lean4/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: 289d38b3055d42b243e9f57a1b6abafaf020c168cff3bb59fd8901dbdcc90c32
+    patches:
+      - no-sys-random.patch
+  # Lake expects leantar to be part of a Lean installation. Build it from
+  # source rather than downloading the platform-specific binary used upstream.
+  - url: https://github.com/digama0/leangz/archive/refs/tags/v${{ leangz_version }}.tar.gz
+    sha256: 209b1d2408f82ab4eaea656097a34535f7a3a005195d482becde00b0b4b3b1d6
+    target_directory: leangz
+
+build:
+  number: 0
+  skip:
+    - win
+    # Lean's bootstrap compiler must run on the build machine.
+    - build_platform != target_platform
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ compiler('rust') }}
+    - ${{ stdlib('c') }}
+    - cargo-bundle-licenses
+    - cmake
+    - make
+    - pkg-config
+    - cadical
+  host:
+    - gmp
+    - libuv
+    - openssl
+    - zlib
+  run:
+    # leanc and Lake compile generated C as part of normal Lean builds.
+    - c-compiler
+    - cadical
+
+tests:
+  - package_contents:
+      bin:
+        - lake
+        - lean
+        - leanc
+        - leanmake
+        - leantar
+      files:
+        - include/lean/lean.h
+        - lib/lean/Init.olean
+  - script:
+      - lean --version
+      - lake --version
+      - leantar --version
+      - cadical --version
+      - lean Main.lean
+      - lake build
+      - .lake/build/bin/smoke | grep "Lean 4 works"
+    files:
+      recipe:
+        - Main.lean
+        - lakefile.toml
+
+about:
+  homepage: https://lean-lang.org/
+  repository: https://github.com/leanprover/lean4
+  documentation: https://lean-lang.org/learn/
+  license: Apache-2.0 AND MIT
+  license_file:
+    - LICENSE
+    - LICENSES
+    - leangz/LICENSE
+    - leangz/THIRDPARTY.yml
+  summary: Functional programming language and interactive theorem prover
+  description: |
+    Lean 4 is a functional programming language and interactive theorem prover.
+    This package contains the Lean compiler, standard library, Lake build tool,
+    C compiler wrapper, and leantar archive utility needed by Lake.
+
+extra:
+  recipe-maintainers:
+    - wolfv

--- a/recipes/lean4/recipe.yaml
+++ b/recipes/lean4/recipe.yaml
@@ -24,6 +24,16 @@ build:
     # Lean's bootstrap compiler must run on the build machine.
     - build_platform != target_platform
   script: build.sh
+  dynamic_linking:
+    # Lean installs its shared libraries in lib/lean rather than lib. Preserve
+    # the upstream executable-relative paths as a workaround for rattler-build
+    # removing @executable_path entries during Mach-O relocation.
+    rpaths:
+      - lib/
+      - lib/lean/
+    rpath_allowlist:
+      - "@executable_path/../lib"
+      - "@executable_path/../lib/lean"
 
 requirements:
   build:

--- a/recipes/lean4/recipe.yaml
+++ b/recipes/lean4/recipe.yaml
@@ -42,6 +42,7 @@ requirements:
     - ${{ compiler('rust') }}
     - ${{ stdlib('c') }}
     - cargo-bundle-licenses
+    - cargo-auditable
     - cmake
     - make
     - pkg-config


### PR DESCRIPTION
Adds Lean 4, the functional programming language and interactive theorem prover.

The package is built from the bootstrapped upstream sources and includes the tightly coupled Lake build tool. Lake's `leantar` helper is also built from its official source instead of using the prebuilt binary downloaded by upstream CMake.

Windows and cross-compilation are skipped initially. Native Linux and macOS builds are enabled.

### Notes

* Configure-time dependency downloads are disabled.
* CaDiCaL and the core native libraries come from conda-forge.
* Lean executables are built through generated C and therefore `leanc` requires the C compiler at runtime.
* Lean intentionally ships its language runtime and standard-library archives because Lake uses them to produce Lean executables. This is intrinsic to the language toolchain, analogous to the language-toolchain exceptions discussed by CFEP-18.
* The glibc compatibility patch only removes an unused `sys/random.h` include; random bytes are read from `/dev/urandom` by that source.

Checklist

- [x] Title of this PR is meaningful.
- [x] License files are packaged.
- [x] Sources are official upstream release tarballs.
- [x] Licenses for the bundled `leantar` helper and its Rust dependencies are packaged.
- [x] Licenses for statically linked dependencies are bundled.
- [x] Static Lean archives are required by the Lean compiler workflow; see note above.
- [x] Build number is 0.
- [x] Tarball URLs are used.
- [x] I am willing to maintain this feedstock.
- [x] The recipe passes `conda-smithy recipe-lint --conda-forge`.
