### PR TITLE
Add ink-md

### DIFF
--- a/recipes/ink-md/recipe.yaml
+++ b/recipes/ink-md/recipe.yaml
@@ -16,9 +16,7 @@ build:
       CARGO_PROFILE_RELEASE_LTO: fat
       CARGO_PROFILE_RELEASE_STRIP: symbols
     content:
-      - if: unix
-        then: cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
-        else: cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
       - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
 
 requirements:

--- a/recipes/ink-md/recipe.yaml
+++ b/recipes/ink-md/recipe.yaml
@@ -1,0 +1,57 @@
+context:
+  version: "0.7.0"
+
+package:
+  name: ink-md
+  version: ${{ version }}
+
+source:
+  url: https://github.com/borghei/ink/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 51a51351d2fbb82f6cd77641441c0a10c9a28709b8dbc3efe36930c4284918a6
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_LTO: fat
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+    content:
+      - if: unix
+        then: cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else: cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-auditable
+    - cargo-bundle-licenses
+
+tests:
+  - script:
+      - ink --help
+      - ink --version
+  - package_contents:
+      bin:
+        - ink
+      strict: true
+
+about:
+  homepage: https://borghei.github.io/ink/
+  summary: Terminal Markdown reader with syntax highlighting and inline images
+  description: |
+    ink is a terminal Markdown reader with syntax highlighting, inline images,
+    Mermaid diagrams, themes, tabs, search, and a table of contents. It can be
+    used as an interactive reader or a pipe-friendly plain-text renderer.
+  license: LicenseRef-ink-md
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://borghei.github.io/ink/
+  repository: https://github.com/borghei/ink
+
+extra:
+  recipe-maintainers:
+    - mariusrueve


### PR DESCRIPTION
Adds `ink-md` 0.7.0, a Rust terminal Markdown reader. The installed command is `ink`.

Upstream uses a custom, non-SPDX-listed license that permits free redistribution but prohibits sale. The recipe records it as `LicenseRef-ink-md`, includes the upstream `LICENSE`, and bundles Rust dependency licenses in `THIRDPARTY.yml`; reviewers should verify the custom-license treatment explicitly.

Local validation: conda-smithy lint passed; the osx-arm64 package built and passed `ink --help`, `ink --version`, and strict content tests; Linux x86_64/ARM64, macOS x86_64, and Windows x86_64 variants render and solve.

Checklist

- [x] Title is meaningful.
- [x] Recipe uses v1 `recipe.yaml`.
- [x] License files are packaged.
- [x] Source is the official tagged source archive.
- [x] Vendored/static Rust dependency licenses are bundled.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] The recipe uses a tarball URL.
- [x] The listed maintainer is the PR author and consents to maintainership.
