### PR TITLE
Add valijson

### DIFF
--- a/recipes/valijson/build.bat
+++ b/recipes/valijson/build.bat
@@ -1,0 +1,17 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/valijson/build.sh
+++ b/recipes/valijson/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja .. 
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/valijson/recipe.yaml
+++ b/recipes/valijson/recipe.yaml
@@ -1,0 +1,44 @@
+schema_version: 1
+
+context:
+  version: "1.1.3"
+
+package:
+  name: valijson
+  version: ${{ version }}
+
+source:
+  url: https://github.com/tristanpenman/valijson/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 887b53b1a924f6fe0b35fa3bbc9bbbe5ae8c72097b7f0f7c17b45f4cfa646029
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+
+tests:
+  - package_contents:
+      include:
+        - valijson/schema.hpp
+        - valijson/schema_parser.hpp
+        - valijson/validator.hpp
+      files:
+        - if: win
+          then: Library/lib/cmake/valijson/valijsonConfig.cmake
+          else: lib/cmake/valijson/valijsonConfig.cmake
+
+about:
+  homepage: https://github.com/tristanpenman/valijson
+  repository: https://github.com/tristanpenman/valijson
+  summary: Header-only JSON Schema validation library for C++
+  license: BSD-2-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Adds valijson 1.1.3, a header-only C++ JSON Schema validation library.

This is a v1 recipe and is required to package Khronos Vulkan-Profiles without vendoring dependencies. It was built and tested locally on linux-64.