### PR TITLE
Add amica 0.1.0

### DIFF
--- a/recipes/amica/recipe.yaml
+++ b/recipes/amica/recipe.yaml
@@ -26,6 +26,11 @@ requirements:
     - python >=${{ python_min }}
     - numpy >=1.21
     - scipy >=1.7
+  run_constraints:
+    # amica-python is a separate AMICA implementation by another author that
+    # also installs a top-level `amica` module, so the two clobber each other
+    # in one environment. Declare them mutually exclusive.
+    - amica-python <0.0a0
 
 tests:
   - python:

--- a/recipes/amica/recipe.yaml
+++ b/recipes/amica/recipe.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  version: "0.1.0"
+
+package:
+  name: amica
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/amica/amica-${{ version }}.tar.gz
+  sha256: c0cb407c9e74328322125002d4673bc51c0d69b79b2d584233a266d0c00f015c
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77.0
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.21
+    - scipy >=1.7
+
+tests:
+  - python:
+      imports:
+        - amica
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+
+about:
+  homepage: https://github.com/snesmaeili/amica
+  repository: https://github.com/snesmaeili/amica
+  documentation: https://snesmaeili.github.io/amica/
+  summary: Native Python implementation of AMICA for MNE-Python and scientific EEG workflows.
+  description: |
+    amica is a native Python implementation of AMICA (Adaptive Mixture
+    Independent Component Analysis), an ICA algorithm used for EEG source
+    separation. The canonical implementation is a Fortran program from UCSD,
+    usually driven from MATLAB or EEGLAB; this package provides an open,
+    extensible Python implementation that integrates with MNE-Python and offers
+    an optional JAX backend for CPU and GPU acceleration.
+
+    JAX, MNE-Python, MNE-ICALabel and matplotlib are optional at runtime and are
+    not installed by default. For acceleration, install jax alongside amica.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - snesmaeili


### PR DESCRIPTION
Adds `amica`, a native Python implementation of AMICA (Adaptive Mixture Independent Component Analysis), an ICA algorithm used for EEG source separation. The canonical implementation is a Fortran program from UCSD normally driven through MATLAB/EEGLAB; this package provides an open Python implementation with optional JAX acceleration and MNE-Python integration.

- Upstream: https://github.com/snesmaeili/amica
- PyPI: [`amica` 0.1.0](https://pypi.org/project/amica/0.1.0/)
- Docs: https://snesmaeili.github.io/amica/
- Archived release: [10.5281/zenodo.21817485](https://doi.org/10.5281/zenodo.21817485)
- License: BSD-3-Clause

**Pure Python**, so the recipe is `noarch: python`. Runtime dependencies are deliberately minimal — only `numpy` and `scipy`. JAX, MNE-Python, MNE-ICALabel and matplotlib are all optional extras upstream and are lazily imported (`import amica` succeeds with numpy/scipy alone), so they are not listed in `run`. Users wanting GPU/CPU acceleration can `conda install -c conda-forge amica jax`. This keeps the base package light rather than pulling JAX in for everyone.

**On the name:** there is an existing `amica-python` package on conda-forge. That is an independent implementation of the same algorithm by a different author. This package is separate upstream work, published to PyPI as `amica` and imported as `amica`, so the conda name matches the PyPI/import name per conda-forge convention. Flagging it up front since the two are easy to confuse.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged — `LICENSE` is present in the PyPI sdist and referenced via `about.license_file`.
- [x] Source is from official source — PyPI sdist, sha256 verified.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged — N/A, pure Python.
- [x] Package does not ship static libraries — N/A, pure Python.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our knowledge base documentation before pinging a team.
