### PR TITLE
Create NVIDIA CUDA `nsight-systems` feedstock

### DIFF
--- a/recipes/nsight-systems/build_cli.bat
+++ b/recipes/nsight-systems/build_cli.bat
@@ -1,0 +1,59 @@
+@echo off
+:: CLI half of the split: the target-side collector (nsys) plus the documentation.
+setlocal enabledelayedexpansion
+
+:: 2025.1.3.140 -> 2025.1.3, the directory NVIDIA creates inside the archive.
+for /f "tokens=1,2,3 delims=." %%a in ("%PKG_VERSION%") do set "version_short=%%a.%%b.%%c"
+
+:: Whether the archive's single top-level directory is stripped during extraction can
+:: differ, so locate the payload rather than assuming it sits at the work-dir root.
+set "archive_root=."
+if not exist "nsight-systems\!version_short!" (
+    for /d %%d in (*) do if exist "%%d\nsight-systems\!version_short!" set "archive_root=%%d"
+)
+set "payload=!archive_root!\nsight-systems\!version_short!"
+if not exist "!payload!" (
+    echo could not locate nsight-systems\!version_short! in the extracted archive
+    exit 1
+)
+
+:: The Windows archive also carries a Linux target collector (~497 MB) so a Windows
+:: host can profile a Linux target remotely, plus the UCRT redistributable stubs that
+:: a conda environment already provides. Neither is shipped.
+if exist "!payload!\target-linux-x64" rmdir /q /s "!payload!\target-linux-x64"
+if exist "!payload!\lib32" rmdir /q /s "!payload!\lib32"
+if exist "!payload!\lib64" rmdir /q /s "!payload!\lib64"
+
+set "dest=%LIBRARY_PREFIX%\nsight-systems\!version_short!"
+if not exist "!dest!" mkdir "!dest!"
+if errorlevel 1 exit 1
+
+move "!payload!\target-windows-x64" "!dest!\" || exit 1
+move "!payload!\documentation" "!dest!\" || exit 1
+
+if not exist "%SCRIPTS%" mkdir "%SCRIPTS%"
+
+:: Shim bodies are built here, outside the for loop, so that `%%` is unambiguously
+:: an escaped percent sign rather than a loop-variable reference.
+set "shim_dir=%%~dp0..\Library\nsight-systems\!version_short!\target-windows-x64"
+set "shim_args=%%*"
+
+:: A .bat launcher per shipped executable. The loop is deliberately NOT recursive:
+:: every shim points at !shim_dir!\<name>.exe, so recursing would emit shims with
+:: paths that don't resolve for any executable nested in a subdirectory.
+:: sqlite3.exe is excluded because it also ships in the GUI half (the two packages
+:: would clobber each other's shim in Scripts\) and because a sqlite3.bat on PATH
+:: would shadow the environment's real sqlite3.
+for %%f in ("!dest!\target-windows-x64\*.exe") do (
+    set "exe_name=%%~nf"
+    set "skip="
+    for %%x in (python sqlite3) do if /i "!exe_name!"=="%%x" set "skip=1"
+    if not defined skip (
+        > "%SCRIPTS%\!exe_name!.bat" echo @echo off
+        >>"%SCRIPTS%\!exe_name!.bat" echo "!shim_dir!\!exe_name!.exe" !shim_args!
+        if errorlevel 1 exit 1
+    )
+)
+
+:: about.license_file resolves against the work directory root.
+if /i not "!archive_root!"=="." copy /y "!archive_root!\LICENSE" LICENSE >nul

--- a/recipes/nsight-systems/build_cli.sh
+++ b/recipes/nsight-systems/build_cli.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# CLI half of the split: the target-side collector (nsys) plus the docs.
+set -euxo pipefail
+
+# 2025.1.3.140 -> 2025.1.3, the directory NVIDIA creates inside the archive.
+version_short="${PKG_VERSION%.*}"
+
+# Whether the archive's single top-level directory is stripped during extraction
+# differs between the tar.xz and zip artifacts, so locate the payload rather than
+# assuming a depth.
+payload="$(find . -maxdepth 3 -type d -path "*/nsight-systems/${version_short}" -print -quit)"
+if [[ ! -d "${payload}" ]]; then
+    echo "could not locate nsight-systems/${version_short} in the extracted archive" >&2
+    exit 1
+fi
+archive_root="$(dirname "$(dirname "${payload}")")"
+
+# The Linux archives ship a full .rpm *and* .deb of the same payload under
+# .packages/ (~800 MB of pure duplication). Nothing in the conda package uses them.
+rm -rf "${archive_root}/.packages"
+
+# Each Linux archive carries exactly one target-side directory, named for the
+# architecture (target-linux-x64 on x86_64, target-linux-sbsa-armv8 on sbsa).
+# Globbing keeps this independent of how the build tool exports target_platform.
+shopt -s nullglob
+target_dirs=("${payload}"/target-linux-*)
+shopt -u nullglob
+if [[ ${#target_dirs[@]} -ne 1 ]]; then
+    echo "expected exactly one target-linux-* directory, found ${#target_dirs[@]}" >&2
+    exit 1
+fi
+target_dir="$(basename "${target_dirs[0]}")"
+
+dest="${PREFIX}/nsight-systems-${version_short}"
+mkdir -p "${dest}"
+mv "${payload}/${target_dir}" "${dest}/"
+mv "${payload}/docs" "${dest}/"
+
+# nsys resolves its bundled libraries through RPATH $ORIGIN, which is computed from
+# the *resolved* path, so a relative symlink on PATH is enough.
+mkdir -p "${PREFIX}/bin"
+ln -s "../nsight-systems-${version_short}/${target_dir}/nsys" "${PREFIX}/bin/nsys"
+
+# about.license_file resolves against the work directory root, which is already
+# where LICENSE lands when the archive's top-level directory is stripped.
+if [[ ! -f ./LICENSE ]]; then
+    cp "${archive_root}/LICENSE" ./LICENSE
+fi
+
+# Verify every shipped ELF object against the declared glibc floor
+# (c_stdlib_version, see conda_build_config.yaml).
+find "${dest}/${target_dir}" -type f \( -name "*.so" -o -name "*.so.*" \) -print0 \
+    | xargs -0 check-glibc "${dest}/${target_dir}/nsys"

--- a/recipes/nsight-systems/build_gui.bat
+++ b/recipes/nsight-systems/build_gui.bat
@@ -1,0 +1,50 @@
+@echo off
+:: GUI half of the split: the Qt-based nsys-ui timeline viewer.
+setlocal enabledelayedexpansion
+
+:: 2025.1.3.140 -> 2025.1.3, the directory NVIDIA creates inside the archive.
+for /f "tokens=1,2,3 delims=." %%a in ("%PKG_VERSION%") do set "version_short=%%a.%%b.%%c"
+
+:: See build_cli.bat: the top-level directory may or may not have been stripped.
+set "archive_root=."
+if not exist "nsight-systems\!version_short!" (
+    for /d %%d in (*) do if exist "%%d\nsight-systems\!version_short!" set "archive_root=%%d"
+)
+set "payload=!archive_root!\nsight-systems\!version_short!"
+if not exist "!payload!" (
+    echo could not locate nsight-systems\!version_short! in the extracted archive
+    exit 1
+)
+
+:: See build_cli.bat: cross-target collector and UCRT stubs are not shipped.
+if exist "!payload!\target-linux-x64" rmdir /q /s "!payload!\target-linux-x64"
+if exist "!payload!\lib32" rmdir /q /s "!payload!\lib32"
+if exist "!payload!\lib64" rmdir /q /s "!payload!\lib64"
+
+:: Shares an install root with nsight-systems-cli, which owns target-windows-x64
+:: and documentation.
+set "dest=%LIBRARY_PREFIX%\nsight-systems\!version_short!"
+if not exist "!dest!" mkdir "!dest!"
+if errorlevel 1 exit 1
+
+move "!payload!\host-windows-x64" "!dest!\" || exit 1
+
+if not exist "%SCRIPTS%" mkdir "%SCRIPTS%"
+
+set "shim_dir=%%~dp0..\Library\nsight-systems\!version_short!\host-windows-x64"
+set "shim_args=%%*"
+
+:: See build_cli.bat for why this loop is not recursive and why sqlite3 is excluded.
+for %%f in ("!dest!\host-windows-x64\*.exe") do (
+    set "exe_name=%%~nf"
+    set "skip="
+    for %%x in (python sqlite3) do if /i "!exe_name!"=="%%x" set "skip=1"
+    if not defined skip (
+        > "%SCRIPTS%\!exe_name!.bat" echo @echo off
+        >>"%SCRIPTS%\!exe_name!.bat" echo "!shim_dir!\!exe_name!.exe" !shim_args!
+        if errorlevel 1 exit 1
+    )
+)
+
+:: about.license_file resolves against the work directory root.
+if /i not "!archive_root!"=="." copy /y "!archive_root!\LICENSE" LICENSE >nul

--- a/recipes/nsight-systems/build_gui.sh
+++ b/recipes/nsight-systems/build_gui.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# GUI half of the split: the Qt-based nsys-ui timeline viewer.
+set -euxo pipefail
+
+# 2025.1.3.140 -> 2025.1.3, the directory NVIDIA creates inside the archive.
+version_short="${PKG_VERSION%.*}"
+
+payload="$(find . -maxdepth 3 -type d -path "*/nsight-systems/${version_short}" -print -quit)"
+if [[ ! -d "${payload}" ]]; then
+    echo "could not locate nsight-systems/${version_short} in the extracted archive" >&2
+    exit 1
+fi
+archive_root="$(dirname "$(dirname "${payload}")")"
+
+# See build_cli.sh: ~800 MB of duplicated rpm/deb payload.
+rm -rf "${archive_root}/.packages"
+
+# Exactly one host-side directory per archive (host-linux-x64 on x86_64,
+# host-linux-armv8 on sbsa). See build_cli.sh for why this is globbed.
+shopt -s nullglob
+host_dirs=("${payload}"/host-linux-*)
+shopt -u nullglob
+if [[ ${#host_dirs[@]} -ne 1 ]]; then
+    echo "expected exactly one host-linux-* directory, found ${#host_dirs[@]}" >&2
+    exit 1
+fi
+host_dir="$(basename "${host_dirs[0]}")"
+
+# Shares an install root with nsight-systems-cli, which owns target-*/ and docs/.
+dest="${PREFIX}/nsight-systems-${version_short}"
+mkdir -p "${dest}"
+mv "${payload}/${host_dir}" "${dest}/"
+
+mkdir -p "${PREFIX}/bin"
+ln -s "../nsight-systems-${version_short}/${host_dir}/nsys-ui" "${PREFIX}/bin/nsys-ui"
+
+# about.license_file resolves against the work directory root, which is already
+# where LICENSE lands when the archive's top-level directory is stripped.
+if [[ ! -f ./LICENSE ]]; then
+    cp "${archive_root}/LICENSE" ./LICENSE
+fi
+
+find "${dest}/${host_dir}" -type f \( -name "*.so" -o -name "*.so.*" \) -print0 \
+    | xargs -0 check-glibc "${dest}/${host_dir}/nsys-ui"

--- a/recipes/nsight-systems/conda-forge.yml
+++ b/recipes/nsight-systems/conda-forge.yml
@@ -1,0 +1,18 @@
+# Settings merged into the generated nsight-systems-feedstock at conversion time.
+#
+# Build on GitHub Actions rather than Azure Pipelines. linux-aarch64 is
+# cross-built on a linux_64 runner, matching the sibling CUDA feedstocks, so the
+# only build platforms in play are linux_64 and win_64.
+provider:
+  linux_64: github_actions
+  win_64: github_actions
+
+build_platform:
+  linux_aarch64: linux_64
+
+workflow_settings:
+  # Each platform archive extracts to ~1.8 GB and the two outputs together add
+  # another ~320 MB, which is tight on a hosted runner's default free space.
+  # `max` additionally prunes unused Docker images on Linux, which is where the
+  # headroom is.
+  free_disk_space: max

--- a/recipes/nsight-systems/conda_build_config.yaml
+++ b/recipes/nsight-systems/conda_build_config.yaml
@@ -1,0 +1,5 @@
+arm_variant_type:  # [aarch64]
+  - sbsa           # [aarch64]
+# The shipped binaries target the same glibc floor as nsight-compute.
+c_stdlib_version:  # [linux]
+  - 2.28           # [linux]

--- a/recipes/nsight-systems/meta.yaml
+++ b/recipes/nsight-systems/meta.yaml
@@ -1,0 +1,235 @@
+# NVIDIA Nsight Systems, split into a CLI package and a full package.
+#
+# Upstream ships one ~1 GB archive per platform containing two independent halves:
+#
+#   target-<platform>/  the collector plus the `nsys` command-line profiler
+#   host-<platform>/    the Qt-based `nsys-ui` timeline viewer
+#
+# Most users -- and effectively every CI job and container -- only ever need
+# `nsys`, so the two halves are published as separate packages. The naming
+# follows NVIDIA's own apt/rpm repositories:
+#
+#   nsight-systems-cli  the `nsys` command-line profiler on its own
+#   nsight-systems      the complete product; ships `nsys-ui` and depends on the CLI
+#
+# This also keeps `nsight-systems` parallel to `nsight-compute`, which likewise
+# names the complete product, and matches the `cuda-nsight-systems` metapackage
+# that NVIDIA's internal metaConda config already defines as depending on
+# `nsight-systems`.
+#
+# Versioning follows Nsight Systems upstream (as nsight-compute-feedstock does),
+# not the CUDA toolkit. `cuda_version` records the CUDA release whose redist
+# manifest this build was taken from: redistrib_12.9.2.json.
+{% set name = "nsight-systems-split" %}
+{% set version = "2025.1.3.140" %}
+# The directory NVIDIA creates inside the archive is the three-component version.
+{% set version_short = version.split(".")[0] + "." + version.split(".")[1] + "." + version.split(".")[2] %}
+{% set cuda_version = "12.9" %}
+{% set platform = "linux-x86_64" %}  # [linux64]
+{% set platform = "linux-sbsa" %}  # [aarch64]
+{% set platform = "windows-x86_64" %}  # [win]
+{% set extension = "tar.xz" %}  # [not win]
+{% set extension = "zip" %}  # [win]
+{% set script_ext = "sh" %}  # [not win]
+{% set script_ext = "bat" %}  # [win]
+{% set sha256 = "dded4227619340307be0ba5bc4e23bcbc966e2df3763170ebb20410c2b54754e" %}  # [linux64]
+{% set sha256 = "479c46de1c459f7c760ef1ea5e5bbe61bfe7f4ba525ce4778d5ba25d874b8e1f" %}  # [aarch64]
+{% set sha256 = "8d61f266a8a1bc1ababd44de3ee38f7b85c8cdfcdaebace14c8f065d7624d0b3" %}  # [win]
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://developer.download.nvidia.com/compute/cuda/redist/nsight_systems/{{ platform }}/nsight_systems-{{ platform }}-{{ version }}-archive.{{ extension }}
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  # Upstream publishes no macOS or ppc64le artifact for Nsight Systems.
+  skip: true  # [osx or ppc64le]
+
+outputs:
+  # -- CLI ---------------------------------------------------------------------
+  - name: nsight-systems-cli
+    script: build_cli.{{ script_ext }}
+    build:
+      # Prebuilt, self-contained binaries: they carry their own RPATHs and bundled
+      # libraries, and deliberately dlopen driver/tracing libraries that are not
+      # present at build time.
+      binary_relocation: false
+      missing_dso_whitelist:
+        - '*'
+      # The shipped binaries use relative $ORIGIN runpaths to find their own
+      # bundled libraries. That is correct and is what makes them relocatable,
+      # but conda-build treats any runpath as an error unless it is whitelisted.
+      runpath_whitelist:
+        - '*'
+    requirements:
+      build:
+        - {{ stdlib("c") }}  # [linux]
+        # Provides check-glibc, used to verify the shipped ELF objects against the
+        # declared glibc floor.
+        - cf-nvidia-tools 1.*  # [linux]
+        - arm-variant * {{ arm_variant_type | default("sbsa") }}  # [aarch64]
+      host:
+        - cuda-version {{ cuda_version }}
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+      run_constrained:
+        - arm-variant * {{ arm_variant_type | default("sbsa") }}  # [aarch64]
+    test:
+      commands:
+        - test -L $PREFIX/bin/nsys                                                        # [linux]
+        - test -d $PREFIX/nsight-systems-{{ version_short }}/docs                         # [linux]
+        - test -x $PREFIX/nsight-systems-{{ version_short }}/target-linux-x64/nsys         # [linux64]
+        - test -x $PREFIX/nsight-systems-{{ version_short }}/target-linux-sbsa-armv8/nsys  # [aarch64]
+        - if not exist %LIBRARY_PREFIX%\nsight-systems\{{ version_short }}\target-windows-x64\nsys.exe exit 1  # [win]
+        - if not exist %LIBRARY_PREFIX%\nsight-systems\{{ version_short }}\documentation exit 1                # [win]
+        - if not exist %SCRIPTS%\nsys.bat exit 1                                                               # [win]
+        # The cross-target Linux collector and the UCRT stubs are dropped.
+        - if exist %LIBRARY_PREFIX%\nsight-systems\{{ version_short }}\target-linux-x64 exit 1  # [win]
+        - if exist %SCRIPTS%\sqlite3.bat exit 1                                                 # [win]
+        - nsys --version  # [build_platform == target_platform]
+    about:
+      home: https://developer.nvidia.com/nsight-systems
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_file: LICENSE
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: NVIDIA Nsight Systems command-line system-wide performance analysis tool
+      description: |
+        NVIDIA Nsight Systems is a system-wide performance analysis tool designed
+        to visualize an application's algorithms, identify the largest opportunities
+        to optimize, and tune to scale efficiently across any quantity or size of
+        CPUs and GPUs.
+
+        This package provides the `nsys` command-line profiler and the target-side
+        collector on their own. Install `nsight-systems` instead for the complete
+        product, which adds the `nsys-ui` timeline viewer.
+      doc_url: https://docs.nvidia.com/nsight-systems/
+
+  # -- Full product (GUI + CLI) ------------------------------------------------
+  # Builds only the GUI half; the CLI half arrives via the run dependency below.
+  - name: nsight-systems
+    script: build_gui.{{ script_ext }}
+    build:
+      binary_relocation: false
+      missing_dso_whitelist:
+        - '*'
+      # The shipped binaries use relative $ORIGIN runpaths to find their own
+      # bundled libraries. That is correct and is what makes them relocatable,
+      # but conda-build treats any runpath as an error unless it is whitelisted.
+      runpath_whitelist:
+        - '*'
+    requirements:
+      build:
+        - {{ stdlib("c") }}  # [linux]
+        - cf-nvidia-tools 1.*  # [linux]
+        - arm-variant * {{ arm_variant_type | default("sbsa") }}  # [aarch64]
+      host:
+        - cuda-version {{ cuda_version }}
+        # The viewer is a Qt application. This mirrors the dependency set that
+        # nsight-compute-feedstock uses for ncu-ui, which is the same Qt stack.
+        - expat
+        - fontconfig
+        - freetype
+        - krb5
+        - libglib
+        - libxcb
+        - libzlib
+        - alsa-lib             # [linux]
+        - dbus                 # [linux]
+        - libglvnd-devel       # [linux]
+        - libopengl-devel      # [linux]
+        - libxkbcommon         # [linux]
+        - libxkbfile           # [linux]
+        - nspr                 # [linux]
+        - nss                  # [linux]
+        - wayland              # [linux]
+        - xcb-util-cursor      # [linux]
+        - xcb-util-image       # [linux]
+        - xcb-util-keysyms     # [linux]
+        - xcb-util-renderutil  # [linux]
+        - xcb-util-wm          # [linux]
+        - xorg-libice          # [linux]
+        - xorg-libsm           # [linux]
+        - xorg-libx11          # [linux]
+        - xorg-libxcomposite   # [linux]
+        - xorg-libxdamage      # [linux]
+        - xorg-libxext         # [linux]
+        - xorg-libxfixes       # [linux]
+        - xorg-libxrandr       # [linux]
+        - xorg-libxrender      # [linux]
+        - xorg-libxtst         # [linux]
+      run:
+        - {{ pin_compatible("cuda-version", max_pin="x.x") }}
+        # What makes this the complete product rather than just the viewer: the CLI
+        # half is also what the viewer runs for a local profiling session.
+        - {{ pin_subpackage("nsight-systems-cli", exact=True) }}
+        - {{ pin_compatible("libxkbfile", max_pin="x.x") }}          # [linux]
+        - {{ pin_compatible("xorg-libxcomposite", max_pin="x.x") }}  # [linux]
+        - {{ pin_compatible("xorg-libxdamage", max_pin="x.x") }}     # [linux]
+        - {{ pin_compatible("xorg-libxfixes", max_pin="x.x") }}      # [linux]
+        - {{ pin_compatible("xorg-libxrandr", max_pin="x.x") }}      # [linux]
+        - {{ pin_compatible("xorg-libxtst", max_pin="x.x") }}        # [linux]
+      run_constrained:
+        - arm-variant * {{ arm_variant_type | default("sbsa") }}  # [aarch64]
+    test:
+      commands:
+        - test -L $PREFIX/bin/nsys-ui                                                        # [linux]
+        - test -x $PREFIX/nsight-systems-{{ version_short }}/host-linux-x64/nsys-ui          # [linux64]
+        - test -x $PREFIX/nsight-systems-{{ version_short }}/host-linux-armv8/nsys-ui        # [aarch64]
+        - if not exist %LIBRARY_PREFIX%\nsight-systems\{{ version_short }}\host-windows-x64\nsys-ui.exe exit 1  # [win]
+        - if not exist %SCRIPTS%\nsys-ui.bat exit 1                                                             # [win]
+        # sqlite3.exe and python.exe ship in both halves; neither is shimmed, so the
+        # two packages cannot clobber each other in Scripts\.
+        - if exist %SCRIPTS%\sqlite3.bat exit 1  # [win]
+        - if exist %SCRIPTS%\python.bat exit 1   # [win]
+        # This is the complete product, so the CLI half must come along with it.
+        - test -L $PREFIX/bin/nsys                # [linux]
+        - if not exist %SCRIPTS%\nsys.bat exit 1  # [win]
+        - nsys --version  # [build_platform == target_platform]
+        # Launching nsys-ui is deliberately not tested, matching the equivalent
+        # ncu-ui test in nsight-compute-feedstock. The viewer needs a display even to
+        # report its version, the CI images are missing X11 libraries it wants, and on
+        # aarch64 the host-side binaries need a newer glibc than the image provides.
+        # Re-enabling would need xorg-x11-server-Xvfb in yum_requirements.txt.
+        # https://github.com/conda-forge/nsight-compute-feedstock/issues/26
+        # https://github.com/conda-forge/conda-forge.github.io/issues/1941
+        # - DISPLAY=localhost:1.0 xvfb-run -a nsys-ui --version  # [linux64]
+    about:
+      home: https://developer.nvidia.com/nsight-systems
+      license: LicenseRef-NVIDIA-End-User-License-Agreement
+      license_file: LICENSE
+      license_url: https://docs.nvidia.com/cuda/eula/index.html
+      summary: NVIDIA Nsight Systems system-wide performance analysis tool
+      description: |
+        NVIDIA Nsight Systems is a system-wide performance analysis tool designed
+        to visualize an application's algorithms, identify the largest opportunities
+        to optimize, and tune to scale efficiently across any quantity or size of
+        CPUs and GPUs.
+
+        This is the complete product: it ships the `nsys-ui` graphical timeline
+        viewer and pulls in `nsight-systems-cli`, which provides the `nsys`
+        command-line profiler. Install `nsight-systems-cli` on its own for a
+        headless or container setup that only needs to collect profiles.
+      doc_url: https://docs.nvidia.com/nsight-systems/
+
+about:
+  home: https://developer.nvidia.com/nsight-systems
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  license_file: LICENSE
+  license_url: https://docs.nvidia.com/cuda/eula/index.html
+  summary: NVIDIA Nsight Systems system-wide performance analysis tool
+  description: |
+    NVIDIA Nsight Systems is a system-wide performance analysis tool designed to
+    visualize an application's algorithms, identify the largest opportunities to
+    optimize, and tune to scale efficiently across any quantity or size of CPUs
+    and GPUs.
+  doc_url: https://docs.nvidia.com/nsight-systems/
+
+extra:
+  feedstock-name: nsight-systems
+  recipe-maintainers:
+    - conda-forge/cuda
+    - hanzov69


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [ ] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.


This feedstock uses a v0 recipe _intentionally_.
Currently, internal NVIDIA tooling does not support v1 style recipes. This will change in the future, once new versions have been released (and after https://github.com/prefix-dev/rattler-build/issues/2771 has been resolved) 