### PR TITLE
Add cloudsmith-api

### DIFF
--- a/recipes/cloudsmith-api/recipe.yaml
+++ b/recipes/cloudsmith-api/recipe.yaml
@@ -14,7 +14,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:

--- a/recipes/cloudsmith-api/recipe.yaml
+++ b/recipes/cloudsmith-api/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  version: 2.0.32
+
+package:
+  name: cloudsmith-api
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/cloudsmith-api/cloudsmith_api-${{ version }}.tar.gz
+  sha256: 17f2a131158c4ff7020087415dd5b7a3b265f6a8b8753e61cff8cd25c0a04915
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+    - wheel >=0.45
+  run:
+    - python >=${{ python_min }}
+    - certifi >=2017.4.17
+    - python-dateutil >=2.1
+    - six >=1.10
+    - urllib3 >=1.23
+
+tests:
+  - python:
+      imports:
+        - cloudsmith_api
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+
+about:
+  homepage: https://cloudsmith.com
+  repository: https://github.com/cloudsmith-io/cloudsmith-api
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Python bindings for the Cloudsmith API
+
+extra:
+  recipe-maintainers:
+    - BartoszBlizniak


### PR DESCRIPTION
Adds `cloudsmith-api` 2.0.32 from its published PyPI sdist as a noarch Python package.

The recipe follows the package's published build and runtime metadata and tests imports and dependency consistency against the minimum and latest supported Python versions.

I confirm that I am willing to maintain this feedstock as `@BartoszBlizniak`.

Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License file is packaged.
- [x] Source is from the official source.
- [x] Package does not vendor other packages.
- [x] Package does not link or ship static libraries.
- [x] Build number is 0.
- [x] A source tarball is used.
- [x] The listed maintainer has confirmed their willingness to maintain the feedstock.
