### PR TITLE
Adding readerkit

### DIFF
--- a/recipes/readerkit/recipe.yaml
+++ b/recipes/readerkit/recipe.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  name: readerkit
+  version: "0.1.0"
+  python_min: "3.12"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/readerkit-${{ version }}.tar.gz
+  sha256: fc0611ce5e0436d95d5600bb07fb413fc13452392fc04d1fc3692dde6b21a37f
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - uv-build >=0.11.29,<0.12
+  run:
+    - python >=${{ python_min }}
+    - platformdirs >=4.3
+    - filelock >=3.30
+    - requests >=2.32
+    - requests-cache >=1.3
+    - requests-ratelimiter >=0.10
+    - urllib3 >=2.0
+
+tests:
+  - python:
+      imports:
+        - readerkit
+        - readerkit.artifacts
+        - readerkit.dirs
+        - readerkit.exceptions
+        - readerkit.http
+        - readerkit.keys
+        - readerkit.refresh
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  summary: Cached HTTP sessions, cache-directory resolution, and a bulk artifact cache for data readers.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/ONEcampaign/readerkit
+  repository: https://github.com/ONEcampaign/readerkit
+
+extra:
+  recipe-maintainers:
+    - jm-rivera


### PR DESCRIPTION
readerkit is the shared transport and cache layer for the ONE Campaign's family of data-reader packages. It provides a configured `requests` session with bounded retries and optional rate limiting, a cache-directory resolver, and a bulk artifact cache with per-key file locking, TTL and LRU eviction. Pure Python, no compiled components. Released to PyPI as 0.1.0 today: https://pypi.org/project/readerkit/

The recipe pins `python_min` to 3.12 in the context block, since the package declares `requires-python >=3.12`. The build backend is `uv_build`, so `uv-build >=0.11.29,<0.12` sits in host to match the upstream `build-system.requires`, following the pattern in `demoji-feedstock` and `pyproject2conda-feedstock`.

Tests are imports plus `pip check`. The sdist ships `src/` without `tests/`, so the suite cannot run from the tarball. That is on my list to fix upstream for the next release.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
