### PR TITLE
Add csmith

### DIFF
--- a/recipes/csmith/0001-fix-FilterKind-enum-range.patch
+++ b/recipes/csmith/0001-fix-FilterKind-enum-range.patch
@@ -1,0 +1,29 @@
+From 11e6354aeb896df52f36d9a6dfec3f6ca18b266e Mon Sep 17 00:00:00 2001
+From: sendaoYan <yansendao.ysd@alibaba-inc.com>
+Date: Fri, 26 Jan 2024 16:45:36 +0800
+Subject: [PATCH] fix bugs: const MAX_FILTER_KIND_SIZE outside the valid range
+
+fix bugs: src/Filter.h:60:14: error: integer value 2 is outside the valid range of values [0, 1] for the enumeration type 'FilterKind' [-Wenum-constexpr-conversion]; https://github.com/csmith-project/csmith/issues/163
+
+Fixes: #163
+Signed-off-by: sendaoYan <yansendao.ysd@alibaba-inc.com>
+---
+ src/Filter.h | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/src/Filter.h b/src/Filter.h
+index 0482d8b48..a1600e95f 100644
+--- a/src/Filter.h
++++ b/src/Filter.h
+@@ -35,10 +35,9 @@
+ enum FilterKind {
+ 	fDefault,
+ 	fDFS,
++	MAX_FILTER_KIND_SIZE,
+ };
+ 
+-#define MAX_FILTER_KIND_SIZE ((FilterKind) (fDFS + 1))
+-
+ // Filter base class
+ class Filter
+ {

--- a/recipes/csmith/0002-skip-static-csmith-lib.patch
+++ b/recipes/csmith/0002-skip-static-csmith-lib.patch
@@ -1,0 +1,24 @@
+--- a/runtime/CMakeLists.txt
++++ b/runtime/CMakeLists.txt
+@@ -41,21 +41,6 @@
+ 
+ include_directories(${CMAKE_BINARY_DIR})
+ 
+-# Build and install the static library.
+-
+-add_library(libcsmith_a STATIC
+-  ${CMAKE_BINARY_DIR}/config.h
+-  volatile_runtime.c
+-  volatile_runtime.h
+-  )
+-set_target_properties(libcsmith_a PROPERTIES OUTPUT_NAME "csmith")
+-
+-install(TARGETS libcsmith_a
+-  ARCHIVE DESTINATION "${LIB_DIR}"
+-  )
+-
+-#####
+-
+ # Build and install the shared library.
+ 
+ add_library(libcsmith_so SHARED

--- a/recipes/csmith/0003-fix-msvc-x64-inline-asm.patch
+++ b/recipes/csmith/0003-fix-msvc-x64-inline-asm.patch
@@ -1,0 +1,25 @@
+From f4207b8314fa88f60b0e337055f15f3525d557cc Mon Sep 17 00:00:00 2001
+From: Joergen Ibsen <ji@ibse.dk>
+Date: Tue, 31 Oct 2017 09:59:29 +0100
+Subject: [PATCH] Fix preprocessor check for inline asm
+
+With MSVC inline asm is only available when compiling for x86.
+WIN32 is defined for all of x86, x64, and ARM. This checks for
+MSVC and x86 instead.
+---
+ src/platform.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/platform.cpp b/src/platform.cpp
+index 492053ae7..248ae6e26 100644
+--- a/src/platform.cpp
++++ b/src/platform.cpp
+@@ -64,7 +64,7 @@ static inline unsigned long read_time(void)
+ 	asm volatile("mftb %0" : "=r" (a));
+ 	return a;
+ }
+-#  elif defined(WIN32)
++#  elif defined(_MSC_VER) && defined(_M_IX86)
+ static unsigned __int64 read_time(void)
+ {
+ 	unsigned l, h;

--- a/recipes/csmith/0004-avoid-deprecated-bind2nd-ptr_fun.patch
+++ b/recipes/csmith/0004-avoid-deprecated-bind2nd-ptr_fun.patch
@@ -1,0 +1,65 @@
+From bc9c9774d47943cf51b1c9900198e89c7e526e1d Mon Sep 17 00:00:00 2001
+From: John Regehr <john.regehr@gmail.com>
+Date: Fri, 27 Feb 2026 14:11:16 -0700
+Subject: [PATCH] avoid some deprecated c++
+
+---
+ src/ProbabilityTable.h | 21 +++------------------
+ 1 file changed, 3 insertions(+), 18 deletions(-)
+
+diff --git a/src/ProbabilityTable.h b/src/ProbabilityTable.h
+index 76137013d..0f8f3a437 100644
+--- a/src/ProbabilityTable.h
++++ b/src/ProbabilityTable.h
+@@ -32,7 +32,6 @@
+ 
+ #include <vector>
+ #include <algorithm>
+-#include <functional>
+ #include <cassert>
+ #include "Probabilities.h"
+ #include "VectorFilter.h"
+@@ -107,20 +106,6 @@ void ProbabilityTable<Key, Value>::initialize(ProbName pname)
+ 	impl_->set_prob_table(this, pname);
+ }
+ 
+-template <class Key, class Value>
+-bool my_less(TableEntry<Key, Value> *t, Key k2)
+-{
+-	Key k1 = t->get_key();
+-	return (k1 < k2);
+-}
+-
+-template <class Key, class Value>
+-bool my_greater(TableEntry<Key, Value> *t, Key k2)
+-{
+-	Key k1 = t->get_key();
+-	return (k1 > k2);
+-}
+-
+ template <class Key, class Value>
+ void
+ ProbabilityTable<Key, Value>::sorted_insert(Entry *t)
+@@ -137,11 +122,10 @@ ProbabilityTable<Key, Value>::sorted_insert(Entry *t)
+ 
+ 	typename vector<Entry *>::iterator i;
+ 	for (i=table_.begin(); i!=table_.end(); i++) {
+-		if (my_greater<Key, Value>(*i, k)) {
++		if ((*i)->get_key() > k) {
+ 			break;
+ 		}
+ 	}
+-	//i = find_if(table_.begin(), table_.end(), std::bind2nd(std::ptr_fun(my_greater<Key, Value>), k));
+ 
+ 	if (i != table_.end()) {
+ 		table_.insert(i, t);
+@@ -167,7 +151,8 @@ ProbabilityTable<Key, Value>::get_value(Key k)
+ 	assert(k < curr_max_key_);
+ 
+ 	typename vector<Entry *>::iterator i;
+-	i = find_if(table_.begin(), table_.end(), std::bind2nd(std::ptr_fun(my_greater<Key, Value>), k));
++	i = find_if(table_.begin(), table_.end(),
++				[k](Entry *e) { return e->get_key() > k; });
+ 
+ 	assert(i != table_.end());
+ 	return (*i)->get_value();

--- a/recipes/csmith/0005-install-csmith-as-cmake-target.patch
+++ b/recipes/csmith/0005-install-csmith-as-cmake-target.patch
@@ -1,0 +1,13 @@
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -224,8 +224,8 @@
+   target_link_libraries(csmith "${BSD_LIBRARY}")
+ endif()
+ 
+-install(PROGRAMS
+-  "${PROJECT_BINARY_DIR}/csmith"
++install(TARGETS
++  csmith
+   DESTINATION "${BIN_DIR}"
+   )
+ 

--- a/recipes/csmith/recipe.yaml
+++ b/recipes/csmith/recipe.yaml
@@ -13,17 +13,21 @@ source:
     - 0001-fix-FilterKind-enum-range.patch
     # Static + shared both named csmith.lib on Windows. Also CFEP-18.
     - 0002-skip-static-csmith-lib.patch
+    # Upstream PR 52: MSVC inline asm is 32-bit only. Needed for win-64.
+    - 0003-fix-msvc-x64-inline-asm.patch
+    # Upstream bc9c977: drop std::bind2nd / ptr_fun in ProbabilityTable.h.
+    - 0004-avoid-deprecated-bind2nd-ptr_fun.patch
 
 build:
   number: 0
   script:
     - if: win
       then: |
-        cmake -G Ninja %CMAKE_ARGS% -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -S . -B build
+        cmake -G Ninja %CMAKE_ARGS% -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_STANDARD=14 -S . -B build
         cmake --build build --config Release
         cmake --install build --config Release
       else: |
-        cmake -G Ninja $CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -S . -B build
+        cmake -G Ninja $CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_STANDARD=14 -S . -B build
         cmake --build build --config Release
         cmake --install build --config Release
 

--- a/recipes/csmith/recipe.yaml
+++ b/recipes/csmith/recipe.yaml
@@ -17,6 +17,8 @@ source:
     - 0003-fix-msvc-x64-inline-asm.patch
     # Upstream bc9c977: drop std::bind2nd / ptr_fun in ProbabilityTable.h.
     - 0004-avoid-deprecated-bind2nd-ptr_fun.patch
+    # Upstream 16668a7: install(TARGETS) so Windows finds csmith.exe.
+    - 0005-install-csmith-as-cmake-target.patch
 
 build:
   number: 0

--- a/recipes/csmith/recipe.yaml
+++ b/recipes/csmith/recipe.yaml
@@ -11,6 +11,8 @@ source:
   patches:
     # Clang 17+ -Wenum-constexpr-conversion. Merged upstream in PR 165.
     - 0001-fix-FilterKind-enum-range.patch
+    # Static + shared both named csmith.lib on Windows. Also CFEP-18.
+    - 0002-skip-static-csmith-lib.patch
 
 build:
   number: 0
@@ -24,7 +26,6 @@ build:
         cmake -G Ninja $CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -S . -B build
         cmake --build build --config Release
         cmake --install build --config Release
-        rm -f "${PREFIX}/lib/libcsmith.a"
 
 requirements:
   build:

--- a/recipes/csmith/recipe.yaml
+++ b/recipes/csmith/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: "2.3.0"
+
+package:
+  name: csmith
+  version: ${{ version }}
+
+source:
+  url: https://github.com/csmith-project/csmith/archive/refs/tags/csmith-${{ version }}.tar.gz
+  sha256: 9d024a6b202f6a1b9e01351218a85888c06b67b837fe4c6f8ef5bd522fae098c
+  patches:
+    # Clang 17+ -Wenum-constexpr-conversion. Merged upstream in PR 165.
+    - 0001-fix-FilterKind-enum-range.patch
+
+build:
+  number: 0
+  script:
+    - if: win
+      then: |
+        cmake -G Ninja %CMAKE_ARGS% -S . -B build
+        cmake --build build --config Release
+        cmake --install build --config Release
+      else: |
+        cmake -G Ninja $CMAKE_ARGS -S . -B build
+        cmake --build build --config Release
+        cmake --install build --config Release
+        rm -f "${PREFIX}/lib/libcsmith.a"
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - m4
+
+tests:
+  - script:
+      - csmith -o test.c
+  - package_contents:
+      bin:
+        - csmith
+      include:
+        - csmith-${{ version }}/csmith.h
+
+about:
+  homepage: https://embed.cs.utah.edu/csmith/
+  repository: https://github.com/csmith-project/csmith
+  summary: Random generator of C programs for compiler testing
+  description: |
+    Csmith generates random C99 programs that aim to be free of undefined
+    behavior, for differential testing of compilers and other C tools.
+    Compile generated files with -I$PREFIX/include/csmith-2.3.0.
+  license: BSD-2-Clause
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - lucasew

--- a/recipes/csmith/recipe.yaml
+++ b/recipes/csmith/recipe.yaml
@@ -17,11 +17,11 @@ build:
   script:
     - if: win
       then: |
-        cmake -G Ninja %CMAKE_ARGS% -S . -B build
+        cmake -G Ninja %CMAKE_ARGS% -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -S . -B build
         cmake --build build --config Release
         cmake --install build --config Release
       else: |
-        cmake -G Ninja $CMAKE_ARGS -S . -B build
+        cmake -G Ninja $CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -S . -B build
         cmake --build build --config Release
         cmake --install build --config Release
         rm -f "${PREFIX}/lib/libcsmith.a"
@@ -33,7 +33,9 @@ requirements:
     - ${{ stdlib('c') }}
     - cmake
     - ninja
-    - m4
+    - if: win
+      then: m2-m4
+      else: m4
 
 tests:
   - script:


### PR DESCRIPTION
Closes conda-forge/staged-recipes#34474.

Csmith generates random C99 programs for compiler testing. This is a v1 recipe for the latest tagged release, 2.3.0.

Build is CMake/Ninja. The only extra source change is the already-merged upstream FilterKind fix (csmith-project/csmith#165) so current Clang can compile 2.3.0. The static `libcsmith.a` is removed after install.

I am willing to maintain this recipe.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.