### PR TITLE
add `r-dlm`

### DIFF
--- a/recipes/r-dlm/bld.bat
+++ b/recipes/r-dlm/bld.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-dlm/build.sh
+++ b/recipes/r-dlm/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-dlm/meta.yaml
+++ b/recipes/r-dlm/meta.yaml
@@ -35,6 +35,8 @@ requirements:
     - {{ posix }}zip             # [win]
   host:
     - r-base
+    - libblas
+    - liblapack
   run:
     - r-base
 

--- a/recipes/r-dlm/meta.yaml
+++ b/recipes/r-dlm/meta.yaml
@@ -23,14 +23,16 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }}              # [not win]
-    - {{ compiler('m2w64_c') }}        # [win]
-    - {{ posix }}filesystem        # [win]
+    - cross-r-base {{ r_base }}  # [build_platform != target_platform]
+    - {{ compiler('c') }}        # [not win]
+    - {{ stdlib('c') }}          # [not win]
+    - {{ compiler('m2w64_c') }}  # [win]
+    - {{ stdlib('m2w64_c') }}    # [win]
+    - {{ posix }}filesystem      # [win]
     - {{ posix }}make
-    - {{ posix }}sed               # [win]
-    - {{ posix }}coreutils         # [win]
-    - {{ posix }}zip               # [win]
-    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+    - {{ posix }}sed             # [win]
+    - {{ posix }}coreutils       # [win]
+    - {{ posix }}zip             # [win]
   host:
     - r-base
   run:
@@ -43,12 +45,13 @@ test:
 
 about:
   home: https://CRAN.R-project.org/package=dlm
-  license: GPL-2.0-only
+  license: GPL-2.0-or-later
   summary: Provides routines for Maximum likelihood, Kalman filtering and smoothing, and Bayesian
     analysis of Normal linear State Space models, also known as Dynamic Linear Models.
   license_family: GPL2
   license_file:
     - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-3'
 
 extra:
   recipe-maintainers:

--- a/recipes/r-dlm/meta.yaml
+++ b/recipes/r-dlm/meta.yaml
@@ -1,0 +1,71 @@
+{% set version = '1.1-6.1' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-dlm
+  version: {{ version|replace("-", "_") }}
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/dlm_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/dlm/dlm_{{ version }}.tar.gz
+  sha256: 73e371de6e0849f943198da3c142248fe08a19551f0336c6c2d4afbf550f5f43
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+  run:
+    - r-base
+
+test:
+  commands:
+    - $R -e "library('dlm')"           # [not win]
+    - "\"%R%\" -e \"library('dlm')\""  # [win]
+
+about:
+  home: https://CRAN.R-project.org/package=dlm
+  license: GPL-2.0-only
+  summary: Provides routines for Maximum likelihood, Kalman filtering and smoothing, and Bayesian
+    analysis of Normal linear State Space models, also known as Dynamic Linear Models.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+
+# Package: dlm
+# Title: Bayesian and Likelihood Analysis of Dynamic Linear Models
+# Version: 1.1-6.1
+# Date: 2022-11-12
+# Suggests: MASS
+# Imports: stats, utils, methods, grDevices, graphics
+# Authors@R: c( person("Giovanni", "Petris", email = "GPetris@uark.edu", role = c("aut", "cre")), person("Wally", "Gilks", role = "ctb", comment = "Author of original C code for ARMS"))
+# Maintainer: Giovanni Petris <GPetris@uark.edu>
+# Description: Provides routines for Maximum likelihood, Kalman filtering and smoothing, and Bayesian analysis of Normal linear State Space models, also known as Dynamic Linear Models.
+# License: GPL (>= 2)
+# NeedsCompilation: yes
+# Packaged: 2024-09-21 08:09:52 UTC; hornik
+# Author: Giovanni Petris [aut, cre], Wally Gilks [ctb] (Author of original C code for ARMS)
+# Repository: CRAN
+# Date/Publication: 2024-09-21 08:15:41 UTC


### PR DESCRIPTION
Adds [CRAN package `dlm`](https://cran.r-project.org/package=dlm) as `r-dlm`. Recipe generated with `conda_r_skeleton_helper`.

NB: v1 R recipe is pending standardization, so continuing with v0.

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
