### PR TITLE
Add shumlib

### DIFF
--- a/recipes/shumlib/build.sh
+++ b/recipes/shumlib/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# CMake options: OpenMP on (the default consumers build against), the bitwise
+# NaN/denormal/IEEE probes off, tests off.
+# The conda-specific bits are BUILD_SHARED_LIBS=ON (so run_exports means something)
+# and CMAKE_INSTALL_LIBDIR=lib (shumlib honours GNUInstallDirs, which would
+# otherwise pick lib64 on some hosts, while consumers look under
+# $SHUMLIB_ROOT/lib).
+#
+# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
+# shellcheck disable=SC2086
+cmake -G Ninja -S . -B build \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILD_OPENMP=ON \
+  -DBUILD_FTHREADS=OFF \
+  -DBUILD_TESTS=OFF \
+  -DIEEE_ARITHMETIC=OFF \
+  -DNAN_BY_BITS=OFF \
+  -DDENORMAL_BY_BITS=OFF
+
+cmake --build build --parallel "${CPU_COUNT:-2}"
+cmake --install build

--- a/recipes/shumlib/build.sh
+++ b/recipes/shumlib/build.sh
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# CMake options: OpenMP on (the default consumers build against), the bitwise
-# NaN/denormal/IEEE probes off, tests off.
+# CMake options: OpenMP on (upstream's default), the bitwise NaN/denormal/IEEE
+# probes off, tests off.
+#
+# BUILD_OPENMP=ON is worth less than it looks in the CMake build: it only makes
+# upstream run `find_package(OpenMP 3.0 REQUIRED)`, and nothing links the
+# resulting OpenMP:: targets or puts -fopenmp on a compile line, so _OPENMP is
+# never defined and libshum acquires no OpenMP runtime dependency. (Upstream's
+# older Makefile build does apply the flags for SHUM_OPENMP=true.) It stays ON
+# to match upstream's default and to keep the flag correct if the CMake build
+# is fixed to link OpenMP; if that happens, the OpenMP runtime will need to be
+# added to the host requirements.
+#
 # The conda-specific bits are BUILD_SHARED_LIBS=ON (so run_exports means something)
 # and CMAKE_INSTALL_LIBDIR=lib (shumlib honours GNUInstallDirs, which would
 # otherwise pick lib64 on some hosts, while consumers look under

--- a/recipes/shumlib/build.sh
+++ b/recipes/shumlib/build.sh
@@ -4,14 +4,13 @@ set -euxo pipefail
 # CMake options: OpenMP on (upstream's default), the bitwise NaN/denormal/IEEE
 # probes off, tests off.
 #
-# BUILD_OPENMP=ON is worth less than it looks in the CMake build: it only makes
-# upstream run `find_package(OpenMP 3.0 REQUIRED)`, and nothing links the
-# resulting OpenMP:: targets or puts -fopenmp on a compile line, so _OPENMP is
-# never defined and libshum acquires no OpenMP runtime dependency. (Upstream's
-# older Makefile build does apply the flags for SHUM_OPENMP=true.) It stays ON
-# to match upstream's default and to keep the flag correct if the CMake build
-# is fixed to link OpenMP; if that happens, the OpenMP runtime will need to be
-# added to the host requirements.
+# BUILD_OPENMP=ON is upstream's default, but on its own the CMake build takes it
+# only as far as `find_package(OpenMP 3.0 REQUIRED)`: nothing links the
+# resulting OpenMP:: targets, so -fopenmp never reaches a compile line and the
+# OpenMP regions are compiled out. patches/0002-link-openmp.patch links them, so
+# this flag now does what it says and the library really is threaded -- matching
+# what upstream's Makefile build produces by default (SHUM_OPENMP ?= true).
+# That is why the OpenMP runtime appears in the host requirements.
 #
 # The conda-specific bits are BUILD_SHARED_LIBS=ON (so run_exports means something)
 # and CMAKE_INSTALL_LIBDIR=lib (shumlib honours GNUInstallDirs, which would

--- a/recipes/shumlib/patches/0001-release-version.patch
+++ b/recipes/shumlib/patches/0001-release-version.patch
@@ -1,0 +1,10 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -15,7 +15,7 @@
+ # format used by CMake and then recombined to allow it to be passed to
+ # shumlib via a pre-processor definition
+ project(shumlib LANGUAGES C Fortran
+-  VERSION 2026.07.1
++  VERSION 2026.07.2
+   DESCRIPTION "Met Office Shared Unifed Model Library"
+   HOMEPAGE_URL "https://github.com/MetOffice/shumlib")

--- a/recipes/shumlib/patches/0001-release-version.patch
+++ b/recipes/shumlib/patches/0001-release-version.patch
@@ -8,3 +8,4 @@
 +  VERSION 2026.07.2
    DESCRIPTION "Met Office Shared Unifed Model Library"
    HOMEPAGE_URL "https://github.com/MetOffice/shumlib")
+ 

--- a/recipes/shumlib/patches/0002-link-openmp.patch
+++ b/recipes/shumlib/patches/0002-link-openmp.patch
@@ -1,0 +1,22 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -62,6 +62,19 @@ target_compile_definitions(shum
+   PUBLIC
+   ${SHUM_DEFINES})
+ 
++# BUILD_OPENMP runs find_package(OpenMP ... REQUIRED) but nothing consumed the
++# imported targets, so no -fopenmp ever reached a compile line: _OPENMP went
++# undefined and the OpenMP regions in the C and Fortran sources were compiled
++# out. Link the targets so the option does what it says, matching the default
++# of the Makefile build (SHUM_OPENMP ?= true). PRIVATE is enough -- no
++# installed header depends on _OPENMP, so consumers need no OpenMP flags.
++if(BUILD_OPENMP)
++  target_link_libraries(shum
++    PRIVATE
++    OpenMP::OpenMP_C
++    OpenMP::OpenMP_Fortran)
++endif()
++
+ # Install shumlib and the C header files for the sub-libraries that
+ # have them
+ install(TARGETS shum

--- a/recipes/shumlib/recipe.yaml
+++ b/recipes/shumlib/recipe.yaml
@@ -1,0 +1,76 @@
+# shumlib -- the UK Met Office's Shared Unified Model Library: low-level C/Fortran
+# utilities factored out of the Unified Model (byteswapping, WGDOS packing,
+# string/data conversion, fieldsfile I/O). Consumers link it as `-lshum` and locate
+# it through SHUMLIB_ROOT.
+#
+# It has no MPI or netCDF dependency, so it carries no `mpi_*` build string. It
+# does ship Fortran .mod files, so it must be built with the same gfortran
+# generation as anything that consumes them (the compiler pin handles that;
+# run_exports carries the shumlib pin).
+schema_version: 1
+
+context:
+  version: "2026.07.2"
+
+package:
+  name: shumlib
+  version: ${{ version }}
+
+source:
+  url: https://github.com/MetOffice/shumlib/archive/refs/tags/${{ version }}.tar.gz
+  sha256: c4c8826ae21ad1371d5737ec8fa614d6a1dc59b880f4e5851f536ca62352d5ed
+
+build:
+  number: 0
+  script: build.sh
+  # Untested on Windows: this recipe was developed and verified only on
+  # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('fortran') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+  # shumlib installs a shared libshum.so and Fortran .mod files; anything built
+  # against it needs the same shumlib at run time (and the same-generation
+  # gfortran runtime, which conda-forge's compiler run_exports already pins).
+  run_exports:
+    - ${{ pin_subpackage('shumlib', upper_bound='x.x') }}
+
+tests:
+  - package_contents:
+      lib:
+        - shum
+  # The Fortran .mod files are the ABI-sensitive part of this package -- assert
+  # they were installed and are readable by this environment's gfortran.
+  - script:
+      - bash test_shumlib.sh
+    requirements:
+      build:
+        - ${{ compiler('fortran') }}
+        - ${{ stdlib('c') }}
+    files:
+      recipe:
+        - test_shumlib.sh
+        - test_shumlib.f90
+
+about:
+  homepage: https://github.com/MetOffice/shumlib
+  repository: https://github.com/MetOffice/shumlib
+  summary: Shared Unified Model Library (shumlib)
+  description: |
+    Shumlib is the collective name for a set of libraries used by the UK Met
+    Office's Unified Model that may be of use to external tools or applications:
+    byteswapping, WGDOS packing, string conversion, data conversion, fieldsfile
+    I/O, and related low-level utilities.
+  license: BSD-3-Clause
+  license_file:
+    - LICENCE
+
+extra:
+  recipe-maintainers:
+    - ickc

--- a/recipes/shumlib/recipe.yaml
+++ b/recipes/shumlib/recipe.yaml
@@ -19,6 +19,14 @@ package:
 source:
   url: https://github.com/MetOffice/shumlib/archive/refs/tags/${{ version }}.tar.gz
   sha256: c4c8826ae21ad1371d5737ec8fa614d6a1dc59b880f4e5851f536ca62352d5ed
+  patches:
+    # The 2026.07.2 tarball still declares `VERSION 2026.07.1` in its top-level
+    # CMakeLists.txt -- upstream tagged the release without bumping it. CMake
+    # feeds that version to the generated lib/pkgconfig/shumlib.pc and, via the
+    # SHUMLIB_VERSION preprocessor define, to the `get_<sublib>_version()`
+    # functions, so an unpatched build reports the previous release everywhere
+    # a consumer might look. Correct it to the version actually being built.
+    - patches/0001-release-version.patch
 
 build:
   number: 0

--- a/recipes/shumlib/recipe.yaml
+++ b/recipes/shumlib/recipe.yaml
@@ -37,8 +37,15 @@ requirements:
   # shumlib installs a shared libshum.so and Fortran .mod files; anything built
   # against it needs the same shumlib at run time (and the same-generation
   # gfortran runtime, which conda-forge's compiler run_exports already pins).
+  #
+  # The bound is the full version. Upstream's version is a date -- year, month,
+  # and a counter of releases within that month -- not a semantic version, so
+  # the third component carries no compatibility promise: two releases in the
+  # same month are as free to change the ABI as two releases in different
+  # months. Upstream states no ABI policy and gives libshum no SONAME version,
+  # so nothing narrower is safe.
   run_exports:
-    - ${{ pin_subpackage('shumlib', upper_bound='x.x') }}
+    - ${{ pin_subpackage('shumlib', upper_bound='x.x.x') }}
 
 tests:
   - package_contents:

--- a/recipes/shumlib/recipe.yaml
+++ b/recipes/shumlib/recipe.yaml
@@ -27,6 +27,15 @@ source:
     # functions, so an unpatched build reports the previous release everywhere
     # a consumer might look. Correct it to the version actually being built.
     - patches/0001-release-version.patch
+    # Upstream's CMake build takes BUILD_OPENMP as far as
+    # `find_package(OpenMP 3.0 REQUIRED)` and stops there -- nothing links the
+    # resulting OpenMP:: targets, so -fopenmp never reaches a compile line,
+    # _OPENMP goes undefined and the OpenMP regions in the C and Fortran
+    # sources are compiled out. The option is on by default, and upstream's
+    # older Makefile build does honour it (SHUM_OPENMP ?= true), so a CMake
+    # build silently produces a serial library where a make build would not.
+    # Link the targets so the option means what it says.
+    - patches/0002-link-openmp.patch
 
 build:
   number: 0
@@ -42,6 +51,16 @@ requirements:
     - ${{ stdlib('c') }}
     - cmake
     - ninja
+  # With the OpenMP link patch applied libshum carries a real dependency on the
+  # OpenMP runtime, so it has to be in host. gcc uses libgomp on linux; on osx
+  # conda-forge's gfortran runtime is built against llvm-openmp (libgfortran5
+  # depends on it), so both the clang-compiled C and the gfortran-compiled
+  # Fortran resolve to the one runtime there rather than two.
+  host:
+    - if: linux
+      then: libgomp
+    - if: osx
+      then: llvm-openmp
   # shumlib installs a shared libshum.so and Fortran .mod files; anything built
   # against it needs the same shumlib at run time (and the same-generation
   # gfortran runtime, which conda-forge's compiler run_exports already pins).

--- a/recipes/shumlib/recipe.yaml
+++ b/recipes/shumlib/recipe.yaml
@@ -22,7 +22,6 @@ source:
 
 build:
   number: 0
-  script: build.sh
   # Untested on Windows: this recipe was developed and verified only on
   # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
   skip:

--- a/recipes/shumlib/test_shumlib.f90
+++ b/recipes/shumlib/test_shumlib.f90
@@ -1,0 +1,6 @@
+program test_shumlib
+  ! f_shum_string_conv_mod is a base module (shum_byteswap USEs it), so it has no
+  ! intra-shumlib dependencies to satisfy -- a clean target for the .mod ABI check.
+  use f_shum_string_conv_mod
+  implicit none
+end program test_shumlib

--- a/recipes/shumlib/test_shumlib.sh
+++ b/recipes/shumlib/test_shumlib.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# .mod ABI check: gfortran can only read module files written by its own
+# generation, so compiling `use f_shum_string_conv_mod` against shumlib's installed
+# module proves this environment's gfortran agrees with the one shumlib was built
+# with. -fsyntax-only keeps it link-free -- the point is the .mod, not the link.
+#
+# FFLAGS/CPPFLAGS carry -I$PREFIX/include from the Fortran compiler activation;
+# pass it explicitly too so the test does not depend on which one gfortran reads.
+# These are flag STRINGS and must word-split.
+# shellcheck disable=SC2086
+${FC} -fsyntax-only ${FFLAGS} -I"$PREFIX/include" test_shumlib.f90
+echo SHUMLIB_MODULES_OK
+
+# libshum must resolve its own runtime dependencies. The shared library is .so
+# on linux and .dylib on macOS; the ldd "not found" gate runs where ldd exists
+# (linux) and is skipped on macOS (which has no ldd).
+case "$(uname -s)" in
+  Darwin) lib="$PREFIX/lib/libshum.dylib" ;;
+  *)      lib="$PREFIX/lib/libshum.so" ;;
+esac
+test -f "$lib"
+if command -v ldd >/dev/null 2>&1; then
+  if ldd "$lib" | grep -i "not found"; then
+    echo "ERROR: unresolved runtime dependencies in $lib"
+    exit 1
+  fi
+fi
+echo SHUMLIB_LIB_OK

--- a/recipes/shumlib/test_shumlib.sh
+++ b/recipes/shumlib/test_shumlib.sh
@@ -13,13 +13,9 @@ set -euxo pipefail
 ${FC} -fsyntax-only ${FFLAGS} -I"$PREFIX/include" test_shumlib.f90
 echo SHUMLIB_MODULES_OK
 
-# libshum must resolve its own runtime dependencies. The shared library is .so
-# on linux and .dylib on macOS; the ldd "not found" gate runs where ldd exists
-# (linux) and is skipped on macOS (which has no ldd).
-case "$(uname -s)" in
-  Darwin) lib="$PREFIX/lib/libshum.dylib" ;;
-  *)      lib="$PREFIX/lib/libshum.so" ;;
-esac
+# libshum must resolve its own runtime dependencies. SHLIB_EXT is supplied by
+# the build tool and is .so on linux and .dylib on macOS.
+lib="$PREFIX/lib/libshum${SHLIB_EXT}"
 test -f "$lib"
 if command -v ldd >/dev/null 2>&1; then
   if ldd "$lib" | grep -i "not found"; then

--- a/recipes/shumlib/test_shumlib.sh
+++ b/recipes/shumlib/test_shumlib.sh
@@ -54,6 +54,18 @@ case "$(uname -s)" in
 esac
 echo SHUMLIB_LIB_OK
 
+# Linking the OpenMP runtime is the whole point of the BUILD_OPENMP patch, and
+# its absence is silent: without the patch upstream still configures cleanly,
+# just with the threaded regions compiled out. Assert the runtime is really
+# there so the patch cannot stop applying unnoticed. gcc uses libgomp; on macOS
+# conda-forge's toolchain resolves both the clang C and the gfortran Fortran to
+# llvm-openmp's libomp, so accept either name.
+if ! printf '%s\n' "$linkage" | grep -Eqi 'lib(gomp|omp)'; then
+  echo "ERROR: $lib links no OpenMP runtime -- BUILD_OPENMP did not take effect"
+  exit 1
+fi
+echo SHUMLIB_OPENMP_OK
+
 # The version shumlib reports comes from its CMakeLists.txt, which upstream
 # forgot to bump for this release and the recipe patches; check the generated
 # pkg-config file agrees with the package so the patch cannot silently stop

--- a/recipes/shumlib/test_shumlib.sh
+++ b/recipes/shumlib/test_shumlib.sh
@@ -17,10 +17,39 @@ echo SHUMLIB_MODULES_OK
 # the build tool and is .so on linux and .dylib on macOS.
 lib="$PREFIX/lib/libshum${SHLIB_EXT}"
 test -f "$lib"
-if command -v ldd >/dev/null 2>&1; then
-  if ldd "$lib" | grep -i "not found"; then
-    echo "ERROR: unresolved runtime dependencies in $lib"
-    exit 1
-  fi
-fi
+
+# Each platform has its own tool for listing what a shared library needs, so
+# branch on which one to ask; the listing is printed either way so the CI log
+# records what libshum ended up linked against.
+case "$(uname -s)" in
+  Darwin)
+    # otool -L reports the install names libshum records, without resolving
+    # them. conda rewrites the ones it owns to @rpath/<name> and points the
+    # rpath at $PREFIX/lib, so those are satisfied exactly when the named file
+    # is there. macOS's own libraries under /usr/lib and /System live in the
+    # dyld shared cache rather than on disk, so they are not checked.
+    linkage=$(otool -L "$lib")
+    printf '%s\n' "$linkage"
+    for dep in $(printf '%s\n' "$linkage" | tail -n +2 | awk '{print $1}'); do
+      case "$dep" in
+        /usr/lib/*|/System/*) continue ;;
+        @rpath/*) dep="$PREFIX/lib/${dep#@rpath/}" ;;
+      esac
+      if [ ! -e "$dep" ]; then
+        echo "ERROR: unresolved runtime dependency $dep in $lib"
+        exit 1
+      fi
+    done
+    ;;
+  *)
+    # ldd resolves the dependencies itself and writes "not found" against any
+    # it cannot satisfy.
+    linkage=$(ldd "$lib")
+    printf '%s\n' "$linkage"
+    if printf '%s\n' "$linkage" | grep -i "not found"; then
+      echo "ERROR: unresolved runtime dependencies in $lib"
+      exit 1
+    fi
+    ;;
+esac
 echo SHUMLIB_LIB_OK

--- a/recipes/shumlib/test_shumlib.sh
+++ b/recipes/shumlib/test_shumlib.sh
@@ -53,3 +53,12 @@ case "$(uname -s)" in
     ;;
 esac
 echo SHUMLIB_LIB_OK
+
+# The version shumlib reports comes from its CMakeLists.txt, which upstream
+# forgot to bump for this release and the recipe patches; check the generated
+# pkg-config file agrees with the package so the patch cannot silently stop
+# applying on a future version bump.
+pc="$PREFIX/lib/pkgconfig/shumlib.pc"
+cat "$pc"
+grep -qx "Version: ${PKG_VERSION}" "$pc"
+echo SHUMLIB_VERSION_OK


### PR DESCRIPTION
Split out of #34287 at the reviewer's request to keep each PR to a single recipe.

shumlib is the UK Met Office's Shared Unified Model Library, a set of low-level C/Fortran utilities factored out of the Unified Model: byteswapping, WGDOS packing, string and data conversion, and fieldsfile I/O. Consumers link it as `-lshum`.

A few things in the recipe that may look unusual:

- Upstream versions by date, so the version string is `2026.07.2` rather than a semantic version.
- The package ships Fortran `.mod` files, which only the gfortran generation that wrote them can read. The test therefore compiles a `use` of an installed module with `-fsyntax-only` to assert this environment's gfortran can read them. `run_exports` carries the shumlib pin; the compiler `run_exports` handle the gfortran generation.
- `skip: win` — I developed and verified the recipe on linux and osx only, and `build.sh` is bash-only.
- `build.sh` builds shared (`BUILD_SHARED_LIBS=ON`, so the `run_exports` pin is meaningful) and forces `CMAKE_INSTALL_LIBDIR=lib`, since shumlib honours GNUInstallDirs and would otherwise install to `lib64` on some hosts. Upstream's bitwise NaN/denormal/IEEE options and its own test suite are left off.

Thanks for taking a look.
