### PR TITLE
Add vulkan-profiles

### DIFF
--- a/recipes/vulkan-profiles/build.bat
+++ b/recipes/vulkan-profiles/build.bat
@@ -1,0 +1,19 @@
+mkdir build
+cd build
+
+cmake ^
+    -G "Ninja" ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -DCMAKE_BUILD_TYPE=Release ^
+    -DBUILD_TESTS=OFF ^
+    -DVULKAN_HEADERS_INSTALL_DIR=%LIBRARY_PREFIX% ^
+    %SRC_DIR%
+if errorlevel 1 exit 1
+
+:: Build.
+cmake --build . --config Release
+if errorlevel 1 exit 1
+
+:: Install.
+cmake --build . --config Release --target install
+if errorlevel 1 exit 1

--- a/recipes/vulkan-profiles/build.sh
+++ b/recipes/vulkan-profiles/build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir build
+cd build
+
+cmake ${CMAKE_ARGS} -GNinja -DBUILD_TESTS=OFF -DVULKAN_HEADERS_INSTALL_DIR=${PREFIX} .. 
+
+cmake --build . --config Release
+cmake --build . --config Release --target install

--- a/recipes/vulkan-profiles/recipe.yaml
+++ b/recipes/vulkan-profiles/recipe.yaml
@@ -47,7 +47,9 @@ tests:
           else:
             - lib/libVkLayer_khronos_profiles.*
             - share/vulkan/explicit_layer.d/VkLayer_khronos_profiles.json
-        - share/vulkan/registry/profiles-0.8-latest.json
+        - if: win
+          then: Library/share/vulkan/registry/profiles-0.8-latest.json
+          else: share/vulkan/registry/profiles-0.8-latest.json
 
 about:
   homepage: https://github.com/KhronosGroup/Vulkan-Profiles

--- a/recipes/vulkan-profiles/recipe.yaml
+++ b/recipes/vulkan-profiles/recipe.yaml
@@ -1,0 +1,63 @@
+schema_version: 1
+
+context:
+  version: "1.4.357.0"
+
+package:
+  name: vulkan-profiles
+  version: ${{ version }}
+
+source:
+  url: https://github.com/KhronosGroup/Vulkan-Profiles/archive/refs/tags/vulkan-sdk-${{ version }}.tar.gz
+  sha256: 08494e824457659d0399075263deff22226ef2c0c1067f551b7ec84a1b11df53
+  patches:
+    # conda-forge provides the shared jsoncpp target.
+    - use-shared-jsoncpp.patch
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ compiler("cxx") }}
+    - ${{ stdlib("c") }}
+    - cmake
+    - ninja
+    - python
+  host:
+    - jsoncpp
+    - libvulkan-headers =${{ version }}
+    - valijson
+    - vulkan-utility-libraries =${{ version }}
+  run_constraints:
+    - libvulkan-headers =${{ version }}
+  run_exports:
+    - ${{ pin_subpackage("vulkan-profiles", upper_bound="x.x.x") }}
+
+tests:
+  - package_contents:
+      include:
+        - vulkan/vulkan_profiles.hpp
+      files:
+        - if: win
+          then:
+            - Library/bin/VkLayer_khronos_profiles.dll
+            - Library/bin/VkLayer_khronos_profiles.json
+          else:
+            - lib/libVkLayer_khronos_profiles.*
+            - share/vulkan/explicit_layer.d/VkLayer_khronos_profiles.json
+        - share/vulkan/registry/profiles-0.8-latest.json
+
+about:
+  homepage: https://github.com/KhronosGroup/Vulkan-Profiles
+  repository: https://github.com/KhronosGroup/Vulkan-Profiles
+  summary: Tools and libraries for Vulkan profile development
+  license: Apache-2.0
+  license_file:
+    - LICENSE.md
+    - LICENSES/Apache-2.0.txt
+
+extra:
+  recipe-maintainers:
+    - wolfv

--- a/recipes/vulkan-profiles/use-shared-jsoncpp.patch
+++ b/recipes/vulkan-profiles/use-shared-jsoncpp.patch
@@ -1,0 +1,13 @@
+diff --git a/layer/CMakeLists.txt b/layer/CMakeLists.txt
+index 0e128b4..d7a3a64 100644
+--- a/layer/CMakeLists.txt
++++ b/layer/CMakeLists.txt
+@@ -149,7 +149,7 @@ target_link_libraries(ProfilesLayer PRIVATE
+     Vulkan::LayerSettings
+     Vulkan::Headers
+     Vulkan::UtilityHeaders
+-    jsoncpp_static
++    JsonCpp::JsonCpp
+     valijson
+ )
+ 


### PR DESCRIPTION
Adds Khronos Vulkan-Profiles from the current stable Vulkan SDK release (1.4.357.0).

This v1 recipe builds the shared Vulkan profiles layer, installs its manifest, generated profile header, schemas, and profile data, and links against conda-forge’s shared jsoncpp target. It builds and tests locally on linux-64.

Blocked by #34398, which adds the currently missing `valijson` dependency. Once that recipe is merged and packages are published, this PR can be marked ready and CI can resolve all dependencies.