### PR TITLE
Add recipe for  ccache-storage-http-go

### DIFF
--- a/recipes/ccache-storage-http-go/recipe.yaml
+++ b/recipes/ccache-storage-http-go/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "0.8"
+
+package:
+  name: ccache-storage-http-go
+  version: ${{ version }}
+
+source:
+  url: https://github.com/ccache/ccache-storage-http-go/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: ca1991ff5f9a6b553b727d7b12e1de04c4b75ef1eeb093ba4359a568abc0fa38
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save . --save_path ../library_licenses
+    - if: unix
+      then:
+        - go build -v -o $PREFIX/bin/ccache-storage-http -ldflags="-s -w" .
+        - ln -s ccache-storage-http $PREFIX/bin/ccache-storage-https
+      else:
+        - go build -v -o %LIBRARY_BIN%\ccache-storage-http.exe -ldflags="-s" .
+        - copy /Y %LIBRARY_BIN%\ccache-storage-http.exe %LIBRARY_BIN%\ccache-storage-https.exe
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+  run_constraints:
+    # ccache-storage-http-cpp installs exactly the same executables with the same names,
+    # so we declare an incompatibility to avoid clobbering
+    - ccache-storage-http-cpp <0.0a0
+
+tests:
+  - package_contents:
+      bin:
+        - ccache-storage-http
+        - ccache-storage-https
+      strict: true
+
+about:
+  homepage: https://github.com/ccache/ccache-storage-http-go
+  summary: ccache HTTP(S) storage helper (Go)
+  description: |
+    ccache-storage-http-go is a ccache remote storage helper for HTTP/HTTPS,
+    implemented in Go.
+  license: MIT
+  license_file:
+    - src/LICENSE
+    - library_licenses/
+  repository: https://github.com/ccache/ccache-storage-http-go
+
+extra:
+  recipe-maintainers:
+    - traversaro


### PR DESCRIPTION
This PR adds a recipe for `ccache-storage-http-go`, a C++ ccache HTTP(S) storage helper.

Upstream repo: https://github.com/ccache/ccache-storage-http-go

This is an alternative implementation in go w.r.t. to the ccache-storage-http-cpp added in https://github.com/conda-forge/staged-recipes/pull/32818, and that I am packaging as it has different features, see https://github.com/ccache/ccache-storage-http-cpp/issues/8 .

As ccache-storage-http-cpp and ccache-storage-http-go install the same executable, they are marked as mutually exclusive.

cc @conda-forge/ccache @conda-forge/ccache-storage-http-cpp


Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
