### PR TITLE
Add pysepal-api

### DIFF
--- a/recipes/pysepal-api/recipe.yaml
+++ b/recipes/pysepal-api/recipe.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  version: "0.3.1"
+
+package:
+  name: pysepal-api
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pysepal-api/pysepal_api-${{ version }}.tar.gz
+  sha256: 745f5bff42578bdc4fbff78490f1e60bb235f67a07ccf959fe4099055d1b885e
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling >=1.18
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - httpx >=0.27
+    - pydantic >=2.6
+
+tests:
+  - python:
+      imports:
+        - pysepal_api
+        - pysepal_api.endpoints
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - pip check
+
+about:
+  summary: UI-free HTTP client for SEPAL platform services (user files, tasks, processing recipes)
+  description: |
+    pysepal-api is a typed, UI-free HTTP client for the SEPAL platform. It
+    provides sync and async clients with identical surfaces for working with
+    user files, processing tasks and recipes, for use from Jupyter notebooks,
+    Voila and Solara apps, CLI scripts and background jobs.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://dfguerrerom.github.io/pysepal-api/
+  repository: https://github.com/dfguerrerom/pysepal-api
+  documentation: https://dfguerrerom.github.io/pysepal-api/
+
+extra:
+  recipe-maintainers:
+    - dfguerrerom


### PR DESCRIPTION
Adds a recipe for [pysepal-api](https://github.com/dfguerrerom/pysepal-api), a pure-Python HTTP client for the SEPAL platform (user files, tasks, processing recipes). It is `noarch: python` with two runtime dependencies, `httpx` and `pydantic`, both already on conda-forge.

It is also the one missing dependency of `pysepal` 3.7+, which is why the existing `pysepal` feedstock cannot be bumped past 3.6.2.

Linted with `conda-smithy recipe-lint --conda-forge`, and built and tested locally with `rattler-build`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
