### PR TITLE
Add gftl, gftl-shared, fargparse and pfunit

### DIFF
--- a/recipes/fargparse/build.sh
+++ b/recipes/fargparse/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# find_package(GFTL) and find_package(GFTL_SHARED) resolve their versioned subdir
+# installs via CMAKE_PREFIX_PATH=$PREFIX. BUILD_TESTING=OFF -- fArgParse's tests
+# want pFUnit, which sits above this package in the dependency chain.
+#
+# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
+# shellcheck disable=SC2086
+cmake -G Ninja -S . -B build \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DBUILD_TESTING=OFF
+
+cmake --build build --parallel "${CPU_COUNT:-2}"
+cmake --install build

--- a/recipes/fargparse/recipe.yaml
+++ b/recipes/fargparse/recipe.yaml
@@ -1,0 +1,65 @@
+# fArgParse -- command-line argument parsing for Fortran. Third layer of the
+# Goddard Fortran Ecosystem (gftl -> gftl-shared -> fargparse -> pfunit).
+#
+# Versioned subdir install (FARGPARSE-<x.y>/), same as the rest of the group. It
+# finds gFTL and gFTL-shared at build time via find_package (resolved through
+# CMAKE_PREFIX_PATH=$PREFIX); its own CMake config then does find_dependency on
+# both, so they must be present when anything builds against fargparse -- hence the
+# run deps. The libraries in this group are static (upstream/Spack default), so no
+# run_exports are needed.
+schema_version: 1
+
+context:
+  version: "1.11.0"
+
+package:
+  name: fargparse
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Goddard-Fortran-Ecosystem/fArgParse/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 867854b0d312ef22ba3938f5398727973942a31d75f4e1abd3cd9d35f0159691
+
+build:
+  number: 0
+  script: build.sh
+  # Untested on Windows: this recipe was developed and verified only on
+  # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('fortran') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - m4
+  host:
+    - gftl
+    - gftl-shared
+  run:
+    - gftl
+    - gftl-shared
+
+tests:
+  - script:
+      - bash test_fargparse.sh
+    files:
+      recipe:
+        - test_fargparse.sh
+
+about:
+  homepage: https://github.com/Goddard-Fortran-Ecosystem/fArgParse
+  repository: https://github.com/Goddard-Fortran-Ecosystem/fArgParse
+  summary: Command-line argument parsing for Fortran
+  description: |
+    fArgParse is a Fortran library for parsing command-line arguments, modelled on
+    Python's argparse. Part of the Goddard Fortran Ecosystem; a pFUnit dependency.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - ickc

--- a/recipes/fargparse/recipe.yaml
+++ b/recipes/fargparse/recipe.yaml
@@ -4,9 +4,11 @@
 # Versioned subdir install (FARGPARSE-<x.y>/), same as the rest of the group. It
 # finds gFTL and gFTL-shared at build time via find_package (resolved through
 # CMAKE_PREFIX_PATH=$PREFIX); its own CMake config then does find_dependency on
-# both, so they must be present when anything builds against fargparse -- hence the
-# run deps. The libraries in this group are static (upstream/Spack default), so no
-# run_exports are needed.
+# both, so they must be present whenever anything builds against fArgParse. Each
+# package in this group therefore carries a weak self run_export pinned to its
+# minor series. The libraries are static (upstream/Spack default), so the pin is
+# not about shared-object ABI -- it is about the Fortran .mod files and the
+# versioned CMake config, which are only interchangeable within a minor series.
 schema_version: 1
 
 context:
@@ -37,9 +39,10 @@ requirements:
   host:
     - gftl
     - gftl-shared
-  run:
-    - gftl
-    - gftl-shared
+  # Weak self run_export, as for the layers below: consumers that list fargparse in
+  # `host` get this pin, and gftl/gftl-shared come with it via their own exports.
+  run_exports:
+    - ${{ pin_subpackage('fargparse', upper_bound='x.x') }}
 
 tests:
   - script:

--- a/recipes/fargparse/recipe.yaml
+++ b/recipes/fargparse/recipe.yaml
@@ -22,7 +22,6 @@ source:
 
 build:
   number: 0
-  script: build.sh
   # Untested on Windows: this recipe was developed and verified only on
   # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
   skip:

--- a/recipes/fargparse/test_fargparse.sh
+++ b/recipes/fargparse/test_fargparse.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Versioned subdir install ($PREFIX/FARGPARSE-<x.y>/). Assert the CMake package
+# config, the Fortran modules and the static library landed. Building at all proves
+# find_package(GFTL) and find_package(GFTL_SHARED) resolved across the subdir
+# installs.
+sub=$(echo "$PREFIX"/FARGPARSE-*)
+test -d "$sub/include"
+test -f "$sub/cmake/FARGPARSEConfig.cmake"
+ls "$sub"/lib*/libfargparse.a
+echo "fArgParse installed at: $sub"
+echo FARGPARSE_OK

--- a/recipes/gftl-shared/build.sh
+++ b/recipes/gftl-shared/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# find_package(GFTL) resolves $PREFIX/GFTL-1.17/cmake via CMAKE_PREFIX_PATH (conda
+# sets it to $PREFIX). BUILD_TESTING=OFF -- upstream's tests want pFUnit, which is
+# above this package in the dependency chain.
+#
+# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
+# shellcheck disable=SC2086
+cmake -G Ninja -S . -B build \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DBUILD_TESTING=OFF
+
+cmake --build build --parallel "${CPU_COUNT:-2}"
+cmake --install build

--- a/recipes/gftl-shared/recipe.yaml
+++ b/recipes/gftl-shared/recipe.yaml
@@ -1,0 +1,67 @@
+# gFTL-shared -- ready-made gFTL containers of Fortran intrinsic types. Second
+# layer of the Goddard Fortran Ecosystem (gftl -> gftl-shared -> fargparse ->
+# pfunit), and a separately released, separately versioned upstream project from
+# gftl itself -- hence two recipes rather than one.
+#
+# Installs into the versioned subdir GFTL_SHARED-<x.y>/ (see the gftl recipe for
+# why). It finds gFTL at build time via find_package(GFTL) -- which resolves
+# $PREFIX/GFTL-1.17/cmake/ because conda puts $PREFIX on CMAKE_PREFIX_PATH and
+# CMake's config search globs `<prefix>/<name>*/cmake/`. gFTL is therefore a host
+# dependency (compiled in; no runtime shared object).
+schema_version: 1
+
+context:
+  version: "1.12.0"
+
+package:
+  name: gftl-shared
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 38f0353c4d53d474db9d6b301223c2848ac19e5e8c83b136d4c03605ac4bd768
+
+build:
+  number: 0
+  script: build.sh
+  # Untested on Windows: this recipe was developed and verified only on
+  # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('fortran') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - m4
+  host:
+    - gftl
+  # gFTL-shared's CMake config does find_dependency(GFTL), so anything that builds
+  # against gFTL-shared also needs gFTL present. Propagate it.
+  run:
+    - gftl
+
+tests:
+  - script:
+      - bash test_gftl_shared.sh
+    files:
+      recipe:
+        - test_gftl_shared.sh
+
+about:
+  homepage: https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared
+  repository: https://github.com/Goddard-Fortran-Ecosystem/gFTL-shared
+  summary: Ready-made gFTL containers of Fortran intrinsic types
+  description: |
+    gFTL-shared provides instantiations of the gFTL containers (Vector, Set, Map,
+    ...) for common Fortran intrinsic types, so downstream projects need not
+    re-instantiate them. Part of the Goddard Fortran Ecosystem; a pFUnit dependency.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - ickc

--- a/recipes/gftl-shared/recipe.yaml
+++ b/recipes/gftl-shared/recipe.yaml
@@ -23,7 +23,6 @@ source:
 
 build:
   number: 0
-  script: build.sh
   # Untested on Windows: this recipe was developed and verified only on
   # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
   skip:

--- a/recipes/gftl-shared/recipe.yaml
+++ b/recipes/gftl-shared/recipe.yaml
@@ -7,7 +7,8 @@
 # why). It finds gFTL at build time via find_package(GFTL) -- which resolves
 # $PREFIX/GFTL-1.17/cmake/ because conda puts $PREFIX on CMAKE_PREFIX_PATH and
 # CMake's config search globs `<prefix>/<name>*/cmake/`. gFTL is therefore a host
-# dependency (compiled in; no runtime shared object).
+# dependency (compiled in; no runtime shared object), and its run_export carries
+# the version pin downstream from there.
 schema_version: 1
 
 context:
@@ -37,10 +38,13 @@ requirements:
     - m4
   host:
     - gftl
-  # gFTL-shared's CMake config does find_dependency(GFTL), so anything that builds
-  # against gFTL-shared also needs gFTL present. Propagate it.
-  run:
-    - gftl
+  # Same story as gFTL: compiled into its consumers, and its CMake config does
+  # find_dependency(GFTL). The weak self run_export pins gftl-shared for anything
+  # that has it in `host`; gFTL itself arrives alongside, because gftl's own
+  # run_export lands in this package's `run` and host dependencies bring their run
+  # requirements with them.
+  run_exports:
+    - ${{ pin_subpackage('gftl-shared', upper_bound='x.x') }}
 
 tests:
   - script:

--- a/recipes/gftl-shared/test_gftl_shared.sh
+++ b/recipes/gftl-shared/test_gftl_shared.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Versioned subdir install ($PREFIX/GFTL_SHARED-<x.y>/). Assert the CMake package
+# config and the Fortran modules landed. That this package built at all is the
+# proof that find_package(GFTL) resolved the subdir-installed gFTL.
+sub=$(echo "$PREFIX"/GFTL_SHARED-*)
+test -d "$sub/include"
+test -f "$sub/cmake/GFTL_SHAREDConfig.cmake"
+echo "gFTL-shared installed at: $sub"
+echo GFTL_SHARED_OK

--- a/recipes/gftl/build.sh
+++ b/recipes/gftl/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Header/template library: the build step mostly stages generated templates, and
+# install copies them plus the CMake package config into $PREFIX/GFTL-<x.y>/.
+# BUILD_TESTING=OFF because gFTL's own tests want pFUnit (its CMakeLists does a
+# `find_package(PFUNIT 4.1 QUIET)`), which is not present at build time.
+#
+# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
+# shellcheck disable=SC2086
+cmake -G Ninja -S . -B build \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DBUILD_TESTING=OFF
+
+cmake --build build --parallel "${CPU_COUNT:-2}"
+cmake --install build

--- a/recipes/gftl/build.sh
+++ b/recipes/gftl/build.sh
@@ -3,16 +3,18 @@ set -euxo pipefail
 
 # Header/template library: the build step mostly stages generated templates, and
 # install copies them plus the CMake package config into $PREFIX/GFTL-<x.y>/.
-# BUILD_TESTING=OFF because gFTL's own tests want pFUnit (its CMakeLists does a
-# `find_package(PFUNIT 4.1 QUIET)`), which is not present at build time.
+# The project is `LANGUAGES NONE`; its tests are guarded by check_language(Fortran)
+# plus `find_package(PFUNIT 4.1 QUIET)`, neither of which is satisfied here, so
+# they are skipped without asking. (gFTL never reads BUILD_TESTING, so passing it
+# only earned an "unused variable" warning.)
 #
-# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
+# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split; it
+# is unset here because this build needs no compiler, hence the :- default.
 # shellcheck disable=SC2086
 cmake -G Ninja -S . -B build \
-  ${CMAKE_ARGS} \
+  ${CMAKE_ARGS:-} \
   -DCMAKE_BUILD_TYPE=Release \
-  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-  -DBUILD_TESTING=OFF
+  -DCMAKE_INSTALL_PREFIX="$PREFIX"
 
 cmake --build build --parallel "${CPU_COUNT:-2}"
 cmake --install build

--- a/recipes/gftl/recipe.yaml
+++ b/recipes/gftl/recipe.yaml
@@ -1,0 +1,67 @@
+# gFTL -- Fortran template container library (Vector/Set/Map), the base of NASA's
+# Goddard Fortran Ecosystem, whose four projects are separate upstream releases
+# stacked on one another: gftl -> gftl-shared -> fargparse -> pfunit. It is a
+# header/template library (no compiled .so/.a): it installs preprocessor templates
+# and a CMake package config, and gets compiled INTO its consumers.
+#
+# Layout note (applies to the whole Goddard group): upstream installs into a
+# VERSIONED subdirectory `GFTL-<major>.<minor>/{include,cmake}`, not the standard
+# $PREFIX/{include,lib}. This is deliberate (so versions coexist) and is what the
+# upstream Spack packages do as well. It composes cleanly at build time because
+# CMake's config-mode search under a CMAKE_PREFIX_PATH entry includes
+# `<prefix>/<name>*/cmake/`, so `find_package(GFTL)` finds
+# `$PREFIX/GFTL-1.17/cmake/` with no extra hints (conda sets CMAKE_PREFIX_PATH).
+schema_version: 1
+
+context:
+  version: "1.17.0"
+
+package:
+  name: gftl
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Goddard-Fortran-Ecosystem/gFTL/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 2a86047d329297c1c6147b1619d1412259a21d9c2188e229ebf6c4e73ec51546
+
+build:
+  number: 0
+  # noarch is tempting (it is template source), but the CMake config records the
+  # build layout and upstream's own test build wants a Fortran compiler present,
+  # so keep it a normal (arch) build for parity with how it is consumed.
+  script: build.sh
+  # Untested on Windows: this recipe was developed and verified only on
+  # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('fortran') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - m4
+
+tests:
+  - script:
+      - bash test_gftl.sh
+    files:
+      recipe:
+        - test_gftl.sh
+
+about:
+  homepage: https://github.com/Goddard-Fortran-Ecosystem/gFTL
+  repository: https://github.com/Goddard-Fortran-Ecosystem/gFTL
+  summary: Fortran template library for generic containers (Vector, Set, Map)
+  description: |
+    gFTL provides a mechanism to easily create robust generic containers and
+    associated iterators in Fortran, closely modelled on the C++ STL. It is the
+    foundation of the Goddard Fortran Ecosystem (gFTL-shared, fArgParse, pFUnit).
+  license: Apache-2.0
+  license_file:
+    - License.txt
+
+extra:
+  recipe-maintainers:
+    - ickc

--- a/recipes/gftl/recipe.yaml
+++ b/recipes/gftl/recipe.yaml
@@ -26,18 +26,22 @@ source:
 
 build:
   number: 0
-  # noarch is tempting (it is template source), but the CMake config records the
-  # build layout and upstream's own test build wants a Fortran compiler present,
-  # so keep it a normal (arch) build for parity with how it is consumed.
+  # Kept as a normal (arch) build rather than noarch: the installed CMake package
+  # config bakes in the prefix and the versioned subdir layout of the build, and
+  # the rest of the group is built per-platform anyway. Nothing is compiled here,
+  # so noarch: generic would also be defensible.
   # Untested on Windows: this recipe was developed and verified only on
   # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
   skip:
     - win
 
 requirements:
+  # No compiler (and hence no stdlib): upstream declares `project(GFTL ...
+  # LANGUAGES NONE)` and this build only runs m4 over the templates and installs
+  # them. gFTL's optional test suite is the only thing that wants a Fortran
+  # compiler, and it is not built here. Leaving the compiler in would attach
+  # libgfortran/libgcc/glibc run_exports to a package that contains no binaries.
   build:
-    - ${{ compiler('fortran') }}
-    - ${{ stdlib('c') }}
     - cmake
     - ninja
     - m4

--- a/recipes/gftl/recipe.yaml
+++ b/recipes/gftl/recipe.yaml
@@ -29,7 +29,6 @@ build:
   # noarch is tempting (it is template source), but the CMake config records the
   # build layout and upstream's own test build wants a Fortran compiler present,
   # so keep it a normal (arch) build for parity with how it is consumed.
-  script: build.sh
   # Untested on Windows: this recipe was developed and verified only on
   # linux-64/-aarch64 and osx-64/-arm64, and build.sh is bash-only besides.
   skip:

--- a/recipes/gftl/recipe.yaml
+++ b/recipes/gftl/recipe.yaml
@@ -41,6 +41,15 @@ requirements:
     - cmake
     - ninja
     - m4
+  # gFTL ships no runtime object of its own -- it is compiled INTO its consumers,
+  # and its CMake package config is find_dependency'd by the rest of the group --
+  # so every consumer needs a matching gFTL present when IT is built. A weak self
+  # run_export states that: anything that lists gftl in `host` gets this pin in its
+  # own `run`, which is in turn what puts gFTL into the host environment of the
+  # layer above it. Upstream keeps the templates and the installed layout
+  # compatible only within a minor series, hence upper_bound='x.x'.
+  run_exports:
+    - ${{ pin_subpackage('gftl', upper_bound='x.x') }}
 
 tests:
   - script:

--- a/recipes/gftl/test_gftl.sh
+++ b/recipes/gftl/test_gftl.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# gFTL installs into a versioned subdir ($PREFIX/GFTL-<x.y>/), so the standard
+# package_contents include/lib matchers do not apply -- assert the templates and
+# the CMake package config landed there. The real proof that find_package(GFTL)
+# resolves is that gftl-shared builds against this package.
+sub=$(echo "$PREFIX"/GFTL-*)
+test -d "$sub/include"
+test -f "$sub/cmake/GFTLConfig.cmake"
+echo "GFTL installed at: $sub"
+echo GFTL_OK

--- a/recipes/pfunit/build.sh
+++ b/recipes/pfunit/build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Belt-and-braces against archive extraction leaving the top-level pFUnit-v<ver>/
+# dir in place: if CMakeLists.txt is not at the source root, descend into it.
+if [ ! -f CMakeLists.txt ]; then
+  d="$(find . -maxdepth 1 -type d -name 'pFUnit-*' | head -1)"
+  [ -n "$d" ] && cd "$d"
+fi
+
+# Build options:
+#  - static libraries (BUILD_SHARED_LIBS=OFF), as the whole Goddard group is built;
+#  - MPI enabled (SKIP_MPI=NO): pFUnit's CMake does find_package(MPI COMPONENTS
+#    Fortran), which picks up conda's MPI from $PREFIX -- no need to override the
+#    Fortran compiler to mpif90;
+#  - OpenMP/hamcrest/ESMF and pFUnit's own tests skipped;
+#  - MAX_ASSERT_RANK=5, the upstream/Spack default.
+# find_package(GFTL/GFTL_SHARED/FARGPARSE) and find_package(Python) resolve from
+# the host dependencies via CMAKE_PREFIX_PATH=$PREFIX.
+#
+# CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
+# shellcheck disable=SC2086
+cmake -G Ninja -S . -B build \
+  ${CMAKE_ARGS} \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DSKIP_MPI=NO \
+  -DSKIP_OPENMP=YES \
+  -DSKIP_FHAMCREST=YES \
+  -DSKIP_ESMF=YES \
+  -DENABLE_TESTS=NO \
+  -DENABLE_MPI_F08=NO \
+  -DMAX_ASSERT_RANK=5
+
+cmake --build build --parallel "${CPU_COUNT:-2}"
+cmake --install build

--- a/recipes/pfunit/build.sh
+++ b/recipes/pfunit/build.sh
@@ -15,8 +15,10 @@ fi
 #    Fortran compiler to mpif90;
 #  - OpenMP/hamcrest/ESMF and pFUnit's own tests skipped;
 #  - MAX_ASSERT_RANK=5, the upstream/Spack default.
-# find_package(GFTL/GFTL_SHARED/FARGPARSE) and find_package(Python) resolve from
-# the host dependencies via CMAKE_PREFIX_PATH=$PREFIX.
+# find_package(GFTL/GFTL_SHARED/FARGPARSE) resolve from the host dependencies via
+# CMAKE_PREFIX_PATH=$PREFIX; find_package(Python) resolves the build environment's
+# interpreter, which is all that is needed -- the installed .pf preprocessor is a
+# plain script and PFUNITConfig.cmake re-resolves Python in the consumer.
 #
 # CMAKE_ARGS is a flag STRING from the compiler activation and must word-split.
 # shellcheck disable=SC2086

--- a/recipes/pfunit/recipe.yaml
+++ b/recipes/pfunit/recipe.yaml
@@ -1,0 +1,81 @@
+# pFUnit -- unit-testing framework for Fortran (JUnit-style, serial and MPI). Top
+# of the Goddard Fortran Ecosystem (gftl -> gftl-shared -> fargparse -> pfunit),
+# built on the other three.
+#
+# Built with MPI support, so it carries the mpi_${mpi}_* build string and depends
+# on the same MPI as the rest of the stack. Its `.pf` test preprocessor is a
+# Python tool consumers run at build time, hence python is also a run dependency.
+# Versioned subdir install (PFUNIT-<x.y>/), like the rest of the group.
+schema_version: 1
+
+context:
+  version: "4.19.0"
+
+package:
+  name: pfunit
+  version: ${{ version }}
+
+source:
+  # A GitHub RELEASE asset (a plain .tar), not an archive/refs/tags tarball -- this
+  # is the source Spack uses. No `file_name:` here: setting it made rattler-build
+  # treat the download as a plain file and NOT extract it, so the work dir held the
+  # .tar instead of its contents and CMake could not find CMakeLists.txt. Letting
+  # the URL's .tar extension drive extraction strips the single top-level
+  # pFUnit-v<ver>/ dir, exactly as the .tar.gz sources of the other recipes do.
+  url: https://github.com/Goddard-Fortran-Ecosystem/pFUnit/releases/download/v${{ version }}/pFUnit-v${{ version }}.tar
+  sha256: ec84e2e17d79598d782edc5468e7ebfe392ccf5aff9170a15c10f0b52f9f62b4
+
+build:
+  number: 0
+  # MPI-linked, so it carries the conda-forge mpi_<flavour>_* build string.
+  string: mpi_${{ mpi }}_${{ hash }}_${{ build_number }}
+  # mpich/openmpi are not built for win-64 on conda-forge (only msmpi/impi_rt,
+  # a different API this recipe does not support).
+  skip:
+    - win
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('fortran') }}
+    - ${{ stdlib('c') }}
+    - cmake
+    - ninja
+    - m4
+    - python
+  host:
+    - ${{ mpi }}
+    - gftl
+    - gftl-shared
+    - fargparse
+    - python
+  run:
+    - ${{ mpi }}
+    - gftl
+    - gftl-shared
+    - fargparse
+    # pFUnit's .pf-file preprocessor (funitproc / pFUnitParser) is a Python script
+    # that consumers invoke when building their tests.
+    - python
+
+tests:
+  - script:
+      - bash test_pfunit.sh
+    files:
+      recipe:
+        - test_pfunit.sh
+
+about:
+  homepage: https://github.com/Goddard-Fortran-Ecosystem/pFUnit
+  repository: https://github.com/Goddard-Fortran-Ecosystem/pFUnit
+  summary: Unit-testing framework for Fortran, with MPI support
+  description: |
+    pFUnit is a unit-testing framework enabling JUnit-like testing of serial and
+    MPI-parallel software written in Fortran. Built here with MPI support.
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+
+extra:
+  recipe-maintainers:
+    - ickc

--- a/recipes/pfunit/recipe.yaml
+++ b/recipes/pfunit/recipe.yaml
@@ -4,7 +4,8 @@
 #
 # Built with MPI support, so it carries the mpi_${mpi}_* build string and depends
 # on the same MPI as the rest of the stack. Its `.pf` test preprocessor is a
-# Python tool consumers run at build time, hence python is also a run dependency.
+# Python tool consumers run at build time, hence python is a run dependency (but
+# not a host one -- no part of pFUnit links against the Python ABI).
 # Versioned subdir install (PFUNIT-<x.y>/), like the rest of the group.
 schema_version: 1
 
@@ -33,6 +34,13 @@ build:
   # a different API this recipe does not support).
   skip:
     - win
+  # Nothing here is built against the Python ABI (see the requirements below), but
+  # `python` is a global variant key, so the interpreter in `build` would still
+  # fan this recipe out into one build per supported Python minor. Ignore the key
+  # to keep it at one build per MPI flavour.
+  variant:
+    ignore_keys:
+      - python
 
 requirements:
   build:
@@ -42,13 +50,16 @@ requirements:
     - cmake
     - ninja
     - m4
+    # CMake's find_package(Python) picks up the build environment's interpreter;
+    # python is deliberately NOT in `host`, because the installed preprocessor is
+    # a plain script -- nothing links against the Python ABI, and putting it in
+    # host would only add a python_abi pin and a build per Python minor.
     - python
   host:
     - ${{ mpi }}
     - gftl
     - gftl-shared
     - fargparse
-    - python
   run:
     - ${{ mpi }}
     # pFUnit's .pf-file preprocessor (funitproc / pFUnitParser) is a Python script

--- a/recipes/pfunit/recipe.yaml
+++ b/recipes/pfunit/recipe.yaml
@@ -51,12 +51,13 @@ requirements:
     - python
   run:
     - ${{ mpi }}
-    - gftl
-    - gftl-shared
-    - fargparse
     # pFUnit's .pf-file preprocessor (funitproc / pFUnitParser) is a Python script
-    # that consumers invoke when building their tests.
+    # that consumers invoke when building their tests, and PFUNITConfig.cmake does
+    # find_dependency(Python).
     - python
+    # gftl, gftl-shared and fargparse are deliberately not listed: each exports a
+    # weak self run_export, so having them in `host` above already adds them here,
+    # pinned to the minor series pFUnit was built against.
 
 tests:
   - script:

--- a/recipes/pfunit/test_pfunit.sh
+++ b/recipes/pfunit/test_pfunit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Versioned subdir install ($PREFIX/PFUNIT-<x.y>/). Assert the CMake package config
+# and the static libraries consumers link (-lpfunit -lfunit) landed, plus the .pf
+# preprocessor consumers invoke. Building at all proves find_package resolved the
+# gftl/gftl-shared/fargparse subdir installs and that MPI was found.
+sub=$(echo "$PREFIX"/PFUNIT-*)
+test -d "$sub/include"
+test -f "$sub/cmake/PFUNITConfig.cmake"
+ls "$sub"/lib*/libpfunit.a
+ls "$sub"/lib*/libfunit.a
+# The .pf preprocessor lands under the subdir's bin.
+ls "$sub"/bin/funitproc 2>/dev/null || ls "$sub"/bin/pFUnitParser.py 2>/dev/null || {
+  echo "ERROR: pFUnit .pf preprocessor not found under $sub/bin"; ls "$sub/bin" || true; exit 1; }
+echo "pFUnit installed at: $sub"
+echo PFUNIT_OK

--- a/recipes/pfunit/test_pfunit.sh
+++ b/recipes/pfunit/test_pfunit.sh
@@ -10,8 +10,9 @@ test -d "$sub/include"
 test -f "$sub/cmake/PFUNITConfig.cmake"
 ls "$sub"/lib*/libpfunit.a
 ls "$sub"/lib*/libfunit.a
-# The .pf preprocessor lands under the subdir's bin.
-ls "$sub"/bin/funitproc 2>/dev/null || ls "$sub"/bin/pFUnitParser.py 2>/dev/null || {
-  echo "ERROR: pFUnit .pf preprocessor not found under $sub/bin"; ls "$sub/bin" || true; exit 1; }
+# The .pf preprocessor lands under the subdir's bin. Run it rather than just
+# looking for it: that also checks its `funit` package came along and that the
+# python run dependency satisfies its #!/usr/bin/env python shebang.
+"$sub/bin/funitproc" --help
 echo "pFUnit installed at: $sub"
 echo PFUNIT_OK

--- a/recipes/pfunit/variants.yaml
+++ b/recipes/pfunit/variants.yaml
@@ -1,0 +1,5 @@
+# staged-recipes' base configs (.ci_support/*.yaml) define no `mpi` key, so this
+# recipe has to supply one. mpich is the flavour pFUnit was built and tested
+# against here; an openmpi variant can be added on the feedstock later.
+mpi:
+  - mpich


### PR DESCRIPTION
Split out of #34287 at the reviewer's request. I have kept these four together because they are the Goddard Fortran Ecosystem and form a strict build-time chain, gftl -> gftl-shared -> fargparse -> pfunit: each is a separately released, separately versioned upstream project, and each finds the previous through `find_package` while building. pfunit is the package the other three are dependencies of.

- **gftl** -- Fortran template library for generic containers (Vector, Set, Map), modelled on the C++ STL.
- **gftl-shared** -- ready-made instantiations of those containers for Fortran intrinsic types.
- **fargparse** -- command-line argument parsing for Fortran, modelled on Python's argparse.
- **pfunit** -- JUnit-style unit-testing framework for Fortran, built here with MPI support.

Things in these recipes that are not standard, and why:

- **Versioned install layout, all four.** Upstream installs into a versioned subdirectory (`GFTL-<major>.<minor>/{include,cmake}`, `GFTL_SHARED-<x.y>/`, `FARGPARSE-<x.y>/`, `PFUNIT-<x.y>/`) rather than `$PREFIX/{include,lib}`. This is deliberate upstream so that versions can coexist, and it is what the upstream Spack packages do too. It composes cleanly because CMake's config-mode search under a `CMAKE_PREFIX_PATH` entry globs `<prefix>/<name>*/cmake/`, so `find_package(GFTL)` resolves with no extra hints. The package tests assert that layout instead of the usual include/lib matchers.
- **gftl is not `noarch`** even though it is template source: the installed CMake config records the build layout, and upstream's own test build wants a Fortran compiler present.
- **No `run_exports`.** The libraries in this group are static, as upstream and Spack build them. Their CMake configs do `find_dependency` on their parents, so the parents are listed as run dependencies instead.
- **pfunit's source is a GitHub release asset**, a plain `.tar` -- the same archive Spack uses -- not an `archive/refs/tags` tarball. No `file_name:` is set, deliberately: setting it made rattler-build treat the download as a plain file and not extract it. Letting the URL's `.tar` extension drive extraction strips the single top-level directory, as the other recipes' `.tar.gz` sources do.
- **pfunit build string and python run dep.** It carries an `mpi_${{ mpi }}_*` build string per conda-forge convention for MPI-linked packages. `variants.yaml` supplies the `mpi` key because the staged-recipes base configs define none; mpich is the flavour I built and tested against, and openmpi can be added on the feedstock. `python` is a run dependency because the `.pf` test preprocessor (funitproc / pFUnitParser) is a Python script that consumers invoke when building their tests.
- **`skip: win` on all four.** mpich and openmpi are not built for win-64 on conda-forge (only msmpi and impi_rt, a different API), and the build scripts are bash-only.

Thanks for taking a look.
