### PR TITLE
Add flash-attn-3

### DIFF
--- a/recipes/flash-attn-3/0001-respect-offline-builds.patch
+++ b/recipes/flash-attn-3/0001-respect-offline-builds.patch
@@ -1,0 +1,26 @@
+diff --git a/hopper/setup.py b/hopper/setup.py
+index e3926ae..2821704 100755
+--- a/hopper/setup.py
++++ b/hopper/setup.py
+@@ -494,6 +494,6 @@ ext_modules = []
+ # We want this even if SKIP_CUDA_BUILD because when we run python setup.py sdist we want the .hpp
+ # files included in the source distribution, in case the user compiles from source.
+-if not USE_TRITON_ROCM:
++if not USE_TRITON_ROCM and not is_offline_build():
+     subprocess.run(["git", "submodule", "update", "--init", "../csrc/cutlass"])
+ 
+ if not SKIP_CUDA_BUILD:
+@@ -518,7 +518,12 @@ if not SKIP_CUDA_BUILD:
+     # We want to use the nvcc front end from 12.6 however, since if we use nvcc 12.8
+     # Cutlass 3.8 will expect the new data types in cuda.h from CTK 12.8, which we don't have.
+     # For CUDA 13.0+, use system nvcc instead of downloading CUDA 12.x toolchain
+-    if bare_metal_version >= Version("12.3") and bare_metal_version < Version("13.0") and bare_metal_version != Version("12.8"):
++    if (
++        not is_offline_build()
++        and bare_metal_version >= Version("12.3")
++        and bare_metal_version < Version("13.0")
++        and bare_metal_version != Version("12.8")
++    ):
+         download_and_copy(
+             name="nvcc",
+             src_func=lambda system, arch, version: f"cuda_nvcc-{system}-{arch}-{version}-archive/bin",

--- a/recipes/flash-attn-3/0002-trim-runtime-requirements.patch
+++ b/recipes/flash-attn-3/0002-trim-runtime-requirements.patch
@@ -1,0 +1,28 @@
+diff --git a/hopper/setup.py b/hopper/setup.py
+index 2821704..39e2e06 100755
+--- a/hopper/setup.py
++++ b/hopper/setup.py
+@@ -791,20 +791,8 @@ class CachedWheelsCommand(_bdist_wheel):
+             super().run()
+ 
+-# Build install_requires based on platform
+-if IS_ROCM:
+-    # Note: torch is excluded because pip resolves it to CUDA PyTorch from PyPI, overwriting any pre-installed ROCm PyTorch. Users must have torch installed.
+-    install_requires = [
+-        "einops",
+-        "packaging",
+-        "ninja",
+-    ]
+-else:
+-    install_requires = [
+-        "torch",
+-        "einops",
+-        "packaging",
+-        "ninja",
+-    ]
++# packaging and ninja are build-only dependencies; einops is only used by
++# benchmarks and tests that are not installed.
++install_requires = [] if IS_ROCM else ["torch"]
+ 
+ setup(
+     name=PACKAGE_NAME,

--- a/recipes/flash-attn-3/build.sh
+++ b/recipes/flash-attn-3/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+"${PYTHON}" -m pip install ./hopper -vv --no-deps --no-build-isolation

--- a/recipes/flash-attn-3/recipe.yaml
+++ b/recipes/flash-attn-3/recipe.yaml
@@ -28,8 +28,10 @@ source:
 build:
   number: ${{ build_number }}
   # Bootstrap the feedstock without compiling on the 8 GiB staged-recipes
-  # workers. Remove this after creation, restore the platform/ABI skips from
-  # the preceding commit, and configure the feedstock's larger runner.
+  # workers. After creation, configure the larger runner and replace this with:
+  # skip:
+  #   - not linux or cuda_compiler_version == "None"
+  #   - is_abi3 and not is_python_min
   skip: true
   string: ${{ cuda_build_string }}_py${{ python_min | version_to_buildstring }}h${{ hash }}_${{ build_number }}
   python:

--- a/recipes/flash-attn-3/recipe.yaml
+++ b/recipes/flash-attn-3/recipe.yaml
@@ -39,7 +39,9 @@ build:
     env:
       FLASH_ATTENTION_FORCE_BUILD: "TRUE"
       FLASH_ATTENTION_OFFLINE_BUILD: "TRUE"
-      MAX_JOBS: "2"
+      # Azure's staged-recipes workers have 8 GiB RAM; two concurrent nvcc
+      # processes exhausted it while compiling the large backward kernels.
+      MAX_JOBS: "1"
       NVCC_THREADS: "1"
     file: build.sh
 

--- a/recipes/flash-attn-3/recipe.yaml
+++ b/recipes/flash-attn-3/recipe.yaml
@@ -1,0 +1,103 @@
+schema_version: 1
+
+context:
+  version: "3.0.0"
+  build_number: 0
+  source_rev: 0251105a2fb19d2957484b7f023cd8c115286ced
+  cutlass_rev: 7127592069c2fe01b041e174ba4345ef9b279671
+  cuda_build_string: cuda_${{ cuda_compiler_version | default("None") | version_to_buildstring }}
+
+package:
+  name: flash-attn-3
+  version: ${{ version }}
+
+source:
+  # FlashAttention-3 is versioned independently inside the flash-attention
+  # repository. This is the exact source revision used by the successful
+  # 2026-08-17 flash-attention3-wheels release builds; upstream also tags it as
+  # fa4-v4.0.0.beta27.
+  - url: https://github.com/Dao-AILab/flash-attention/archive/${{ source_rev }}.tar.gz
+    sha256: 633428c95fed01f90969e6f8a4ec729eef0e3ccedfff03b9422a85bfb7cd0130
+    patches:
+      - 0001-respect-offline-builds.patch
+      - 0002-trim-runtime-requirements.patch
+  - url: https://github.com/NVIDIA/cutlass/archive/${{ cutlass_rev }}.tar.gz
+    sha256: 12baa9c2bf22eaca065b5e55387c21bb4ac742992a6ecd2dd1d3b016dfd25a0a
+    target_directory: csrc/cutlass
+
+build:
+  number: ${{ build_number }}
+  skip:
+    - not linux or cuda_compiler_version == "None"
+    - is_abi3 and not is_python_min
+  string: ${{ cuda_build_string }}_py${{ python_min | version_to_buildstring }}h${{ hash }}_${{ build_number }}
+  python:
+    version_independent: true
+  script:
+    env:
+      FLASH_ATTENTION_FORCE_BUILD: "TRUE"
+      FLASH_ATTENTION_OFFLINE_BUILD: "TRUE"
+      MAX_JOBS: "4"
+      NVCC_THREADS: "1"
+    file: build.sh
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - ninja
+    - if: linux and cuda_compiler_version != "None"
+      then:
+        - ${{ compiler('cuda') }}
+        - cuda-version ==${{ cuda_compiler_version }}
+  host:
+    - packaging
+    - pip
+    - python ${{ python_min }}.*
+    - pytorch
+    - setuptools
+    - wheel
+    - if: linux and cuda_compiler_version != "None"
+      then:
+        - cuda-version ==${{ cuda_compiler_version }}
+        - cuda-driver-dev
+        - cuda-cudart-dev
+        - libcublas-dev
+        - libcusolver-dev
+        - libcusparse-dev
+        - pytorch * cuda*
+  run:
+    - python >=${{ python_min }}
+    - pytorch * cuda*
+  ignore_run_exports:
+    from_package:
+      - libcublas-dev
+      - libcusolver-dev
+      - libcusparse-dev
+
+tests:
+  - python:
+      imports:
+        - flash_attn_3
+        - flash_attn_3._C
+        - flash_attn_3.flash_attn_interface
+        - flash_attn_config
+        - flash_attn_interface
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/Dao-AILab/flash-attention
+  repository: https://github.com/Dao-AILab/flash-attention
+  summary: FlashAttention-3 CUDA kernels for fast and memory-efficient attention
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+    - csrc/cutlass/LICENSE.txt
+
+extra:
+  recipe-maintainers:
+    - jeongseok-meta

--- a/recipes/flash-attn-3/recipe.yaml
+++ b/recipes/flash-attn-3/recipe.yaml
@@ -27,6 +27,8 @@ source:
 
 build:
   number: ${{ build_number }}
+  # Upstream declares this extension Unix-only. The available Windows wheel
+  # builds apply separate source, CUTLASS, and CUDA-header patches.
   skip:
     - not linux or cuda_compiler_version == "None"
     - is_abi3 and not is_python_min
@@ -37,7 +39,7 @@ build:
     env:
       FLASH_ATTENTION_FORCE_BUILD: "TRUE"
       FLASH_ATTENTION_OFFLINE_BUILD: "TRUE"
-      MAX_JOBS: "4"
+      MAX_JOBS: "2"
       NVCC_THREADS: "1"
     file: build.sh
 

--- a/recipes/flash-attn-3/recipe.yaml
+++ b/recipes/flash-attn-3/recipe.yaml
@@ -27,11 +27,10 @@ source:
 
 build:
   number: ${{ build_number }}
-  # Upstream declares this extension Unix-only. The available Windows wheel
-  # builds apply separate source, CUTLASS, and CUDA-header patches.
-  skip:
-    - not linux or cuda_compiler_version == "None"
-    - is_abi3 and not is_python_min
+  # Bootstrap the feedstock without compiling on the 8 GiB staged-recipes
+  # workers. Remove this after creation, restore the platform/ABI skips from
+  # the preceding commit, and configure the feedstock's larger runner.
+  skip: true
   string: ${{ cuda_build_string }}_py${{ python_min | version_to_buildstring }}h${{ hash }}_${{ build_number }}
   python:
     version_independent: true


### PR DESCRIPTION
## Why

xformers 0.0.35 now treats `flash_attn_3` as a separately installed optional acceleration backend. The existing `flash-attn` feedstock packages FlashAttention 2, so it cannot provide that import. This follows the packaging discussion in https://github.com/conda-forge/xformers-feedstock/pull/79#issuecomment-5472378337.

This needs a distinct package rather than a version upgrade of the existing `flash-attn` output. Upstream still releases the root `flash_attn` distribution as 2.8.3, while FlashAttention-3 is independently versioned as 3.0.0, built from the `hopper/` subdirectory, and imported as `flash_attn_3`. Replacing `flash-attn` would remove the established FlashAttention-2 package contract and still would not give xformers the separately named dependency it probes for.

## What

Add the complete `flash-attn-3` 3.0.0 Linux CUDA recipe using the Python stable ABI from 3.10 onward. The eventual package excludes CPU and non-Linux variants: macOS has no CUDA path, and the available Windows wheels require downstream source, CUTLASS, and CUDA-header patches that are not part of upstream.

The recipe is temporarily and unconditionally skipped only for feedstock bootstrapping. This follows the maintainer proposal in https://github.com/conda-forge/staged-recipes/pull/34680#issuecomment-5476413488: after feedstock creation, the first follow-up will restore the Linux/CUDA and ABI skip rules and enable the established larger runner before any package is published.

## How

- Pin upstream source revision [0251105a2fb19d2957484b7f023cd8c115286ced](https://github.com/Dao-AILab/flash-attention/commit/0251105a2fb19d2957484b7f023cd8c115286ced), which declares `flash_attn_3` version 3.0.0 and is also tagged `fa4-v4.0.0.beta27`. This is the exact revision used by the successful 2026-08-17 `flash-attention3-wheels` builds.
- Reproduce the pinned CUTLASS submodule at [7127592069c2fe01b041e174ba4345ef9b279671](https://github.com/NVIDIA/cutlass/commit/7127592069c2fe01b041e174ba4345ef9b279671) and package its license. The newer standalone conda-forge CUTLASS release is not substituted because upstream pins this revision for the generated kernels.
- Force an offline source build and avoid Git submodule or private CUDA-toolchain downloads so conda-forge CUDA 12.9/13.0 toolchains are used.
- Remove build/test-only Python requirements from wheel runtime metadata; the installed module itself requires PyTorch.
- Test the stable-ABI package on both the minimum and latest supported Python, including the extension and the import paths consumed by xformers.
- Merge current staged-recipes `main` in [daced30b60814c6d5de2b5b00150d203d087fc73](https://github.com/jeongseok-meta/staged-recipes/commit/daced30b60814c6d5de2b5b00150d203d087fc73), add the temporary bootstrap skip in [48e1641728357906e3086d00bd15ac79aad60639](https://github.com/jeongseok-meta/staged-recipes/commit/48e1641728357906e3086d00bd15ac79aad60639), and preserve the exact post-creation skip rules beside it in [1f83397d6a7d731681dbae4a475691de43c206d2](https://github.com/jeongseok-meta/staged-recipes/commit/1f83397d6a7d731681dbae4a475691de43c206d2). History remains additive.

## Validation

```bash
conda-smithy recipe-lint --conda-forge recipes/flash-attn-3
```

Result: pass, no hints.

```bash
rattler-build build --recipe recipes/flash-attn-3/recipe.yaml -m .ci_support/linux64_cuda129.yaml --variant python_min=3.10 --variant is_abi3=false --build-platform linux-64 --target-platform linux-64 --render-only
rattler-build build --recipe recipes/flash-attn-3/recipe.yaml -m .ci_support/linux64_cuda130.yaml --variant python_min=3.10 --variant is_abi3=false --build-platform linux-64 --target-platform linux-64 --render-only
```

Result: both CUDA variants render successfully and are explicitly reported as skipped by the bootstrap rule.

The source archives were independently hashed, both patches apply to the pinned source, the patched `setup.py` compiles, and both license files are present. The prior CI establishes a staged-recipes resource limit rather than a source error:

- With `MAX_JOBS=2` and `NVCC_THREADS=1`, Azure build 1577315 exceeded the 7-8 GiB worker memory; CUDA 12.9 reported `cicc` killed by signal 9 and the CUDA 13.0 agent stopped responding.
- With both values set to `1`, [Azure build 1577356](https://dev.azure.com/conda-forge/84710dde-1620-425b-80d0-4cf5baca359d/_build/results?buildId=1577356) compiled continuously but hit the 360-minute cap at 122/293 objects for CUDA 12.9 and 128/293 for CUDA 13.0, with physical-memory warnings around 96%.
- The exact source revision completes Linux source builds on 16-CPU/64-GiB runners in [upstream run 31975710305](https://github.com/windreamer/flash-attention3-wheels/actions/runs/31975710305). The existing `flash-attn-feedstock` also has an established 32-GiB runner configuration suitable for the generated feedstock follow-up.

## Checklist

- [x] The title is meaningful.
- [x] The recipe uses the v1 `recipe.yaml` format.
- [x] The upstream and CUTLASS license files are packaged.
- [x] Sources are official, immutable tarballs with SHA-256 checksums.
- [x] The pinned CUTLASS source and reason for retaining it are documented.
- [x] No static libraries are shipped.
- [x] The build number is 0.
- [x] The listed maintainer is the PR author.