### PR TITLE
Adding ``pylint-pydantic``

### DIFF
--- a/recipes/pylint-pydantic/conda-forge.yml
+++ b/recipes/pylint-pydantic/conda-forge.yml
@@ -1,0 +1,9 @@
+bot:
+  # Only propose version bumps for published GitHub Releases. The default source
+  # set reads releases.atom, which lists bare tags, so any tag pushed without an
+  # accompanying Release (version bumps, .dev builds) would be proposed as a new
+  # version. githubreleases follows /releases/latest, which GitHub only serves
+  # for a published, non-draft, non-prerelease Release.
+  version_updates:
+    sources:
+      - githubreleases

--- a/recipes/pylint-pydantic/recipe.yaml
+++ b/recipes/pylint-pydantic/recipe.yaml
@@ -32,15 +32,23 @@ tests:
         - pylint_pydantic
       pip_check: true
       python_version: ${{ python_min }}.*
-  - script:
-      - pylint --load-plugins pylint_pydantic --rcfile=pylintrc tests/
-    requirements:
-      run:
-        - python ${{ python_min }}.*
-    files:
-      source:
-        - pylintrc
-        - tests/
+  # Upstream's own lint suite, which exercises the plugin rather than just
+  # importing it. Skipped on Windows: registering the plugin trips a known
+  # upstream bug in pylint_plugin_utils.augment_visit that only reproduces
+  # there (pylint_plugin_utils.NoSuchChecker: MisdesignChecker).
+  # See https://github.com/fcfangcc/pylint-pydantic/issues/31
+  # and https://github.com/pylint-dev/pylint-django/issues/378
+  - if: not win
+    then:
+      script:
+        - pylint --load-plugins pylint_pydantic --rcfile=pylintrc tests/
+      requirements:
+        run:
+          - python ${{ python_min }}.*
+      files:
+        source:
+          - pylintrc
+          - tests/
 
 about:
   homepage: https://github.com/fcfangcc/pylint-pydantic

--- a/recipes/pylint-pydantic/recipe.yaml
+++ b/recipes/pylint-pydantic/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.4.1"
+
+package:
+  name: pylint-pydantic
+  version: ${{ version }}
+
+source:
+  # No sdist is published on PyPI, so use the GitHub archive.
+  url: https://github.com/fcfangcc/pylint-pydantic/archive/v${{ version }}.tar.gz
+  sha256: fed38d594e5ad09c0683fd2403aff3ebe9a80ae558f246242c9a0113f30dc686
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - pylint >2.0,<5.0
+    - pydantic <3.0
+    - pylint-plugin-utils
+
+tests:
+  - python:
+      imports:
+        - pylint_pydantic
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - pylint --load-plugins pylint_pydantic --rcfile=pylintrc tests/
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+    files:
+      source:
+        - pylintrc
+        - tests/
+
+about:
+  homepage: https://github.com/fcfangcc/pylint-pydantic
+  summary: A Pylint plugin to help Pylint understand the Pydantic
+  description: |
+    pylint-pydantic is a Pylint plugin that teaches Pylint about Pydantic
+    models, suppressing false positives such as no-member, no-self-argument
+    and too-many-instance-attributes that Pylint reports for code using
+    Pydantic. Enable it with `pylint --load-plugins pylint_pydantic ...`.
+  license: GPL-3.0-only
+  license_file: LICENSE
+  repository: https://github.com/fcfangcc/pylint-pydantic
+
+extra:
+  recipe-maintainers:
+    - pb01ka

--- a/recipes/pylint-pydantic/recipe.yaml
+++ b/recipes/pylint-pydantic/recipe.yaml
@@ -31,7 +31,9 @@ tests:
       imports:
         - pylint_pydantic
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   # Upstream's own lint suite, which exercises the plugin rather than just
   # importing it. Skipped on Windows: registering the plugin trips a known
   # upstream bug in pylint_plugin_utils.augment_visit that only reproduces


### PR DESCRIPTION
<!--
Thank you very much for putting in this recipe PR!

This repository is very active, so if you need help with a PR, please let the
right people know. There are language-specific teams for reviewing recipes.

| Language        | Name of review team           |
| --------------- | ----------------------------- |
| c/c++           | `@conda-forge/help-c-cpp`     |
| go              | `@conda-forge/help-go`        |
| java            | `@conda-forge/help-java`      |
| Julia           | `@conda-forge/help-julia`     |
| nodejs          | `@conda-forge/help-nodejs`    |
| perl            | `@conda-forge/help-perl`      |
| python          | `@conda-forge/help-python`    |
| python/c hybrid | `@conda-forge/help-python-c`  |
| r               | `@conda-forge/help-r`         |
| ruby            | `@conda-forge/help-ruby`      |
| rust            | `@conda-forge/help-rust`      |
| other           | `@conda-forge/staged-recipes` |

Once the PR is ready for review, please mention one of the teams above in a
new comment. i.e. `@conda-forge/help-some-language, ready for review!`
Then, a bot will label the PR as 'review-requested'.

Due to GitHub limitations, first time contributors to conda-forge are unable
to ping conda-forge teams directly, but you can [ask a bot to ping the team][1]
using a special command in a comment on the PR to get the attention of the
`staged-recipes` team. You can also consider asking on our [Zulip chat][2]
if your recipe isn't reviewed promptly.

[1]: https://conda-forge.org/docs/maintainer/infrastructure.html#conda-forge-admin-please-ping-team
[2]: https://conda-forge.zulipchat.com

All apologies in advance if your recipe PR does not receive prompt attention.
This is a high volume repository and the reviewers are volunteers. Review times
vary depending on the number of reviewers on a given language team and may be days
or weeks. We are always looking for more staged-recipe reviewers. If you are
interested in volunteering, please contact a member of @conda-forge/core.
We'd love to have the help!
-->

Adds a recipe for [`pylint-pydantic`](https://github.com/fcfangcc/pylint-pydantic).

#### Why the source is the GitHub archive rather than PyPI

`pylint-pydantic` publishes **only wheels** to PyPI. Its latest release has no sdist available on PyPI. The recipe therefore builds from the upstream `v0.4.1` GitHub tag archive, which is also the official source and additionally ships `LICENSE` and `tests/`, so the license can be packaged and the plugin can be exercised at test time.

#### Why `version_updates` is configured in `recipes/pylint-pydantic/conda-forge.yml`?

Quoting the **Problem** section from https://github.com/conda-forge/langflow-feedstock/pull/7,

> The autotick bot has been opening version PRs for upstream git tags that were never actually released.
>
> With `bot.version_updates.sources` unset, the bot tries all available sources. The `github` source reads `https://github.com/langflow-ai/langflow/releases.atom` - and **that feed lists bare git tags, not just published Releases**. Compare the two views of upstream:
> 
> ```
> releases.atom       (github source)  -> v1.11.0.dev49, v1.11.0.dev48, v1.11.0, v1.10.3, ...
> /releases/latest    (githubreleases) -> v1.10.2
> ```
> 
> `langflow-ai/langflow` tags a lot of commits - `.dev` builds, version bumps, release candidates - without cutting a GitHub Release or publishing to PyPI. The bot's substring filter drops the obvious `.dev*` tags, but a clean-looking tag like `v1.10.3` carries no marker and passes straight through.
> 
> Concretely, both of these were proposed from tags with no corresponding Release and no PyPI upload:
> 
> - https://github.com/conda-forge/langflow-feedstock/pull/2 - `v1.10.3` (merged)
> - https://github.com/conda-forge/langflow-feedstock/pull/3 - `v1.11.0` (merged)
> 
> At the time of writing, the newest genuine upstream release is `v1.10.2` on both GitHub Releases and PyPI.

To avoid this issue in `pylint-pydantic`, I have pre-emptively configured the bot to create version bump PRs only and only when a new Github release is created.

### Cross-refs, links to issues, etc:

- Upstream repository: https://github.com/fcfangcc/pylint-pydantic
- PyPI: https://pypi.org/project/pylint-pydantic/

---

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
