### PR TITLE
Add dynaref

### DIFF
--- a/recipes/dynaref/conda-forge.yml
+++ b/recipes/dynaref/conda-forge.yml
@@ -1,0 +1,4 @@
+noarch_platforms:
+  - linux_64
+  - osx_64
+  - win_64

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: 6.9.1
+  version: 6.10.0
 
 package:
   name: dynaref
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/D/DynaRef/dynaref-${{ version }}.tar.gz
-  sha256: debcebffefe502be354036bf0a12c13a60a3a1a3f0828c223fc35b054e42a269
+  sha256: e4257edabe5a9ef4bdd5d8cb6aa2b325c537e51b5608097464d0eb75c0fb1d44
 
 build:
   number: 0
@@ -39,7 +39,7 @@ tests:
       - python -m dyna.cli --help
       - if: unix
         then: dyna-sim --help
-      - python -c "import dyna; assert dyna.__version__ == '6.9.1'"
+      - python -c "import dyna; assert dyna.__version__ == '6.10.0'"
 
 about:
   summary: X-ray magnetic reflectivity simulation and fitting

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: 6.9.0
+
+package:
+  name: dynaref
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/d/dynaref/dynaref-${{ version }}.tar.gz
+  sha256: 393c1d629af168e46b3f327a97f09fdbad41c3b6d403f4b41ce34c22b0f461b7
+
+build:
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.10
+    - numpy >=1.22.4
+    - scipy >=1.8.1
+    - matplotlib >=3.5.2
+    - pyqt >=5.15.6,<6
+    - pyyaml >=6.0
+    - if: osx
+      then: pyobjc-framework-cocoa >=10.0
+
+tests:
+  - python:
+      imports:
+        - dyna
+      pip_check: true
+  - script:
+      - dyna-sim --help
+      - python -c "import dyna; assert dyna.__version__ == '6.9.0'"
+
+about:
+  summary: X-ray magnetic reflectivity simulation and fitting
+  description: >-
+    Dyna simulates and fits X-ray reflectivity, transmissivity, Kerr, and
+    Faraday signals from resonant, magnetic, and anisotropic multilayers.
+  license: GPL-2.0-or-later
+  license_file: LICENSE.txt
+  homepage: https://pydyna.readthedocs.io
+  repository: https://gitlab.com/dynadevgroup/Dyna
+  documentation: https://pydyna.readthedocs.io
+
+extra:
+  recipe-maintainers:
+    - StefGre

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -21,10 +21,10 @@ requirements:
     - pip
     - setuptools >=68
   run:
-    - python >=3.10
+    - python
     - numpy >=1.22.4
     - scipy >=1.8.1
-    - matplotlib >=3.5.2
+    - matplotlib-base >=3.5.2
     - pyqt >=5.15.6,<6
     - pyyaml >=6.0
     - if: osx

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -36,7 +36,9 @@ tests:
         - dyna
       pip_check: true
   - script:
-      - dyna-sim --help
+      - python -m dyna.cli --help
+      - if: unix
+        then: dyna-sim --help
       - python -c "import dyna; assert dyna.__version__ == '6.9.1'"
 
 about:

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: 6.10.0
+  python_min: "3.10"
 
 package:
   name: dynaref
@@ -13,33 +14,48 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=68
   run:
-    - python
+    - python >=${{ python_min }}
     - numpy >=1.22.4
     - scipy >=1.8.1
     - matplotlib-base >=3.5.2
     - pyqt >=5.15.6,<6
     - pyyaml >=6.0
+    - if: linux
+      then:
+        - __linux
     - if: osx
-      then: pyobjc-framework-cocoa >=10.0
+      then:
+        - __osx
+        - pyobjc-framework-cocoa >=10.0
+    - if: win
+      then:
+        - __win
 
 tests:
   - python:
       imports:
         - dyna
       pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - python -m dyna.cli --help
       - if: unix
         then: dyna-sim --help
-      - python -c "import dyna; assert dyna.__version__ == '6.10.0'"
+      - python -c "import dyna; assert dyna.__version__ == '${{ version }}'"
+    requirements:
+      run:
+        - python ${{ python_min }}.*
 
 about:
   summary: X-ray magnetic reflectivity simulation and fitting

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -1,15 +1,15 @@
 schema_version: 1
 
 context:
-  version: 6.9.0
+  version: 6.9.1
 
 package:
   name: dynaref
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/d/dynaref/dynaref-${{ version }}.tar.gz
-  sha256: 393c1d629af168e46b3f327a97f09fdbad41c3b6d403f4b41ce34c22b0f461b7
+  url: https://pypi.org/packages/source/D/DynaRef/dynaref-${{ version }}.tar.gz
+  sha256: debcebffefe502be354036bf0a12c13a60a3a1a3f0828c223fc35b054e42a269
 
 build:
   number: 0
@@ -37,7 +37,7 @@ tests:
       pip_check: true
   - script:
       - dyna-sim --help
-      - python -c "import dyna; assert dyna.__version__ == '6.9.0'"
+      - python -c "import dyna; assert dyna.__version__ == '6.9.1'"
 
 about:
   summary: X-ray magnetic reflectivity simulation and fitting

--- a/recipes/dynaref/recipe.yaml
+++ b/recipes/dynaref/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: 6.10.0
-  python_min: "3.10"
 
 package:
   name: dynaref


### PR DESCRIPTION
This recipe adds DynaRef 6.9.0, an application for simulating and
fitting X-ray magnetic reflectivity, transmissivity, Kerr, and
Faraday signals from multilayer structures.

The recipe was built and tested locally with rattler-build.