### PR TITLE
Add unimpeded

### DIFF
--- a/recipes/unimpeded/recipe.yaml
+++ b/recipes/unimpeded/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "1.2.6"
+  version: "1.2.7"
 
 package:
   name: unimpeded
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/u/unimpeded/unimpeded-${{ version }}.tar.gz
-  sha256: 5cbff55c2854f8ca4379bd266be35937eb32816643956aa4aa1a06abc515765a
+  sha256: 2eb8d1ec19739dc1bd40ce05a9306427794a30cf80249eb79a094d87a85bf735
 
 build:
   number: 0
@@ -30,6 +30,8 @@ requirements:
     - requests
     - anesthetic
     - pyyaml
+    - numpy
+    - scipy
 
 tests:
   - python:

--- a/recipes/unimpeded/recipe.yaml
+++ b/recipes/unimpeded/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "1.2.6"
+  python_min: "3.10"
+
+package:
+  name: unimpeded
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/u/unimpeded/unimpeded-${{ version }}.tar.gz
+  sha256: 5cbff55c2854f8ca4379bd266be35937eb32816643956aa4aa1a06abc515765a
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  python:
+    entry_points:
+      - download-unimpeded-tutorial = unimpeded.cli:download_unimpeded_tutorial
+      - launch-unimpeded-tutorial = unimpeded.cli:launch_unimpeded_tutorial
+
+requirements:
+  host:
+    - python ${{ python_min }}
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - requests
+    - anesthetic
+    - pyyaml
+
+tests:
+  - python:
+      imports:
+        - unimpeded
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - download-unimpeded-tutorial --help
+      - launch-unimpeded-tutorial --help
+
+about:
+  homepage: https://github.com/handley-lab/unimpeded
+  summary: Universal model comparison & parameter estimation over diverse datasets
+  description: |
+    unimpeded provides access to a public database of pre-computed nested
+    sampling and MCMC chains for cosmological analysis, together with a
+    tension statistics calculator built on anesthetic. Chains are archived
+    on Zenodo with permanent DOIs and retrieved through the unimpeded API.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://unimpeded.readthedocs.io/
+  repository: https://github.com/handley-lab/unimpeded
+
+extra:
+  recipe-maintainers:
+    - DilyOng
+    - williamjameshandley

--- a/recipes/unimpeded/recipe.yaml
+++ b/recipes/unimpeded/recipe.yaml
@@ -1,6 +1,7 @@
+schema_version: 1
+
 context:
   version: "1.2.6"
-  python_min: "3.10"
 
 package:
   name: unimpeded
@@ -11,9 +12,9 @@ source:
   sha256: 5cbff55c2854f8ca4379bd266be35937eb32816643956aa4aa1a06abc515765a
 
 build:
-  noarch: python
-  script: python -m pip install . -vv --no-deps --no-build-isolation
   number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
   python:
     entry_points:
       - download-unimpeded-tutorial = unimpeded.cli:download_unimpeded_tutorial
@@ -21,7 +22,7 @@ build:
 
 requirements:
   host:
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - pip
     - setuptools
   run:
@@ -35,7 +36,9 @@ tests:
       imports:
         - unimpeded
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - download-unimpeded-tutorial --help
       - launch-unimpeded-tutorial --help

--- a/recipes/unimpeded/recipe.yaml
+++ b/recipes/unimpeded/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "1.2.7"
+  version: "1.2.8"
 
 package:
   name: unimpeded
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/u/unimpeded/unimpeded-${{ version }}.tar.gz
-  sha256: 2eb8d1ec19739dc1bd40ce05a9306427794a30cf80249eb79a094d87a85bf735
+  sha256: 7a63388699a84a42944676afd6634e218c98e7db95d6b142346fed141ea0b0bd
 
 build:
   number: 0
@@ -28,7 +28,7 @@ requirements:
   run:
     - python >=${{ python_min }}
     - requests
-    - anesthetic
+    - anesthetic >=2.11.0
     - pyyaml
     - numpy
     - scipy

--- a/recipes/unimpeded/recipe.yaml
+++ b/recipes/unimpeded/recipe.yaml
@@ -59,4 +59,3 @@ about:
 extra:
   recipe-maintainers:
     - DilyOng
-    - williamjameshandley


### PR DESCRIPTION
Adds `unimpeded`, a Python library providing access to a public database of pre-computed nested sampling and MCMC chains for cosmological analysis, with a tension statistics calculator built on `anesthetic`. Chains are archived on Zenodo with permanent DOIs.

- Source: https://github.com/handley-lab/unimpeded
- Docs: https://unimpeded.readthedocs.io/
- PyPI: https://pypi.org/project/unimpeded/

Submitted in the v1 (`recipe.yaml`) format.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

### Notes

`LICENSE` is included in the sdist and referenced via `about.license_file` (verified by unpacking `unimpeded-1.2.6.tar.gz`).

All runtime dependencies (`anesthetic`, `requests`, `pyyaml`) are already on conda-forge.

The package is pure Python (`noarch: python`). Its minimum is Python 3.10, inherited from `anesthetic`, and is declared as `requires-python = ">=3.10"` upstream.


---


**Maintainers:** the recipe now lists only @DilyOng, the submitting author and upstream maintainer. A second maintainer may be added in a follow-up PR once confirmed.
