### PR TITLE
Add topo-tools

### DIFF
--- a/recipes/topo-tools/recipe.yaml
+++ b/recipes/topo-tools/recipe.yaml
@@ -41,7 +41,6 @@ tests:
         - "*"
   - requirements:
       run:
-        - pip
         - python ${{ python_min }}.*
     script:
       - topo-tools --help

--- a/recipes/topo-tools/recipe.yaml
+++ b/recipes/topo-tools/recipe.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  version: "0.5.3"
+
+package:
+  name: topo-tools
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/topo-tools/topo_tools-${{ version }}.tar.gz
+  sha256: 989f95a7fc276d725085f58fe91f9dc5912b368511066744c3c090aed18a9d7a
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - topo-tools = topo_tools.cli.main:cli
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - click
+    - python-duckdb >=1.5.5
+    - psutil
+    - pyyaml >=6.0.3
+
+tests:
+  - python:
+      imports:
+        - topo_tools
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - topo-tools --help
+
+about:
+  summary: DuckDB-powered geospatial topology utilities (edge-matching, topology cleaning, more)
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/OCHA-DAP/topo-tools-py
+  repository: https://github.com/OCHA-DAP/topo-tools-py
+  documentation: https://github.com/OCHA-DAP/topo-tools-py#readme
+
+extra:
+  recipe-maintainers:
+    - maxmalynowsky


### PR DESCRIPTION
DuckDB-powered geospatial topology utilities (edge-matching, topology cleaning, and more) for cleaning up administrative boundary datasets. Pure-Python `noarch: python` package, published on PyPI as `topo-tools`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
