### PR TITLE
Add `leapp`

### DIFF
--- a/recipes/leapp/recipe.yaml
+++ b/recipes/leapp/recipe.yaml
@@ -1,0 +1,67 @@
+context:
+  name: leapp
+  version: "0.6.0"
+  build_number: 0
+  # Upstream requires-python is >=3.10, but the visualization dependencies
+  # (`fast-sugiyama`, `pillow`) are required for python >=3.11. Since a noarch
+  # package cannot express python-version-conditional run deps, we pin the
+  # minimum to 3.11 so the shipped visualization support always resolves.
+  python_min: "3.11"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/nvidia-isaac/leapp/releases/download/v${{ version }}/leapp-${{ version }}.tar.gz
+  sha256: 164ff80e2039aae3a24ed8d5debe0b8fb58a3a3c3e80b205b7af62c21f070a9f
+
+build:
+  noarch: python
+  script: $PYTHON -m pip install . -vv --no-deps --no-build-isolation
+  number: ${{ build_number }}
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=61.0
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    - pytorch >=2.6.0
+    - pyyaml >=6.0
+    - onnx >=1.19.0
+    - onnxruntime >=1.20.0
+    - onnxscript >=0.1.0
+    - safetensors >=0.5.0
+    - fast-sugiyama >=0.5.3
+    - pillow >=10.0.0
+
+tests:
+  - python:
+      imports:
+        - leapp
+        - leapp_visualization
+      # `pip check` is disabled because the conda-forge `onnxruntime` package
+      # does not ship Python dist metadata, so pip wrongly reports it as missing.
+      pip_check: false
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/nvidia-isaac/leapp
+  summary: Lightweight Export Annotations for Policy Pipelines
+  description: |
+    LEAPP (Lightweight Export Annotations for Policy Pipelines) is a Python
+    package for tracing and exporting multi-step PyTorch computational graphs.
+    Annotate your existing code with lightweight markers, and LEAPP captures the
+    graph structure, exports each stage as an individual model, and generates a
+    deployment-ready YAML specification.
+  license: Apache-2.0
+  license_file: LICENSE
+  repository: https://github.com/nvidia-isaac/leapp
+  documentation: https://github.com/nvidia-isaac/leapp
+
+extra:
+  recipe-maintainers:
+    - diegoferigo

--- a/recipes/leapp/recipe.yaml
+++ b/recipes/leapp/recipe.yaml
@@ -46,7 +46,9 @@ tests:
       # `pip check` is disabled because the conda-forge `onnxruntime` package
       # does not ship Python dist metadata, so pip wrongly reports it as missing.
       pip_check: false
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/nvidia-isaac/leapp

--- a/recipes/leapp/recipe.yaml
+++ b/recipes/leapp/recipe.yaml
@@ -2,10 +2,11 @@ context:
   name: leapp
   version: "0.6.0"
   build_number: 0
-  # Upstream requires-python is >=3.10, but the visualization dependencies
-  # (`fast-sugiyama`, `pillow`) are required for python >=3.11. Since a noarch
-  # package cannot express python-version-conditional run deps, we pin the
-  # minimum to 3.11 so the shipped visualization support always resolves.
+  # Upstream requires-python is >=3.10, but `fast-sugiyama` (a hard run dep of the
+  # bundled `leapp_visualization`) is only published for python >=3.11, on both
+  # PyPI and conda-forge (no cp310 build exists). A noarch package cannot express
+  # python-version-conditional run deps, so we set the minimum to 3.11: below that
+  # the run environment is unsolvable.
   python_min: "3.11"
 
 package:

--- a/recipes/leapp/recipe.yaml
+++ b/recipes/leapp/recipe.yaml
@@ -19,7 +19,7 @@ source:
 
 build:
   noarch: python
-  script: $PYTHON -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: ${{ build_number }}
 
 requirements:


### PR DESCRIPTION
Adds a recipe for [`leapp`](https://github.com/nvidia-isaac/leapp) (NVIDIA Isaac) — Lightweight Export Annotations for Policy Pipelines, a pure-Python (noarch) package for tracing/exporting PyTorch computational graphs.

The only external dependency that was missing from conda-forge, [`fast-sugiyama`](https://github.com/conda-forge/fast-sugiyama-feedstock) (conda-forge/staged-recipes#34558), is now available, so CI can resolve the full environment.

`pip_check` is disabled because the conda-forge `onnxruntime` package ships no dist metadata, causing a false "not installed" report.

### Checklist
- [x] Title is meaningful
- [x] Recipe uses the v1 `recipe.yaml` format
- [x] License file is packaged (`LICENSE`)
- [x] Source is from official source (GitHub release sdist)
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] A tarball (`url`) is used
- [x] Maintainers confirmed
