### PR TITLE
Adding ri-kernels

### DIFF
--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -96,6 +96,13 @@ requirements:
         # symbols out of the dynamic table, so XLA's own runtime cannot
         # interpose them via the global scope.
         - cuda-cudart-static
+  ignore_run_exports:
+    by_name:
+      # CUDA::cudart_static embeds the runtime in libri_kernels_cuda.so, so
+      # cuda-cudart-dev's shared-runtime export is not a runtime dependency.
+      # Keep the CUDA compiler's cuda-version export, which records toolkit
+      # compatibility independently of how cudart itself is linked.
+      - cuda-cudart
   run:
     - python
     - jax >=${{ jaxlib_min }}

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -49,6 +49,22 @@ build:
       # is the build-prefix interpreter (wrong headers) when cross compiling.
       export SKBUILD_CMAKE_DEFINE="RI_KERNELS_BUNDLED_HIGHWAY=OFF;JAXLIB_HOME=${SP_DIR}/jaxlib"
 
+      # CMakeLists.txt defaults CMAKE_CUDA_ARCHITECTURES to a narrow 75/80/90
+      # list, but as a non-FORCE cache entry, so -D on the command line wins.
+      # conda-forge's nvcc activation exports CUDAARCHS covering every
+      # architecture the toolkit supports (sm_50..sm_121 for CUDA 12.9, plus
+      # 121-virtual PTX so anything newer still runs), which is what a
+      # redistributable build wants. Left alone when CUDAARCHS is unset, so the
+      # CPU variant and non-conda builds keep upstream's default.
+      #
+      # This goes through CMAKE_ARGS rather than SKBUILD_CMAKE_DEFINE because
+      # the latter is itself semicolon-separated and offers no way to escape a
+      # semicolon inside a value -- scikit-build-core splits the architecture
+      # list and then fails on the fragments.
+      if [ -n "${CUDAARCHS:-}" ]; then
+        export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CUDA_ARCHITECTURES=${CUDAARCHS}"
+      fi
+
       $PYTHON -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -131,3 +147,4 @@ about:
 extra:
   recipe-maintainers:
     - chrisfinlay
+    - AdhocMan

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.2.0"
+  version: "0.2.1"
   build: 0
   # The kernels compile against the XLA FFI headers that ship inside jaxlib,
   # and that ABI is only backward compatible: a library built against jaxlib X
@@ -18,7 +18,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/r/ri_kernels/ri_kernels-${{ version }}.tar.gz
-  sha256: 367ae12c1bf165c4c4266fee342d7a7ea5bf4f3eebc4f8116c39156ffcf3f01c
+  sha256: 92d4b633c454cec517fd268385d454ef6db1016cb01ead8fcc8a34edaaddb587
 
 build:
   number: ${{ build if cuda_compiler_version == "None" else build + 200 }}
@@ -48,6 +48,13 @@ build:
       # shells out to whatever `python3` is first on PATH to locate it, which
       # is the build-prefix interpreter (wrong headers) when cross compiling.
       export SKBUILD_CMAKE_DEFINE="RI_KERNELS_BUNDLED_HIGHWAY=OFF;JAXLIB_HOME=${SP_DIR}/jaxlib"
+
+      # PyPI wheels retain upstream's static cudart default for self-contained
+      # installs. Conda supplies shared CUDA libraries as managed dependencies,
+      # so let cuda-cudart-dev's run export provide the matching runtime.
+      if [ "${RI_KERNELS_CUDA}" = "1" ]; then
+        export SKBUILD_CMAKE_DEFINE="${SKBUILD_CMAKE_DEFINE};RI_KERNELS_STATIC_CUDART=OFF"
+      fi
 
       # CMakeLists.txt defaults CMAKE_CUDA_ARCHITECTURES to a narrow 75/80/90
       # list, but as a non-FORCE cache entry, so -D on the command line wins.
@@ -92,17 +99,6 @@ requirements:
       then:
         - cuda-version ${{ cuda_compiler_version }}.*
         - cuda-cudart-dev
-        # CUDA::cudart_static -- linking the runtime statically keeps the CUDA
-        # symbols out of the dynamic table, so XLA's own runtime cannot
-        # interpose them via the global scope.
-        - cuda-cudart-static
-  ignore_run_exports:
-    by_name:
-      # CUDA::cudart_static embeds the runtime in libri_kernels_cuda.so, so
-      # cuda-cudart-dev's shared-runtime export is not a runtime dependency.
-      # Keep the CUDA compiler's cuda-version export, which records toolkit
-      # compatibility independently of how cudart itself is linked.
-      - cuda-cudart
   run:
     - python
     - jax >=${{ jaxlib_min }}

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -18,7 +18,7 @@ source:
 build:
   number: ${{ build if cuda_compiler_version == "None" else build + 200 }}
   string: ${{ "cpu" if cuda_compiler_version == "None" else "cuda" + (cuda_compiler_version | replace('.', '')) }}_py${{ python | version_to_buildstring }}h${{ hash }}_${{ build if cuda_compiler_version == "None" else build + 200 }}
-  skip: win
+  skip: win or cuda_compiler_version == "13.0"
   dynamic_linking:
     # macOS reports the dylib's own LC_ID_DYLIB as a missing dependency.
     missing_dso_allowlist:

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -3,13 +3,8 @@ schema_version: 1
 context:
   version: "0.2.1"
   build: 0
-  # The kernels compile against the XLA FFI headers that ship inside jaxlib,
-  # and that ABI is only backward compatible: a library built against jaxlib X
-  # loads fine on any newer XLA runtime, but aborts the interpreter outright
-  # (silent SIGABRT, no Python traceback) on an older one. So build against the
-  # floor upstream declares in pyproject.toml -- jax >=0.6.0, built with
-  # jax==0.6.0 -- and let the run requirement state that same floor. Bumping
-  # this raises the minimum jax users can install, so keep the two in step.
+  # XLA's FFI ABI is backward compatible, so build against the minimum jaxlib
+  # supported upstream and use the same floor at runtime.
   jaxlib_min: "0.6.0"
 
 package:
@@ -23,51 +18,24 @@ source:
 build:
   number: ${{ build if cuda_compiler_version == "None" else build + 200 }}
   string: ${{ "cpu" if cuda_compiler_version == "None" else "cuda" + (cuda_compiler_version | replace('.', '')) }}_py${{ python | version_to_buildstring }}h${{ hash }}_${{ build if cuda_compiler_version == "None" else build + 200 }}
-  # The loader in ri_kernels/jax_api/rfi_vis_op.py dlopens `libri_kernels.so`
-  # by that exact name, and upstream publishes no Windows wheels.
   skip: win
   dynamic_linking:
-    # Every macOS dylib names itself in LC_ID_DYLIB, and otool reports that as
-    # a dependency. Here it is `@rpath/libri_kernels.so`, which resolves
-    # against nothing because the library ships in site-packages rather than
-    # lib/ -- it is loaded by absolute path via ctypes, never through an rpath.
-    # The reference is to itself, so there is nothing to satisfy.
+    # macOS reports the dylib's own LC_ID_DYLIB as a missing dependency.
     missing_dso_allowlist:
       - "@rpath/libri_kernels.so"
   script:
     env:
-      # pyproject.toml turns this into -DRI_KERNELS_CUDA=ON through a
-      # scikit-build-core `overrides` entry keyed on the environment.
       RI_KERNELS_CUDA: ${{ "1" if cuda_compiler_version != "None" else "0" }}
     content: |
-      # CMakeLists.txt fetches Google Highway with FetchContent by default,
-      # which needs network access at configure time. Use conda-forge's libhwy
-      # instead -- it is the same 1.4.0 release that FetchContent would pull.
-      #
-      # JAXLIB_HOME is passed explicitly because CMakeLists.txt otherwise
-      # shells out to whatever `python3` is first on PATH to locate it, which
-      # is the build-prefix interpreter (wrong headers) when cross compiling.
+      # Disable network fetching and locate the target jaxlib when cross compiling.
       export SKBUILD_CMAKE_DEFINE="RI_KERNELS_BUNDLED_HIGHWAY=OFF;JAXLIB_HOME=${SP_DIR}/jaxlib"
 
-      # PyPI wheels retain upstream's static cudart default for self-contained
-      # installs. Conda supplies shared CUDA libraries as managed dependencies,
-      # so let cuda-cudart-dev's run export provide the matching runtime.
+      # Conda supplies cudart as a managed shared runtime dependency.
       if [ "${RI_KERNELS_CUDA}" = "1" ]; then
         export SKBUILD_CMAKE_DEFINE="${SKBUILD_CMAKE_DEFINE};RI_KERNELS_STATIC_CUDART=OFF"
       fi
 
-      # CMakeLists.txt defaults CMAKE_CUDA_ARCHITECTURES to a narrow 75/80/90
-      # list, but as a non-FORCE cache entry, so -D on the command line wins.
-      # conda-forge's nvcc activation exports CUDAARCHS covering every
-      # architecture the toolkit supports (sm_50..sm_121 for CUDA 12.9, plus
-      # 121-virtual PTX so anything newer still runs), which is what a
-      # redistributable build wants. Left alone when CUDAARCHS is unset, so the
-      # CPU variant and non-conda builds keep upstream's default.
-      #
-      # This goes through CMAKE_ARGS rather than SKBUILD_CMAKE_DEFINE because
-      # the latter is itself semicolon-separated and offers no way to escape a
-      # semicolon inside a value -- scikit-build-core splits the architecture
-      # list and then fails on the fragments.
+      # CUDAARCHS is supplied by conda-forge's nvcc activation and includes PTX.
       if [ -n "${CUDAARCHS:-}" ]; then
         export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_CUDA_ARCHITECTURES=${CUDAARCHS}"
       fi
@@ -91,8 +59,7 @@ requirements:
     - python
     - pip
     - scikit-build-core >=0.10
-    # Headers only -- nothing links against jaxlib, the FFI entry points are
-    # dlopened by XLA at run time. See the jaxlib_min note above.
+    # Header-only build dependency; XLA loads the FFI entry points at runtime.
     - jaxlib ==${{ jaxlib_min }}
     - libhwy
     - if: cuda_compiler_version != "None"
@@ -105,9 +72,6 @@ requirements:
     - if: cuda_compiler_version != "None"
       then:
         - __cuda
-        # A CUDA build of the kernels is only useful next to a CUDA-enabled
-        # jax; without this the GPU kernels register but XLA never has a CUDA
-        # device to dispatch them to, which fails silently as "no speedup".
         - jaxlib * cuda*
 
 tests:
@@ -116,9 +80,6 @@ tests:
         - ri_kernels
         - ri_kernels.jax_api
       pip_check: true
-  # The import test above only proves the package resolves. This one proves the
-  # shared library was found, dlopened, and registered with XLA as a working
-  # FFI target, which is the entire point of the package.
   - script:
       - pytest -v tests
     requirements:

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -25,6 +25,7 @@ build:
       - "@rpath/libri_kernels.so"
   script:
     env:
+      CMAKE_GENERATOR: Ninja
       RI_KERNELS_CUDA: ${{ "1" if cuda_compiler_version != "None" else "0" }}
     content: |
       # Disable network fetching and locate the target jaxlib when cross compiling.

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+
+context:
+  version: "0.2.0"
+  build: 0
+  # The kernels compile against the XLA FFI headers that ship inside jaxlib,
+  # and that ABI is only backward compatible: a library built against jaxlib X
+  # loads fine on any newer XLA runtime, but aborts the interpreter outright
+  # (silent SIGABRT, no Python traceback) on an older one. So build against the
+  # floor upstream declares in pyproject.toml -- jax >=0.6.0, built with
+  # jax==0.6.0 -- and let the run requirement state that same floor. Bumping
+  # this raises the minimum jax users can install, so keep the two in step.
+  jaxlib_min: "0.6.0"
+
+package:
+  name: ri-kernels
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/ri_kernels/ri_kernels-${{ version }}.tar.gz
+  sha256: 367ae12c1bf165c4c4266fee342d7a7ea5bf4f3eebc4f8116c39156ffcf3f01c
+
+build:
+  number: ${{ build if cuda_compiler_version == "None" else build + 200 }}
+  string: ${{ "cpu" if cuda_compiler_version == "None" else "cuda" + (cuda_compiler_version | replace('.', '')) }}_py${{ python | version_to_buildstring }}h${{ hash }}_${{ build if cuda_compiler_version == "None" else build + 200 }}
+  # The loader in ri_kernels/jax_api/rfi_vis_op.py dlopens `libri_kernels.so`
+  # by that exact name, and upstream publishes no Windows wheels.
+  skip: win
+  dynamic_linking:
+    # Every macOS dylib names itself in LC_ID_DYLIB, and otool reports that as
+    # a dependency. Here it is `@rpath/libri_kernels.so`, which resolves
+    # against nothing because the library ships in site-packages rather than
+    # lib/ -- it is loaded by absolute path via ctypes, never through an rpath.
+    # The reference is to itself, so there is nothing to satisfy.
+    missing_dso_allowlist:
+      - "@rpath/libri_kernels.so"
+  script:
+    env:
+      # pyproject.toml turns this into -DRI_KERNELS_CUDA=ON through a
+      # scikit-build-core `overrides` entry keyed on the environment.
+      RI_KERNELS_CUDA: ${{ "1" if cuda_compiler_version != "None" else "0" }}
+    content: |
+      # CMakeLists.txt fetches Google Highway with FetchContent by default,
+      # which needs network access at configure time. Use conda-forge's libhwy
+      # instead -- it is the same 1.4.0 release that FetchContent would pull.
+      #
+      # JAXLIB_HOME is passed explicitly because CMakeLists.txt otherwise
+      # shells out to whatever `python3` is first on PATH to locate it, which
+      # is the build-prefix interpreter (wrong headers) when cross compiling.
+      export SKBUILD_CMAKE_DEFINE="RI_KERNELS_BUNDLED_HIGHWAY=OFF;JAXLIB_HOME=${SP_DIR}/jaxlib"
+
+      $PYTHON -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - if: cuda_compiler_version != "None"
+      then:
+        - ${{ compiler('cuda') }}
+    - cmake >=3.20
+    - ninja
+    - if: build_platform != host_platform
+      then:
+        - python
+        - cross-python_${{ host_platform }}
+  host:
+    - python
+    - pip
+    - scikit-build-core >=0.10
+    # Headers only -- nothing links against jaxlib, the FFI entry points are
+    # dlopened by XLA at run time. See the jaxlib_min note above.
+    - jaxlib ==${{ jaxlib_min }}
+    - libhwy
+    - if: cuda_compiler_version != "None"
+      then:
+        - cuda-version ${{ cuda_compiler_version }}.*
+        - cuda-cudart-dev
+        # CUDA::cudart_static -- linking the runtime statically keeps the CUDA
+        # symbols out of the dynamic table, so XLA's own runtime cannot
+        # interpose them via the global scope.
+        - cuda-cudart-static
+  run:
+    - python
+    - jax >=${{ jaxlib_min }}
+    - if: cuda_compiler_version != "None"
+      then:
+        - __cuda
+        # A CUDA build of the kernels is only useful next to a CUDA-enabled
+        # jax; without this the GPU kernels register but XLA never has a CUDA
+        # device to dispatch them to, which fails silently as "no speedup".
+        - jaxlib * cuda*
+
+tests:
+  - python:
+      imports:
+        - ri_kernels
+        - ri_kernels.jax_api
+      pip_check: true
+  # The import test above only proves the package resolves. This one proves the
+  # shared library was found, dlopened, and registered with XLA as a working
+  # FFI target, which is the entire point of the package.
+  - script:
+      - pytest -v tests
+    requirements:
+      run:
+        - pytest
+    files:
+      source:
+        - tests/
+
+about:
+  homepage: https://github.com/epfl-radio-astro/ri-kernels
+  repository: https://github.com/epfl-radio-astro/ri-kernels
+  summary: CPU and GPU kernels for radio interferometry, exposed to JAX as FFI custom calls
+  description: |
+    RI Kernels provides CPU and GPU compute kernels for radio interferometry,
+    exposed to JAX as FFI custom calls with full support for automatic
+    differentiation.
+
+    The CPU kernels use Google Highway for portable SIMD with run-time dispatch
+    across instruction sets. The CUDA kernels are built into the same package
+    and are selected automatically when a GPU is present.
+
+    The kernels back the RFI visibility calculations used by TABASCAL, a
+    Bayesian method for removing radio frequency interference from radio
+    interferometric observations.
+  license: GPL-3.0-only
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - chrisfinlay

--- a/recipes/ri-kernels/recipe.yaml
+++ b/recipes/ri-kernels/recipe.yaml
@@ -111,4 +111,3 @@ about:
 extra:
   recipe-maintainers:
     - chrisfinlay
-    - AdhocMan


### PR DESCRIPTION
## Summary

This adds `ri-kernels` 0.2.1, a Python/C++/CUDA package exposing radio-interferometry kernels to JAX through XLA FFI.

- v1 recipe built from the official PyPI sdist
- CPU variants on Linux and macOS
- CUDA 12.9 variant with conda-managed shared `cudart`
- CUDA requires a matching CUDA-enabled `jaxlib`
- upstream test suite included as a package test

The CUDA 12.9 aarch64 package was also built outside CI and tested on four NVIDIA GH200 GPUs: all 112 CPU/GPU tests passed, and the packaged CUDA library was verified to link dynamically to `libcudart.so.12`.

The base build number is 0. CUDA variants use the standard +200 offset so the solver prefers them when a CUDA-enabled environment is requested.

## Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License file is packaged.
- [x] Source is from the official PyPI sdist.
- [x] Package does not vendor other packages; bundled dependency fetching is disabled in favor of conda-forge's `libhwy`.
- [x] No third-party static libraries are linked; CUDA variants use shared `cudart`.
- [x] Package does not ship static libraries.
- [x] Base build number is 0.
- [x] A release tarball is used.
- [x] All listed maintainers have confirmed willingness to maintain the feedstock.
- [x] The conda-forge knowledge base and recent accepted compiled/CUDA recipes were reviewed.
