### PR TITLE
Add vulkan-utility-libraries

### DIFF
--- a/recipes/vulkan-utility-libraries/build-shared-libraries.patch
+++ b/recipes/vulkan-utility-libraries/build-shared-libraries.patch
@@ -1,0 +1,28 @@
+diff --git a/src/layer/CMakeLists.txt b/src/layer/CMakeLists.txt
+index 5afff80..cd89139 100644
+--- a/src/layer/CMakeLists.txt
++++ b/src/layer/CMakeLists.txt
+@@ -5,7 +5,8 @@
+ # SPDX-License-Identifier: Apache-2.0
+ set(CMAKE_FOLDER "${CMAKE_FOLDER}/VulkanLayerSettings")
+ 
+-add_library(VulkanLayerSettings STATIC)
++add_library(VulkanLayerSettings)
++set_target_properties(VulkanLayerSettings PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ add_library(Vulkan::LayerSettings ALIAS VulkanLayerSettings)
+ 
+ target_sources(VulkanLayerSettings PRIVATE
+diff --git a/src/vulkan/CMakeLists.txt b/src/vulkan/CMakeLists.txt
+index 04e7f0a..a5a268c 100644
+--- a/src/vulkan/CMakeLists.txt
++++ b/src/vulkan/CMakeLists.txt
+@@ -5,7 +5,8 @@
+ # SPDX-License-Identifier: Apache-2.0
+ set(CMAKE_FOLDER "${CMAKE_FOLDER}/VulkanSafeStruct")
+ 
+-add_library(VulkanSafeStruct STATIC)
++add_library(VulkanSafeStruct)
++set_target_properties(VulkanSafeStruct PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+ add_library(Vulkan::SafeStruct ALIAS VulkanSafeStruct)
+ 
+ target_sources(VulkanSafeStruct PRIVATE

--- a/recipes/vulkan-utility-libraries/build.bat
+++ b/recipes/vulkan-utility-libraries/build.bat
@@ -1,0 +1,17 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/vulkan-utility-libraries/build.bat
+++ b/recipes/vulkan-utility-libraries/build.bat
@@ -5,6 +5,7 @@ cmake ^
     -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_SHARED_LIBS=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipes/vulkan-utility-libraries/build.sh
+++ b/recipes/vulkan-utility-libraries/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. 
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/vulkan-utility-libraries/build.sh
+++ b/recipes/vulkan-utility-libraries/build.sh
@@ -3,7 +3,7 @@
 mkdir build
 cd build
 
-cmake ${CMAKE_ARGS} -GNinja .. 
+cmake ${CMAKE_ARGS} -GNinja -DBUILD_SHARED_LIBS=ON .. 
 
 cmake --build . --config Release
 cmake --build . --config Release --target install

--- a/recipes/vulkan-utility-libraries/recipe.yaml
+++ b/recipes/vulkan-utility-libraries/recipe.yaml
@@ -11,6 +11,8 @@ package:
 source:
   url: https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
   sha256: 6d450436aea4a821d7b0d8bb914c2e375088d98eeeaad0fbf059fdb06ac937f4
+  patches:
+    - build-shared-libraries.patch
 
 build:
   number: 0
@@ -25,20 +27,17 @@ requirements:
     - libvulkan-headers =${{ version }}
   run_constraints:
     - libvulkan-headers =${{ version }}
+  run_exports:
+    - ${{ pin_subpackage("vulkan-utility-libraries", upper_bound="x.x.x") }}
 
 tests:
   - package_contents:
       include:
         - vulkan/layer/vk_layer_settings.h
         - vulkan/utility/vk_safe_struct.hpp
-      files:
-        - if: win
-          then:
-            - Library/lib/VulkanLayerSettings.lib
-            - Library/lib/VulkanSafeStruct.lib
-          else:
-            - lib/libVulkanLayerSettings.a
-            - lib/libVulkanSafeStruct.a
+      lib:
+        - VulkanLayerSettings
+        - VulkanSafeStruct
 
 about:
   homepage: https://github.com/KhronosGroup/Vulkan-Utility-Libraries

--- a/recipes/vulkan-utility-libraries/recipe.yaml
+++ b/recipes/vulkan-utility-libraries/recipe.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+context:
+  version: "1.4.357.0"
+
+package:
+  name: vulkan-utility-libraries
+  version: ${{ version }}
+
+# Vulkan SDK components use vulkan-sdk-* tags for stable releases.
+source:
+  url: https://github.com/KhronosGroup/Vulkan-Utility-Libraries/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
+  sha256: 6d450436aea4a821d7b0d8bb914c2e375088d98eeeaad0fbf059fdb06ac937f4
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+  host:
+    - libvulkan-headers =${{ version }}
+  run_constraints:
+    - libvulkan-headers =${{ version }}
+
+tests:
+  - package_contents:
+      include:
+        - vulkan/layer/vk_layer_settings.h
+        - vulkan/utility/vk_safe_struct.hpp
+      files:
+        - if: win
+          then:
+            - Library/lib/VulkanLayerSettings.lib
+            - Library/lib/VulkanSafeStruct.lib
+          else:
+            - lib/libVulkanLayerSettings.a
+            - lib/libVulkanSafeStruct.a
+
+about:
+  homepage: https://github.com/KhronosGroup/Vulkan-Utility-Libraries
+  repository: https://github.com/KhronosGroup/Vulkan-Utility-Libraries
+  summary: Utility libraries intended for implementing Vulkan SDK components
+  license: Apache-2.0
+  license_file:
+    - LICENSE.md
+    - LICENSES/Apache-2.0.txt
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Adds the Khronos Vulkan Utility Libraries at the current stable Vulkan SDK version (1.4.357.0).

This is a v1 recipe and is the prerequisite for packaging Vulkan-ExtensionLayer and Vulkan-Profiles.

The recipe was built and tested locally on linux-64.