### PR TITLE
Adding peptide-calculations

### DIFF
--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,5 +1,6 @@
 context:
   version: "0.1.0"
+  python_min: "3.9"
 
 package:
   name: peptide-calculations
@@ -19,14 +20,17 @@ build:
 
 requirements:
   host:
-    - python
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68
   run:
-    - python
+    - python >=${{ python_min }}
 
 tests:
   - python:
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
       imports:
         - peptide_calculations
       pip_check: true

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,45 +1,42 @@
-context:
-  version: "0.1.0"
-  python_min: "3.9"
+{% set python_min = "3.9" %}
+{% set version = "0.1.0" %}
 
 package:
   name: peptide-calculations
-  version: ${{ version }}
+  version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/p/peptide-calculations/peptide_calculations-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/peptide-calculations/peptide_calculations-{{ version }}.tar.gz
   sha256: d288612301e1c2229ee87abf062672e77f6dfd4fdbb1d3ace22cf5172b060513
 
 build:
+  entry_points:
+    - peptide-calculations = peptide_calculations.cli:main
   noarch: python
-  script: python -m pip install . -vv
-  python:
-    entry_points:
-      - peptide-calculations = peptide_calculations.cli:main
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python ${{ python_min }}.*
-    - pip
+    - python {{ python_min }}.*
     - setuptools >=68
+    - pip
   run:
-    - python >=${{ python_min }}
+    - python >={{ python_min }}
 
-tests:
-  - python:
-      python_version:
-        - ${{ python_min }}.*
-        - "*"
-      imports:
-        - peptide_calculations
-      pip_check: true
-  - script:
-      - python -m peptide_calculations reconstitution --mass 10 --target 5
+test:
+  imports:
+    - peptide_calculations
+  commands:
+    - pip check
+    - peptide-calculations --help
+  requires:
+    - pip
+    - python {{ python_min }}.*
 
 about:
-  homepage: https://peptidomexico.com.mx/calculadora/
-  documentation: https://peptidomexico-open-science.readthedocs.io/en/latest/peptide-calculations-python/
+  home: https://peptidomexico.com.mx/calculadora/
+  doc_url: https://peptidomexico-open-science.readthedocs.io/en/latest/peptide-calculations-python/
   repository: https://github.com/PeptidoMexico/peptidomexico-open-science
   summary: Unit-safe peptide reconstitution, concentration, dilution and molarity calculations.
   description: |

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,33 +1,32 @@
 context:
   version: "0.1.0"
-  python_min: "3.9"
 
 package:
   name: peptide-calculations
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/6f/4e/66437c3efe8fe5ffd8263476090da1f9e8fe576f4d3853b6ca97aab2f8fa/peptide_calculations-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/peptide-calculations/peptide_calculations-${{ version }}.tar.gz
   sha256: d288612301e1c2229ee87abf062672e77f6dfd4fdbb1d3ace22cf5172b060513
 
 build:
   noarch: python
   script: python -m pip install . -vv
+  python:
+    entry_points:
+      - peptide-calculations = peptide_calculations.cli:main
   number: 0
 
 requirements:
   host:
-    - python ${{ python_min }}.*
+    - python
     - pip
     - setuptools >=68
   run:
-    - python >=${{ python_min }}
+    - python
 
 tests:
   - python:
-      python_version:
-        - ${{ python_min }}.*
-        - "*"
       imports:
         - peptide_calculations
       pip_check: true

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,5 +1,6 @@
+schema_version: 1
+
 context:
-  python_min: "3.9"
   version: "0.1.0"
 
 package:
@@ -11,34 +12,36 @@ source:
   sha256: d288612301e1c2229ee87abf062672e77f6dfd4fdbb1d3ace22cf5172b060513
 
 build:
-  entry_points:
-    - peptide-calculations = peptide_calculations.cli:main
   noarch: python
-  script: python -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
+  python:
+    entry_points:
+      - peptide-calculations = peptide_calculations.cli:main
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}.*
+    - python ${{ python_min }}.*
     - setuptools >=68
     - pip
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
 
-test:
-  imports:
-    - peptide_calculations
-  commands:
-    - pip check
-    - peptide-calculations --help
-  requires:
-    - pip
-    - python {{ python_min }}.*
+tests:
+  - python:
+      imports:
+        - peptide_calculations
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+  - script:
+      - peptide-calculations --help
 
 about:
-  home: https://peptidomexico.com.mx/calculadora/
-  doc_url: https://peptidomexico-open-science.readthedocs.io/en/latest/peptide-calculations-python/
+  homepage: https://peptidomexico.com.mx/calculadora/
   repository: https://github.com/PeptidoMexico/peptidomexico-open-science
+  documentation: https://peptidomexico-open-science.readthedocs.io/en/latest/peptide-calculations-python/
   summary: Unit-safe peptide reconstitution, concentration, dilution and molarity calculations.
   description: |
     Dependency-free Python API and CLI for transparent peptide laboratory

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,0 +1,47 @@
+context:
+  version: "0.1.0"
+
+package:
+  name: peptide-calculations
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/6f/4e/66437c3efe8fe5ffd8263476090da1f9e8fe576f4d3853b6ca97aab2f8fa/peptide_calculations-${{ version }}.tar.gz
+  sha256: d288612301e1c2229ee87abf062672e77f6dfd4fdbb1d3ace22cf5172b060513
+
+build:
+  noarch: python
+  script: python -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.9
+
+tests:
+  - python:
+      imports:
+        - peptide_calculations
+      pip_check: true
+  - script:
+      - peptide-calculations reconstitution --mass 10 --target 5
+
+about:
+  homepage: https://peptidomexico.com.mx/calculadora/
+  documentation: https://peptidomexico-open-science.readthedocs.io/en/latest/peptide-calculations-python/
+  repository: https://github.com/PeptidoMexico/peptidomexico-open-science
+  summary: Unit-safe peptide reconstitution, concentration, dilution and molarity calculations.
+  description: |
+    Dependency-free Python API and CLI for transparent peptide laboratory
+    calculations. The package is research-use-only software and does not
+    provide dosing, administration or clinical interpretation.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - PeptidoMexico-OpenScience

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,19 +1,20 @@
-{% set python_min = "3.9" %}
-{% set version = "0.1.0" %}
+context:
+  python_min: "3.9"
+  version: "0.1.0"
 
 package:
   name: peptide-calculations
-  version: {{ version }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/p/peptide-calculations/peptide_calculations-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/peptide-calculations/peptide_calculations-${{ version }}.tar.gz
   sha256: d288612301e1c2229ee87abf062672e77f6dfd4fdbb1d3ace22cf5172b060513
 
 build:
   entry_points:
     - peptide-calculations = peptide_calculations.cli:main
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: python -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -1,5 +1,6 @@
 context:
   version: "0.1.0"
+  python_min: "3.9"
 
 package:
   name: peptide-calculations
@@ -16,14 +17,17 @@ build:
 
 requirements:
   host:
-    - python >=3.9
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68
   run:
-    - python >=3.9
+    - python >=${{ python_min }}
 
 tests:
   - python:
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
       imports:
         - peptide_calculations
       pip_check: true

--- a/recipes/peptide-calculations/recipe.yaml
+++ b/recipes/peptide-calculations/recipe.yaml
@@ -32,7 +32,7 @@ tests:
         - peptide_calculations
       pip_check: true
   - script:
-      - peptide-calculations reconstitution --mass 10 --target 5
+      - python -m peptide_calculations reconstitution --mass 10 --target 5
 
 about:
   homepage: https://peptidomexico.com.mx/calculadora/


### PR DESCRIPTION
## Summary

Adds the v1 conda recipe for `peptide-calculations`, a dependency-free Python API and CLI for research-use-only peptide reconstitution, concentration, dilution, and molarity calculations.

## Validation

- Official PyPI sdist with verified SHA-256 checksum
- MIT license packaged from the source distribution
- `python -m pip install . -vv` smoke-tested from the published sdist
- `peptide-calculations reconstitution --mass 10 --target 5` returns 2 mL
- Package has no runtime dependencies beyond Python

## Scope and disclosure

This is transparent laboratory calculation software for research use only. It does not provide dosing, administration, clinical interpretation, or medical advice. The maintainer operates in the research-materials sector; the source project, documentation, and disclosure are public.