### PR TITLE
Adding pytest-conda-solvers

### DIFF
--- a/recipes/pytest-conda-solvers/recipe.yaml
+++ b/recipes/pytest-conda-solvers/recipe.yaml
@@ -50,6 +50,8 @@ tests:
 
 about:
   summary: A pytest plugin to run conda solver tests
+  # The sdist bundles zlib 1.2.11 package archives as solver-test fixtures,
+  # so the package includes the zlib license even though it does not link zlib.
   license: BSD-3-Clause AND Zlib
   license_file:
     - LICENSE

--- a/recipes/pytest-conda-solvers/recipe.yaml
+++ b/recipes/pytest-conda-solvers/recipe.yaml
@@ -46,7 +46,7 @@ tests:
         - python ${{ python_min }}.*
     script:
       - python -c "from pytest_conda_solvers import solver_tests_path; assert (solver_tests_path() / 'basic.yaml').is_file()"
-      - python -c "import subprocess, sys; output = subprocess.check_output([sys.executable, '-m', 'pytest', '--trace-config', '--collect-only'], stderr=subprocess.STDOUT, text=True); assert 'pytest_conda_solvers.plugin' in output"
+      - python -c "import subprocess, sys; output = subprocess.check_output([sys.executable, '-m', 'pytest', '--trace-config', '--help'], stderr=subprocess.STDOUT, text=True); assert 'pytest_conda_solvers.plugin' in output"
 
 about:
   summary: A pytest plugin to run conda solver tests

--- a/recipes/pytest-conda-solvers/recipe.yaml
+++ b/recipes/pytest-conda-solvers/recipe.yaml
@@ -61,3 +61,5 @@ about:
 extra:
   recipe-maintainers:
     - jezdez
+    - jaimergp
+    - agriyakhetarpal

--- a/recipes/pytest-conda-solvers/recipe.yaml
+++ b/recipes/pytest-conda-solvers/recipe.yaml
@@ -51,7 +51,9 @@ tests:
 about:
   summary: A pytest plugin to run conda solver tests
   license: BSD-3-Clause AND Zlib
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - zlib-LICENSE.txt
   homepage: https://github.com/conda-incubator/pytest-conda-solvers
   documentation: https://conda-incubator.github.io/pytest-conda-solvers/
   repository: https://github.com/conda-incubator/pytest-conda-solvers

--- a/recipes/pytest-conda-solvers/recipe.yaml
+++ b/recipes/pytest-conda-solvers/recipe.yaml
@@ -1,0 +1,61 @@
+schema_version: 1
+
+context:
+  version: "0.1.0"
+
+package:
+  name: pytest-conda-solvers
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pytest-conda-solvers/pytest_conda_solvers-${{ version }}.tar.gz
+  sha256: 92b38e1ca5a8fa03183dea85712770c2602328756d7f73f1fc0d3edfa86830d9
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling >=1.12.2
+    - hatch-vcs >=0.2.0
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - boltons >=23.0
+    - conda >=26.3
+    - fastapi
+    - fastapi-cache2
+    - msgspec-yaml
+    - pytest >=8.1
+    - typer
+
+tests:
+  - python:
+      imports:
+        - pytest_conda_solvers
+        - pytest_conda_solvers.plugin
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - python -c "from pytest_conda_solvers import solver_tests_path; assert (solver_tests_path() / 'basic.yaml').is_file()"
+      - python -c "import subprocess, sys; output = subprocess.check_output([sys.executable, '-m', 'pytest', '--trace-config', '--collect-only'], stderr=subprocess.STDOUT, text=True); assert 'pytest_conda_solvers.plugin' in output"
+
+about:
+  summary: A pytest plugin to run conda solver tests
+  license: BSD-3-Clause AND Zlib
+  license_file: LICENSE
+  homepage: https://github.com/conda-incubator/pytest-conda-solvers
+  documentation: https://conda-incubator.github.io/pytest-conda-solvers/
+  repository: https://github.com/conda-incubator/pytest-conda-solvers
+
+extra:
+  recipe-maintainers:
+    - jezdez

--- a/recipes/pytest-conda-solvers/zlib-LICENSE.txt
+++ b/recipes/pytest-conda-solvers/zlib-LICENSE.txt
@@ -1,0 +1,23 @@
+  zlib.h -- interface of the 'zlib' general purpose compression library
+  version 1.2.7, May 2nd, 2012
+
+  Copyright (C) 1995-2012 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu


### PR DESCRIPTION
Adds the first conda-forge recipe for `pytest-conda-solvers`, based on the published 0.1.0 PyPI source distribution.

Tracks conda-incubator/pytest-conda-solvers#104.

The source distribution includes zlib 1.2.11 `.conda` and `.tar.bz2` package archives for four platforms. They provide the mock channel used by the solver tests and are not linked into `$PREFIX/lib`. Each archive retains its zlib notice, and the recipe also packages a standalone copy as `zlib-LICENSE.txt`. This is why the vendoring and no-static-libraries items remain unchecked below.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [ ] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [ ] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
