### PR TITLE
Add perix

### DIFF
--- a/recipes/perix/check_poisson.py
+++ b/recipes/perix/check_poisson.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+
+
+def values(element):
+    return [float(value) for value in (element.text or "").split()]
+
+
+def main():
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: check_poisson.py LOG PD_RESULTS_VTU")
+
+    log = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+    required_messages = (
+        "assembly: openmp",
+        "backend=Pardiso",
+        "Static solve is done",
+    )
+    for message in required_messages:
+        if message not in log:
+            raise RuntimeError(f"missing runtime evidence: {message}")
+    if "boundary-ghost DoF rows carry no boundary condition" in log:
+        raise RuntimeError("the package test left a boundary-ghost row unconstrained")
+
+    root = ET.parse(sys.argv[2]).getroot()
+    point_values = root.find(".//PointData/DataArray[@Name='u']")
+    point_coordinates = root.find(".//Points/DataArray")
+    if point_values is None or point_coordinates is None:
+        raise RuntimeError("the PD result does not contain u values and coordinates")
+
+    solution = values(point_values)
+    coordinates = values(point_coordinates)
+    if len(coordinates) != 3 * len(solution):
+        raise RuntimeError("the VTU point and solution counts are inconsistent")
+
+    max_error = max(
+        abs(value - coordinates[3 * point])
+        for point, value in enumerate(solution)
+    )
+    print(f"max |u-x| = {max_error:.3e}")
+    if max_error > 1.0e-10:
+        raise RuntimeError("the packaged PARDISO solve failed the u=x oracle")
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/perix/poisson_pardiso.json
+++ b/recipes/perix/poisson_pardiso.json
@@ -1,0 +1,59 @@
+{
+  "Mesh": {
+    "type": "perix",
+    "dim": 2,
+    "xmax": 1.0,
+    "ymax": 1.0,
+    "nx": 12,
+    "ny": 12,
+    "meshtype": "quad4",
+    "savemesh": false
+  },
+  "PDMesh": {
+    "HorizonRadiusFactor": 2.5,
+    "Order": 2
+  },
+  "DOFs": ["u"],
+  "ElmtSystem": {
+    "poisson": {
+      "type": "poisson",
+      "params": {
+        "sigma": 1.0,
+        "f": 0.0
+      }
+    }
+  },
+  "BCSystem": {
+    "left": {
+      "type": "dirichlet",
+      "phygroup": "leftnodes_ghost",
+      "dofs": ["u"],
+      "value": 0.0
+    },
+    "right": {
+      "type": "dirichlet",
+      "phygroup": "rightnodes_ghost",
+      "dofs": ["u"],
+      "value": 1.0
+    },
+    "bottom": {
+      "type": "neumann",
+      "phygroup": "bottomnodes_ghost",
+      "dofs": ["u"],
+      "value": 0.0
+    },
+    "top": {
+      "type": "neumann",
+      "phygroup": "topnodes_ghost",
+      "dofs": ["u"],
+      "value": 0.0
+    }
+  },
+  "JobSystem": {
+    "type": "static",
+    "assemble": "openmp"
+  },
+  "LinearSolver": {
+    "type": "pardiso"
+  }
+}

--- a/recipes/perix/recipe.yaml
+++ b/recipes/perix/recipe.yaml
@@ -1,0 +1,76 @@
+context:
+  version: "0.1.1"
+
+package:
+  name: perix
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/MatMechLab/PeriX/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: b8767043d8d005493e686214042832029b6fcb861d91d19fa9d8348d56fc2349
+  - url: https://gitlab.com/libeigen/eigen/-/raw/5.0.1/COPYING.MPL2
+    sha256: 66a3107d5ad6a058aab753eaac2047ccb2ed0e39465dd0fe5844da3e300d5172
+    file_name: COPYING.MPL2
+    target_directory: vendor-licenses
+  - url: https://raw.githubusercontent.com/nlohmann/json/v3.12.0/LICENSE.MIT
+    sha256: 46a65cffd1ea955132d95a8dd921640714a8d6b537d2e4e482d31145ae95b603
+    file_name: LICENSE.MIT
+    target_directory: vendor-licenses
+
+build:
+  number: 0
+  skip:
+    - not (linux and x86_64)
+  script:
+    - cmake ${CMAKE_ARGS} -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DBUILD_TESTING=ON -DPARALLEL_ASSEMBLE=ON -DUSE_ONEAPI=ON -DONEAPI_DIR=${PREFIX} -DUSE_AMGCL=OFF -DCUDA_ASSEMBLE=OFF -DUSE_CUDSS=OFF
+    - cmake --build build --parallel ${CPU_COUNT}
+    - ctest --test-dir build --output-on-failure --parallel 1
+    - cmake --install build
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  host:
+    - libgomp
+    - llvm-openmp
+    - mkl-devel
+  run:
+    - mkl
+
+tests:
+  - files:
+      recipe:
+        - check_poisson.py
+        - poisson_pardiso.json
+    requirements:
+      run:
+        - python
+    script:
+      - test -x "${PREFIX}/bin/perix"
+      - test -f "${PREFIX}/share/perix/examples/poisson.json"
+      - test -f "${PREFIX}/share/doc/PeriX/PeriXManual.pdf"
+      - test -f "${PREFIX}/share/doc/PeriX/licenses/LICENSE"
+      - OMP_NUM_THREADS=2 MKL_NUM_THREADS=2 perix -i poisson_pardiso.json > perix.log
+      - python check_poisson.py perix.log poisson_pardiso-PD-results.vtu
+
+about:
+  homepage: https://github.com/MatMechLab/PeriX
+  repository: https://github.com/MatMechLab/PeriX
+  documentation: https://github.com/MatMechLab/PeriX/blob/v${{ version }}/documents/PeriXManual.pdf
+  license: GPL-3.0-only AND MPL-2.0 AND MIT
+  license_file:
+    - LICENSE
+    - vendor-licenses/COPYING.MPL2
+    - vendor-licenses/LICENSE.MIT
+  summary: Peridynamics framework for multiphysics simulation
+  description: |
+    PeriX is a C++20 peridynamics framework for multiphysics simulation.
+    This package enables the OpenMP assembly backend and Intel oneAPI MKL
+    PARDISO solver. AMGCL, CUDA assembly, and cuDSS are not included.
+
+extra:
+  recipe-maintainers:
+    - yangbai90

--- a/recipes/perix/recipe.yaml
+++ b/recipes/perix/recipe.yaml
@@ -1,21 +1,13 @@
 context:
-  version: "0.1.1"
+  version: "0.1.2"
 
 package:
   name: perix
   version: ${{ version }}
 
 source:
-  - url: https://github.com/MatMechLab/PeriX/archive/refs/tags/v${{ version }}.tar.gz
-    sha256: b8767043d8d005493e686214042832029b6fcb861d91d19fa9d8348d56fc2349
-  - url: https://gitlab.com/libeigen/eigen/-/raw/5.0.1/COPYING.MPL2
-    sha256: 66a3107d5ad6a058aab753eaac2047ccb2ed0e39465dd0fe5844da3e300d5172
-    file_name: COPYING.MPL2
-    target_directory: vendor-licenses
-  - url: https://raw.githubusercontent.com/nlohmann/json/v3.12.0/LICENSE.MIT
-    sha256: 46a65cffd1ea955132d95a8dd921640714a8d6b537d2e4e482d31145ae95b603
-    file_name: LICENSE.MIT
-    target_directory: vendor-licenses
+  url: https://github.com/MatMechLab/PeriX/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 03212c5150372af02b68a77b07125ac3fcb3e2fe6a75f5faec8cb37c488baf12
 
 build:
   number: 0
@@ -34,9 +26,11 @@ requirements:
     - cmake
     - ninja
   host:
+    - eigen >=5.0.1
     - libgomp
     - llvm-openmp
     - mkl-devel
+    - nlohmann_json >=3.12.0
   run:
     - mkl
 
@@ -60,11 +54,8 @@ about:
   homepage: https://github.com/MatMechLab/PeriX
   repository: https://github.com/MatMechLab/PeriX
   documentation: https://github.com/MatMechLab/PeriX/blob/v${{ version }}/documents/PeriXManual.pdf
-  license: GPL-3.0-only AND MPL-2.0 AND MIT
-  license_file:
-    - LICENSE
-    - vendor-licenses/COPYING.MPL2
-    - vendor-licenses/LICENSE.MIT
+  license: GPL-3.0-only
+  license_file: LICENSE
   summary: Peridynamics framework for multiphysics simulation
   description: |
     PeriX is a C++20 peridynamics framework for multiphysics simulation.

--- a/recipes/perix/recipe.yaml
+++ b/recipes/perix/recipe.yaml
@@ -27,7 +27,6 @@ requirements:
     - ninja
   host:
     - eigen >=5.0.1
-    - libgomp
     - llvm-openmp
     - mkl-devel
     - nlohmann_json >=3.12.0

--- a/recipes/perix/recipe.yaml
+++ b/recipes/perix/recipe.yaml
@@ -27,7 +27,7 @@ requirements:
     - ninja
   host:
     - eigen >=5.0.1
-    - llvm-openmp
+    - libgomp
     - mkl-devel
     - nlohmann_json >=3.12.0
 

--- a/recipes/perix/recipe.yaml
+++ b/recipes/perix/recipe.yaml
@@ -31,8 +31,6 @@ requirements:
     - llvm-openmp
     - mkl-devel
     - nlohmann_json >=3.12.0
-  run:
-    - mkl
 
 tests:
   - files:

--- a/recipes/perix/recipe.yaml
+++ b/recipes/perix/recipe.yaml
@@ -27,7 +27,9 @@ requirements:
     - ninja
   host:
     - eigen >=5.0.1
-    - libgomp
+    - if: linux
+      then: libgomp
+      else: llvm-openmp
     - mkl-devel
     - nlohmann_json >=3.12.0
 


### PR DESCRIPTION
## Summary

Add the initial conda-forge recipe for [PeriX](https://github.com/MatMechLab/PeriX), a C++20 peridynamics framework for multiphysics simulation.

The Linux x86_64 package:

- enables OpenMP assembly;
- enables Intel oneAPI MKL PARDISO;
- disables AMGCL, CUDA assembly, and cuDSS;
- installs the executable, examples, manual, and license;
- runs all upstream CTests and an installed-package PARDISO Poisson solve with an analytical solution check.

PeriX v0.1.2 removes the vendored Eigen and nlohmann/json source trees. The upstream build now finds and links the standard `Eigen3::Eigen` and `nlohmann_json::nlohmann_json` CMake targets, and this recipe supplies them from conda-forge as host dependencies.

## Local verification

- `conda-smithy recipe-lint --conda-forge recipes/perix`: passed
- v1 recipe rendering with current conda-forge pinning: passed
- full local recipe build with conda-forge GCC 16, Eigen 5.0.1, nlohmann-json 3.12.0, and MKL 2026.1: passed
- upstream CTest suite: 27/27 passed
- isolated installed-package PARDISO/OpenMP test: passed
- numerical oracle: `max |u-x| = 1.110e-16`
- isolated runtime linkage: MKL and OpenMP resolve from the conda environment

## Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] PeriX's GPL-3.0-only license file is packaged.
- [x] Source is the official [v0.1.2 release tarball](https://github.com/MatMechLab/PeriX/releases/tag/v0.1.2).
- [x] Eigen and nlohmann-json are unvendored and supplied by conda-forge packages.
- [x] No external static library is linked or shipped.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A release tarball URL is used.
- [x] I am `yangbai90` and confirm that I am willing to be listed as a recipe maintainer.
- [x] The conda-forge knowledge base was consulted for the Linux OpenMP provider configuration.

## Limitations

This initial recipe is Linux x86_64 only. AMGCL, CUDA assembly, and cuDSS are intentionally not included.
