### PR TITLE
Add better-profanity 0.7.0

### DIFF
--- a/recipes/better-profanity/recipe.yaml
+++ b/recipes/better-profanity/recipe.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+
+context:
+  version: "0.7.0"
+
+package:
+  name: better-profanity
+  version: ${{ version }}
+
+source:
+  - url: https://pypi.org/packages/source/b/better-profanity/better_profanity-${{ version }}.tar.gz
+    sha256: 8a6fdc8606d7471e7b5f6801917eca98ec211098262e82f62da4f5de3a73145b
+  # The sdist ships no licence file, so the build fails on "No license files
+  # were copied". Fetched from the matching upstream tag instead; `file_name`
+  # keeps rattler-build from trying to extract it as an archive.
+  - url: https://raw.githubusercontent.com/snguyenthanh/better_profanity/${{ version }}/LICENSE
+    sha256: ec423cc5506eea1ffbfc9955c3ec8f86139996963d84ff306a5ee41eda8a4ff1
+    file_name: LICENSE
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools
+    - wheel
+    - pip
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - better_profanity
+      pip_check: true
+      python_version: ["${{ python_min }}.*", "*"]
+  # The package is a wordlist matcher, so an import test passes even when the
+  # bundled data files never made it into the artifact. This asserts they did.
+  - script:
+      - python -c "from better_profanity import profanity; profanity.load_censor_words(); assert len(profanity.CENSOR_WORDSET) > 100"
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+
+about:
+  summary: Blazingly fast cleaning swear words (and their leetspeak) in strings
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/snguyenthanh/better_profanity
+  repository: https://github.com/snguyenthanh/better_profanity
+
+extra:
+  recipe-maintainers:
+    - killua156


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
