### PR TITLE
adds `r-rdtools`

### DIFF
--- a/recipes/r-rdtools/bld.bat
+++ b/recipes/r-rdtools/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-rdtools/build.sh
+++ b/recipes/r-rdtools/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-rdtools/meta.yaml
+++ b/recipes/r-rdtools/meta.yaml
@@ -1,0 +1,80 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-rdtools
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/rdtools_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/rdtools/rdtools_{{ version }}.tar.gz
+  sha256: 90fdaef0c78ad322ca76f4b401c68b4028c2437cd51a1b6ccbf411d9c66c094b
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('rdtools')"           # [not win]
+    - "\"%R%\" -e \"library('rdtools')\""  # [win]
+
+about:
+  home: https://rdtools.r-lib.org, https://github.com/r-lib/rdtools
+  license: MIT
+  summary: Provides fast, cached lookup of help topics and aliases across installed, source,
+    and in-development packages, plus efficient retrieval of parsed 'Rd' ('R' documentation)
+    objects. Per-package indexes are built once and cached, making repeated retrieval
+    cheap enough to call in a tight loop.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: rdtools
+# Title: Efficient Manipulation of 'Rd' Files and Help Topics
+# Version: 0.1.0
+# Authors@R: c( person("Hadley", "Wickham", , "hadley@posit.co", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0003-4757-117X")), person("Posit Software, PBC", role = c("cph", "fnd"), comment = c(ROR = "03wc8by49")) )
+# Description: Provides fast, cached lookup of help topics and aliases across installed, source, and in-development packages, plus efficient retrieval of parsed 'Rd' ('R' documentation) objects. Per-package indexes are built once and cached, making repeated retrieval cheap enough to call in a tight loop.
+# License: MIT + file LICENSE
+# URL: https://rdtools.r-lib.org, https://github.com/r-lib/rdtools
+# BugReports: https://github.com/r-lib/rdtools/issues
+# Depends: R (>= 4.0)
+# Imports: stats, tools
+# Suggests: testthat (>= 3.0.0), withr
+# Config/testthat/edition: 3
+# Encoding: UTF-8
+# RoxygenNote: 8.0.0
+# Config/Needs/website: tidyverse/tidytemplate
+# NeedsCompilation: yes
+# Packaged: 2026-07-07 19:24:27 UTC; hadleywickham
+# Author: Hadley Wickham [aut, cre, cph] (ORCID: <https://orcid.org/0000-0003-4757-117X>), Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)
+# Maintainer: Hadley Wickham <hadley@posit.co>
+# Repository: CRAN
+# Date/Publication: 2026-07-16 13:20:02 UTC

--- a/recipes/r-rdtools/meta.yaml
+++ b/recipes/r-rdtools/meta.yaml
@@ -23,14 +23,16 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ posix }}filesystem        # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+    - {{ compiler('c') }}        # [not win]
+    - {{ stdlib('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}  # [win]
+    - {{ stdlib('m2w64_c') }}    # [win]
+    - {{ posix }}filesystem      # [win]
     - {{ posix }}make
-    - {{ posix }}sed               # [win]
-    - {{ posix }}coreutils         # [win]
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}sed             # [win]
+    - {{ posix }}coreutils       # [win]
+    - {{ posix }}zip             # [win]
   host:
     - r-base
   run:
@@ -42,7 +44,8 @@ test:
     - "\"%R%\" -e \"library('rdtools')\""  # [win]
 
 about:
-  home: https://rdtools.r-lib.org, https://github.com/r-lib/rdtools
+  home: https://rdtools.r-lib.org
+  dev_url: https://github.com/r-lib/rdtools
   license: MIT
   summary: Provides fast, cached lookup of help topics and aliases across installed, source,
     and in-development packages, plus efficient retrieval of parsed 'Rd' ('R' documentation)


### PR DESCRIPTION
Adds [CRAN package `rdtools`](https://cran.r-project.org/package=rdtools) as `r-rdtools`. Recipe generated with `conda_r_skeleton_helper`.

Needed by https://github.com/conda-forge/r-roxygen2-feedstock/pull/36.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
