### PR TITLE
Add maxwelllink package for self-consistent light-matter simulations

### DIFF
--- a/recipes/maxwelllink/recipe.yaml
+++ b/recipes/maxwelllink/recipe.yaml
@@ -1,0 +1,73 @@
+schema_version: 1
+
+context:
+  version: "0.4.1"
+
+package:
+  name: maxwelllink
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/m/maxwelllink/maxwelllink-${{ version }}.tar.gz
+  sha256: d812bd479e05a07ad1da0dc1a4c988fd2e9947e9b1737fbf522ac554b4622fce
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - mxl = maxwelllink.cli.mxl:main
+      - mxl-clean = maxwelllink.cli.mxl_clean:mxl_clean_main
+      - mxl-init = maxwelllink.cli.mxl_init:mxl_init_main
+      - mxl_bridge = maxwelllink.sockets.aggregated:mxl_bridge_main
+      - mxl_driver = maxwelllink.mxl_drivers.python.mxl_driver:mxl_driver_main
+      - mxl_driver.py = maxwelllink.mxl_drivers.python.mxl_driver:mxl_driver_main
+      - mxl_install_lammps = maxwelllink.mxl_drivers.lammps.install:mxl_lammps_main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=68
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.24
+    - scipy >=1.10
+    - cmake >=3.18
+    - requests >=2.31
+
+tests:
+  - python:
+      imports:
+        - maxwelllink
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      # Conda's cmake package supplies the required executable but no Python
+      # distribution metadata that pip can recognize.
+      pip_check: false
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - python -c "import numpy, requests, scipy"
+      - cmake --version
+      - mxl --help
+      - mxl_driver --help
+
+about:
+  homepage: https://github.com/TaoELi/MaxwellLink
+  summary: A unified framework for self-consistent light-matter simulations
+  description: |
+    MaxwellLink couples classical electromagnetic solvers to external molecular
+    drivers through a modular socket interface.
+  license: GPL-2.0-only
+  license_file: LICENSE
+  documentation: https://taoeli.github.io/MaxwellLink
+  repository: https://github.com/TaoELi/MaxwellLink
+
+extra:
+  recipe-maintainers:
+    - TaoELi


### PR DESCRIPTION
MaxwellLink is a modular Python framework for self-consistent light-matter simulations. It connects electromagnetic solvers to a wide range of molecular drivers, from multilevel open quantum systems to first-principles molecular dynamics. 

MaxwellLink is described in [arXiv:2512.06173](https://arxiv.org/abs/2512.06173) and a recent application of this package is available at [arXiv:2606.27463](https://arxiv.org/abs/2606.27463).
 
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

This recipe builds MaxwellLink 0.4.1 from its PyPI source distribution.