### PR TITLE
Add pixi-pfx

### DIFF
--- a/recipes/pixi-pfx/recipe.yaml
+++ b/recipes/pixi-pfx/recipe.yaml
@@ -1,0 +1,66 @@
+schema_version: 1
+
+context:
+  version: "0.3.1"
+
+package:
+  name: pixi-pfx
+  version: ${{ version }}
+
+source:
+  url: https://github.com/prefix-dev/pixi-pfx/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 2574ee937821af5a645634631610cf92d5cf64981f67c8f47e9547aa26df9c82
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_LTO: "fat"
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+    content:
+      - if: unix
+        then: cargo auditable install --locked --no-track --root "$PREFIX" --path .
+        else: cargo auditable install --locked --no-track --root "%PREFIX%" --path .
+      - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ compiler("c") }}
+    - ${{ stdlib("c") }}
+    - ${{ compiler("rust") }}
+    - cargo-auditable
+    - cargo-bundle-licenses
+    - cmake
+    - pkg-config
+    - if: unix
+      then: make
+    - if: win
+      then: ninja
+  host:
+    - if: linux
+      then: dbus
+
+tests:
+  - script:
+      - pixi-pfx --help
+      - pixi-pfx describe
+  - package_contents:
+      strict: true
+      bin:
+        - pixi-pfx
+
+about:
+  homepage: https://github.com/prefix-dev/pixi-pfx
+  repository: https://github.com/prefix-dev/pixi-pfx
+  license: BSD-3-Clause
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: CLI client for the prefix.dev GraphQL API
+  description: |
+    pixi-pfx is a command-line client for the prefix.dev GraphQL API,
+    shipped as the `pixi pfx` plugin.
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License files are packaged.
- [x] Source is the official tagged release.
- [x] Package does not vendor other packages.
- [x] Build number is 0.
- [x] Maintainer is willing to be listed.

`pixi-pfx` is the `pixi pfx` command-line client for the prefix.dev GraphQL API.

The recipe was rendered for Linux, macOS, and Windows. I also started a local Linux build; dependency resolution succeeded, but the local build environment hit its disk quota while linking the Rust toolchain.
