### PR TITLE
Adding datamaite

### DIFF
--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -58,7 +58,7 @@ about:
   summary: A unified framework for dataset loading, conversion, and quality validation.
   license: Apache-2.0
   license_file: LICENSE.md
-
+    repository: https://github.com/openteams-ai/datamaite
 extra:
   recipe-maintainers:
     - mikemazara

--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -60,7 +60,7 @@ about:
   summary: A unified framework for dataset loading, conversion, and quality validation.
   license: Apache-2.0
   license_file: LICENSE.md
-    repository: https://github.com/openteams-ai/datamaite
+  repository: https://github.com/openteams-ai/datamaite
 extra:
   recipe-maintainers:
     - mikemazara

--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+
+context:
+  version: "0.4.1"
+  python_min: "3.10"
+
+package:
+  name: datamaite
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/d/datamaite/datamaite-${{ version }}.tar.gz
+  sha256: 9b9706e858dc3c400d46229a96c9f01e813cc43f9b4a4c1a72e6a83e07c0dd45
+
+build:
+  number: 0
+  noarch: python
+  # UV_DYNAMIC_VERSIONING_BYPASS is inert on 0.4.1 (sdist has a static
+  # version and build-system requires only hatchling). It is load-bearing
+  # from 0.5.0, whose sdist derives the version from the git tag and ships
+  # no .git — without bypass the backend falls back to 0.0.0 while the
+  # conda package is named 0.5.0.
+  script:
+    content: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    env:
+      UV_DYNAMIC_VERSIONING_BYPASS: ${{ version }}
+  python:
+    entry_points:
+      - datamaite = datamaite._cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling
+    # Unused on 0.4.1; required from 0.5.0 (see build script comment).
+    - uv-dynamic-versioning
+  run:
+    - python >=${{ python_min }},<3.15
+    - pydantic >=2.0
+    - numpy >=1.24
+    - fsspec >=2024.5.0
+    - universal_pathlib >=0.3.8
+
+tests:
+  - python:
+      imports:
+        - datamaite
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - datamaite --help
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+
+about:
+  homepage: https://pypi.org/project/datamaite/
+  summary: A unified framework for dataset loading, conversion, and quality validation.
+  license: Apache-2.0
+  license_file: LICENSE.md
+
+extra:
+  recipe-maintainers:
+    - mikemazara

--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -46,7 +46,9 @@ tests:
       imports:
         - datamaite
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - datamaite --help
     requirements:

--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "0.4.1"
-  python_min: "3.10"
 
 package:
   name: datamaite

--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -63,3 +63,9 @@ about:
 extra:
   recipe-maintainers:
     - mikemazara
+    - nenb
+    - oren-openteams
+    - kcpevey
+    - brandonrc
+    - kenafoster
+    - oldsj

--- a/recipes/datamaite/recipe.yaml
+++ b/recipes/datamaite/recipe.yaml
@@ -61,6 +61,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE.md
   repository: https://github.com/openteams-ai/datamaite
+
 extra:
   recipe-maintainers:
     - mikemazara


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

## Package

Core-only noarch Python package from the PyPI 0.4.1 sdist (`https://pypi.org/project/datamaite/`). Equivalent to `pip install datamaite`. Source is GitLab-hosted so the recipe uses the PyPI tarball, not a git URL.

Run deps: `pydantic`, `numpy`, `fsspec`, `universal_pathlib` (conda-forge name; PyPI is `universal-pathlib`). Extras (`opencv`, `av`, cloud FS) are not in `run:` for v1.

`UV_DYNAMIC_VERSIONING_BYPASS` and host `uv-dynamic-versioning` are inert on 0.4.1 (static version, hatchling-only build-system) and load-bearing from 0.5.0, whose sdist is tag-derived and ships no `.git`.

I am the listed maintainer and will confirm in a follow-up comment.

Made with [Cursor](https://cursor.com)