### PR TITLE
Adding sage-data-elliptic-curves

### DIFF
--- a/recipes/sage-data-elliptic-curves/recipe.yaml
+++ b/recipes/sage-data-elliptic-curves/recipe.yaml
@@ -32,7 +32,10 @@ tests:
       python_version:
         - ${{ python_min }}.*
         - "*"
-  - script:
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
       - >-
         python -c "from sage_data_elliptic_curves import cremona_mini_resource, rank_resource;
         assert cremona_mini_resource().open('rb').read(16) == b'SQLite format 3\0';
@@ -46,7 +49,9 @@ about:
     sage-data-elliptic-curves provides a compact SQLite database of John
     Cremona's elliptic curves of conductor below 10,000 and William Stein's
     collection of interesting elliptic curves, exposed through
-    importlib.resources.
+    importlib.resources. It is the Python-resource successor to the legacy
+    sagemath-db-elliptic-curves conda package, which installs the historical
+    data into a shared prefix; both layouts can coexist during migration.
   license: GPL-2.0-or-later
   license_file:
     - LICENSE

--- a/recipes/sage-data-elliptic-curves/recipe.yaml
+++ b/recipes/sage-data-elliptic-curves/recipe.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+
+context:
+  version: "0.8.1"
+
+package:
+  name: sage-data-elliptic-curves
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/sage-data-elliptic-curves/sage_data_elliptic_curves-${{ version }}.tar.gz
+  sha256: b31297c7357b8757092d734d74cfde5c3dc419dc9b14d751a1df5ae447b4d6eb
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - sage_data_elliptic_curves
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - >-
+        python -c "from sage_data_elliptic_curves import cremona_mini_resource, rank_resource;
+        assert cremona_mini_resource().open('rb').read(16) == b'SQLite format 3\0';
+        assert rank_resource(28).open('r', encoding='ascii').readline().split()[4] == '28'"
+
+about:
+  homepage: https://github.com/cxzhong/sage-data-elliptic-curves
+  repository: https://github.com/cxzhong/sage-data-elliptic-curves
+  summary: Elliptic-curve databases for SageMath and other Python software
+  description: |
+    sage-data-elliptic-curves provides a compact SQLite database of John
+    Cremona's elliptic curves of conductor below 10,000 and William Stein's
+    collection of interesting elliptic curves, exposed through
+    importlib.resources.
+  license: GPL-2.0-or-later
+  license_file:
+    - LICENSE
+    - DATA_LICENSES.md
+
+extra:
+  recipe-maintainers:
+    - cxzhong


### PR DESCRIPTION
This adds `sage-data-elliptic-curves` 0.8.1 as a pure-Python `noarch: python` package.

The package provides SageMath's compact Cremona SQLite database and rank data through `importlib.resources`. The recipe installs the published PyPI source distribution and tests both resource access and the SQLite header. The package metadata and this recipe declare `GPL-2.0-or-later`; `LICENSE` and `DATA_LICENSES.md` are packaged.

Licensing note: `DATA_LICENSES.md` records that the legacy Sage data archive did not contain a separate data-specific license notice. It is included so that this history is visible during review while this submission uses the `GPL-2.0-or-later` declaration.

Upstream: https://github.com/cxzhong/sage-data-elliptic-curves  
PyPI: https://pypi.org/project/sage-data-elliptic-curves/0.8.1/  
SageMath tracking issue: https://github.com/sagemath/sage/issues/42722

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (`git_url`) is used in the recipe.
- [x] The GitHub user listed in the maintainer section is submitting this PR and confirms willingness to maintain the feedstock.
- [x] I checked the conda-forge knowledge base relevant to this recipe.
