### PR TITLE
Add `jupyter-live-content`

### DIFF
--- a/recipes/jupyter-live-content/recipe.yaml
+++ b/recipes/jupyter-live-content/recipe.yaml
@@ -1,0 +1,48 @@
+context:
+  version: "0.1.1"
+
+package:
+  name: jupyter-live-content
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/j/jupyter-live-content/jupyter_live_content-${{ version }}.tar.gz
+  sha256: 0acc3dd881bf9ffd765fc321c21cda06414bca3733af9780612a134ce3db96e0
+
+build:
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling >=1.5.0
+    - hatch-nodejs-version >=0.3.2
+    - jupyter-builder >=1.2.0,<2
+    - hatch-jupyter-builder >=0.5
+  run:
+    - python >=${{ python_min }}
+    - jupyter_server >=2.13.0,<3
+    - watchfiles >=0.21
+
+tests:
+  - python:
+      imports:
+        - jupyter_live_content
+      pip_check: true
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/jupyter-ai-contrib/jupyter-live-content
+  summary: "A minimal JupyterLab extension that provides live content updates from the filesystem."
+  license: BSD-3-Clause
+  license_file: LICENSE
+  repository: https://github.com/jupyter-ai-contrib/jupyter-live-content
+
+extra:
+  recipe-maintainers:
+    - dlqqq

--- a/recipes/jupyter-live-content/recipe.yaml
+++ b/recipes/jupyter-live-content/recipe.yaml
@@ -46,3 +46,4 @@ about:
 extra:
   recipe-maintainers:
     - dlqqq
+    - krassowski

--- a/recipes/jupyter-live-content/recipe.yaml
+++ b/recipes/jupyter-live-content/recipe.yaml
@@ -32,9 +32,9 @@ tests:
       imports:
         - jupyter_live_content
       pip_check: true
-    requirements:
-      run:
-        - python ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/jupyter-ai-contrib/jupyter-live-content


### PR DESCRIPTION
Adds a v1 recipe for [`jupyter-live-content`](https://github.com/jupyter-ai-contrib/jupyter-live-content) (v0.1.1), a minimal JupyterLab extension that provides live content updates from the filesystem.

Upstream: https://github.com/jupyter-ai-contrib/jupyter-live-content
PyPI: https://pypi.org/project/jupyter-live-content/

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
