### PR TITLE
Add pantheon-gpu

### DIFF
--- a/recipes/pantheon-gpu/recipe.yaml
+++ b/recipes/pantheon-gpu/recipe.yaml
@@ -27,13 +27,17 @@ requirements:
     - python >=${{ python_min }}
     - pandas
     - numpy
+    - psutil
+    - nvidia-ml-py
 
 tests:
   - python:
       imports:
         - pantheon_gpu
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - pantheon --version
       - pantheon-gpu --version

--- a/recipes/pantheon-gpu/recipe.yaml
+++ b/recipes/pantheon-gpu/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: "1.2.0"
+
+package:
+  name: pantheon-gpu
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pantheon-gpu/pantheon_gpu-${{ version }}.tar.gz
+  sha256: d9493d88db0a20cfccbb8de3f11afa2c8b7e38ab83d1b3378b8b1d303cb5fbc0
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+  python:
+    entry_points:
+      - pantheon = pantheon_gpu._entry:main
+      - pantheon-gpu = pantheon_gpu._entry:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - pandas
+    - numpy
+
+tests:
+  - python:
+      imports:
+        - pantheon_gpu
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - pantheon --version
+      - pantheon-gpu --version
+
+about:
+  homepage: https://pantheongpu.com
+  summary: GPU stress testing and diagnostics for NVIDIA CUDA and AMD ROCm
+  description: |
+    Pantheon runs targeted stress and diagnostic workloads against NVIDIA and
+    AMD GPUs: power viruses, memory diagnostics (march tests, disturb and
+    retention patterns), interconnect and AI-shaped workloads, with RAS/ECC
+    snapshots collected on every run. The package carries the kernel sources
+    rather than prebuilt binaries; workloads compile for the GPU actually
+    present on first run, which needs make, a C++ compiler and the CUDA or
+    ROCm toolkit installed on the host. Use `--platform mock` to exercise
+    the tooling with no GPU at all.
+  license: Apache-2.0
+  license_file: LICENSE
+  documentation: https://pantheongpu.com/getting-started/
+  repository: https://github.com/pantheongpu/pantheon
+
+extra:
+  recipe-maintainers:
+    - saqibkh


### PR DESCRIPTION
Adds **pantheon-gpu** — GPU stress testing and diagnostics for NVIDIA CUDA and AMD ROCm ([pantheongpu.com](https://pantheongpu.com), [source](https://github.com/pantheongpu/pantheon), [PyPI](https://pypi.org/project/pantheon-gpu/)). Pure-Python noarch package; the kernel sources compile on first run against the host's CUDA/ROCm toolchain, and a mock backend exercises the tooling with no GPU.

Checklist:
- [x] Title of this PR is meaningful
- [x] License file is packaged (LICENSE in the sdist)
- [x] Source is from an official source (PyPI sdist)
- [x] Package does not vendor other packages
- [x] Build number is 0
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used
- [x] GitHub users listed in the maintainer section have commented on this PR or are the PR author

🤖 Generated with [Claude Code](https://claude.com/claude-code)