### PR TITLE
Adding opendal

### DIFF
--- a/recipes/opendal/recipe.yaml
+++ b/recipes/opendal/recipe.yaml
@@ -39,7 +39,7 @@ requirements:
     - pip
     - maturin >=1,<2
   run:
-    - python >=3.10
+    - python
 
 tests:
   - python:

--- a/recipes/opendal/recipe.yaml
+++ b/recipes/opendal/recipe.yaml
@@ -1,0 +1,72 @@
+schema_version: 1
+
+context:
+  name: opendal
+  version: "0.47.6"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/o/opendal/opendal-${{ version }}.tar.gz
+  sha256: 297b876ab44162490d4e38041ecb712800ad14814ee35c4c3c196af4b26ffd61
+
+build:
+  number: 0
+  script:
+    env:
+      MATURIN_PEP517_ARGS: "--locked --features pyo3/extension-module,services-all"
+    content:
+      - if: unix
+        then: sh -c 'cd bindings/python && cargo-bundle-licenses --features pyo3/extension-module,services-all --format yaml --output ../../THIRDPARTY.yml'
+        else: cmd /d /c "cd /d bindings\python && cargo-bundle-licenses --features pyo3/extension-module,services-all --format yaml --output ..\..\THIRDPARTY.yml"
+      - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - maturin >=1,<2
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - ${{ compiler("rust") }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1,<2
+  run:
+    - python >=3.10
+
+tests:
+  - python:
+      imports:
+        - opendal
+      pip_check: true
+  - script:
+      - python -c "import opendal; operator = opendal.Operator('memory'); operator.write('smoke', b'ok'); assert operator.read('smoke') == b'ok'"
+      - python -c "from opendal.services import Scheme; assert Scheme.Dropbox.value == 'dropbox'"
+      - if: unix
+        then: python -c "from opendal.services import Scheme; assert Scheme.Sftp.value == 'sftp'"
+
+about:
+  homepage: https://opendal.apache.org/
+  documentation: https://opendal.apache.org/docs/python/index.html
+  repository: https://github.com/apache/opendal
+  summary: Apache OpenDAL Python binding
+  description: |
+    Apache OpenDAL is a data access layer that allows users to easily and
+    efficiently retrieve data from various storage services in a unified way.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE
+    - LICENSE-MPL-2.0.txt
+    - THIRDPARTY.yml
+
+extra:
+  recipe-maintainers:
+    - Xuanwo

--- a/recipes/opendal/recipe.yaml
+++ b/recipes/opendal/recipe.yaml
@@ -49,8 +49,6 @@ tests:
   - script:
       - python -c "import opendal; operator = opendal.Operator('memory'); operator.write('smoke', b'ok'); assert operator.read('smoke') == b'ok'"
       - python -c "from opendal.services import Scheme; assert Scheme.Dropbox.value == 'dropbox'"
-      - if: unix
-        then: python -c "from opendal.services import Scheme; assert Scheme.Sftp.value == 'sftp'"
 
 about:
   homepage: https://opendal.apache.org/

--- a/recipes/opendal/recipe.yaml
+++ b/recipes/opendal/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: opendal
   version: "0.47.6"
 
 package:
-  name: ${{ name }}
+  name: opendal
   version: ${{ version }}
 
 source:
@@ -14,13 +13,16 @@ source:
 
 build:
   number: 0
+  skip: is_abi3 and not is_python_min
+  python:
+    version_independent: ${{ is_abi3 }}
   script:
     env:
-      MATURIN_PEP517_ARGS: "--locked --features pyo3/extension-module,services-all"
+      MATURIN_PEP517_ARGS: "--locked --features pyo3/extension-module,services-all${{ ',abi3' if is_abi3 else '' }}"
     content:
       - if: unix
-        then: sh -c 'cd bindings/python && cargo-bundle-licenses --features pyo3/extension-module,services-all --format yaml --output ../../THIRDPARTY.yml'
-        else: cmd /d /c "cd /d bindings\python && cargo-bundle-licenses --features pyo3/extension-module,services-all --format yaml --output ..\..\THIRDPARTY.yml"
+        then: sh -c 'cd bindings/python && cargo-bundle-licenses --features pyo3/extension-module,services-all${{ ",abi3" if is_abi3 else "" }} --format yaml --output ../../THIRDPARTY.yml'
+        else: cmd /d /c "cd /d bindings\python && cargo-bundle-licenses --features pyo3/extension-module,services-all${{ ',abi3' if is_abi3 else '' }} --format yaml --output ..\..\THIRDPARTY.yml"
       - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -35,6 +37,8 @@ requirements:
     - ${{ compiler("rust") }}
     - cargo-bundle-licenses
   host:
+    - if: is_abi3
+      then: python-abi3
     - python
     - pip
     - maturin >=1,<2
@@ -46,9 +50,22 @@ tests:
       imports:
         - opendal
       pip_check: true
+      python_version:
+        - if: is_abi3
+          then: ${{ python_min }}.*
+        - "*"
   - script:
       - python -c "import opendal; operator = opendal.Operator('memory'); operator.write('smoke', b'ok'); assert operator.read('smoke') == b'ok'"
       - python -c "from opendal.services import Scheme; assert Scheme.Dropbox.value == 'dropbox'"
+  - if: is_abi3
+    then:
+      requirements:
+        run:
+          - abi3audit
+      script:
+        - if: unix
+          then: abi3audit $SP_DIR/opendal/_opendal.abi3.so -s -v --assume-minimum-abi3 ${{ python_min }}
+          else: abi3audit %SP_DIR%\opendal\_opendal.pyd -s -v --assume-minimum-abi3 ${{ python_min }}
 
 about:
   homepage: https://opendal.apache.org/


### PR DESCRIPTION
This recipe packages version 0.47.6 of the Apache OpenDAL Python binding from its official PyPI source distribution.

It builds the binding with the same `services-all` feature set used for PyPI wheels, bundles Rust dependency licenses in `THIRDPARTY.yml`, and tests both memory I/O and a representative non-default service.

Upstream tracking:
- https://github.com/apache/opendal/issues/4391
- https://github.com/apache/opendal/issues/8170

AI assistance: Codex helped draft the recipe. The maintainer reviewed the source release, version, feature set, license handling, and test coverage.

Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License files are packaged.
- [x] Source is from the official PyPI release.
- [x] Package does not vendor other packages; Rust dependency licenses are bundled.
- [x] Licenses for statically linked Rust dependencies are packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A release tarball is used.
- [x] I am willing to be listed as a recipe maintainer.