### PR TITLE
Add WAMR interpreter, AOT, JIT, and compiler packages

### DIFF
--- a/recipes/wamr-aot/build.bat
+++ b/recipes/wamr-aot/build.bat
@@ -1,0 +1,4 @@
+@echo on
+
+call "%RECIPE_DIR%\..\wamr\build-wamr.bat" aot
+if errorlevel 1 exit /b 1

--- a/recipes/wamr-aot/build.sh
+++ b/recipes/wamr-aot/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+exec bash "$RECIPE_DIR/../wamr/build-wamr.sh" aot

--- a/recipes/wamr-aot/recipe.yaml
+++ b/recipes/wamr-aot/recipe.yaml
@@ -1,0 +1,44 @@
+context:
+  version: "2.4.5"
+
+package:
+  name: wamr-aot
+  version: ${{ version }}
+
+source:
+  url: https://github.com/wasm-micro-runtime/wasm-micro-runtime/archive/refs/tags/WAMR-${{ version }}.tar.gz
+  sha256: 1ab09d51099f276ca4a1d6629f6b589aab2bd0caa01445e05031a4bed22c199b
+
+build:
+  number: 0
+  script: build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  run_exports:
+    - ${{ pin_subpackage('wamr-aot', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - iwasm
+      include:
+        - wasm_c_api.h
+        - wasm_export.h
+        - lib_export.h
+
+about:
+  homepage: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  repository: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  documentation: https://bytecodealliance.github.io/wamr.dev/
+  license: Apache-2.0 WITH LLVM-exception
+  license_file: LICENSE
+  summary: WebAssembly Micro Runtime with AOT loading support
+
+extra:
+  recipe-maintainers:
+    - tritao

--- a/recipes/wamr-compiler/build.bat
+++ b/recipes/wamr-compiler/build.bat
@@ -1,0 +1,4 @@
+@echo on
+
+call "%RECIPE_DIR%\..\wamr\build-wamr.bat" compiler
+if errorlevel 1 exit /b 1

--- a/recipes/wamr-compiler/build.sh
+++ b/recipes/wamr-compiler/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+exec bash "$RECIPE_DIR/../wamr/build-wamr.sh" compiler

--- a/recipes/wamr-compiler/recipe.yaml
+++ b/recipes/wamr-compiler/recipe.yaml
@@ -1,0 +1,67 @@
+context:
+  version: "2.4.5"
+
+package:
+  name: wamr-compiler
+  version: ${{ version }}
+
+source:
+  url: https://github.com/wasm-micro-runtime/wasm-micro-runtime/archive/refs/tags/WAMR-${{ version }}.tar.gz
+  sha256: 1ab09d51099f276ca4a1d6629f6b589aab2bd0caa01445e05031a4bed22c199b
+
+build:
+  number: 0
+  script: build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - if: linux
+      then:
+        - llvmdev >=19,<20
+    - if: win
+      then:
+        - llvmdev >=19,<20
+    - if: osx
+      then:
+        - llvmdev >=18,<19
+    - zlib
+    - libxml2-devel
+  run:
+    - if: linux
+      then:
+        - libllvm19 >=19,<20
+        - libgcc >=14
+        - libstdcxx >=14
+    - if: win
+      then:
+        - libllvm19 >=19,<20
+    - if: osx
+      then:
+        - libllvm18 >=18,<19
+  ignore_run_exports:
+    from_package:
+      - zlib
+      - libxml2-devel
+
+tests:
+  - package_contents:
+      bin:
+        - wamrc
+
+about:
+  homepage: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  repository: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  documentation: https://bytecodealliance.github.io/wamr.dev/
+  license: Apache-2.0 WITH LLVM-exception
+  license_file: LICENSE
+  summary: WAMR AOT compiler
+
+extra:
+  recipe-maintainers:
+    - tritao

--- a/recipes/wamr-jit/build.bat
+++ b/recipes/wamr-jit/build.bat
@@ -1,0 +1,4 @@
+@echo on
+
+call "%RECIPE_DIR%\..\wamr\build-wamr.bat" jit
+if errorlevel 1 exit /b 1

--- a/recipes/wamr-jit/build.sh
+++ b/recipes/wamr-jit/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+exec bash "$RECIPE_DIR/../wamr/build-wamr.sh" jit

--- a/recipes/wamr-jit/recipe.yaml
+++ b/recipes/wamr-jit/recipe.yaml
@@ -1,0 +1,73 @@
+context:
+  version: "2.4.5"
+
+package:
+  name: wamr-jit
+  version: ${{ version }}
+
+source:
+  url: https://github.com/wasm-micro-runtime/wasm-micro-runtime/archive/refs/tags/WAMR-${{ version }}.tar.gz
+  sha256: 1ab09d51099f276ca4a1d6629f6b589aab2bd0caa01445e05031a4bed22c199b
+
+build:
+  number: 0
+  script: build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - if: linux
+      then:
+        - llvmdev >=19,<20
+    - if: win
+      then:
+        - llvmdev >=19,<20
+    - if: osx
+      then:
+        - llvmdev >=18,<19
+    - zlib
+    - libxml2-devel
+  run_exports:
+    - ${{ pin_subpackage('wamr-jit', upper_bound='x.x') }}
+  run:
+    - if: linux
+      then:
+        - libllvm19 >=19,<20
+        - libgcc >=14
+        - libstdcxx >=14
+    - if: win
+      then:
+        - libllvm19 >=19,<20
+    - if: osx
+      then:
+        - libllvm18 >=18,<19
+  ignore_run_exports:
+    from_package:
+      - zlib
+      - libxml2-devel
+
+tests:
+  - package_contents:
+      lib:
+        - iwasm
+      include:
+        - wasm_c_api.h
+        - wasm_export.h
+        - lib_export.h
+
+about:
+  homepage: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  repository: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  documentation: https://bytecodealliance.github.io/wamr.dev/
+  license: Apache-2.0 WITH LLVM-exception
+  license_file: LICENSE
+  summary: WebAssembly Micro Runtime with LLVM JIT support
+
+extra:
+  recipe-maintainers:
+    - tritao

--- a/recipes/wamr/build-wamr.bat
+++ b/recipes/wamr/build-wamr.bat
@@ -1,0 +1,78 @@
+@echo on
+
+set WAMR_PROFILE=%~1
+if "%WAMR_PROFILE%"=="" (
+  echo WAMR profile is required
+  exit /b 1
+)
+
+if "%WAMR_PROFILE%"=="compiler" goto compiler
+
+set FAST_INTERP=0
+set BUILD_AOT=0
+set BUILD_JIT=0
+set INSTRUCTION_METERING=1
+set LLVM_DIR_ARG=
+set LLVM_LIBXML2_ARGS=
+if "%WAMR_PROFILE%"=="aot" (
+  set FAST_INTERP=1
+  set BUILD_AOT=1
+  set INSTRUCTION_METERING=0
+)
+if "%WAMR_PROFILE%"=="jit" (
+  set FAST_INTERP=0
+  set BUILD_AOT=1
+  set BUILD_JIT=1
+  set INSTRUCTION_METERING=0
+  set LLVM_CONFIG_DIR=%BUILD_PREFIX%\freecad-wamr-llvm-config
+  if not exist "%LLVM_CONFIG_DIR%" mkdir "%LLVM_CONFIG_DIR%"
+  > "%LLVM_CONFIG_DIR%\LLVMConfig.cmake" echo include("%LIBRARY_PREFIX%/lib/cmake/llvm/LLVMConfig.cmake")
+  >> "%LLVM_CONFIG_DIR%\LLVMConfig.cmake" echo set(LLVM_AVAILABLE_LIBS LLVM)
+  > "%LLVM_CONFIG_DIR%\LLVMConfigVersion.cmake" echo set(PACKAGE_VERSION "0")
+  set LLVM_DIR_ARG=-DLLVM_DIR=%LLVM_CONFIG_DIR%
+  set LLVM_LIBXML2_ARGS=-DLIBXML2_LIBRARY=%LIBRARY_PREFIX%/lib/libxml2.lib -DLIBXML2_INCLUDE_DIR=%LIBRARY_PREFIX%/include/libxml2
+)
+
+cmake -S . -B build -G Ninja ^
+  %CMAKE_ARGS% ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+  -DBUILD_SHARED_LIBS=ON ^
+  -DWAMR_BUILD_INTERP=1 ^
+  -DWAMR_BUILD_FAST_INTERP=%FAST_INTERP% ^
+  -DWAMR_BUILD_AOT=%BUILD_AOT% ^
+  -DWAMR_BUILD_JIT=%BUILD_JIT% ^
+  -DWAMR_BUILD_FAST_JIT=0 ^
+  -DWAMR_BUILD_LIBC_BUILTIN=1 ^
+  -DWAMR_BUILD_LIBC_WASI=0 ^
+  -DWAMR_BUILD_MULTI_MODULE=0 ^
+  -DWAMR_BUILD_BULK_MEMORY=1 ^
+  -DWAMR_BUILD_SHARED_MEMORY=0 ^
+  -DWAMR_BUILD_THREAD_MGR=0 ^
+  -DWAMR_BUILD_LIB_PTHREAD=0 ^
+  -DWAMR_BUILD_LIB_WASI_THREADS=0 ^
+  -DWAMR_BUILD_MINI_LOADER=0 ^
+  -DWAMR_BUILD_SIMD=1 ^
+  -DWAMR_BUILD_REF_TYPES=1 ^
+  -DWAMR_BUILD_MEMORY64=0 ^
+  -DWAMR_BUILD_MULTI_MEMORY=0 ^
+  -DWAMR_BUILD_INSTRUCTION_METERING=%INSTRUCTION_METERING% ^
+  %LLVM_LIBXML2_ARGS% ^
+  %LLVM_DIR_ARG%
+if errorlevel 1 exit /b 1
+goto build
+
+:compiler
+cmake -S wamr-compiler -B build -G Ninja ^
+  %CMAKE_ARGS% ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+  -DWAMR_BUILD_WITH_CUSTOM_LLVM=1 ^
+  -DLLVM_DIR=%LIBRARY_PREFIX%\lib\cmake\llvm ^
+  -DLIBXML2_LIBRARY=%LIBRARY_PREFIX%/lib/libxml2.lib ^
+  -DLIBXML2_INCLUDE_DIR=%LIBRARY_PREFIX%/include/libxml2
+if errorlevel 1 exit /b 1
+
+:build
+cmake --build build --target install --parallel
+if errorlevel 1 exit /b 1

--- a/recipes/wamr/build-wamr.sh
+++ b/recipes/wamr/build-wamr.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+profile="${1:-}"
+case "${profile}" in
+  interp|aot|jit|compiler)
+    ;;
+  *)
+    echo "Unsupported WAMR profile: ${profile}" >&2
+    exit 1
+    ;;
+esac
+
+make_jit_llvm_config() {
+  local config_dir="${BUILD_PREFIX}/freecad-wamr-llvm-config"
+  mkdir -p "${config_dir}"
+  printf '%s\n' \
+    "include(\"${PREFIX}/lib/cmake/llvm/LLVMConfig.cmake\")" \
+    'set(LLVM_AVAILABLE_LIBS LLVM)' \
+    > "${config_dir}/LLVMConfig.cmake"
+  printf '%s\n' \
+    'set(PACKAGE_VERSION "0")' \
+    > "${config_dir}/LLVMConfigVersion.cmake"
+  printf '%s' "${config_dir}"
+}
+
+if [[ "${profile}" == compiler ]]; then
+  cmake_args=(
+    -S wamr-compiler -B build -G Ninja
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+    -DWAMR_BUILD_WITH_CUSTOM_LLVM=1
+    -DLLVM_DIR="${PREFIX}/lib/cmake/llvm"
+  )
+  if [[ -n "${CMAKE_ARGS:-}" ]]; then
+    cmake_args+=( ${CMAKE_ARGS} )
+  fi
+  cmake "${cmake_args[@]}"
+else
+  fast_interp=0
+  aot=0
+  jit=0
+  instruction_metering=1
+
+  case "${profile}" in
+    aot)
+      fast_interp=1
+      aot=1
+      instruction_metering=0
+      ;;
+    jit)
+      fast_interp=0
+      aot=1
+      jit=1
+      instruction_metering=0
+      ;;
+  esac
+
+  cmake_args=(
+    -S . -B build -G Ninja
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}"
+    -DBUILD_SHARED_LIBS=ON
+    -DWAMR_BUILD_INTERP=1
+    -DWAMR_BUILD_FAST_INTERP="${fast_interp}"
+    -DWAMR_BUILD_AOT="${aot}"
+    -DWAMR_BUILD_JIT="${jit}"
+    -DWAMR_BUILD_FAST_JIT=0
+    -DWAMR_BUILD_LIBC_BUILTIN=1
+    -DWAMR_BUILD_LIBC_WASI=0
+    -DWAMR_BUILD_MULTI_MODULE=0
+    -DWAMR_BUILD_BULK_MEMORY=1
+    -DWAMR_BUILD_SHARED_MEMORY=0
+    -DWAMR_BUILD_THREAD_MGR=0
+    -DWAMR_BUILD_LIB_PTHREAD=0
+    -DWAMR_BUILD_LIB_WASI_THREADS=0
+    -DWAMR_BUILD_MINI_LOADER=0
+    -DWAMR_BUILD_SIMD=1
+    -DWAMR_BUILD_REF_TYPES=1
+    -DWAMR_BUILD_MEMORY64=0
+    -DWAMR_BUILD_MULTI_MEMORY=0
+    -DWAMR_BUILD_INSTRUCTION_METERING="${instruction_metering}"
+  )
+  if [[ "${profile}" == jit ]]; then
+    cmake_args+=("-DLLVM_DIR=$(make_jit_llvm_config)")
+  fi
+  if [[ -n "${CMAKE_ARGS:-}" ]]; then
+    cmake_args+=( ${CMAKE_ARGS} )
+  fi
+  cmake "${cmake_args[@]}"
+fi
+
+cmake --build build --target install --parallel

--- a/recipes/wamr/build.bat
+++ b/recipes/wamr/build.bat
@@ -1,0 +1,4 @@
+@echo on
+
+call "%RECIPE_DIR%\build-wamr.bat" interp
+if errorlevel 1 exit /b 1

--- a/recipes/wamr/build.sh
+++ b/recipes/wamr/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+exec bash "$RECIPE_DIR/build-wamr.sh" interp

--- a/recipes/wamr/recipe.yaml
+++ b/recipes/wamr/recipe.yaml
@@ -1,0 +1,44 @@
+context:
+  version: "2.4.5"
+
+package:
+  name: wamr
+  version: ${{ version }}
+
+source:
+  url: https://github.com/wasm-micro-runtime/wasm-micro-runtime/archive/refs/tags/WAMR-${{ version }}.tar.gz
+  sha256: 1ab09d51099f276ca4a1d6629f6b589aab2bd0caa01445e05031a4bed22c199b
+
+build:
+  number: 0
+  script: build
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  run_exports:
+    - ${{ pin_subpackage('wamr', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - iwasm
+      include:
+        - wasm_c_api.h
+        - wasm_export.h
+        - lib_export.h
+
+about:
+  homepage: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  repository: https://github.com/wasm-micro-runtime/wasm-micro-runtime
+  documentation: https://bytecodealliance.github.io/wamr.dev/
+  license: Apache-2.0 WITH LLVM-exception
+  license_file: LICENSE
+  summary: WebAssembly Micro Runtime
+
+extra:
+  recipe-maintainers:
+    - tritao


### PR DESCRIPTION
Adds WAMR 2.4.5 packages for the supported runtime profiles:

- `wamr`: classic interpreter with instruction metering
- `wamr-aot`: fast interpreter with AOT loading
- `wamr-jit`: LLVM JIT runtime
- `wamr-compiler`: `wamrc` AOT compiler

The profile-specific recipes share one build implementation and keep WASI, shared memory, pthreads, multi-module support, and the mini-loader disabled. LLVM development dependencies are host-only; runtime LLVM libraries are declared for the JIT and compiler packages. Windows installs use `%LIBRARY_PREFIX%` so package-content tests match the conda package layout.

The build scripts preserve conda-forge `CMAKE_ARGS`. The LLVM-consuming profiles use `libxml2-devel`, and Windows passes its library and include paths explicitly so LLVM can resolve `LibXml2::LibXml2`.

The three runtime packages are alternative `iwasm` implementations and should be selected one at a time. Each runtime package exports a version-bounded dependency for downstream consumers; build-only libxml2 exports are suppressed.