### PR TITLE
Add cloudsmith-cli 1.26.0

### DIFF
--- a/recipes/cloudsmith-cli/recipe.yaml
+++ b/recipes/cloudsmith-cli/recipe.yaml
@@ -69,6 +69,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   summary: Command-line interface for Cloudsmith
+  documentation: https://docs.cloudsmith.com/developer-tools/cli
 
 extra:
   recipe-maintainers:

--- a/recipes/cloudsmith-cli/recipe.yaml
+++ b/recipes/cloudsmith-cli/recipe.yaml
@@ -1,0 +1,75 @@
+schema_version: 1
+
+context:
+  version: 1.26.0
+
+package:
+  name: cloudsmith-cli
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/c/cloudsmith-cli/cloudsmith_cli-${{ version }}.tar.gz
+  sha256: d7cf5d9a91a7ed2ba6391413ac3543b0b53a302135d7f6ec6353b0f7628c652b
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
+  python:
+    entry_points:
+      - cloudsmith = cloudsmith_cli.cli.commands.main:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools ==83.0.0
+    - wheel ==0.47.0
+  run:
+    - python >=${{ python_min }}
+    - click >=8.2,!=8.3.0
+    - click-configfile >=0.2.3
+    - click-didyoumean >=0.0.3
+    - click-spinner >=0.1.7
+    - json5 >=0.9.0
+    - cloudsmith-api >=2.0.31,<3.0
+    - keyring >=25.4.1
+    - keyrings.alt >=5.0.2
+    - keyrings.cryptfile >=1.3.9
+    - mcp ==1.28.1
+    - pyjwt >=2.0.0
+    - cryptography >=3.3.1
+    - python-toon ==0.1.2
+    - requests >=2.18.4
+    - requests-toolbelt >=1.0.0
+    - rich >=13.0.0
+    - semver >=2.7.9
+    - urllib3 >=2.5
+    - tomlkit >=0.15.0
+
+tests:
+  - python:
+      imports:
+        - cloudsmith_cli
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+  - script:
+      - cloudsmith --help
+      - cloudsmith --version
+      - cloudsmith credential-helper --help
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+
+about:
+  homepage: https://cloudsmith.com
+  repository: https://github.com/cloudsmith-io/cloudsmith-cli
+  license: Apache-2.0
+  license_file: LICENSE
+  summary: Command-line interface for Cloudsmith
+
+extra:
+  recipe-maintainers:
+    - BartoszBlizniak


### PR DESCRIPTION
Adds `cloudsmith-cli` 1.26.0 as a noarch Python package from the published PyPI sdist.

The recipe declares the upstream build and runtime requirements and tests package imports, dependency consistency, and CLI startup, including the credential-helper command.

I’ll maintain the feedstock as @BartoszBlizniak.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
