### PR TITLE
Add r-locom2 recipe (CRAN package, LOCOM2 v1.0)

### DIFF
--- a/recipes/r-locom2/meta.yaml
+++ b/recipes/r-locom2/meta.yaml
@@ -1,0 +1,81 @@
+{% set version = '1.0' %}
+{% set posix = 'm2-' if win else '' %}
+
+package:
+  name: r-locom2
+  version: "{{ version|replace('-', '_') }}"
+
+source:
+  url:
+    - {{ cran_mirror }}/src/contrib/LOCOM2_{{ version }}.tar.gz
+    - {{ cran_mirror }}/src/contrib/Archive/LOCOM2/LOCOM2_{{ version }}.tar.gz
+  sha256: abb48ae535928fbf88bf270478741fb8139853c6c0e2564556b3d3fce6ec3c9d
+
+build:
+  number: 0
+  rpaths:
+    - lib/R/lib/
+    - lib/
+  missing_dso_whitelist:
+    - '*/R.dll'        # [win]
+    - '*/Rblas.dll'    # [win]
+    - '*/Rlapack.dll'  # [win]
+
+requirements:
+  build:
+    - {{ compiler('c') }}              # [not win]
+    - {{ stdlib('c') }}                # [not win]
+    - {{ compiler('m2w64_c') }}        # [win]
+    - {{ stdlib('m2w64_c') }}          # [win]
+    - {{ compiler('cxx') }}            # [not win]
+    - {{ compiler('m2w64_cxx') }}      # [win]
+    - {{ posix }}filesystem        # [win]
+    - {{ posix }}make
+    - {{ posix }}sed               # [win]
+    - {{ posix }}coreutils         # [win]
+    - {{ posix }}zip               # [win]
+    - cross-r-base {{ r_base }}    # [build_platform != target_platform]
+  host:
+    - r-base
+    - r-rcpp >=1.0.11
+    - r-rcpparmadillo
+    - r-abind
+    - r-car
+    - r-matrixstats
+    - r-permute
+    - bioconductor-biocparallel
+    - libblas
+    - liblapack
+  run:
+    - r-base
+    - r-rcpp >=1.0.11
+    - r-rcpparmadillo
+    - r-abind
+    - r-car
+    - r-matrixstats
+    - r-permute
+    - bioconductor-biocparallel
+
+test:
+  commands:
+    - $R -e "library('LOCOM2')"           # [not win]
+    - "\"%R%\" -e \"library('LOCOM2')\""  # [win]
+
+about:
+  home: https://github.com/yijuanhu/LOCOM2
+  dev_url: https://github.com/yijuanhu/LOCOM2
+  license: GPL-2.0-or-later
+  summary: A Logistic Regression Model for Testing Microbial Differential Abundance
+  description: |
+    Tests differential abundance in microbial communities at both individual
+    taxa and community-wide levels using log-ratio approaches. Accommodates
+    continuous, discrete, and multivariate traits while allowing for
+    confounder adjustment.
+  license_family: GPL2
+  license_file:
+    - '{{ environ["PREFIX"] }}/lib/R/share/licenses/GPL-2'
+
+extra:
+  recipe-maintainers:
+    - MartinaCardinali
+    - conda-forge/r


### PR DESCRIPTION
## Summary

Add a conda-forge recipe for [LOCOM2](https://cran.r-project.org/package=LOCOM2) v1.0, an R package for testing microbial differential abundance using logistic regression on log-ratios.

- **CRAN**: https://cran.r-project.org/package=LOCOM2
- **GitHub**: https://github.com/yijuanhu/LOCOM2
- **Author**: Yi-Juan Hu
- **License**: GPL-2.0-or-later

## Why

LOCOM2 is a dependency of the [nf-core/daamicrobiome](https://github.com/nf-core/daamicrobiome) pipeline, which requires all software to be available via conda for container builds (nf-core convention).

## Notes

- Needs compilation (C++ via Rcpp/RcppArmadillo), so not `noarch: generic`.
- Depends on `bioconductor-biocparallel` (from bioconda channel).
- An earlier PR was submitted to bioconda ([bioconda/bioconda-recipes#66976](https://github.com/bioconda/bioconda-recipes/pull/66976)), but since LOCOM2 is a CRAN package, conda-forge is the appropriate channel.

## Checklist

- [x] Source is from CRAN with correct SHA256
- [x] License matches CRAN metadata (GPL >= 2)
- [x] All Imports listed as dependencies
- [x] Build/host requirements include compilers for Rcpp
- [x] Test command validates library loading