### PR TITLE
Adding liquilens-evidence 0.15.0

### DIFF
--- a/recipes/liquilens-evidence/recipe.yaml
+++ b/recipes/liquilens-evidence/recipe.yaml
@@ -1,12 +1,11 @@
 schema_version: 1
 
 context:
-  name: liquilens-evidence
   version: "0.15.0"
   python_min: "3.11"
 
 package:
-  name: ${{ name }}
+  name: liquilens-evidence
   version: ${{ version }}
 
 source:

--- a/recipes/liquilens-evidence/recipe.yaml
+++ b/recipes/liquilens-evidence/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: liquilens-evidence
-  version: "0.13.6"
+  version: "0.14.0"
   python_min: "3.11"
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/beepboop2025/liquilens-evidence-carrier/releases/download/v${{ version }}/liquilens_evidence-${{ version }}.tar.gz
-  sha256: 63ccb12e6d82c34e546ba4fe11058d5aee216a70bd8f9fa96335a4cc9d5bfd6c
+  sha256: bd7a0a61bdb99784071021f95c160b9baeb22e00054f80abc03445a6cf576567
 
 build:
   number: 0
@@ -20,6 +20,7 @@ build:
   python:
     entry_points:
       - liquilens-evidence = liquilens_evidence.evidence_cli:main
+      - liquilens-evidence-mcp = liquilens_evidence.mcp_server:main
 
 requirements:
   host:
@@ -42,6 +43,7 @@ tests:
         - python ${{ python_min }}.*
     script:
       - liquilens-evidence --help
+      - liquilens-evidence-mcp --help
 
 about:
   homepage: https://liquilens.in/protocol/

--- a/recipes/liquilens-evidence/recipe.yaml
+++ b/recipes/liquilens-evidence/recipe.yaml
@@ -34,7 +34,9 @@ tests:
       imports:
         - liquilens_evidence
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - requirements:
       run:
         - python ${{ python_min }}.*

--- a/recipes/liquilens-evidence/recipe.yaml
+++ b/recipes/liquilens-evidence/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  name: liquilens-evidence
+  version: "0.13.5"
+  python_min: "3.11"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/beepboop2025/liquilens-evidence-carrier/releases/download/v${{ version }}/liquilens_evidence-${{ version }}.tar.gz
+  sha256: 9367367225c2aca4bd0380075a83b0e69a0f61b176976bf3eb55b301c879a02f
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - liquilens-evidence = liquilens_evidence.evidence_cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools ==84.0.0
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - liquilens_evidence
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - liquilens-evidence --help
+
+about:
+  homepage: https://liquilens.in/protocol/
+  summary: Portable, fail-closed financial evidence provenance
+  description: |
+    LiquiLens Evidence Carrier is a transport-neutral contract for moving
+    financial evidence through files, warehouses, event buses, observability
+    systems, data catalogs, financial desktops, notebooks, citations, and AI
+    agents without dropping provenance, rights, freshness, or authority
+    boundaries.
+  license: Apache-2.0
+  license_file: LICENSE
+  repository: https://github.com/beepboop2025/liquilens-evidence-carrier
+  documentation: https://github.com/beepboop2025/liquilens-evidence-carrier#readme
+
+extra:
+  recipe-maintainers:
+    - beepboop2025

--- a/recipes/liquilens-evidence/recipe.yaml
+++ b/recipes/liquilens-evidence/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: liquilens-evidence
-  version: "0.14.0"
+  version: "0.15.0"
   python_min: "3.11"
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/beepboop2025/liquilens-evidence-carrier/releases/download/v${{ version }}/liquilens_evidence-${{ version }}.tar.gz
-  sha256: bd7a0a61bdb99784071021f95c160b9baeb22e00054f80abc03445a6cf576567
+  sha256: 3c8976fff003e4671ebc3f5dab7d9e26562f2950d182460cf0ee2f57ebe72f75
 
 build:
   number: 0
@@ -43,7 +43,10 @@ tests:
         - python ${{ python_min }}.*
     script:
       - liquilens-evidence --help
+      - liquilens-evidence issue-brief --help
+      - liquilens-evidence verify-brief --help
       - liquilens-evidence-mcp --help
+      - python -c "from datetime import datetime, timezone; from liquilens_evidence import issue_fleet_brief, verify_fleet_brief; now = datetime(2026, 8, 25, tzinfo=timezone.utc); brief = issue_fleet_brief(carriers={}, evaluated_at=now); verified = verify_fleet_brief(brief, evaluated_at=now); assert set(verified.states.values()) == {'missing'}"
 
 about:
   homepage: https://liquilens.in/protocol/

--- a/recipes/liquilens-evidence/recipe.yaml
+++ b/recipes/liquilens-evidence/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: liquilens-evidence
-  version: "0.13.5"
+  version: "0.13.6"
   python_min: "3.11"
 
 package:
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/beepboop2025/liquilens-evidence-carrier/releases/download/v${{ version }}/liquilens_evidence-${{ version }}.tar.gz
-  sha256: 9367367225c2aca4bd0380075a83b0e69a0f61b176976bf3eb55b301c879a02f
+  sha256: 63ccb12e6d82c34e546ba4fe11058d5aee216a70bd8f9fa96335a4cc9d5bfd6c
 
 build:
   number: 0


### PR DESCRIPTION
This adds the first conda-forge recipe for liquilens-evidence 0.15.0.

The recipe uses the immutable GitHub release sdist (SHA-256 `3c8976fff003e4671ebc3f5dab7d9e26562f2950d182460cf0ee2f57ebe72f75`), builds a noarch Python package, packages the Apache-2.0 license, and tests the installed Python API and CLI surfaces. The 0.15.0 release adds the content-addressed, rights-aware Fleet Brief v1 contract across LiquiLens, Seiche, Undertow, and Palimpsest while retaining the offline, read-only Evidence Carrier MCP server.

Local validation:
- `conda-smithy recipe-lint --conda-forge recipes/*` passed
- `rattler-build 0.74.0` solved and built the release sdist against conda-forge on macOS ARM
- import and pip integrity checks passed on Python 3.11 and the latest supported Python 3.14
- the main CLI, Fleet Brief issue/verify subcommands, and MCP help commands passed
- an installed-package Fleet Brief issue/verify round trip passed with all four product sections fail-closed as `missing`

Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 recipe.yaml format.
- [x] License file is packaged.
- [x] Source is from the official project release.
- [x] Package does not vendor other packages.
- [x] No static libraries are linked in.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A release tarball URL is used.
- [x] The listed maintainer confirmed willingness in a PR comment.
- [x] The conda-forge knowledge base was consulted.