### PR TITLE
Add spirv-reflect

### DIFF
--- a/recipes/spirv-reflect/add-shared-library.patch
+++ b/recipes/spirv-reflect/add-shared-library.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d893b0d..0626d2a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -5,6 +5,7 @@ project(spirv-reflect)
+ OPTION(SPIRV_REFLECT_EXECUTABLE     "Build spirv-reflect executable" ON)
+ 
+ OPTION(SPIRV_REFLECT_STATIC_LIB     "Build a SPIRV-Reflect static library" OFF)
++OPTION(SPIRV_REFLECT_SHARED_LIB     "Build a SPIRV-Reflect shared library" OFF)
+ OPTION(SPIRV_REFLECT_BUILD_TESTS    "Build the SPIRV-Reflect test suite" OFF)
+ OPTION(SPIRV_REFLECT_ENABLE_ASSERTS "Enable asserts for debugging" OFF)
+ OPTION(SPIRV_REFLECT_ENABLE_ASAN    "Use address sanitization" OFF)
+@@ -128,3 +129,24 @@ if(SPIRV_REFLECT_STATIC_LIB)
+                 PUBLIC_HEADER DESTINATION include)
+     endif()
+ endif()
++
++if(SPIRV_REFLECT_SHARED_LIB)
++    add_library(spirv-reflect-shared SHARED ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.h
++                                     ${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.c)
++
++    target_include_directories(spirv-reflect-shared
++                               PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
++
++    set_target_properties(spirv-reflect-shared PROPERTIES
++                          OUTPUT_NAME spirv-reflect
++                          PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/spirv_reflect.h"
++                          WINDOWS_EXPORT_ALL_SYMBOLS ON)
++
++    if(SPIRV_REFLECT_INSTALL)
++        install(TARGETS spirv-reflect-shared
++                RUNTIME DESTINATION bin
++                LIBRARY DESTINATION lib
++                ARCHIVE DESTINATION lib
++                PUBLIC_HEADER DESTINATION include)
++    endif()
++endif()

--- a/recipes/spirv-reflect/build.bat
+++ b/recipes/spirv-reflect/build.bat
@@ -1,0 +1,17 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/spirv-reflect/build.bat
+++ b/recipes/spirv-reflect/build.bat
@@ -5,7 +5,7 @@ cmake ^
     -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
-    -DSPIRV_REFLECT_STATIC_LIB=ON ^
+    -DSPIRV_REFLECT_SHARED_LIB=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipes/spirv-reflect/build.bat
+++ b/recipes/spirv-reflect/build.bat
@@ -5,6 +5,7 @@ cmake ^
     -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_BUILD_TYPE=Release ^
+    -DSPIRV_REFLECT_STATIC_LIB=ON ^
     %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipes/spirv-reflect/build.sh
+++ b/recipes/spirv-reflect/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja -DSPIRV_REFLECT_STATIC_LIB=ON .. 
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/spirv-reflect/build.sh
+++ b/recipes/spirv-reflect/build.sh
@@ -3,7 +3,7 @@
 mkdir build
 cd build
 
-cmake ${CMAKE_ARGS} -GNinja -DSPIRV_REFLECT_STATIC_LIB=ON .. 
+cmake ${CMAKE_ARGS} -GNinja -DSPIRV_REFLECT_SHARED_LIB=ON .. 
 
 cmake --build . --config Release
 cmake --build . --config Release --target install

--- a/recipes/spirv-reflect/recipe.yaml
+++ b/recipes/spirv-reflect/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: "1.4.357.0"
+
+package:
+  name: spirv-reflect
+  version: ${{ version }}
+
+# Vulkan SDK components use vulkan-sdk-* tags for stable releases.
+source:
+  url: https://github.com/KhronosGroup/SPIRV-Reflect/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
+  sha256: c865bd55459c5b8020a6ac962e462fc33eb4bf2dae8bf7c474357c58ce22a95d
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+
+tests:
+  - package_contents:
+      include:
+        - spirv_reflect.h
+      files:
+        - if: win
+          then:
+            - Library/bin/spirv-reflect.exe
+            - Library/bin/spirv-reflect-pp.exe
+            - Library/lib/spirv-reflect-static.lib
+          else:
+            - bin/spirv-reflect
+            - bin/spirv-reflect-pp
+            - lib/libspirv-reflect-static.a
+
+about:
+  homepage: https://github.com/KhronosGroup/SPIRV-Reflect
+  repository: https://github.com/KhronosGroup/SPIRV-Reflect
+  summary: Lightweight library for SPIR-V shader reflection
+  license: Apache-2.0
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - wolfv

--- a/recipes/spirv-reflect/recipe.yaml
+++ b/recipes/spirv-reflect/recipe.yaml
@@ -11,6 +11,8 @@ package:
 source:
   url: https://github.com/KhronosGroup/SPIRV-Reflect/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
   sha256: c865bd55459c5b8020a6ac962e462fc33eb4bf2dae8bf7c474357c58ce22a95d
+  patches:
+    - add-shared-library.patch
 
 build:
   number: 0
@@ -22,6 +24,8 @@ requirements:
     - ${{ stdlib("c") }}
     - cmake
     - ninja
+  run_exports:
+    - ${{ pin_subpackage("spirv-reflect", upper_bound="x") }}
 
 tests:
   - package_contents:
@@ -32,11 +36,13 @@ tests:
           then:
             - Library/bin/spirv-reflect.exe
             - Library/bin/spirv-reflect-pp.exe
-            - Library/lib/spirv-reflect-static.lib
+            - Library/bin/spirv-reflect.dll
+            - Library/lib/spirv-reflect.lib
           else:
             - bin/spirv-reflect
             - bin/spirv-reflect-pp
-            - lib/libspirv-reflect-static.a
+      lib:
+        - spirv-reflect
 
 about:
   homepage: https://github.com/KhronosGroup/SPIRV-Reflect


### PR DESCRIPTION
Adds Khronos SPIRV-Reflect from the current stable Vulkan SDK release (1.4.357.0), including its command-line tools and a shared library.

Upstream only exposes a static-library CMake option, so this recipe carries a small opt-in patch adding a portable shared target. Windows exports are generated with `WINDOWS_EXPORT_ALL_SYMBOLS`.

The recipe uses the v1 format and was built and tested locally on linux-64.