### PR TITLE
Add lean-ctx

### DIFF
--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -21,7 +21,8 @@ build:
       # tikv-jemalloc-sys requires _rjem_-prefixed symbols on macOS,
       # which conda-forge's jemalloc does not provide.
       - if: linux
-        then: export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
+        then: >-
+          export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
       - cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
       - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -21,8 +21,8 @@ build:
       # tikv-jemalloc-sys requires _rjem_-prefixed symbols on macOS,
       # which conda-forge's jemalloc does not provide.
       - if: linux
-        then: >-
-          export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
+        then:
+          - export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
       - cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
       - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -23,6 +23,8 @@ requirements:
     - ${{ stdlib('c') }}
     - ${{ compiler('c') }}
     - ${{ compiler('rust') }}
+    - if: unix
+      then: make
     - brush
     - cargo-auditable
     - cargo-bundle-licenses

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -15,6 +15,7 @@ build:
     interpreter: brush
     content: |
       cd rust
+      export LIBSQLITE3_SYS_USE_PKG_CONFIG=1 ZSTD_SYS_USE_PKG_CONFIG=1
       # tikv-jemalloc-sys requires _rjem_-prefixed symbols on macOS,
       # which conda-forge's jemalloc does not provide.
       if test "${SHLIB_EXT}" = ".so"; then
@@ -33,7 +34,10 @@ requirements:
     - brush
     - cargo-auditable
     - cargo-bundle-licenses
+    - pkg-config
   host:
+    - sqlite
+    - zstd
     - if: linux
       then: jemalloc
   run:

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -22,7 +22,8 @@ build:
       # which conda-forge's jemalloc does not provide.
       - if: linux
         then:
-          - export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
+          - export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1
+          - export JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
       - cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
       - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -15,6 +15,9 @@ build:
     interpreter: brush
     content: |
       cd rust
+      if test "${SHLIB_EXT}" = ".so"; then
+        export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
+      fi
       cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
       cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
@@ -23,11 +26,14 @@ requirements:
     - ${{ stdlib('c') }}
     - ${{ compiler('c') }}
     - ${{ compiler('rust') }}
-    - if: unix
+    - if: osx
       then: make
     - brush
     - cargo-auditable
     - cargo-bundle-licenses
+  host:
+    - if: linux
+      then: jemalloc
   run:
     - onnxruntime-cpp
 

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -15,6 +15,8 @@ build:
     interpreter: brush
     content: |
       cd rust
+      # tikv-jemalloc-sys requires _rjem_-prefixed symbols on macOS,
+      # which conda-forge's jemalloc does not provide.
       if test "${SHLIB_EXT}" = ".so"; then
         export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
       fi

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -13,9 +13,11 @@ build:
   number: 0
   script:
     interpreter: brush
+    env:
+      LIBSQLITE3_SYS_USE_PKG_CONFIG: "1"
+      ZSTD_SYS_USE_PKG_CONFIG: "1"
     content: |
       cd rust
-      export LIBSQLITE3_SYS_USE_PKG_CONFIG=1 ZSTD_SYS_USE_PKG_CONFIG=1
       # tikv-jemalloc-sys requires _rjem_-prefixed symbols on macOS,
       # which conda-forge's jemalloc does not provide.
       if test "${SHLIB_EXT}" = ".so"; then

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -16,15 +16,14 @@ build:
     env:
       LIBSQLITE3_SYS_USE_PKG_CONFIG: "1"
       ZSTD_SYS_USE_PKG_CONFIG: "1"
-    content: |
-      cd rust
+    content:
+      - cd rust
       # tikv-jemalloc-sys requires _rjem_-prefixed symbols on macOS,
       # which conda-forge's jemalloc does not provide.
-      if test "${SHLIB_EXT}" = ".so"; then
-        export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
-      fi
-      cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
-      cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+      - if: linux
+        then: export CARGO_FEATURE_UNPREFIXED_MALLOC_ON_SUPPORTED_PLATFORMS=1 JEMALLOC_OVERRIDE="${PREFIX}/lib/libjemalloc${SHLIB_EXT}"
+      - cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
+      - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 requirements:
   build:

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -1,0 +1,57 @@
+context:
+  version: "3.9.18"
+
+package:
+  name: lean-ctx
+  version: ${{ version }}
+
+source:
+  url: https://github.com/yvgude/lean-ctx/releases/download/v${{ version }}/lean-ctx-${{ version }}-source.tar.gz
+  sha256: 1292776f9549307cf3feade95d75411ba6fce24a9f96d4a07ad6146884686350
+
+build:
+  number: 0
+  script:
+    interpreter: brush
+    content: |
+      cd rust
+      cargo auditable install --locked --no-track --bins --root "${PREFIX}" --path .
+      cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - brush
+    - cargo-auditable
+    - cargo-bundle-licenses
+  run:
+    - onnxruntime-cpp
+
+tests:
+  - script:
+      - lean-ctx --help
+      - lean-ctx --version
+  - package_contents:
+      bin:
+        - lean-ctx
+      strict: true
+
+about:
+  homepage: https://leanctx.com
+  summary: Context engineering layer for AI coding agents
+  description: |
+    LeanCTX is a local context engineering layer for AI coding agents. It
+    provides repository access, command execution, context compression,
+    persistent memory, access controls, and context usage reporting.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - rust/THIRDPARTY.yml
+  documentation: https://leanctx.com/docs/getting-started
+  repository: https://github.com/yvgude/lean-ctx
+
+extra:
+  recipe-maintainers:
+    - baszalmstra

--- a/recipes/lean-ctx/recipe.yaml
+++ b/recipes/lean-ctx/recipe.yaml
@@ -15,7 +15,7 @@ build:
     interpreter: brush
     content: |
       cd rust
-      cargo auditable install --locked --no-track --bins --root "${PREFIX}" --path .
+      cargo auditable install --locked --no-track --bins --root "${LIBRARY_PREFIX:-${PREFIX}}" --path .
       cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
 
 requirements:


### PR DESCRIPTION
 This adds the current `3.9.18` release.

The recipe builds the default upstream feature set using `cargo-auditable` and a single cross-platform Brush script. It includes `onnxruntime-cpp`, which is loaded dynamically by the embeddings feature, and bundles the Rust dependency licenses.

Upstream vendors patched copies of `rmcp` and `rmcp-macros`. Their licenses are included in `THIRDPARTY.yml`, but I left the vendoring checkbox unchecked to make this explicit.

## Testing

I built the recipe locally for `linux-64` using conda-forge’s current GCC 14, Rust 1.97, and glibc 2.17 pins.

```text
lean-ctx 3.9.18 (official, https://github.com/yvgude/lean-ctx)
```

The following checks passed:

* `lean-ctx --help`
* `lean-ctx --version`
* Package contents check
* `conda-smithy recipe-lint --conda-forge recipes/*`

Checklist

* [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
* [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
* [x] License file is packaged.
* [x] Source is from official source.
* [ ] Package does not vendor other packages.
* [x] If static libraries are linked in, the license of the static library is packaged.
* [x] Package does not ship static libraries.
* [x] Build number is 0.
* [x] A tarball (`url`) rather than a repo is used in the recipe.
* [x] GitHub users listed in the maintainer section have confirmed they are willing to be listed there.
* [x] When in trouble, I checked the conda-forge knowledge base before pinging a team.
