### PR TITLE
Adding sage-data-graphs

### DIFF
--- a/recipes/sage-data-graphs/recipe.yaml
+++ b/recipes/sage-data-graphs/recipe.yaml
@@ -1,0 +1,57 @@
+schema_version: 1
+
+context:
+  version: "20210214.0"
+
+package:
+  name: sage-data-graphs
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/sage-data-graphs/sage_data_graphs-${{ version }}.tar.gz
+  sha256: 4b82c49cca79ae0ff15942fe6ee05b00c64eb7bca9438648f89106add63b6620
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - sage_data_graphs
+        - sage_data_graphs.data
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - python -c "from sage_data_graphs import DATA_FILES; assert set(DATA_FILES) == {'brouwer_srg_database.json', 'graphs.db', 'isgci_sage.xml', 'smallgraphs.txt'}"
+      - python -c "from sage_data_graphs import graph_database_connection; c = graph_database_connection(); db = c.__enter__(); assert db.execute('PRAGMA integrity_check').fetchone() == ('ok',); assert db.execute('SELECT count(*) FROM graph_data').fetchone() == (1252,); c.__exit__(None, None, None)"
+      - python -c "import xml.etree.ElementTree as ET; from sage_data_graphs import open_resource; f = open_resource('isgci_sage.xml'); root = ET.parse(f).getroot(); f.close(); assert root.tag == 'ISGCI'; assert root.find('stats').attrib['nodes'] == '1461'"
+      - python -c "from sage_data_graphs import load_brouwer_database, open_resource; assert len(load_brouwer_database()) == 4538; f = open_resource('smallgraphs.txt', 'r'); lines = f.readlines(); f.close(); assert len(lines) == 565"
+
+about:
+  homepage: https://github.com/cxzhong/sage-data-graphs
+  repository: https://github.com/cxzhong/sage-data-graphs
+  summary: Graph database resources for SageMath and other Python applications
+  description: |
+    sage-data-graphs packages the graph database resources historically
+    shipped as SageMath's graphs data package. It provides read-only resource
+    helpers and has no dependency on SageMath.
+  license: GPL-2.0-or-later
+  license_file:
+    - LICENSE
+    - DATA_LICENSES.md
+
+extra:
+  recipe-maintainers:
+    - cxzhong

--- a/recipes/sage-data-graphs/recipe.yaml
+++ b/recipes/sage-data-graphs/recipe.yaml
@@ -33,7 +33,10 @@ tests:
       python_version:
         - ${{ python_min }}.*
         - "*"
-  - script:
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
       - python -c "from sage_data_graphs import DATA_FILES; assert set(DATA_FILES) == {'brouwer_srg_database.json', 'graphs.db', 'isgci_sage.xml', 'smallgraphs.txt'}"
       - python -c "from sage_data_graphs import graph_database_connection; c = graph_database_connection(); db = c.__enter__(); assert db.execute('PRAGMA integrity_check').fetchone() == ('ok',); assert db.execute('SELECT count(*) FROM graph_data').fetchone() == (1252,); c.__exit__(None, None, None)"
       - python -c "import xml.etree.ElementTree as ET; from sage_data_graphs import open_resource; f = open_resource('isgci_sage.xml'); root = ET.parse(f).getroot(); f.close(); assert root.tag == 'ISGCI'; assert root.find('stats').attrib['nodes'] == '1461'"
@@ -46,7 +49,10 @@ about:
   description: |
     sage-data-graphs packages the graph database resources historically
     shipped as SageMath's graphs data package. It provides read-only resource
-    helpers and has no dependency on SageMath.
+    helpers and has no dependency on SageMath. It is the Python-resource
+    successor to the legacy sagemath-db-graphs conda package, which installs
+    the same data into a shared prefix; both layouts can coexist during
+    migration.
   license: GPL-2.0-or-later
   license_file:
     - LICENSE


### PR DESCRIPTION
This adds `sage-data-graphs` 20210214.0 as a pure-Python `noarch: python` package.

The package provides SageMath's graph database resources through `importlib.resources`, including the graph SQLite database, ISGCI XML, strongly regular graph data, and small graph data. The recipe installs the published PyPI source distribution and validates each resource. The package metadata and this recipe declare `GPL-2.0-or-later`; `LICENSE` and `DATA_LICENSES.md` are packaged.

Licensing note: `DATA_LICENSES.md` records the individual data sources and that the legacy Sage archive did not contain more specific redistribution notices. It is included so that this history is visible during review while this submission uses the `GPL-2.0-or-later` declaration.

Upstream: https://github.com/cxzhong/sage-data-graphs  
PyPI: https://pypi.org/project/sage-data-graphs/20210214.0/  
SageMath tracking issue: https://github.com/sagemath/sage/issues/42722

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (`git_url`) is used in the recipe.
- [x] The GitHub user listed in the maintainer section is submitting this PR and confirms willingness to maintain the feedstock.
- [x] I checked the conda-forge knowledge base relevant to this recipe.
