### PR TITLE
Add npm

### DIFF
--- a/recipes/npm/build.bat
+++ b/recipes/npm/build.bat
@@ -1,0 +1,15 @@
+@echo on
+
+set "npm_config_cache=%SRC_DIR%\.npm-cache"
+call npm pack --ignore-scripts --silent --pack-destination "%BUILD_PREFIX%"
+if errorlevel 1 exit 1
+call npm install --global --ignore-scripts --silent "%BUILD_PREFIX%\npm-%PKG_VERSION%.tgz" --prefix "%LIBRARY_PREFIX%\share\npm"
+if errorlevel 1 exit 1
+
+mkdir "%PREFIX%\etc\conda\activate.d"
+mkdir "%PREFIX%\etc\conda\deactivate.d"
+copy "%RECIPE_DIR%\npm_activate.bat" "%PREFIX%\etc\conda\activate.d\npm.bat"
+copy "%RECIPE_DIR%\npm_activate.ps1" "%PREFIX%\etc\conda\activate.d\npm.ps1"
+copy "%RECIPE_DIR%\npm_deactivate.bat" "%PREFIX%\etc\conda\deactivate.d\npm.bat"
+copy "%RECIPE_DIR%\npm_deactivate.ps1" "%PREFIX%\etc\conda\deactivate.d\npm.ps1"
+if errorlevel 1 exit 1

--- a/recipes/npm/build.sh
+++ b/recipes/npm/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -exuo pipefail
+
+export npm_config_cache="${SRC_DIR}/.npm-cache"
+npm pack --ignore-scripts --silent --pack-destination "${BUILD_PREFIX}"
+npm install \
+    --global \
+    --ignore-scripts \
+    --silent \
+    --prefix "${PREFIX}/libexec/npm" \
+    "${BUILD_PREFIX}/npm-${PKG_VERSION}.tgz"
+
+mkdir -p "${PREFIX}/etc/conda/activate.d" "${PREFIX}/etc/conda/deactivate.d"
+cp "${RECIPE_DIR}/npm_activate.sh" "${PREFIX}/etc/conda/activate.d/npm.sh"
+cp "${RECIPE_DIR}/npm_deactivate.sh" "${PREFIX}/etc/conda/deactivate.d/npm.sh"

--- a/recipes/npm/npm_activate.bat
+++ b/recipes/npm/npm_activate.bat
@@ -1,0 +1,3 @@
+@if defined _CONDA_NPM_PATH_BACKUP goto :eof
+@set "_CONDA_NPM_PATH_BACKUP=%PATH%"
+@set "PATH=%CONDA_PREFIX%\Library\share\npm;%PATH%"

--- a/recipes/npm/npm_activate.ps1
+++ b/recipes/npm/npm_activate.ps1
@@ -1,0 +1,4 @@
+if (-not (Test-Path Env:_CONDA_NPM_PATH_BACKUP)) {
+    $Env:_CONDA_NPM_PATH_BACKUP = $Env:PATH
+    $Env:PATH = "$Env:CONDA_PREFIX\Library\share\npm;$Env:PATH"
+}

--- a/recipes/npm/npm_activate.sh
+++ b/recipes/npm/npm_activate.sh
@@ -1,0 +1,4 @@
+if [ -z "${_CONDA_NPM_PATH_BACKUP+x}" ]; then
+    export _CONDA_NPM_PATH_BACKUP="${PATH}"
+    export PATH="${CONDA_PREFIX}/libexec/npm/bin:${PATH}"
+fi

--- a/recipes/npm/npm_deactivate.bat
+++ b/recipes/npm/npm_deactivate.bat
@@ -1,0 +1,3 @@
+@if not defined _CONDA_NPM_PATH_BACKUP goto :eof
+@set "PATH=%_CONDA_NPM_PATH_BACKUP%"
+@set "_CONDA_NPM_PATH_BACKUP="

--- a/recipes/npm/npm_deactivate.ps1
+++ b/recipes/npm/npm_deactivate.ps1
@@ -1,0 +1,4 @@
+if (Test-Path Env:_CONDA_NPM_PATH_BACKUP) {
+    $Env:PATH = $Env:_CONDA_NPM_PATH_BACKUP
+    Remove-Item Env:_CONDA_NPM_PATH_BACKUP
+}

--- a/recipes/npm/npm_deactivate.sh
+++ b/recipes/npm/npm_deactivate.sh
@@ -1,0 +1,4 @@
+if [ -n "${_CONDA_NPM_PATH_BACKUP+x}" ]; then
+    export PATH="${_CONDA_NPM_PATH_BACKUP}"
+    unset _CONDA_NPM_PATH_BACKUP
+fi

--- a/recipes/npm/recipe.yaml
+++ b/recipes/npm/recipe.yaml
@@ -35,8 +35,9 @@ tests:
         then:
           - set "CONDA_PREFIX=%PREFIX%"
           - call "%PREFIX%\etc\conda\activate.d\npm.bat"
-          - npm --version | findstr /x "${{ version }}"
-          - npx --version | findstr /x "${{ version }}"
+          - npm --version
+          - npx --version
+          - node -e "if (require(process.env.PREFIX + '/Library/share/npm/node_modules/npm/package.json').version !== '${{ version }}') process.exit(1)"
           - npm install --help
           - npm config get prefix --global
   - package_contents:

--- a/recipes/npm/recipe.yaml
+++ b/recipes/npm/recipe.yaml
@@ -1,0 +1,78 @@
+schema_version: 1
+
+context:
+  name: npm
+  version: "12.0.2"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://registry.npmjs.org/${{ name }}/-/${{ name }}-${{ version }}.tgz
+  sha256: 5dbb86c71d07a1957f2e90734092dd6a58bdcd9ebc2d8d41ca1c6e6a21d364e1
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - nodejs >=26
+  run:
+    - nodejs >=26
+
+tests:
+  - script:
+      - if: unix
+        then:
+          - export CONDA_PREFIX="${PREFIX}"
+          - source "${PREFIX}/etc/conda/activate.d/npm.sh"
+          - test "$(npm --version)" = "${{ version }}"
+          - test "$(npx --version)" = "${{ version }}"
+          - npm install --help
+          - test "$(npm config get prefix --global)" = "${PREFIX}"
+      - if: win
+        then:
+          - set "CONDA_PREFIX=%PREFIX%"
+          - call "%PREFIX%\etc\conda\activate.d\npm.bat"
+          - npm --version | findstr /x "${{ version }}"
+          - npx --version | findstr /x "${{ version }}"
+          - npm install --help
+          - npm config get prefix --global
+  - package_contents:
+      files:
+        - if: unix
+          then:
+            - libexec/npm/bin/npm
+            - libexec/npm/bin/npx
+            - libexec/npm/lib/node_modules/npm/*
+            - etc/conda/activate.d/npm.sh
+            - etc/conda/deactivate.d/npm.sh
+        - if: win
+          then:
+            - Library/share/npm/npm.cmd
+            - Library/share/npm/npx.cmd
+            - Library/share/npm/node_modules/npm/*
+            - etc/conda/activate.d/npm.bat
+            - etc/conda/activate.d/npm.ps1
+            - etc/conda/deactivate.d/npm.bat
+            - etc/conda/deactivate.d/npm.ps1
+
+about:
+  license: Artistic-2.0
+  license_file:
+    - LICENSE
+    - node_modules/**/LICENSE*
+    - node_modules/**/license
+    - node_modules/**/license.md
+  summary: Package manager for JavaScript
+  description: |
+    npm is the package manager for the JavaScript platform. It puts modules in
+    place so that Node.js can find them and manages dependency conflicts.
+  homepage: https://www.npmjs.com/
+  repository: https://github.com/npm/cli
+  documentation: https://docs.npmjs.com/
+
+extra:
+  recipe-maintainers:
+    - ytausch


### PR DESCRIPTION
This adds npm 12.0.2 as an independently versioned conda-forge package.

The existing `nodejs` package bundles npm and owns its normal global-install
paths. Installing another npm directly over those paths produces roughly 1,900
file collisions. To avoid that, this recipe installs npm into a private prefix
and uses conda activation scripts to put its `npm` and `npx` ahead of the
versions bundled with Node.js. npm's global package prefix remains the active
conda environment.

The build follows the approach used by `pnpm-feedstock`: Node.js/npm bootstrap
the official registry tarball, and the resulting CLI is tested after conda
activation. The upstream npm tarball vendors 132 JavaScript dependencies; all
of their distributed license files are included under `info/licenses`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (npm's official distribution vendors its JavaScript dependencies; their license files are packaged.)
- [x] If static libraries are linked in, the license of the static library is packaged. (No static libraries are linked.)
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
