### PR TITLE
Adding speedups

### DIFF
--- a/recipes/speedups/recipe.yaml
+++ b/recipes/speedups/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "2.3.1"
+  version: "2.3.2"
 
 package:
   name: speedups
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/s/speedups/speedups-${{ version }}.tar.gz
-  sha256: ca08c674fba55e3d000cf87b4413155917602aa51fbff8008067840b25a6c877
+  sha256: 3d49636f23faf73836a0f100580d2b6321292709af438831c895f512e9cfb52e
 
 build:
   number: 0

--- a/recipes/speedups/recipe.yaml
+++ b/recipes/speedups/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "2.3.2"
+  version: "2.3.3"
 
 package:
   name: speedups
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/s/speedups/speedups-${{ version }}.tar.gz
-  sha256: 3d49636f23faf73836a0f100580d2b6321292709af438831c895f512e9cfb52e
+  sha256: 1ae20adda8ba8d52355595750c021ce5c87f1ccf921399653bbe0d73f17a37bc
 
 build:
   number: 0

--- a/recipes/speedups/recipe.yaml
+++ b/recipes/speedups/recipe.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:

--- a/recipes/speedups/recipe.yaml
+++ b/recipes/speedups/recipe.yaml
@@ -1,0 +1,64 @@
+context:
+  version: "2.3.1"
+
+package:
+  name: speedups
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/speedups/speedups-${{ version }}.tar.gz
+  sha256: ca08c674fba55e3d000cf87b4413155917602aa51fbff8008067840b25a6c877
+
+build:
+  number: 0
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - pip
+    - setuptools >=75
+    - wheel
+    - cython >=3.0.8
+    - numpy
+  run:
+    - python
+    - numpy >=1.23.5
+
+tests:
+  - python:
+      imports:
+        - speedups
+        - speedups.stl
+        - speedups.psycopg_array
+        - speedups.progressbar
+      pip_check: true
+  - files:
+      source:
+        - tests/
+    requirements:
+      run:
+        - pytest >=8
+    script:
+      - python -m pytest tests --ignore=tests/test_arrays.py --import-mode=importlib -q
+
+about:
+  homepage: https://github.com/wolph/speedups
+  repository: https://github.com/wolph/speedups
+  summary: C/Cython extensions for fast STL I/O (used by numpy-stl) and PostgreSQL-to-NumPy conversion
+  license: BSD-3-Clause AND Apache-2.0
+  # LICENSE-APACHE covers hton.h, vendored from MagicStack/py-pgproto.
+  license_file:
+    - LICENSE
+    - LICENSE-APACHE
+  description: |
+    C and Cython extensions for fast ASCII STL read and write (about 3x
+    faster than pure Python, used by numpy-stl) and PostgreSQL binary
+    array to NumPy conversion for psycopg.
+
+extra:
+  recipe-maintainers:
+    - wolph


### PR DESCRIPTION
Adds [speedups](https://github.com/wolph/speedups): C and Cython extensions for fast ASCII STL I/O (used by [numpy-stl](https://github.com/wolph/numpy-stl)) and PostgreSQL binary array to NumPy conversion for psycopg. On PyPI as [speedups](https://pypi.org/project/speedups/), BSD-3-Clause, I am the upstream author and maintainer. I've placed these optional speedups in a separate package because maintaining a binary package for dozens of platforms is a bit of a pain. This way I only have 1 binary package to maintain and my other packages can import it if available.

License note: the source vendors a single header (`hton.h`, byte-order helpers) from [MagicStack/py-pgproto](https://github.com/MagicStack/py-pgproto) which is Apache-2.0. The license expression is therefore `BSD-3-Clause AND Apache-2.0` and the sdist ships both license texts (`LICENSE`, `LICENSE-APACHE`).

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged). *One vendored header from py-pgproto; its Apache-2.0 license is packaged, see note above.*
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. *Sole maintainer is me (@wolph, PR author).*
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
