### PR TITLE
Add jamica

### DIFF
--- a/recipes/jamica/recipe.yaml
+++ b/recipes/jamica/recipe.yaml
@@ -21,17 +21,10 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - setuptools >=77.0
-    - wheel
   run:
     - python >=${{ python_min }}
     - numpy >=1.21
     - scipy >=1.7
-  # NOTE: the old `amica` recipe carried
-  #     run_constraints:
-  #       - amica-python <0.0a0
-  # because both packages installed a top-level `amica` module and clobbered
-  # each other. Under the `jamica` module name they share no paths, so the
-  # constraint is deliberately dropped -- the two can now coexist.
 
 tests:
   - python:

--- a/recipes/jamica/recipe.yaml
+++ b/recipes/jamica/recipe.yaml
@@ -1,0 +1,67 @@
+schema_version: 1
+
+context:
+  version: "0.2.0"
+
+package:
+  name: jamica
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/j/jamica/jamica-${{ version }}.tar.gz
+  sha256: 3845127d84895949cf6dd252b548a6fb39bd0cdbbe651c40891aa242ef302f2d
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77.0
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.21
+    - scipy >=1.7
+  # NOTE: the old `amica` recipe carried
+  #     run_constraints:
+  #       - amica-python <0.0a0
+  # because both packages installed a top-level `amica` module and clobbered
+  # each other. Under the `jamica` module name they share no paths, so the
+  # constraint is deliberately dropped -- the two can now coexist.
+
+tests:
+  - python:
+      imports:
+        - jamica
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+
+about:
+  homepage: https://github.com/snesmaeili/jamica
+  repository: https://github.com/snesmaeili/jamica
+  documentation: https://snesmaeili.github.io/jamica/
+  summary: Native Python implementation of AMICA for MNE-Python and scientific EEG workflows.
+  description: |
+    jamica is a native Python implementation of AMICA (Adaptive Mixture
+    Independent Component Analysis), an ICA algorithm used for EEG source
+    separation. The canonical implementation is a Fortran program from UCSD,
+    usually driven from MATLAB or EEGLAB; this package provides an open,
+    extensible Python implementation that integrates with MNE-Python and offers
+    an optional JAX backend for CPU and GPU acceleration.
+
+    Released as `amica` through version 0.1.0 and renamed to `jamica` at 0.2.0.
+
+    JAX, MNE-Python, MNE-ICALabel and matplotlib are optional at runtime and are
+    not installed by default. For acceleration, install jax alongside jamica.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - snesmaeili


### PR DESCRIPTION
Adds `jamica` — a native Python/JAX implementation of AMICA (Adaptive Mixture Independent Component Analysis) for EEG source separation, integrating with MNE-Python.

- Source: https://github.com/snesmaeili/jamica
- PyPI: https://pypi.org/project/jamica/0.2.0/
- License: BSD-3-Clause
- noarch: python, pure Python, runtime deps are numpy and scipy only

### Note for reviewers: this supersedes an existing feedstock

This package is currently on conda-forge as [`amica`](https://anaconda.org/conda-forge/amica) ([feedstock](https://github.com/conda-forge/amica-feedstock)), which I maintain. Upstream renamed the distribution and import module from `amica` to `jamica` at version 0.2.0, so this is a new recipe rather than a version bump.

The rename exists to resolve a namespace collision. The old name installed a top-level `amica` module, which is also what the unrelated `amica-python` distribution (a different author's implementation of the same algorithm) installs. The two clobbered each other, which is why the current `amica` recipe carries:

```yaml
run_constraints:
  - amica-python <0.0a0
```

Under the `jamica` module name the two packages share no paths — verified in a clean environment, 0 overlapping files between the two distributions — so **`run_constraints` is deliberately omitted here** and the two can be co-installed.

Once `jamica-feedstock` is up, I'll open the usual `admin-requests` PR to archive `amica-feedstock`.

Checklist:

- [x] Title of this PR is "Add jamica"
- [x] License file is packaged (`license_file: LICENSE`)
- [x] Source is from an official source (PyPI sdist, sha256 pinned)
- [x] Package is not already in conda-forge under this name
- [x] All dependencies are already available in conda-forge