### PR TITLE
[meta] update v1 example readme

### DIFF
--- a/recipes/example-v1/README.md
+++ b/recipes/example-v1/README.md
@@ -1,14 +1,18 @@
 # V1 recipe format
 
-This recipe is an example of the v1 recipe format that was defined by
-[CEP 13](https://github.com/conda/ceps/blob/main/cep-0013.md) and
-[CEP 14](https://github.com/conda/ceps/blob/main/cep-0014.md).
-The v1 recipe format currently requires rattler-build as a build tool.
+This recipe is an example of the v1 (`recipe.yaml`) recipe format defined by
+[CEP 13] and [CEP 14].
 
-Conda-forge's infrastructure has seen a steady stream of effort to ensure things work as usual with v1 recipes.
-As of late 2025, v1 recipes are integrated without any major restrictions. The biggest missing feature is the
-lack of [support](https://github.com/conda/ceps/pull/102) for a shared build step between multiple outputs,
-though this is not relevant for most recipes.
+The v1  [format] currently requires [rattler-build] as a build tool.
 
-See https://github.com/conda-forge/conda-forge.github.io/issues/2308 for progress on general support for this new format.
-See https://conda-forge.org/docs/maintainer/example_recipes for example recipes.
+As of August 2026, v1 recipes are the preferred submission format, and submissions
+of v0 (`meta.yaml`) recipes are deprecated and less likely to be reviewed
+in a timely manner.
+
+See the conda-forge Knowledge Base for [example recipes].
+
+[CEP 13]: https://github.com/conda/ceps/blob/main/cep-0013.md
+[CEP 14]: https://github.com/conda/ceps/blob/main/cep-0014.md
+[format]: https://github.com/prefix-dev/recipe-format/blob/main/schema.json
+[example recipes]: https://conda-forge.org/docs/maintainer/example_recipes
+[rattler-build]: https://rattler-build.prefix.dev


### PR DESCRIPTION
This updates the prose in the `v1-example` to provide more contextual links, and remove references to any blockers.