### PR TITLE
Add textparser

### DIFF
--- a/recipes/textparser/recipe.yaml
+++ b/recipes/textparser/recipe.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+
+context:
+  version: "0.26.2"
+
+package:
+  name: textparser
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/textparser/textparser-${{ version }}.tar.gz
+  sha256: 859825876a9c38f7c313ee1cf991a59d6b56232a9f67be6dcc0a758d84654fba
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=68
+    - setuptools-scm >=8
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - textparser
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/cantools/textparser
+  documentation: https://textparser.readthedocs.io/
+  repository: https://github.com/cantools/textparser
+  license: MIT
+  license_file: LICENSE
+  summary: A text parser library for Python
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. “Adding my_nifty_package”, not “updated meta.yaml”.
- [x] License file is packaged.
- [x] Source is from an official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.

This package is required by `cantools >=28.7.2` and is currently missing from conda-forge. A follow-up cantools-feedstock PR will update cantools and port its recipe to v1.