### PR TITLE
Add rhapsody-py, radical.asyncflow and radical.orbit

### DIFF
--- a/recipes/radical.asyncflow/recipe.yaml
+++ b/recipes/radical.asyncflow/recipe.yaml
@@ -35,7 +35,9 @@ tests:
       imports:
         - radical.asyncflow
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/radical-cybertools/radical.asyncflow

--- a/recipes/radical.asyncflow/recipe.yaml
+++ b/recipes/radical.asyncflow/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: radical.asyncflow
   version: "0.5.0"
 
 package:
-  name: ${{ name|lower }}
+  name: radical.asyncflow
   version: ${{ version }}
 
 source:
@@ -15,7 +14,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipes/radical.asyncflow/recipe.yaml
+++ b/recipes/radical.asyncflow/recipe.yaml
@@ -1,0 +1,54 @@
+schema_version: 1
+
+context:
+  name: radical.asyncflow
+  version: "0.5.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/radical.asyncflow/radical_asyncflow-${{ version }}.tar.gz
+  sha256: e7a0d203fb0731d21f064ac913ecd4b50876436050be7f91a04771a45ea332c9
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=61.0
+    - wheel
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pydantic
+    - typeguard
+    - requests
+    - cloudpickle
+
+tests:
+  - python:
+      imports:
+        - radical.asyncflow
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/radical-cybertools/radical.asyncflow
+  summary: A high performance asynchronous workflow scripting library
+  description: |
+    RADICAL-AsyncFlow is an asyncio-based workflow scripting library
+    for expressing dynamic task graphs in plain Python. HPC execution
+    backends are provided by RHAPSODY (rhapsody-py) and are optional.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://radical-cybertools.github.io/radical.asyncflow/
+  repository: https://github.com/radical-cybertools/radical.asyncflow
+
+extra:
+  recipe-maintainers:
+    - andre-merzky

--- a/recipes/radical.orbit/recipe.yaml
+++ b/recipes/radical.orbit/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: radical.orbit
-  version: "0.5.0"
+  version: "0.6.0"
 
 package:
   name: ${{ name|lower }}
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/r/radical.orbit/radical_orbit-${{ version }}.tar.gz
-  sha256: b8670a5d898edc3d1f523210d0ad765dc17f589ba64ba7d7ca03466103df5871
+  sha256: fcceba51f060ced0bc4d099e8588c1699c867701413a968adeb3deef13c1679c
 
 build:
   number: 0

--- a/recipes/radical.orbit/recipe.yaml
+++ b/recipes/radical.orbit/recipe.yaml
@@ -1,0 +1,67 @@
+schema_version: 1
+
+context:
+  name: radical.orbit
+  version: "0.4.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/radical.orbit/radical_orbit-${{ version }}.tar.gz
+  sha256: 5db16645bab617d7542937048c12d059ad4719a08f21108fc32f20d85f05f884
+
+build:
+  number: 0
+  # not noarch: setup.py templates the build interpreter's purelib path
+  # (lib/pythonX.Y/site-packages) into bin/radical-orbit-endpoint-wrapper.sh
+  skip: match(python, "<3.10")
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - setuptools
+    - wheel
+    - pip
+  run:
+    - python
+    - httpx
+    - msgpack-python
+    - cloudpickle
+    - requests
+    - websockets
+    - websocket-client
+    - fastapi
+    - uvicorn
+    - psutil
+    - rich
+    - psij-python
+    - rhapsody-py
+    - globus-sdk
+    - authlib
+
+tests:
+  - python:
+      imports:
+        - radical.orbit
+      pip_check: true
+
+about:
+  homepage: https://github.com/radical-cybertools/radical.orbit
+  summary: Broker-based distributed framework connecting RADICAL-Cybertools applications with HPC resources
+  description: |
+    ORBIT connects external RADICAL-Cybertools applications with HPC
+    resources through a star topology: one active broker hub routes
+    between endpoint participants, each dialing in over a single
+    outbound WebSocket. A broker-hosted gateway serves an
+    HTTP/SSE/Explorer compatibility surface.
+  license: MIT
+  license_file: LICENSE.md
+  documentation: https://radicalorbit.readthedocs.io/
+  repository: https://github.com/radical-cybertools/radical.orbit
+
+extra:
+  recipe-maintainers:
+    - andre-merzky

--- a/recipes/radical.orbit/recipe.yaml
+++ b/recipes/radical.orbit/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: radical.orbit
   version: "0.6.0"
 
 package:
-  name: ${{ name|lower }}
+  name: radical.orbit
   version: ${{ version }}
 
 source:
@@ -16,8 +15,10 @@ build:
   number: 0
   # not noarch: setup.py templates the build interpreter's purelib path
   # (lib/pythonX.Y/site-packages) into bin/radical-orbit-endpoint-wrapper.sh
-  skip: match(python, "<3.10")
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  # POSIX-only upstream (shell-script entry points, POSIX classifiers)
+  skip:
+    - win
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -47,6 +48,8 @@ tests:
       imports:
         - radical.orbit
       pip_check: true
+  - script:
+      - radical-orbit-endpoint-wrapper.sh --help
 
 about:
   homepage: https://github.com/radical-cybertools/radical.orbit

--- a/recipes/radical.orbit/recipe.yaml
+++ b/recipes/radical.orbit/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: radical.orbit
-  version: "0.4.0"
+  version: "0.5.0"
 
 package:
   name: ${{ name|lower }}
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/r/radical.orbit/radical_orbit-${{ version }}.tar.gz
-  sha256: 5db16645bab617d7542937048c12d059ad4719a08f21108fc32f20d85f05f884
+  sha256: b8670a5d898edc3d1f523210d0ad765dc17f589ba64ba7d7ca03466103df5871
 
 build:
   number: 0

--- a/recipes/rhapsody-py/recipe.yaml
+++ b/recipes/rhapsody-py/recipe.yaml
@@ -34,7 +34,9 @@ tests:
       imports:
         - rhapsody
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/radical-cybertools/rhapsody

--- a/recipes/rhapsody-py/recipe.yaml
+++ b/recipes/rhapsody-py/recipe.yaml
@@ -1,0 +1,59 @@
+# TODO before opening the PR: bump to 0.4.1 + new sha256 once released
+# (0.4.1 fixes the __version__ = "0.2.0" skew in the 0.4.0 sdist).
+schema_version: 1
+
+context:
+  name: rhapsody-py
+  version: "0.4.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/rhapsody-py/rhapsody_py-${{ version }}.tar.gz
+  sha256: e1f8c29b469ca667867f18d1bc4f6638c0e697061c0a1c0dd23b21d8172973a8
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=61.0
+    - wheel
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pydantic >=2.0.0
+    - typeguard >=4.0.0
+    - requests >=2.25.0
+
+tests:
+  - python:
+      imports:
+        - rhapsody
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/radical-cybertools/rhapsody
+  summary: Runtime system for heterogeneous HPC-AI workflows with dynamic task graphs
+  description: |
+    RHAPSODY executes heterogeneous HPC-AI workflows with dynamic task
+    graphs on high-performance computing infrastructures, running
+    services (e.g. inference servers) alongside tasks. Execution
+    backends (Dask, RADICAL-Pilot, Dragon) are optional; this package
+    ships the core. Backend dependencies are installed separately,
+    e.g. `conda install dask radical.pilot` or `pip install dragonhpc`
+    for the Dragon backend.
+  license: MIT
+  license_file: LICENSE.md
+  documentation: https://radical-cybertools.github.io/rhapsody/
+  repository: https://github.com/radical-cybertools/rhapsody
+
+extra:
+  recipe-maintainers:
+    - andre-merzky

--- a/recipes/rhapsody-py/recipe.yaml
+++ b/recipes/rhapsody-py/recipe.yaml
@@ -1,10 +1,8 @@
-# TODO before opening the PR: bump to 0.4.1 + new sha256 once released
-# (0.4.1 fixes the __version__ = "0.2.0" skew in the 0.4.0 sdist).
 schema_version: 1
 
 context:
   name: rhapsody-py
-  version: "0.4.0"
+  version: "0.5.0"
 
 package:
   name: ${{ name|lower }}
@@ -12,7 +10,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/r/rhapsody-py/rhapsody_py-${{ version }}.tar.gz
-  sha256: e1f8c29b469ca667867f18d1bc4f6638c0e697061c0a1c0dd23b21d8172973a8
+  sha256: 229c217c64564aac0e206a64f138976ab9de3b33cc16c9d8b02d815be27f4c4b
 
 build:
   number: 0

--- a/recipes/rhapsody-py/recipe.yaml
+++ b/recipes/rhapsody-py/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: rhapsody-py
   version: "0.5.0"
 
 package:
-  name: ${{ name|lower }}
+  name: rhapsody-py
   version: ${{ version }}
 
 source:
@@ -15,7 +14,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:


### PR DESCRIPTION
Three new pure-Python packages from the RADICAL-Cybertools ecosystem, forming the packaging basis of the NSF SINAPSE SDK. Submitted together because they are interdependent: `radical.orbit` has a hard runtime dependency on `rhapsody-py`.

- **rhapsody-py 0.5.0** — runtime system for heterogeneous HPC-AI workflows (noarch)
- **radical.asyncflow 0.5.0** — asyncio-based workflow scripting library (noarch)
- **radical.orbit 0.6.0** — broker-based distributed framework connecting applications with HPC resources (per-python: its `setup.py` templates the interpreter's purelib path into an installed shell wrapper)

All sources are PyPI sdists with pinned sha256; all ship their MIT license files. All other run dependencies are existing conda-forge packages (`msgpack-python`, `psij-python`, `globus-sdk`, `fastapi`, …).

Checklist:
- [x] Title of this PR is meaningful
- [x] License file is packaged
- [x] Source is from official source
- [x] Package does not vendor other packages
- [x] Package does not ship static libraries
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo is used
- [x] GitHub users listed as maintainers have commented on the PR (author)

🤖 Generated with [Claude Code](https://claude.com/claude-code)