### PR TITLE
Add conda-sboms

### DIFF
--- a/recipes/conda-sboms/recipe.yaml
+++ b/recipes/conda-sboms/recipe.yaml
@@ -1,0 +1,61 @@
+schema_version: 1
+
+context:
+  version: "0.3.0"
+
+package:
+  name: conda-sboms
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/conda-sboms/conda_sboms-${{ version }}.tar.gz
+  sha256: e5ed20967668d102300e0314c6526982f69931bf40960525a74d6ad93bf92c25
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling >=1.27
+    - hatch-vcs >=0.4
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - conda >=26.3
+    - cyclonedx-python-lib >=11.12,<12
+    - packageurl-python >=0.16
+
+tests:
+  - python:
+      imports:
+        - conda_sboms.cyclonedx
+        - conda_sboms.plugin
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - python -c "import conda_sboms; assert conda_sboms.__version__ == '${{ version }}'"
+      - python -c "import subprocess, sys; assert 'cyclonedx-json' in subprocess.check_output([sys.executable, '-m', 'conda', 'export', '--help'], text=True)"
+
+about:
+  homepage: https://conda-incubator.github.io/conda-sboms/
+  summary: Generate software bills of materials from conda environments
+  description: |
+    conda-sboms provides software bill of materials exporters through conda's
+    environment exporter plugin hook. Its first exporter emits CycloneDX 1.7
+    JSON from resolved conda package records.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  documentation: https://conda-incubator.github.io/conda-sboms/
+  repository: https://github.com/conda-incubator/conda-sboms
+
+extra:
+  recipe-maintainers:
+    - jezdez


### PR DESCRIPTION
[conda-sboms](https://github.com/conda-incubator/conda-sboms) is a conda exporter plugin that generates CycloneDX 1.7 software bills of materials from resolved conda environments.

The recipe packages the 0.3.0 [PyPI source distribution](https://pypi.org/project/conda-sboms/0.3.0/) as a noarch Python package and declares conda as the runtime that provides the exporter hook.

- **Documentation**: https://conda-incubator.github.io/conda-sboms/
- **License**: BSD-3-Clause

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
