### PR TITLE
Adding advect

### DIFF
--- a/recipes/advect/recipe.yaml
+++ b/recipes/advect/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: advect
   version: "0.1.0"
 
 package:
-  name: ${{ name }}
+  name: advect
   version: ${{ version }}
 
 source:

--- a/recipes/advect/recipe.yaml
+++ b/recipes/advect/recipe.yaml
@@ -27,7 +27,6 @@ requirements:
         - python
         - cross-python_${{ target_platform }}
         - maturin >=1.12,<2
-    - ${{ compiler('c') }}
     - ${{ stdlib('c') }}
     - ${{ compiler('rust') }}
     - cargo-bundle-licenses

--- a/recipes/advect/recipe.yaml
+++ b/recipes/advect/recipe.yaml
@@ -1,0 +1,71 @@
+schema_version: 1
+
+context:
+  name: advect
+  version: "0.1.0"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/advect/advect-${{ version }}.tar.gz
+  sha256: 80734116c228fb3e2e07ded631b1a35de6de62d73050b11a52b80a1e271658c9
+
+build:
+  number: 0
+  skip:
+    - match(python, '<3.12')
+    - match(python, '>=3.15')
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - maturin >=1.12,<2
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1.12,<2
+  run:
+    - python
+    - array-api-compat >=1.11.2,<2
+    - numpy >=2.0,<2.6
+
+tests:
+  - python:
+      imports:
+        - advect
+      pip_check: true
+  - requirements:
+      run:
+        - pip
+    script:
+      - 'python -c "import advect as ad; import numpy as np; np.testing.assert_allclose(ad.grad(lambda x: np.sum(x**2))(np.array([1.0, 2.0])), [2.0, 4.0])"'
+
+about:
+  homepage: https://yaugenst.github.io/advect/
+  repository: https://github.com/yaugenst/advect
+  documentation: https://yaugenst.github.io/advect/
+  summary: Automatic differentiation for the NumPy code you already write
+  license: MIT
+  license_file:
+    - LICENSE
+    - RUST_STDLIB_COPYRIGHT.html
+    - RUST_STDLIB_LICENSE_MIT.txt
+    - RUST_STDLIB_LICENSE_UNICODE_3_0.txt
+    - THIRD_PARTY_LICENSES.txt
+    - THIRDPARTY.yml
+
+extra:
+  recipe-maintainers:
+    - yaugenst

--- a/recipes/advect/recipe.yaml
+++ b/recipes/advect/recipe.yaml
@@ -44,10 +44,7 @@ tests:
       imports:
         - advect
       pip_check: true
-  - requirements:
-      run:
-        - pip
-    script:
+  - script:
       - 'python -c "import advect as ad; import numpy as np; np.testing.assert_allclose(ad.grad(lambda x: np.sum(x**2))(np.array([1.0, 2.0])), [2.0, 4.0])"'
 
 about:


### PR DESCRIPTION
Adds the first conda-forge recipe for [Advect](https://github.com/yaugenst/advect), a NumPy-focused automatic differentiation library with a Rust extension.

Validated locally with `conda-smithy recipe-lint --conda-forge recipes/advect` and the official Linux `build-locally.py` path. Python 3.12 and 3.13 builds passed import, `pip check`, and a real gradient smoke test.

Checklist

- [x] The title is meaningful.
- [x] The recipe uses the v1 `recipe.yaml` format.
- [x] License files are packaged, including bundled Rust dependency licenses.
- [x] The source is the official PyPI sdist.
- [x] No packages are vendored.
- [x] No static libraries are linked or shipped.
- [x] The build number is 0.
- [x] The recipe uses a tarball URL.
- [x] I, `@yaugenst`, am willing to be listed as a recipe maintainer.