### PR TITLE
Add vulkan-extension-layer

### DIFF
--- a/recipes/vulkan-extension-layer/build.bat
+++ b/recipes/vulkan-extension-layer/build.bat
@@ -1,0 +1,21 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTS=OFF ^
+    -DBUILD_WSI_XCB_SUPPORT=OFF ^
+    -DBUILD_WSI_XLIB_SUPPORT=OFF ^
+    -DBUILD_WSI_WAYLAND_SUPPORT=OFF ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/vulkan-extension-layer/build.sh
+++ b/recipes/vulkan-extension-layer/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja -DBUILD_TESTS=OFF -DBUILD_WSI_XCB_SUPPORT=OFF -DBUILD_WSI_XLIB_SUPPORT=OFF -DBUILD_WSI_WAYLAND_SUPPORT=OFF .. 
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/vulkan-extension-layer/recipe.yaml
+++ b/recipes/vulkan-extension-layer/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  version: "1.4.357.0"
+
+package:
+  name: vulkan-extension-layer
+  version: ${{ version }}
+
+source:
+  url: https://github.com/KhronosGroup/Vulkan-ExtensionLayer/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
+  sha256: 9187eaa5950f8d06ebbafded16266fc4b35d224e84207b249ba5f5d1be6c9eb9
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+    - pkg-config
+  host:
+    - libvulkan-headers =${{ version }}
+    - vulkan-utility-libraries =${{ version }}
+  run_constraints:
+    - libvulkan-headers =${{ version }}
+  run_exports:
+    - ${{ pin_subpackage("vulkan-extension-layer", upper_bound="x.x.x") }}
+
+tests:
+  - package_contents:
+      files:
+        - if: win
+          then:
+            - Library/bin/VkLayer_khronos_shader_object.dll
+            - Library/bin/VkLayer_khronos_shader_object.json
+            - Library/bin/VkLayer_khronos_synchronization2.dll
+            - Library/bin/VkLayer_khronos_synchronization2.json
+          else:
+            - lib/libVkLayer_khronos_shader_object.*
+            - lib/libVkLayer_khronos_synchronization2.*
+            - lib/libVkLayer_khronos_timeline_semaphore.*
+        - if: unix
+          then:
+            - share/vulkan/explicit_layer.d/VkLayer_khronos_shader_object.json
+            - share/vulkan/explicit_layer.d/VkLayer_khronos_synchronization2.json
+            - share/vulkan/explicit_layer.d/VkLayer_khronos_timeline_semaphore.json
+
+about:
+  homepage: https://github.com/KhronosGroup/Vulkan-ExtensionLayer
+  repository: https://github.com/KhronosGroup/Vulkan-ExtensionLayer
+  summary: Vulkan layers that implement extensions outside of the Vulkan driver
+  license: Apache-2.0
+  license_file: LICENSES/Apache-2.0.txt
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Adds Khronos Vulkan-ExtensionLayer from the current stable Vulkan SDK release (1.4.357.0).

The v1 recipe uses the newly available shared Vulkan Utility Libraries package and installs the extension layer modules and Vulkan layer manifests. It was built and tested locally on linux-64.