### PR TITLE
Adding repotrials

### DIFF
--- a/recipes/repotrials/recipe.yaml
+++ b/recipes/repotrials/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  python_min: "3.11"
+  version: "0.1.0"
+
+package:
+  name: repotrials
+  version: ${{ version }}
+
+source:
+  url: https://github.com/PozziTiv4ik/Repo-Trials/releases/download/v${{ version }}/repotrials-${{ version }}.tar.gz
+  sha256: f1e732a9f8640b14ff7b5d6c454af432161e7b85b14efebeb02d4d171bf3a31e
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - repotrials = repotrials.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+  run:
+    - python >=${{ python_min }}
+    - git
+
+tests:
+  - python:
+      imports:
+        - repotrials
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - repotrials --version
+
+about:
+  homepage: https://github.com/PozziTiv4ik/Repo-Trials
+  summary: Turn Git history into private, reproducible coding-agent evaluations
+  description: |
+    RepoTrials is a Python CLI that mines test-backed fixes from a repository's
+    Git history and turns them into private, reproducible coding-agent evaluation
+    tasks. It supports local execution and reporting, plus Harbor-compatible export.
+  license: Apache-2.0
+  license_file: LICENSE
+  repository: https://github.com/PozziTiv4ik/Repo-Trials
+  documentation: https://github.com/PozziTiv4ik/Repo-Trials/tree/main/docs
+
+extra:
+  recipe-maintainers:
+    - PozziTiv4ik


### PR DESCRIPTION
## Summary

Adds a conda-forge recipe for [RepoTrials](https://github.com/PozziTiv4ik/Repo-Trials) 0.1.0.

I maintain RepoTrials and am submitting the project's first public release. RepoTrials is an Apache-2.0, noarch Python CLI with no third-party Python runtime dependencies; Git is declared as its external runtime dependency.

## Local validation

- Downloaded the official GitHub Release sdist and verified SHA-256 `f1e732a9f8640b14ff7b5d6c454af432161e7b85b14efebeb02d4d171bf3a31e`.
- Built `repotrials-0.1.0-pyh1e124ca_0.conda` with `rattler-build 0.73.0`.
- Installed and tested the built package in clean conda-forge environments with Python 3.11 and Python 3.14.
- `import repotrials`, `pip check`, and `repotrials --version` all passed; the CLI reported `RepoTrials 0.1.0`.

Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License file is packaged.
- [x] Source is from the official GitHub Release.
- [x] Package does not vendor other packages.
- [x] No static libraries are linked or shipped.
- [x] Build number is 0.
- [x] A release tarball URL is used.
- [x] The listed maintainer confirms willingness in a comment below.
- [x] I checked the staged-recipes guidance and knowledge base before submission.