### PR TITLE
Add pyaesa 1.2.8

### DIFF
--- a/recipes/pyaesa/recipe.yaml
+++ b/recipes/pyaesa/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "1.2.8"
+  python_min: "3.11"
+
+package:
+  name: pyaesa
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pyaesa/pyaesa-${{ version }}.tar.gz
+  sha256: 58b20b072337cf25c211b392c5360037f0213e415f8c95866d47beb541d88bbb
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=61.0
+    - wheel
+    - pip
+  run:
+    - python >=${{ python_min }},<3.15
+    - matplotlib-base >=3.10,<4
+    - numpy >=1.24.4,<3
+    - pandas >=1.5,<4
+    - pyarrow >=11,<24
+    - pycountry >=22.3,<27
+    - pymrio >=0.5.1,<0.7
+    - python-calamine >=0.6,<1
+    - requests >=2.28,<3
+    - salib >=1.4.8,<2
+    - scipy >=1.10,<2
+    - statsmodels >=0.14,<1
+    - wbgapi >=1.0.12,<2
+    - xlsxwriter >=3.2,<4
+
+tests:
+  - python:
+      imports:
+        - pyaesa
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: pyaesa is a Python package for absolute environmental sustainability assessment (AESA), covering data download and processing, deterministic and uncertainty assessment, and figure generation.
+  license: GPL-3.0-only
+  license_file: LICENSE
+  homepage: https://github.com/AESAtoolkit/pyaesa
+  documentation: https://pyaesa.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - Ike-EDB


### PR DESCRIPTION
This pull request adds the initial conda forge recipe for pyaesa 1.2.8.

pyaesa is published on PyPI:
https://pypi.org/project/pyaesa/1.2.8/

The recipe uses the PyPI source distribution and the corresponding SHA256 hash.