### PR TITLE
add r-suggests

### DIFF
--- a/recipes/r-suggests/bld.bat
+++ b/recipes/r-suggests/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-suggests/build.sh
+++ b/recipes/r-suggests/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-suggests/meta.yaml
+++ b/recipes/r-suggests/meta.yaml
@@ -1,0 +1,77 @@
+{% set version = '0.1.0' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-suggests
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/suggests_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/suggests/suggests_{{ version }}.tar.gz
+  sha256: c25427600636b391b5c869c34cd542100f14f2f97169b8e76e19b1aa6ce4e217
+
+build:
+  number: 0
+  noarch: generic
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('suggests')"           # [not win]
+    - "\"%R%\" -e \"library('suggests')\""  # [win]
+
+about:
+  home: https://github.com/owenjonesuob/suggests
+  license: MIT
+  summary: By adding dependencies to the "Suggests" field of a package's DESCRIPTION file, and
+    then declaring that they are needed within any dependent functionality, it is often
+    possible to significantly reduce the number of "hard" dependencies required by a
+    package. This package provides a minimal way to declare when a suggested package
+    is needed.
+  license_family: MIT
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - vsuppiyar
+
+# Package: suggests
+# Type: Package
+# Title: Declare when Suggested Packages are Needed
+# Version: 0.1.0
+# Date: 2023-07-14
+# Authors@R: person("Owen", "Jones", role = c("aut", "cre"), email = "owenjonesuob@gmail.com", comment = c(ORCID = "0000-0002-8410-9585"))
+# Description: By adding dependencies to the "Suggests" field of a package's DESCRIPTION file, and then declaring that they are needed within any dependent functionality, it is often possible to significantly reduce the number of "hard" dependencies required by a package. This package provides a minimal way to declare when a suggested package is needed.
+# License: MIT + file LICENSE
+# URL: https://github.com/owenjonesuob/suggests
+# BugReports: https://github.com/owenjonesuob/suggests/issues
+# Imports: utils
+# Suggests: covr, testthat (>= 3.0.0)
+# Encoding: UTF-8
+# RoxygenNote: 7.2.3
+# Config/testthat/edition: 3
+# NeedsCompilation: no
+# Packaged: 2023-08-07 17:07:51 UTC; Owen
+# Author: Owen Jones [aut, cre] (<https://orcid.org/0000-0002-8410-9585>)
+# Maintainer: Owen Jones <owenjonesuob@gmail.com>
+# Repository: CRAN
+# Date/Publication: 2023-08-08 14:30:02 UTC


### PR DESCRIPTION
Add recipe for `r-suggests` (R package on CRAN, MIT license). Generated using [conda_r_skeleton_helper](https://github.com/bgruening/conda_r_skeleton_helper).