### PR TITLE
Add okf-ingest

### DIFF
--- a/recipes/okf-ingest/meta.yaml
+++ b/recipes/okf-ingest/meta.yaml
@@ -1,18 +1,12 @@
-{% set version = "0.10.0" %}
+{% set version = "0.11.0" %}
 
 package:
   name: okf-ingest
   version: {{ version }}
 
 source:
-  - url: https://pypi.org/packages/source/o/okf-ingest/okf_ingest-{{ version }}.tar.gz
-    sha256: c4004ce4cfe76fe2b332c5857be6cd9d4f2ab8834c0aea47633f42260427da0d
-  # The 0.10.0 sdist does not ship the license file; fetch it from the
-  # release commit. Fixed upstream for the next release (py/LICENSE is now
-  # included in the sdist), at which point this second source goes away.
-  - url: https://raw.githubusercontent.com/travisjakel/okf-ingest/51e568770f2eddcb50ec3fd1b7911954dff18dd7/LICENSE
-    sha256: fecf17c303aab8c9bd25fa5b1b552a46c857d27284ae929acf468f2bdb66ccc7
-    folder: license
+  url: https://pypi.org/packages/source/o/okf-ingest/okf_ingest-{{ version }}.tar.gz
+  sha256: 237577465b9cf8c082acc703a0fed9e8f8f4d961407b22dda18df952bcf3bbc3
 
 build:
   entry_points:
@@ -51,11 +45,11 @@ about:
     portable, SQL-queryable DuckDB catalog. Deterministic and agent-free:
     link graph, exact Personalized-PageRank ranking, lexical query seeding,
     index-first LLM context assembly, HTML render, concept-level diff, and
-    optional local-embedding RAG. One of five conformance-locked bindings
-    (R, Python, Rust, C++, MATLAB) held byte-identical by a shared fixture
-    corpus.
+    optional local-embedding RAG. Supports OKF spec v0.2 and v0.1 bundles.
+    One of five conformance-locked bindings (R, Python, Rust, C++, MATLAB)
+    held byte-identical by a shared fixture corpus.
   license: Apache-2.0
-  license_file: license/LICENSE
+  license_file: LICENSE
 
 extra:
   recipe-maintainers:

--- a/recipes/okf-ingest/meta.yaml
+++ b/recipes/okf-ingest/meta.yaml
@@ -1,0 +1,62 @@
+{% set version = "0.10.0" %}
+
+package:
+  name: okf-ingest
+  version: {{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/o/okf-ingest/okf_ingest-{{ version }}.tar.gz
+    sha256: c4004ce4cfe76fe2b332c5857be6cd9d4f2ab8834c0aea47633f42260427da0d
+  # The 0.10.0 sdist does not ship the license file; fetch it from the
+  # release commit. Fixed upstream for the next release (py/LICENSE is now
+  # included in the sdist), at which point this second source goes away.
+  - url: https://raw.githubusercontent.com/travisjakel/okf-ingest/51e568770f2eddcb50ec3fd1b7911954dff18dd7/LICENSE
+    sha256: fecf17c303aab8c9bd25fa5b1b552a46c857d27284ae929acf468f2bdb66ccc7
+    folder: license
+
+build:
+  entry_points:
+    - okf = okf.cli:main
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - setuptools >=77
+    - pip
+  run:
+    - python >={{ python_min }}
+    - pyyaml >=6
+    - python-duckdb >=1.0
+
+test:
+  imports:
+    - okf
+  commands:
+    - pip check
+    - okf --help
+  requires:
+    - pip
+    - python {{ python_min }}
+
+about:
+  home: https://github.com/travisjakel/okf-ingest
+  dev_url: https://github.com/travisjakel/okf-ingest
+  doc_url: https://github.com/travisjakel/okf-ingest#readme
+  summary: Deterministic, agent-free ingestion tool for Open Knowledge Format (OKF) bundles
+  description: |
+    Read, validate, and load Open Knowledge Format (OKF) bundles into a
+    portable, SQL-queryable DuckDB catalog. Deterministic and agent-free:
+    link graph, exact Personalized-PageRank ranking, lexical query seeding,
+    index-first LLM context assembly, HTML render, concept-level diff, and
+    optional local-embedding RAG. One of five conformance-locked bindings
+    (R, Python, Rust, C++, MATLAB) held byte-identical by a shared fixture
+    corpus.
+  license: Apache-2.0
+  license_file: license/LICENSE
+
+extra:
+  recipe-maintainers:
+    - travisjakel

--- a/recipes/okf-ingest/recipe.yaml
+++ b/recipes/okf-ingest/recipe.yaml
@@ -1,44 +1,47 @@
-{% set version = "0.11.0" %}
+schema_version: 1
+
+context:
+  version: "0.11.0"
 
 package:
   name: okf-ingest
-  version: {{ version }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/o/okf-ingest/okf_ingest-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/o/okf-ingest/okf_ingest-${{ version }}.tar.gz
   sha256: 237577465b9cf8c082acc703a0fed9e8f8f4d961407b22dda18df952bcf3bbc3
 
 build:
-  entry_points:
-    - okf = okf.cli:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: python -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  python:
+    entry_points:
+      - okf = okf.cli:main
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - setuptools >=77
     - pip
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - pyyaml >=6
     - python-duckdb >=1.0
 
-test:
-  imports:
-    - okf
-  commands:
-    - pip check
-    - okf --help
-  requires:
-    - pip
-    - python {{ python_min }}
+tests:
+  - python:
+      imports:
+        - okf
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - okf --help
 
 about:
-  home: https://github.com/travisjakel/okf-ingest
-  dev_url: https://github.com/travisjakel/okf-ingest
-  doc_url: https://github.com/travisjakel/okf-ingest#readme
+  homepage: https://github.com/travisjakel/okf-ingest
+  repository: https://github.com/travisjakel/okf-ingest
+  documentation: https://github.com/travisjakel/okf-ingest#readme
   summary: Deterministic, agent-free ingestion tool for Open Knowledge Format (OKF) bundles
   description: |
     Read, validate, and load Open Knowledge Format (OKF) bundles into a

--- a/recipes/okf-ingest/recipe.yaml
+++ b/recipes/okf-ingest/recipe.yaml
@@ -34,7 +34,9 @@ tests:
       imports:
         - okf
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - okf --help
 


### PR DESCRIPTION
Adds **okf-ingest** — a deterministic, agent-free ingestion tool for Open Knowledge Format (OKF) bundles: validate, load into a portable DuckDB catalog, graph/rank (exact Personalized PageRank), assemble LLM context, render, and diff. Pure Python, `noarch`; PyPI: https://pypi.org/project/okf-ingest/ · source: https://github.com/travisjakel/okf-ingest

Recipe notes:
- Generated with grayskull from the PyPI 0.10.0 sdist, then hand-tuned.
- The 0.10.0 sdist does not ship the license file, so the recipe adds a second sha256-pinned source fetching `LICENSE` from the release commit. This is already fixed upstream (the sdist will carry `LICENSE` from the next release), at which point the second source will be dropped.
- Runtime deps (`pyyaml`, `python-duckdb`) are both on conda-forge.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (I am the sole listed maintainer and the upstream author.)
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
