### PR TITLE
Add qt-tour recipe

### DIFF
--- a/recipes/qt-tour/recipe.yaml
+++ b/recipes/qt-tour/recipe.yaml
@@ -1,0 +1,51 @@
+schema_version: 1
+
+context:
+  version: "0.2.0"
+  python_min: "3.10"
+
+package:
+  name: qt-tour
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/q/qt-tour/qt_tour-${{ version }}.tar.gz
+  sha256: 30214c904971e72ac8714bcf7567f8eb602422b518d17b6fa388a73abfa770ff
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - uv-build >=0.12.3,<0.13.0
+  run:
+    - python >=${{ python_min }}
+    - qtpy >=2.4.3
+
+tests:
+  - requirements:
+      run:
+        - pyqt6
+    python:
+      imports:
+        - qt_tour
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/sdiebolt/qt-tour
+  repository: https://github.com/sdiebolt/qt-tour
+  documentation: https://sdiebolt.github.io/qt-tour/
+  summary: Small guided tours for Python Qt applications
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - sdiebolt

--- a/recipes/qt-tour/recipe.yaml
+++ b/recipes/qt-tour/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.2.1"
+  version: "0.2.2"
 
 package:
   name: qt-tour
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/q/qt-tour/qt_tour-${{ version }}.tar.gz
-  sha256: b6bff77527ef6e390ea92835a3b0122486acaf30f02f4dfb2153b05f0dd7303d
+  sha256: a4e3d906303710f664fe7f2d88789b093d09166021e24d9628b59734f45665dd
 
 build:
   noarch: python
@@ -28,7 +28,7 @@ requirements:
 tests:
   - requirements:
       run:
-        - pyqt6
+        - pyqt
     python:
       imports:
         - qt_tour

--- a/recipes/qt-tour/recipe.yaml
+++ b/recipes/qt-tour/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "0.2.0"
-  python_min: "3.10"
 
 package:
   name: qt-tour

--- a/recipes/qt-tour/recipe.yaml
+++ b/recipes/qt-tour/recipe.yaml
@@ -28,7 +28,7 @@ requirements:
 tests:
   - requirements:
       run:
-        - pyqt
+        - pyqt6
     python:
       imports:
         - qt_tour

--- a/recipes/qt-tour/recipe.yaml
+++ b/recipes/qt-tour/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.2.0"
+  version: "0.2.1"
 
 package:
   name: qt-tour
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/q/qt-tour/qt_tour-${{ version }}.tar.gz
-  sha256: 30214c904971e72ac8714bcf7567f8eb602422b518d17b6fa388a73abfa770ff
+  sha256: b6bff77527ef6e390ea92835a3b0122486acaf30f02f4dfb2153b05f0dd7303d
 
 build:
   noarch: python

--- a/recipes/qt-tour/recipe.yaml
+++ b/recipes/qt-tour/recipe.yaml
@@ -28,14 +28,12 @@ requirements:
 tests:
   - requirements:
       run:
+        - python ${{ python_min }}.*
         - pyqt6
-    python:
-      imports:
-        - qt_tour
-      pip_check: true
-      python_version:
-        - ${{ python_min }}.*
-        - "*"
+        - pip
+    script:
+      - python -c "import qt_tour"
+      - python -m pip check
 
 about:
   homepage: https://github.com/sdiebolt/qt-tour


### PR DESCRIPTION
Adds a new `qt-tour` recipe.

- PyPI source: `qt-tour 0.2.2`
- pure Python / `noarch: python`
- runtime dependency: `qtpy >=2.4.3`
- test-only dependency: `pyqt6`, used via a script test so `qtpy` has a Qt binding during `import qt_tour`

Linted locally with:

```bash
pixi run lint
```
