### PR TITLE
Add pyramids-eo recipe

### DIFF
--- a/recipes/pyramids-eo/recipe.yaml
+++ b/recipes/pyramids-eo/recipe.yaml
@@ -26,16 +26,9 @@ requirements:
     - wheel
   run:
     - python >=${{ python_min }}
-    # `pyramids` is the conda-forge name of the `pyramids-gis` PyPI distribution
-    # this package is built on (conda-forge/pyramids-feedstock).
     - pyramids >=0.53.0
     - numpy >=2.0.0
     - pyyaml >=6.0
-    # pyramids-eo drives GDAL directly (`from osgeo import gdal, osr`) for the
-    # Earth Engine (EEDAI) and sensor readers; the FCI L1C reader opens
-    # `NETCDF:` subdatasets, so the netCDF driver is required as well. The PyPI
-    # wheels rely on the GDAL bundled with `pyramids-gis`; on conda-forge the
-    # stack is a real dependency, so it is declared explicitly here.
     - gdal >=3.10.0,<4
     - libgdal-netcdf >=3.10.0,<4
 

--- a/recipes/pyramids-eo/recipe.yaml
+++ b/recipes/pyramids-eo/recipe.yaml
@@ -1,0 +1,80 @@
+schema_version: 1
+
+context:
+  name: pyramids-eo
+  version: "0.3.0"
+  python_min: "3.11"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/pyramids_eo-${{ version }}.tar.gz
+  sha256: 3ecd7c839400d60a653ff904fed9c393f934f0b89a9c5d4a580b63b4d910fb0d
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --disable-pip-version-check
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=80.0.0
+    - wheel
+  run:
+    - python >=${{ python_min }}
+    # `pyramids` is the conda-forge name of the `pyramids-gis` PyPI distribution
+    # this package is built on (conda-forge/pyramids-feedstock).
+    - pyramids >=0.53.0
+    - numpy >=2.0.0
+    - pyyaml >=6.0
+    # pyramids-eo drives GDAL directly (`from osgeo import gdal, osr`) for the
+    # Earth Engine (EEDAI) and sensor readers; the FCI L1C reader opens
+    # `NETCDF:` subdatasets, so the netCDF driver is required as well. The PyPI
+    # wheels rely on the GDAL bundled with `pyramids-gis`; on conda-forge the
+    # stack is a real dependency, so it is declared explicitly here.
+    - gdal >=3.10.0,<4
+    - libgdal-netcdf >=3.10.0,<4
+
+tests:
+  - python:
+      imports:
+        - pyramids_eo
+        - pyramids_eo.composites
+        - pyramids_eo.earthengine
+        - pyramids_eo.sensors
+        - pyramids_eo.sensors.readers
+        - pyramids_eo.sensors.registry
+        - pyramids_eo.stac
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  summary: Remote-sensing / Earth-observation tier for the pyramids GIS stack
+  description: |
+    pyramids-eo is the Earth-observation layer of the pyramids GIS stack. Where
+    pyramids (the `pyramids-gis` distribution) provides the generic raster and
+    vector engine, pyramids-eo adds the logic that is specific to
+    Earth-observation data: which subdataset is which instrument channel, how to
+    calibrate it, how to build RGB composites, and how to reach signed EO cloud
+    assets.
+
+    It provides byte-level readers for EUMETSAT MSG/SEVIRI native and MTG/FCI
+    L1C products, a YAML sensor registry with per-channel calibration metadata,
+    true-colour and night composites, Google Earth Engine ingestion (including
+    oversize tiling and local mosaicking), and STAC asset signers for the major
+    EO catalogues.
+  license: GPL-3.0-only
+  license_file: LICENSE
+  homepage: https://github.com/serapeum-org/pyramids-eo
+  repository: https://github.com/serapeum-org/pyramids-eo
+  documentation: https://serapeum-org.github.io/pyramids-eo
+
+extra:
+  recipe-maintainers:
+    - MAfarrag


### PR DESCRIPTION
Adds a recipe for [pyramids-eo](https://github.com/serapeum-org/pyramids-eo) — the Earth-observation layer of the
pyramids GIS stack. It sits on top of the existing [`pyramids`](https://github.com/conda-forge/pyramids-feedstock)
package (the `pyramids-gis` PyPI distribution) and adds EUMETSAT MSG/SEVIRI and MTG/FCI L1C readers, a YAML sensor
registry with per-channel calibration, RGB composites, Google Earth Engine ingestion, and STAC asset signers.

Noarch Python, built from the PyPI sdist of the 0.3.0 release.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
