### PR TITLE
Fix the CUDA host-compiler pinning for `decord2`

### DIFF
--- a/recipes/decord2/conda_build_config.yaml
+++ b/recipes/decord2/conda_build_config.yaml
@@ -8,5 +8,7 @@ MACOSX_SDK_VERSION:  # [osx]
 # build compiles. GCC 13 is also valid for the CPU and CUDA 13 builds.
 c_compiler_version:    # [linux]
   - "13"               # [linux]
+  - "13"               # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]
 cxx_compiler_version:  # [linux]
   - "13"               # [linux]
+  - "13"               # [linux and (x86_64 or aarch64) and os.environ.get("CF_CUDA_ENABLED", "False") == "True"]


### PR DESCRIPTION
`decord2` was merged in [#34560](https://github.com/conda-forge/staged-recipes/pull/34560), but the `conda-forge/decord2-feedstock` repo stayed empty because feedstock population failed with a variant length mismatch (see the [admin-requests run](https://github.com/conda-forge/admin-requests/actions/runs/32459252252/job/96702676503#step:7:1536)).

The CUDA-enabled linux variants add an extra dimension to the build matrix, so `c_compiler_version` and `cxx_compiler_version` need a second entry guarded by the `CF_CUDA_ENABLED` selector to keep the zip in sync. This PR applies exactly the diff suggested by @jaimergp in the original thread. The recipe itself is already on `main`, so the only change here is `recipes/decord2/conda_build_config.yaml`, and merging this re-triggers the feedstock population.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
