### PR TITLE
Add `albumentationsx`

### DIFF
--- a/recipes/albumentationsx/patches/0001-disable-telemetry-by-default.patch
+++ b/recipes/albumentationsx/patches/0001-disable-telemetry-by-default.patch
@@ -1,0 +1,27 @@
+diff --git a/albumentations/core/analytics/settings.py b/albumentations/core/analytics/settings.py
+index 1e0df87..4a594fc 100644
+--- a/albumentations/core/analytics/settings.py
++++ b/albumentations/core/analytics/settings.py
+@@ -23,7 +23,7 @@ class SettingsManager:
+         """
+         self.settings_file = settings_file or (get_cache_dir() / "settings.json")
+         self.defaults = {
+-            "telemetry": True,
++            "telemetry": False,
+         }
+         self._settings = self._load_settings()
+ 
+@@ -89,10 +89,10 @@ class SettingsManager:
+ 
+     @property
+     def telemetry_enabled(self) -> bool:
+-        """True if telemetry is enabled (from settings file or env). Default True unless
+-        ALBUMENTATIONS_NO_TELEMETRY or OFFLINE is set.
++        """True if telemetry is enabled (from settings file or env). Defaults to False in
++        the conda-forge build; opt in with `settings.update(telemetry=True)`.
+         """
+-        return self.get("telemetry", True)
++        return self.get("telemetry", False)
+ 
+ 
+ # Global settings instance

--- a/recipes/albumentationsx/recipe.yaml
+++ b/recipes/albumentationsx/recipe.yaml
@@ -84,7 +84,9 @@ outputs:
             - albumentations.augmentations
             - albumentations.core
           pip_check: true
-          python_version: ${{ python_min }}.*
+          python_version:
+            - ${{ python_min }}.*
+            - "*"
       - script:
           - python -c "from albumentations.core.analytics.settings import settings; assert not settings.telemetry_enabled"
         requirements:

--- a/recipes/albumentationsx/recipe.yaml
+++ b/recipes/albumentationsx/recipe.yaml
@@ -1,0 +1,187 @@
+schema_version: 1
+
+context:
+  name: albumentationsx
+  version: "2.3.8"
+  build_number: 0
+  # Upstream supports Python >=3.10, but the required scipy >=1.15.3 is only
+  # available on conda-forge starting from 1.16.0, which needs Python >=3.11.
+  python_min: "3.11"
+
+recipe:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/albumentations-team/AlbumentationsX/releases/download/${{ version }}/albumentationsx-${{ version }}.tar.gz
+  sha256: 8fdae28d822ae53ce9314985845cecbac27ce781649e451cad364196026d6d03
+  patches:
+    # Upstream enables Mixpanel telemetry by default on `A.Compose` construction.
+    # Opt out by default; it can still be re-enabled with `settings.update(telemetry=True)`.
+    - patches/0001-disable-telemetry-by-default.patch
+
+build:
+  number: ${{ build_number }}
+
+outputs:
+  # ===================
+  # albumentationsx-all
+  # ===================
+  - package:
+      name: ${{ name }}-all
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name, exact=True) }}
+        - ${{ pin_subpackage(name ~ '-hub', exact=True) }}
+        - ${{ pin_subpackage(name ~ '-pillow', exact=True) }}
+        - ${{ pin_subpackage(name ~ '-pytorch', exact=True) }}
+        - ${{ pin_subpackage(name ~ '-pyvips', exact=True) }}
+    tests:
+      - python:
+          imports:
+            - albumentations
+            - albumentations.pytorch
+          pip_check: true
+          python_version: ${{ python_min }}.*
+  # ===============
+  # albumentationsx
+  # ===============
+  - package:
+      name: ${{ name }}
+    build:
+      noarch: python
+      script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - python ${{ python_min }}.*
+        - hatchling
+        - pip
+      run:
+        - python >=${{ python_min }}
+        - albucore ==0.2.9
+        - numkong !=7.7.1
+        - numpy >=2.2.6
+        - pydantic >=2.12.4
+        - pyyaml
+        - scipy >=1.15.3
+        - typing_extensions >=4.9.0
+        # The upstream `contrib`, `contrib-headless`, `gui` and `headless` extras only
+        # select a flavour of the opencv-python wheels.
+        # On conda-forge a single `opencv` package provides the contrib modules, and the
+        # headless/GUI split is a build variant, so opencv is a plain run dependency of
+        # this base package (it is imported at the top level of `albumentations.core`).
+        - opencv >=5.0.0
+      run_constraints:
+        # AlbumentationsX is a drop-in replacement of albumentations and ships
+        # the very same `albumentations` Python module.
+        - albumentations <0a0
+    tests:
+      - python:
+          imports:
+            - albumentations
+            - albumentations.augmentations
+            - albumentations.core
+          pip_check: true
+          python_version: ${{ python_min }}.*
+      - script:
+          - python -c "from albumentations.core.analytics.settings import settings; assert not settings.telemetry_enabled"
+        requirements:
+          run:
+            - python ${{ python_min }}.*
+  # ===================
+  # albumentationsx-hub
+  # ===================
+  - package:
+      name: ${{ name }}-hub
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name, exact=True) }}
+        - huggingface_hub
+    tests:
+      - python:
+          imports:
+            - albumentations.core.hub_mixin
+            - huggingface_hub
+          pip_check: true
+          python_version: ${{ python_min }}.*
+  # ======================
+  # albumentationsx-pillow
+  # ======================
+  # Covers both the `pillow` and the `text` upstream extras.
+  - package:
+      name: ${{ name }}-pillow
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name, exact=True) }}
+        - pillow
+    tests:
+      - python:
+          imports:
+            - albumentations
+            - PIL
+          pip_check: true
+          python_version: ${{ python_min }}.*
+  # =======================
+  # albumentationsx-pytorch
+  # =======================
+  - package:
+      name: ${{ name }}-pytorch
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name, exact=True) }}
+        - pytorch
+    tests:
+      - python:
+          imports:
+            - albumentations.pytorch
+          pip_check: true
+          python_version: ${{ python_min }}.*
+  # ======================
+  # albumentationsx-pyvips
+  # ======================
+  - package:
+      name: ${{ name }}-pyvips
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - ${{ pin_subpackage(name, exact=True) }}
+        # The conda-forge `pyvips` package already pulls in `libvips`,
+        # i.e. the conda equivalent of the upstream `pyvips[binary]` extra.
+        - pyvips
+    tests:
+      - python:
+          imports:
+            - albumentations
+            - pyvips
+          pip_check: true
+          python_version: ${{ python_min }}.*
+
+about:
+  license: AGPL-3.0-only
+  license_file:
+    - LICENSE
+    - LICENSING.md
+    - THIRD_PARTY_NOTICES.md
+    - THIRD_PARTY_LICENSES/MIT-Albumentations-2.0.8.txt
+  summary: Fast, flexible, and advanced augmentation library for computer vision and medical imaging
+  description: |
+    AlbumentationsX is a Python library for image augmentation. It provides high-performance,
+    robust implementations and cutting-edge features for computer vision tasks.
+    Image augmentation is used in deep learning and computer vision to increase the quality of trained models.
+    The purpose of image augmentation is to create new training samples from the existing data.
+  homepage: https://albumentations.ai
+  repository: https://github.com/albumentations-team/AlbumentationsX
+  documentation: https://albumentations.ai/docs/
+
+extra:
+  recipe-maintainers:
+    - diegoferigo

--- a/recipes/albumentationsx/recipe.yaml
+++ b/recipes/albumentationsx/recipe.yaml
@@ -187,3 +187,4 @@ about:
 extra:
   recipe-maintainers:
     - diegoferigo
+    - mukhery


### PR DESCRIPTION
This adds a recipe for [AlbumentationsX](https://github.com/albumentations-team/AlbumentationsX), the actively developed fork of `albumentations` by the original author. It ships the very same `albumentations` Python module, so it is a drop-in replacement of the existing [albumentations](https://github.com/conda-forge/albumentations-feedstock) feedstock and the two packages are made mutually exclusive with `run_constraints`.

The recipe is a multi-output one. The main `albumentationsx` output carries the core dependencies, and each upstream optional extra gets its own `noarch: generic` metapackage:

| output | upstream extra |
| --- | --- |
| `albumentationsx` | core, plus `opencv` |
| `albumentationsx-hub` | `hub` |
| `albumentationsx-pillow` | `pillow`, `text` |
| `albumentationsx-pytorch` | `pytorch` |
| `albumentationsx-pyvips` | `pyvips` |
| `albumentationsx-all` | all of the above |

A few decisions that are worth a comment from a reviewer:

- The `contrib`, `contrib-headless`, `gui` and `headless` extras only select a flavour of the `opencv-python` wheels. Since `cv2` is imported at the top level of `albumentations.core`, and conda-forge ships a single `opencv` package where the headless/GUI split is a build variant, `opencv` is a plain run dependency of the main output and those four extras get no metapackage.
- `python_min` is raised to 3.11 in `context`. Upstream declares `requires-python >=3.10`, but it also requires `scipy >=1.15.3`, and the oldest `scipy` available here is 1.16.0, which needs Python 3.11.
- Upstream enables Mixpanel telemetry by default, and it fires on every `A.Compose` construction. The recipe patches the default to `False`, so users have to opt in explicitly with `settings.update(telemetry=True)`. Happy to drop the patch if this is not the preferred policy.
- The `pyvips[binary]` extra bundles `libvips` in the wheel, which the conda-forge `pyvips` package already depends on, so no extra dependency is needed there.

Tested locally with `rattler-build build -r recipe.yaml -c conda-forge`: all six outputs build and their tests pass, including `pip_check` and a check that telemetry is off by default. `conda-smithy recipe-lint --conda-forge recipes/albumentationsx` reports the recipe is in fine form.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
