### PR TITLE
Add kspace

### DIFF
--- a/recipes/kspace/recipe.yaml
+++ b/recipes/kspace/recipe.yaml
@@ -1,5 +1,6 @@
 context:
   version: "0.1.0"
+  python_min: "3.11"
 
 package:
   name: kspace
@@ -16,11 +17,11 @@ build:
 
 requirements:
   host:
-    - python >=3.11
+    - python ${{ python_min }}.*
     - pip
     - hatchling
   run:
-    - python >=3.11
+    - python >=${{ python_min }}
     - numpy >=2.3.3
     - scipy >=1.16.2
     - numba >=0.62.1
@@ -30,6 +31,9 @@ tests:
       imports:
         - kspace
       pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/jzuhone/kspace

--- a/recipes/kspace/recipe.yaml
+++ b/recipes/kspace/recipe.yaml
@@ -1,0 +1,51 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: kspace
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/k/kspace/kspace-${{ version }}.tar.gz
+  sha256: a8c9e93e8c33216463708759a5d474b38f9e260f0188c0d6eb32c0a0274a7fbf
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - hatchling
+  run:
+    - python >=3.11
+    - numpy >=2.3.3
+    - scipy >=1.16.2
+    - numba >=0.62.1
+
+tests:
+  - python:
+      imports:
+        - kspace
+      pip_check: true
+
+about:
+  homepage: https://github.com/jzuhone/kspace
+  summary: Tools for generating and analyzing Gaussian random fields and their power spectra on regular grids
+  description: |
+    kspace generates Gaussian random field realizations (scalar or vector,
+    including divergence-free fields) from a prescribed power spectrum, and
+    provides FFT-based analysis of fields on regular grids: binned power
+    spectra, divergence/curl, vector-potential inversion, and windowing.
+    Works in 1, 2, or 3 dimensions. Built for astrophysical/cosmological
+    applications.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://jzuhone.github.io/kspace/
+  repository: https://github.com/jzuhone/kspace
+
+extra:
+  recipe-maintainers:
+    - jzuhone


### PR DESCRIPTION
## Description

Adds a recipe for `kspace`, a small pure-Python library for generating
Gaussian random field realizations from a prescribed power spectrum, and
FFT-based analysis of fields on regular grids (binned power spectra,
divergence/curl, vector-potential inversion, windowing). Works in 1, 2, or
3 dimensions; built for astrophysical/cosmological applications.

- PyPI: https://pypi.org/project/kspace/
- Repository: https://github.com/jzuhone/kspace
- Documentation: https://jzuhone.github.io/kspace/

#### Checklist

- [x] License file is packaged (`license_file` points to the correct path in the source tarball)
- [x] Package does not vendor unlicensed dependencies
- [x] Recipe maintainer is the package author (me)