### PR TITLE
Add qassemble and pydlr

### DIFF
--- a/recipes/pydlr/meta.yaml
+++ b/recipes/pydlr/meta.yaml
@@ -30,6 +30,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/pydlr/meta.yaml
+++ b/recipes/pydlr/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "pydlr" %}
+{% set version = "1.0.1" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/pydlr-{{ version }}.tar.gz
+  sha256: 6876ac6cc93b99df309bc4c0ed70e560b80c522ba21b4b3b26ad415dcbaea402
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools
+  run:
+    - python >={{ python_min }}
+    - numpy
+    - scipy
+
+test:
+  imports:
+    - pydlr
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/jasonkaye/libdlr
+  summary: Imaginary time calculations using the Discrete Lehmann Representation (DLR)
+  license: Apache-2.0
+  license_file: LICENSE
+  dev_url: https://github.com/jasonkaye/libdlr
+
+extra:
+  recipe-maintainers:
+    - Mo-Seong-Jun

--- a/recipes/qassemble/meta.yaml
+++ b/recipes/qassemble/meta.yaml
@@ -41,6 +41,7 @@ test:
     - qassemble --help
     - qassemble-migrate-hdf5 --help
   requires:
+    - python {{ python_min }}
     - pip
 
 about:

--- a/recipes/qassemble/meta.yaml
+++ b/recipes/qassemble/meta.yaml
@@ -1,0 +1,61 @@
+{% set name = "qassemble" %}
+{% set version = "1.0.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/QAssemble/qassemble/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 7bab835af8b438e131200a3e72e2de5e9bb080560c4ccf9572927f8c68b34400
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  entry_points:
+    - qassemble = QAssemble.CLI:main
+    - qassemble-migrate-hdf5 = QAssemble.migrate_hdf5:main
+
+requirements:
+  host:
+    - python {{ python_min }}
+    - pip
+    - setuptools >=68.0
+    - setuptools-scm >=8.0
+  run:
+    - python >={{ python_min }}
+    - numpy
+    - scipy
+    - h5py
+    - matplotlib-base
+    - pydlr
+    - sympy
+    - pymatgen
+
+test:
+  imports:
+    - QAssemble
+  commands:
+    - pip check
+    - qassemble --help
+    - qassemble-migrate-hdf5 --help
+  requires:
+    - pip
+
+about:
+  home: https://github.com/QAssemble/qassemble
+  summary: Pure-Python quantum simulation package for electronic structure calculations
+  description: |
+    QAssemble implements tight-binding, Hartree-Fock, and GW workflows for
+    model Hamiltonians in a unified object-oriented architecture, using the
+    discrete Lehmann representation for compact imaginary-time/Matsubara
+    treatment of dynamic quantities.
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  doc_url: https://www.qassemble.org/
+  dev_url: https://github.com/QAssemble/qassemble
+
+extra:
+  recipe-maintainers:
+    - Mo-Seong-Jun


### PR DESCRIPTION
Adding **qassemble** 1.0.0 and its dependency **pydlr** 1.0.1 (not yet on conda-forge) in a single PR.

- qassemble: pure-Python quantum many-body package (tight-binding / Hartree-Fock / GW), GPL-3.0-or-later, source from the v1.0.0 GitHub release tarball. Accompanies a Computer Physics Communications submission.
- pydlr: Python implementation of the Discrete Lehmann Representation (part of jasonkaye/libdlr), Apache-2.0, source from the PyPI sdist. Included here because it is a runtime dependency of qassemble.

I maintain qassemble and am willing to maintain both feedstocks (@Mo-Seong-Jun, PR author).

### Checklist
- [x] Title of this PR is meaningful.
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (url) rather than a repo (e.g. git_url) is used in the recipes.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there (I am the PR author).
- [x] When in trouble, please check our knowledge base documentation before pinging a team.
