### PR TITLE
Add spirv-cross

### DIFF
--- a/recipes/spirv-cross/build.bat
+++ b/recipes/spirv-cross/build.bat
@@ -1,0 +1,17 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/spirv-cross/build.bat
+++ b/recipes/spirv-cross/build.bat
@@ -5,6 +5,8 @@ cmake ^
     -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
+    -DSPIRV_CROSS_SHARED=ON ^
+    -DSPIRV_CROSS_ENABLE_TESTS=OFF ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipes/spirv-cross/build.bat
+++ b/recipes/spirv-cross/build.bat
@@ -17,3 +17,9 @@ if errorlevel 1 exit 1
 :: Install.
 cmake --build . --config Release --target install
 if errorlevel 1 exit 1
+
+:: The CLI requires the static targets at build time. Remove their installed
+:: artifacts while retaining the shared C API import library.
+for %%F in (%LIBRARY_LIB%\spirv-cross-*.lib) do (
+    if /I not "%%~nxF"=="spirv-cross-c-shared.lib" del "%%F"
+)

--- a/recipes/spirv-cross/build.sh
+++ b/recipes/spirv-cross/build.sh
@@ -7,3 +7,7 @@ cmake ${CMAKE_ARGS} -GNinja -DSPIRV_CROSS_SHARED=ON -DSPIRV_CROSS_ENABLE_TESTS=O
 
 cmake --build . --config Release
 cmake --build . --config Release --target install
+
+# The CLI requires the static targets at build time, but conda-forge should
+# expose the supported shared C API rather than shipping static libraries.
+find "${PREFIX}/lib" -maxdepth 1 -name 'libspirv-cross-*.a' -delete

--- a/recipes/spirv-cross/build.sh
+++ b/recipes/spirv-cross/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja -DSPIRV_CROSS_SHARED=ON -DSPIRV_CROSS_ENABLE_TESTS=OFF .. 
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/spirv-cross/recipe.yaml
+++ b/recipes/spirv-cross/recipe.yaml
@@ -33,10 +33,10 @@ tests:
         - if: win
           then:
             - Library/bin/spirv-cross.exe
-            - Library/lib/spirv-cross-c.lib
+            - Library/bin/spirv-cross-c-shared.dll
+            - Library/lib/spirv-cross-c-shared.lib
           else:
             - bin/spirv-cross
-            - lib/libspirv-cross-c.a
       lib:
         - spirv-cross-c-shared
 

--- a/recipes/spirv-cross/recipe.yaml
+++ b/recipes/spirv-cross/recipe.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+
+context:
+  version: "1.4.357.0"
+
+package:
+  name: spirv-cross
+  version: ${{ version }}
+
+# Vulkan SDK components use vulkan-sdk-* tags for stable releases.
+source:
+  url: https://github.com/KhronosGroup/SPIRV-Cross/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
+  sha256: 97c910326afdd44d794ce8561326fa675fd1958b27142f03295403044d639639
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+  run_exports:
+    - ${{ pin_subpackage("spirv-cross", upper_bound="x") }}
+
+tests:
+  - package_contents:
+      include:
+        - spirv_cross/spirv_cross_c.h
+        - spirv_cross/spirv_cross.hpp
+      files:
+        - if: win
+          then:
+            - Library/bin/spirv-cross.exe
+            - Library/lib/spirv-cross-c.lib
+          else:
+            - bin/spirv-cross
+            - lib/libspirv-cross-c.a
+      lib:
+        - spirv-cross-c-shared
+
+about:
+  homepage: https://github.com/KhronosGroup/SPIRV-Cross
+  repository: https://github.com/KhronosGroup/SPIRV-Cross
+  summary: Tool and libraries for performing reflection on and disassembling SPIR-V
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Adds Khronos SPIRV-Cross from the current stable Vulkan SDK release (1.4.357.0). Both the static libraries and shared C API are enabled.

The recipe uses the v1 format and was built and tested locally on linux-64.