### PR TITLE
Add libe57format

### DIFF
--- a/recipes/libe57format/recipe.yaml
+++ b/recipes/libe57format/recipe.yaml
@@ -1,0 +1,84 @@
+schema_version: 1
+
+context:
+  name: libe57format
+  version: 3.3.0
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/asmaloney/libE57Format/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 0ba6de5c2ff6122c847867e81bf3f987b43ce4116b4949550c9cda277099e796
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - cmake -G Ninja -S . -B build ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DCMAKE_BUILD_TYPE=Release -DE57_BUILD_SHARED=ON -DE57_BUILD_TEST=OFF -DE57_USE_EXTERNAL_CRCPP=ON -DE57_RELEASE_LTO=OFF
+        - cmake --build build
+        - cmake --install build
+    - if: win
+      then:
+        - cmake -G Ninja -S . -B build %CMAKE_ARGS% -DCMAKE_INSTALL_PREFIX="%PREFIX%" -DCMAKE_BUILD_TYPE=Release -DE57_BUILD_SHARED=ON -DE57_BUILD_TEST=OFF -DE57_USE_EXTERNAL_CRCPP=ON -DE57_RELEASE_LTO=OFF
+        - cmake --build build
+        - cmake --install build
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  host:
+    - xerces-c
+    - libcrcpp
+  run_exports:
+    - ${{ pin_subpackage('libe57format', upper_bound='x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - E57Format
+      include:
+        - E57Format/E57Format.h
+        - E57Format/E57SimpleReader.h
+        - E57Format/E57SimpleWriter.h
+      files:
+        exists:
+          - ${{ "Library/" if win }}lib/cmake/E57Format/e57format-config.cmake
+  - script:
+      - if: unix
+        then:
+          - cmake -G Ninja -S test -B build ${CMAKE_ARGS}
+          - cmake --build build
+          - ./build/e57-test
+      - if: win
+        then:
+          - cmake -G Ninja -S test -B build %CMAKE_ARGS%
+          - cmake --build build
+          - build\e57-test.exe
+    files:
+      recipe:
+        - test/CMakeLists.txt
+        - test/test.cpp
+    requirements:
+      build:
+        - ${{ compiler('cxx') }}
+        - ${{ stdlib('c') }}
+        - cmake
+        - ninja
+
+about:
+  homepage: https://github.com/asmaloney/libE57Format
+  repository: https://github.com/asmaloney/libE57Format
+  documentation: https://asmaloney.github.io/libE57Format-docs/
+  summary: Library for reading and writing E57 point-cloud files
+  license: BSL-1.0
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - swahtz

--- a/recipes/libe57format/test/CMakeLists.txt
+++ b/recipes/libe57format/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(e57-test CXX)
+
+find_package(E57Format CONFIG REQUIRED)
+
+add_executable(e57-test test.cpp)
+target_link_libraries(e57-test E57Format)

--- a/recipes/libe57format/test/test.cpp
+++ b/recipes/libe57format/test/test.cpp
@@ -1,0 +1,66 @@
+#include <E57Format/E57SimpleReader.h>
+#include <E57Format/E57SimpleWriter.h>
+
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+int main()
+{
+    const char fileName[] = "e57-test.e57";
+    const int64_t numPoints = 8;
+
+    {
+        e57::WriterOptions options;
+        options.guid = "conda-forge-libe57format-test";
+        e57::Writer writer(fileName, options);
+
+        e57::Data3D header;
+        header.guid = "conda-forge-libe57format-test-scan";
+        header.pointCount = numPoints;
+        header.pointFields.cartesianXField = true;
+        header.pointFields.cartesianYField = true;
+        header.pointFields.cartesianZField = true;
+
+        std::vector<double> x(numPoints), y(numPoints), z(numPoints);
+        for (int64_t i = 0; i < numPoints; ++i)
+        {
+            x[i] = static_cast<double>(i);
+            y[i] = static_cast<double>(i) * 2.0;
+            z[i] = static_cast<double>(i) * 3.0;
+        }
+
+        e57::Data3DPointsDouble buffers;
+        buffers.cartesianX = x.data();
+        buffers.cartesianY = y.data();
+        buffers.cartesianZ = z.data();
+
+        const int64_t scanIndex = writer.NewData3D(header);
+        e57::CompressedVectorWriter dataWriter =
+            writer.SetUpData3DPointsData(scanIndex, numPoints, buffers);
+        dataWriter.write(static_cast<size_t>(numPoints));
+        dataWriter.close();
+        writer.Close();
+    }
+
+    {
+        e57::Reader reader(fileName, {});
+        if (reader.GetData3DCount() != 1)
+        {
+            std::fprintf(stderr, "expected 1 scan, got %lld\n",
+                         static_cast<long long>(reader.GetData3DCount()));
+            return 1;
+        }
+
+        e57::Data3D header;
+        if (!reader.ReadData3D(0, header) || header.pointCount != numPoints)
+        {
+            std::fprintf(stderr, "failed to read scan header\n");
+            return 1;
+        }
+        reader.Close();
+    }
+
+    std::remove(fileName);
+    return 0;
+}


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

---

Adds [libE57Format](https://github.com/asmaloney/libE57Format) 3.3.0, a C++ library for reading and writing E57 point-cloud files (BSL-1.0).

