### PR TITLE
Add chronos-forecasting

### DIFF
--- a/recipes/chronos-forecasting/recipe.yaml
+++ b/recipes/chronos-forecasting/recipe.yaml
@@ -33,7 +33,9 @@ tests:
       imports:
         - chronos
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/amazon-science/chronos-forecasting

--- a/recipes/chronos-forecasting/recipe.yaml
+++ b/recipes/chronos-forecasting/recipe.yaml
@@ -1,0 +1,54 @@
+context:
+  version: "2.3.1"
+
+package:
+  name: chronos-forecasting
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/chronos-forecasting/chronos_forecasting-${{ version }}.tar.gz
+  sha256: 785116f3f10aaac44a315700c5e4de71a5fe6385c9c771722d688f402fe75083
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling
+  run:
+    - python >=${{ python_min }}
+    - pytorch >=2.2,<3
+    - transformers >=4.41,<6
+    - accelerate >=1.1.0,<2
+    - numpy >=1.21,<3
+    - einops >=0.7.0,<1
+    - pandas >=2.0,<4
+
+tests:
+  - python:
+      imports:
+        - chronos
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/amazon-science/chronos-forecasting
+  summary: "Chronos: Pretrained models for time series forecasting"
+  description: |
+    Chronos is a family of pretrained time series forecasting models based on
+    language model architectures. A time series is transformed into a sequence
+    of tokens via scaling and quantization, and a model is trained on these
+    tokens. Chronos models can generate probabilistic forecasts in a zero-shot
+    fashion and include the Chronos, Chronos-Bolt, and Chronos-2 model families.
+  license: Apache-2.0
+  license_file: LICENSE
+  documentation: https://github.com/amazon-science/chronos-forecasting
+  repository: https://github.com/amazon-science/chronos-forecasting
+
+extra:
+  recipe-maintainers:
+    - shchur

--- a/recipes/chronos-forecasting/recipe.yaml
+++ b/recipes/chronos-forecasting/recipe.yaml
@@ -54,3 +54,4 @@ about:
 extra:
   recipe-maintainers:
     - shchur
+    - abdulfatir


### PR DESCRIPTION
Adds a recipe for [chronos-forecasting](https://github.com/amazon-science/chronos-forecasting), a package providing pretrained time series forecasting models (Chronos, Chronos-Bolt, and Chronos-2).

I am the package maintainer.

### Checklist
- [x] Title of this PR is meaningful, e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged.)
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.