### PR TITLE
Add DotMatch

### DIFF
--- a/recipes/dotmatch/recipe.yaml
+++ b/recipes/dotmatch/recipe.yaml
@@ -1,0 +1,64 @@
+schema_version: 1
+
+context:
+  version: "0.2.2"
+
+package:
+  name: dotmatch
+  version: ${{ version }}
+
+source:
+  url: https://github.com/dnncha/dotmatch/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 52536b70e379f1aa09d891b3e44c7f67b02875086826f55fabe25f3bcfab89b9
+
+build:
+  number: 0
+  skip: win
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+  host:
+    - python
+    - pip
+    - setuptools >=77
+    - wheel
+    - zlib
+  run:
+    - python
+    - tomli
+    - zlib
+
+tests:
+  - python:
+      imports:
+        - assaycode
+        - dotmatch
+        - quickdna
+      pip_check: true
+      python_version: "3.9"
+  - script:
+      - assaycode --version
+      - dotmatch --version
+      - dotmatch dist ACGT AGGT
+      - dotmatch leq 1 ACGT AGGT
+
+about:
+  summary: Deterministic known-target short-DNA assignment from FASTQ
+  description: |
+    DotMatch assigns fixed FASTQ read windows to known CRISPR guides, barcodes,
+    feature tags, primers, panels, and other finite target lists. It reports
+    unique, ambiguous, unmatched, and invalid reads and writes ordinary TSV,
+    JSON, FASTQ, and HTML outputs. It is not a genome aligner and does not emit
+    SAM/BAM or CIGAR output.
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://dnncha.github.io/dotmatch/
+  documentation: https://dotmatch.readthedocs.io/en/latest/
+  repository: https://github.com/dnncha/dotmatch
+
+extra:
+  recipe-maintainers:
+    - dnncha

--- a/recipes/dotmatch/recipe.yaml
+++ b/recipes/dotmatch/recipe.yaml
@@ -38,7 +38,6 @@ tests:
         - dotmatch
         - quickdna
       pip_check: true
-      python_version: "3.9"
   - script:
       - assaycode --version
       - dotmatch --version


### PR DESCRIPTION
Adds a conda-forge v1 recipe for DotMatch 0.2.2. The recipe uses the published GitHub release archive with a verified SHA256, exposes the assaycode/dotmatch/quickdna modules and CLI smoke tests, and follows current staged-recipes format. Local conda-smithy lint passes.