### PR TITLE
Add metriplane

### DIFF
--- a/recipes/metriplane/recipe.yaml
+++ b/recipes/metriplane/recipe.yaml
@@ -11,6 +11,8 @@ package:
 source:
   url: https://pypi.org/packages/source/m/metriplane/metriplane-${{ version }}.tar.gz
   sha256: 70a7038debe2226e95dcb25ee649195b8f1e223c180d0c2ef6fbfb7286d69ed4
+  patches:
+    - use-conda-opencv-metadata.patch
 
 build:
   number: 0
@@ -38,8 +40,10 @@ tests:
   - python:
       imports:
         - metriplane
-      pip_check: false
-      python_version: ${{ python_min }}.*
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - requirements:
       run:
         - python ${{ python_min }}.*

--- a/recipes/metriplane/recipe.yaml
+++ b/recipes/metriplane/recipe.yaml
@@ -1,0 +1,63 @@
+schema_version: 1
+
+context:
+  version: "0.2.1"
+  python_min: "3.12"
+
+package:
+  name: metriplane
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/metriplane/metriplane-${{ version }}.tar.gz
+  sha256: 70a7038debe2226e95dcb25ee649195b8f1e223c180d0c2ef6fbfb7286d69ed4
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - metriplane = metriplane.cli:main
+      - metriplane-run = metriplane.run:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=77
+    - pip
+  run:
+    - python >=${{ python_min }},<3.14
+    - numpy >=1.26
+    - py-opencv >=4.8
+    - pyyaml >=6.0
+    - websockets >=12.0
+    - pydantic >=2.0
+
+tests:
+  - python:
+      imports:
+        - metriplane
+      pip_check: false
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - metriplane --help
+      - metriplane-run --help
+      - python -c "import cv2; assert hasattr(cv2, 'aruco')"
+
+about:
+  summary: Open-source physical observability for workcell evidence, replay, and regression testing.
+  license: MIT
+  license_file:
+    - LICENSE
+    - NOTICE
+  homepage: https://www.metriplane.com/
+  documentation: https://github.com/Miko997/metriplane/tree/main/docs
+  repository: https://github.com/Miko997/metriplane
+
+extra:
+  recipe-maintainers:
+    - Miko997

--- a/recipes/metriplane/use-conda-opencv-metadata.patch
+++ b/recipes/metriplane/use-conda-opencv-metadata.patch
@@ -1,0 +1,12 @@
+diff --git a/pyproject.toml b/pyproject.toml
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -31,7 +31,7 @@ classifiers = [
+ ]
+ dependencies = [
+   "numpy>=1.26",
+-  "opencv-contrib-python-headless>=4.8",
++  "opencv-python>=4.8",
+   "PyYAML>=6.0",
+   "websockets>=12.0",
+   "pydantic>=2.0",


### PR DESCRIPTION
Adds Metriplane 0.2.1, an open-source Python package for workcell evidence, deterministic replay, incident analysis, and regression testing.

- Source: PyPI
- License: MIT
- Python: >=3.12,<3.14
- Recipe format: v1 `recipe.yaml`
- Local `linux64` conda-forge build: passing
- `conda-smithy recipe-lint`: passing

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in the recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.