### PR TITLE
Add polyxios

### DIFF
--- a/recipes/polyxios/recipe.yaml
+++ b/recipes/polyxios/recipe.yaml
@@ -78,3 +78,5 @@ about:
 extra:
   recipe-maintainers:
     - skoudoro
+    - ganimtron-10
+    - maharshi-gor

--- a/recipes/polyxios/recipe.yaml
+++ b/recipes/polyxios/recipe.yaml
@@ -1,0 +1,80 @@
+context:
+  name: polyxios
+  version: "0.2.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 72946efa4de943ec78f6106795c87d6c127887bb581e2fb68f631b3476030f62
+
+build:
+  number: 0
+  skip:
+    - match(python, "<3.11")
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - meson >=0.64
+    - ninja
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - cython >=3.0
+        - numpy
+  host:
+    - python
+    - pip
+    - meson-python >=0.15
+    - cython >=3.0
+    - numpy
+    - if: osx
+      then:
+        - llvm-openmp
+  run:
+    - python
+    - numpy >=1.24
+
+tests:
+  - python:
+      imports:
+        - polyxios
+        - polyxios.codecs
+        - polyxios.transforms
+      pip_check: true
+  - script:
+      # Tests marked "real"/"3dgs"/"high_order_mesh" download fixture files
+      # from the network, so they are deselected here.
+      - pytest tests -v -k "not real and not 3dgs and not high_order_mesh"
+    requirements:
+      run:
+        - pytest
+    files:
+      source:
+        - tests/
+
+about:
+  homepage: https://github.com/fury-gl/polyxios
+  summary: Fast 3D file format I/O and processing library
+  description: |
+    polyxios reads and writes 3D mesh and point-cloud files through a single
+    pair of functions, px.read() and px.write(). Formats (PLY, OBJ, MEDIT
+    .mesh, VTK legacy, the VTK XML family including its parallel and
+    multiblock variants, and 3D Gaussian Splat .splat) are provided by
+    pluggable codecs that third-party packages can extend through the
+    "polyxios.codecs" entry point group. Meshes are exposed as a PolyData
+    container of NumPy arrays, with zero-copy memory mapping where a format
+    allows it, and Cython kernels for the hot paths.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  repository: https://github.com/fury-gl/polyxios
+
+extra:
+  recipe-maintainers:
+    - skoudoro


### PR DESCRIPTION
Adds a recipe for [polyxios](https://github.com/fury-gl/polyxios), a fast 3D
file-format I/O and processing library (PLY, OBJ, MEDIT `.mesh`, VTK legacy and
the VTK XML family, 3D Gaussian Splat `.splat`). It is a Cython/C extension
package built with meson-python, so the recipe is not `noarch`.

Notes for reviewers:

- Built and tested locally with `rattler-build` for `osx-arm64` / Python 3.12
  using `.ci_support/osx_arm64.yaml`: build succeeded, `python imports`,
  `pip check`, and the upstream test suite all pass.
- `polyxios/meson.build` uses an optional `dependency('openmp')`, hence
  `llvm-openmp` in `host` on osx; the gcc/MSVC toolchains supply it elsewhere.
- A handful of upstream tests download fixture meshes over the network; those
  are deselected in the test `script` via `-k`.
- `requires-python = ">=3.11"` upstream, hence the `match(python, "<3.11")`
  skip.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
