### PR TITLE
Add aws-lc

### DIFF
--- a/recipes/aws-lc/allow-dist-pkg-on-macos.patch
+++ b/recipes/aws-lc/allow-dist-pkg-on-macos.patch
@@ -1,0 +1,25 @@
+Allow ENABLE_DIST_PKG on macOS
+
+ENABLE_DIST_PKG is upstream's packaging mode for installing AWS-LC next to
+another OpenSSL implementation. It sets SET_LIB_SONAME, COHABITANT_HEADERS and
+COHABITANT_BINARIES, none of which are Linux specific: the target VERSION /
+SOVERSION properties it enables are honoured on Apple platforms as the dylib
+compatibility and current version, and the ELF symbol versioning that genuinely
+requires GNU ld is separately gated on `UNIX AND NOT APPLE` further down.
+
+Without this we would have to reimplement the header relocation and library
+renaming in the recipe to avoid clobbering the `openssl` package.
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -90,8 +90,8 @@
+ endif()
+
+ if(ENABLE_DIST_PKG)
+-  if(NOT UNIX OR APPLE)
+-    message(FATAL_ERROR "ENABLE_DIST_PKG is not supported on macOS or Windows and will be ignored.")
++  if(NOT UNIX)
++    message(FATAL_ERROR "ENABLE_DIST_PKG is not supported on Windows and will be ignored.")
+   else()
+     set(SET_LIB_SONAME 1)
+     set(COHABITANT_HEADERS 1)

--- a/recipes/aws-lc/build.sh
+++ b/recipes/aws-lc/build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# The Go toolchain is only used to generate crypto/err/err_data.c, which
+# imports nothing outside the standard library. Keep it from reaching out to
+# the network to resolve the (test-only) module dependencies.
+export GOPROXY=off
+export GOFLAGS="-mod=mod"
+export GOCACHE="${SRC_DIR}/.gocache"
+export GOPATH="${SRC_DIR}/.gopath"
+
+# ENABLE_DIST_PKG is upstream's packaging mode for installing AWS-LC alongside
+# another OpenSSL implementation: headers land in include/aws-lc/openssl, the
+# libraries are named libcrypto-awslc/libssl-awslc and the command line tools
+# are prefixed with aws-lc-. Upstream restricts it to Linux, but everything it
+# turns on that is Linux-specific (ELF symbol versioning) is independently
+# gated on non-Apple, so it works on macOS as well.
+cmake -GNinja -B build -S . \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILD_TESTING=OFF \
+  -DBUILD_LIBSSL=ON \
+  -DBUILD_TOOL=ON \
+  -DENABLE_DIST_PKG=ON \
+  -DENABLE_DIST_PKG_OPENSSL_SHIM=OFF
+
+cmake --build build --config Release
+cmake --install build --config Release

--- a/recipes/aws-lc/recipe.yaml
+++ b/recipes/aws-lc/recipe.yaml
@@ -1,0 +1,101 @@
+schema_version: 1
+
+context:
+  version: "5.5.0"
+
+package:
+  name: aws-lc
+  version: ${{ version }}
+
+source:
+  url: https://github.com/aws/aws-lc/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: d79a5beb1c2f7fd86a17d91eb230ae12da71dc28bedeb775c179863cf279c650
+  patches:
+    - allow-dist-pkg-on-macos.patch
+
+build:
+  number: 0
+  # AWS-LC's CMake build does not support the MSVC generator for assembly.
+  skip: win
+  script: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - perl
+    - ${{ compiler('go-nocgo') }}
+
+tests:
+  - script:
+      - aws-lc-bssl version
+      - aws-lc-openssl version
+      - test -f $PREFIX/include/aws-lc/openssl/ssl.h
+      - test -f $PREFIX/lib/pkgconfig/aws-lc.pc
+      - pkg-config --exists --print-errors aws-lc
+    requirements:
+      run:
+        - pkg-config
+  - package_contents:
+      bin:
+        - aws-lc-bssl
+        - aws-lc-openssl
+      include:
+        - aws-lc/openssl/ssl.h
+        - aws-lc/openssl/crypto.h
+      lib:
+        - crypto-awslc
+        - ssl-awslc
+  # Compile and link a small program against the installed library to verify
+  # the headers, pkg-config metadata and shared libraries are all consistent.
+  - files:
+      recipe:
+        - test_link.c
+    script:
+      - ${{ "$CC" }} $CFLAGS $LDFLAGS test_link.c -o test_link $(pkg-config --cflags --libs aws-lc)
+      - ./test_link
+    requirements:
+      build:
+        - ${{ compiler('c') }}
+        - ${{ stdlib('c') }}
+        - pkg-config
+
+about:
+  homepage: https://github.com/aws/aws-lc
+  summary: AWS-LC is a general-purpose cryptographic library maintained by AWS
+  description: |
+    AWS-LC is a general-purpose cryptographic library maintained by the AWS
+    Cryptography team for AWS and their customers. It is based on code from
+    Google's BoringSSL project and the OpenSSL project.
+
+    AWS-LC contains portable C implementations of algorithms needed for TLS
+    and common applications, with optimized assembly versions for x86 and
+    ARM on several platforms.
+
+    To avoid conflicting with the `openssl` package, this build installs its
+    headers under `$PREFIX/include/aws-lc/openssl`, names the libraries
+    `libcrypto-awslc` and `libssl-awslc`, and prefixes the command line tools
+    with `aws-lc-`. Consumers should use the `aws-lc`, `libcrypto-awslc` or
+    `libssl-awslc` pkg-config files, or the CMake packages `crypto` and `ssl`.
+  # New AWS-LC code is Apache-2.0 OR ISC; the BoringSSL/OpenSSL heritage adds
+  # ISC and Apache-2.0, and the third-party code compiled into libcrypto adds
+  # MIT (fiat), MIT-0 (s2n-bignum) and BSD-3-Clause (jitterentropy, which is
+  # dual BSD/GPL-2.0 upstream but which Amazon expressly distributes as
+  # BSD-3-Clause).
+  license: (Apache-2.0 OR ISC) AND Apache-2.0 AND ISC AND MIT AND MIT-0 AND BSD-3-Clause
+  license_file:
+    - LICENSE
+    - NOTICE
+    - third_party/fiat/LICENSE
+    - third_party/s2n-bignum/s2n-bignum-imported/LICENSE
+    - third_party/jitterentropy/jitterentropy-library/LICENSE
+    - third_party/jitterentropy/jitterentropy-library/LICENSE.bsd
+  documentation: https://github.com/aws/aws-lc/tree/main/docs
+  repository: https://github.com/aws/aws-lc
+
+extra:
+  recipe-maintainers:
+    - pavelzw

--- a/recipes/aws-lc/test_link.c
+++ b/recipes/aws-lc/test_link.c
@@ -1,0 +1,41 @@
+#include <openssl/crypto.h>
+#include <openssl/digest.h>
+#include <openssl/rand.h>
+#include <openssl/service_indicator.h>
+#include <openssl/ssl.h>
+
+#include <stdio.h>
+#include <string.h>
+
+int main(void) {
+  printf("awslc_version_string: %s\n", awslc_version_string());
+
+  unsigned char buf[32];
+  if (RAND_bytes(buf, sizeof(buf)) != 1) {
+    fprintf(stderr, "RAND_bytes failed\n");
+    return 1;
+  }
+
+  unsigned char digest[EVP_MAX_MD_SIZE];
+  unsigned int digest_len = 0;
+  if (EVP_Digest(buf, sizeof(buf), digest, &digest_len, EVP_sha256(), NULL) !=
+      1) {
+    fprintf(stderr, "EVP_Digest failed\n");
+    return 1;
+  }
+  if (digest_len != 32) {
+    fprintf(stderr, "unexpected SHA-256 length %u\n", digest_len);
+    return 1;
+  }
+
+  /* Exercise libssl too, so we know it linked. */
+  SSL_CTX *ctx = SSL_CTX_new(TLS_method());
+  if (ctx == NULL) {
+    fprintf(stderr, "SSL_CTX_new failed\n");
+    return 1;
+  }
+  SSL_CTX_free(ctx);
+
+  printf("ok\n");
+  return 0;
+}


### PR DESCRIPTION
Adds a recipe for [AWS-LC](https://github.com/aws/aws-lc), the general-purpose cryptographic library maintained by the AWS Cryptography team (a fork of BoringSSL, itself a fork of OpenSSL).

### Coexisting with `openssl`

A stock AWS-LC install would clobber the `openssl` package: it writes `include/openssl/*`, `lib/libcrypto.*`, `lib/libssl.*` and `bin/openssl`. This recipe therefore builds with upstream's `ENABLE_DIST_PKG=ON` packaging mode, which is designed exactly for installing AWS-LC alongside another OpenSSL implementation:

| | path |
| --- | --- |
| headers | `include/aws-lc/openssl/` |
| libraries | `lib/libcrypto-awslc`, `lib/libssl-awslc` |
| tools | `bin/aws-lc-bssl`, `bin/aws-lc-openssl`, `bin/aws-lc-c_rehash` |
| pkg-config | `aws-lc.pc`, `libcrypto-awslc.pc`, `libssl-awslc.pc` |
| cmake | `lib/crypto/cmake`, `lib/ssl/cmake` |

`ENABLE_DIST_PKG_OPENSSL_SHIM` is left `OFF` so that no unsuffixed `libcrypto`/`libssl` symlinks or `openssl.pc` are installed. I verified the built package shares no file with `openssl`.

### Patch

`ENABLE_DIST_PKG` is gated to non-Apple upstream, so the recipe carries a one-hunk patch relaxing that. Everything the flag enables that genuinely needs GNU ld (ELF symbol versioning) is separately gated on `UNIX AND NOT APPLE`, so the remaining effects — cohabitant headers/binaries and the `-awslc` library suffix — work fine on macOS. The dylibs come out with correct install names and compatibility/current versions. I'd be happy to send this upstream if reviewers prefer.

### Notes

- `win` is skipped: upstream's CMake build cannot assemble the asm sources with the MSVC generator.
- Go and Perl are build-time code generators only (`err_data.c` and the asm), so they do not appear in `run`. `GOPROXY=off` keeps the Go step from touching the network — the only module dependency (`golang.org/x/crypto`) is used solely by the test suite, which is disabled.
- `BUILD_TESTING=OFF`; the upstream test suite requires network access and the Go module deps.
- Tests cover both CLI tools, the installed layout, pkg-config metadata, and a small C program compiled and linked against the installed library that calls into both libcrypto and libssl.
- Built and tested locally on `osx-arm64`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
