### PR TITLE
Add fiskalizimi-utils

### DIFF
--- a/recipes/fiskalizimi-utils/recipe.yaml
+++ b/recipes/fiskalizimi-utils/recipe.yaml
@@ -31,7 +31,9 @@ tests:
       imports:
         - fiskalizimi_utils
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - fiskalizimi --version
       - fiskalizimi nipt M51418039H

--- a/recipes/fiskalizimi-utils/recipe.yaml
+++ b/recipes/fiskalizimi-utils/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.2.0"
+
+package:
+  name: fiskalizimi-utils
+  version: ${{ version }}
+
+source:
+  url: https://github.com/square-al/fiskalizimi-utils/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 3d528195f8b95a0206736c3a37d354db87c3a835134978687aa88a1c4c0345b3
+
+build:
+  noarch: python
+  number: 0
+  # The Python package lives in the python/ subfolder of the monorepo.
+  script: cd python && ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - fiskalizimi = fiskalizimi_utils.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling >=1.27
+    - pip
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - fiskalizimi_utils
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - fiskalizimi --version
+      - fiskalizimi nipt M51418039H
+      - fiskalizimi paga 100000 --json
+
+about:
+  homepage: https://square.al/fiscalization-api
+  summary: Albanian tax utilities — NIPT/NUIS validation, TVSH (VAT) math, fiscal invoice totals, 2026 payroll and profit tax
+  description: |
+    Zero-dependency, typed utilities for Albanian fiscalization (Law 87/2019)
+    and payroll: NIPT/NUIS format validation with typo detection, TVSH (VAT)
+    add/extract math, fiscal invoice totals with the per-rate VAT breakdown a
+    fiscalized invoice must report, and gross-to-net salary, profit tax,
+    severance and annual-leave calculations over a dated, verified rates
+    config (AL-2026, confirmed against tatime.gov.al). Ships a `fiskalizimi`
+    CLI. A TypeScript twin of the same functions is held to one shared parity
+    fixture.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://fiskalizimi-utils.readthedocs.io
+  repository: https://github.com/square-al/fiskalizimi-utils
+
+extra:
+  recipe-maintainers:
+    - edmirjano


### PR DESCRIPTION
Adds **fiskalizimi-utils** — zero-dependency, typed Python utilities for Albanian fiscalization (Law 87/2019) and payroll: NIPT/NUIS format validation with typo detection, TVSH (VAT) add/extract math, fiscal invoice totals with the per-rate VAT breakdown, and gross↔net salary / profit-tax / severance calculations over a dated, verified rates config. Ships a `fiskalizimi` CLI. Pure Python (`noarch: python`), hatchling build, MIT.

- Upstream: https://github.com/square-al/fiskalizimi-utils (the Python package is the `python/` subfolder of the monorepo, hence the `cd python` in the build script)
- Source: GitHub tag tarball `v0.2.0` — the project is not on PyPI yet, so there is no sdist URL to use instead
- Docs: https://fiskalizimi-utils.readthedocs.io

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1STmaHNffA6rQstGmQmqG