### PR TITLE
Adding arize-phoenix-sqlean

### DIFF
--- a/recipes/arize-phoenix-sqlean/recipe.yaml
+++ b/recipes/arize-phoenix-sqlean/recipe.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.org/packages/source/a/arize-phoenix-sqlean/arize_phoenix_sqlean-${{ version }}.tar.gz
   sha256: 0437552bbe375be920f78c83a78de901fbd7497122aca30aa4e4884cbad1542d
+  patches:
+    - remove-system-paths.patch
 
 build:
   number: 0

--- a/recipes/arize-phoenix-sqlean/recipe.yaml
+++ b/recipes/arize-phoenix-sqlean/recipe.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: python -m pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:

--- a/recipes/arize-phoenix-sqlean/recipe.yaml
+++ b/recipes/arize-phoenix-sqlean/recipe.yaml
@@ -1,0 +1,63 @@
+context:
+  version: "0.1.1"
+
+package:
+  name: arize-phoenix-sqlean
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/a/arize-phoenix-sqlean/arize_phoenix_sqlean-${{ version }}.tar.gz
+  sha256: 0437552bbe375be920f78c83a78de901fbd7497122aca30aa4e4884cbad1542d
+
+build:
+  number: 0
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+  run_constraints:
+    # Installs the same top-level `sqlean` module as upstream sqlean.py,
+    # so the two packages cannot coexist in one environment.
+    - sqlean.py <0a0
+
+tests:
+  - python:
+      imports:
+        - sqlean
+        - sqlean.dbapi2
+      pip_check: true
+  - script:
+      - python smoke_test.py
+    files:
+      recipe:
+        - smoke_test.py
+
+about:
+  homepage: https://github.com/Arize-ai/phoenix/tree/main/packages/phoenix-sqlean
+  summary: sqlite3 with extensions
+  description: |
+    A drop-in replacement for Python's built-in sqlite3 module, bundling
+    SQLite with the Sqlean extensions (crypto, define, fileio, fuzzy,
+    ipaddr, regexp, stats, text, time, unicode, uuid, vsv) compiled in.
+    This is Arize AI's maintained fork of sqlean.py, used by Arize Phoenix.
+  license: Zlib AND MIT AND BSD-2-Clause AND BSD-3-Clause AND PSF-2.0
+  license_file:
+    - LICENSE
+    - THIRD_PARTY_LICENSES
+  repository: https://github.com/Arize-ai/phoenix
+
+extra:
+  recipe-maintainers:
+    - RogerHYang

--- a/recipes/arize-phoenix-sqlean/remove-system-paths.patch
+++ b/recipes/arize-phoenix-sqlean/remove-system-paths.patch
@@ -1,0 +1,8 @@
+--- setup.cfg
++++ setup.cfg
+@@ -1,5 +1,3 @@
+ [build_ext]
+-include_dirs = /usr/include
+-library_dirs = /usr/lib
+ 
+ [egg_info]

--- a/recipes/arize-phoenix-sqlean/smoke_test.py
+++ b/recipes/arize-phoenix-sqlean/smoke_test.py
@@ -1,0 +1,22 @@
+import sqlean
+
+sqlean.extensions.enable_all()
+
+conn = sqlean.connect(":memory:")
+
+# uuid extension
+(uuid,) = conn.execute("select uuid4()").fetchone()
+assert uuid
+
+# stats extension
+(median,) = conn.execute(
+    "select median(value) from (select 1 as value union select 2 union select 3)"
+).fetchone()
+assert median == 2
+
+# regexp extension
+(match,) = conn.execute("select regexp_like('phoenix', 'ph?')").fetchone()
+assert match == 1
+
+print("sqlite version:", sqlean.sqlite_version)
+print("sqlean smoke test OK")


### PR DESCRIPTION
Adds [arize-phoenix-sqlean](https://pypi.org/project/arize-phoenix-sqlean/), Arize AI's maintained fork of [sqlean.py](https://github.com/nalgeon/sqlean.py): a drop-in replacement for Python's built-in `sqlite3` module with the [Sqlean extensions](https://github.com/nalgeon/sqlean) (crypto, define, fileio, fuzzy, ipaddr, regexp, stats, text, time, unicode, uuid, vsv) compiled in. It is used by [Arize Phoenix](https://github.com/Arize-ai/phoenix).

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Notes for reviewers:

- The sdist deliberately vendors the SQLite amalgamation and the Sqlean extension sources (which include PCRE2 and xxHash) and compiles them into the extension module — that is the whole point of the package, same as upstream sqlean.py. The licenses of all vendored components are packaged via `THIRD_PARTY_LICENSES` and reflected in the SPDX expression `Zlib AND MIT AND BSD-2-Clause AND BSD-3-Clause AND PSF-2.0`.
- conda-forge already ships upstream `sqlean.py`, and both packages install the same top-level `sqlean` module, so the recipe declares `run_constraints: sqlean.py <0a0` to prevent co-installation (mirrors the situation on PyPI, where both names exist).
- The `src/sqlean-time-msvc.patch` file in the sdist is vestigial: it is already applied to the shipped `sqlite/sqlean-time.c` (verified by reverse-apply), so no patching is needed for the Windows build.
- I am the maintainer of the upstream package (Arize AI) and the sole recipe maintainer listed.
