### PR TITLE
Adding pytensor-ml

### DIFF
--- a/recipes/pytensor-ml/recipe.yaml
+++ b/recipes/pytensor-ml/recipe.yaml
@@ -38,7 +38,7 @@ tests:
       pip_check: true
       python_version:
         - ${{ python_min }}.*
-        - 3.*
+        - "*"
 
 about:
   homepage: https://github.com/pymc-devs/pytensor-ml

--- a/recipes/pytensor-ml/recipe.yaml
+++ b/recipes/pytensor-ml/recipe.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+context:
+  name: pytensor-ml
+  pypi_name: pytensor_ml
+  version: "0.2.1"
+  python_min: "3.12"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ pypi_name[0] }}/${{ pypi_name }}/${{ pypi_name }}-${{ version }}.tar.gz
+  sha256: eda99127c932d8fce556a2b499304f3e44b0261b91db8c2c9391b41b1e656b4c
+
+build:
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pytensor >=3.2.3,<4.0.0
+    - numpy
+    - safetensors
+
+tests:
+  - python:
+      imports:
+        - pytensor_ml
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - 3.*
+
+about:
+  homepage: https://github.com/pymc-devs/pytensor-ml
+  summary: A(nother) deep learning library, built on top of PyTensor
+  description: |
+    pytensor_ml is a neural network library built on PyTensor. Models are
+    defined as symbolic graphs, so gradients come from PyTensor's autodiff
+    and training functions compile to any of its backends.
+  license: Apache-2.0
+  license_file: LICENSE
+  repository: https://github.com/pymc-devs/pytensor-ml
+
+extra:
+  recipe-maintainers:
+    - jessegrabowski

--- a/recipes/pytensor-ml/recipe.yaml
+++ b/recipes/pytensor-ml/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   name: pytensor-ml
-  pypi_name: pytensor_ml
   version: "0.2.1"
   python_min: "3.12"
 
@@ -11,7 +10,7 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ pypi_name[0] }}/${{ pypi_name }}/${{ pypi_name }}-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pytensor_ml/pytensor_ml-${{ version }}.tar.gz
   sha256: eda99127c932d8fce556a2b499304f3e44b0261b91db8c2c9391b41b1e656b4c
 
 build:


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Pure-Python `noarch` package. I am the upstream author and the sole listed maintainer.

The source URL uses a separate `pypi_name` context variable because the sdist filename keeps the underscore (`pytensor_ml-0.2.1.tar.gz`) while the conda package is named `pytensor-ml`.
