### PR TITLE
Add dpnp

### DIFF
--- a/recipes/dpnp/build.bat
+++ b/recipes/dpnp/build.bat
@@ -1,0 +1,49 @@
+:: conda-forge folds the Intel compiler runtime libs (libircmt.lib, ...) into the
+:: build-only dpcpp_impl package (not visible from the host env), so they live
+:: in the build prefix and are off the linker's default LIB
+set "LIB=%BUILD_PREFIX%\Library\lib;%LIB%"
+
+"%PYTHON%" setup.py clean --all
+
+set "MKLROOT=%PREFIX%/Library"
+set "TBB_ROOT_HINT=%PREFIX%/Library"
+set "DPL_ROOT_HINT=%PREFIX%/Library"
+:: useful for building in resources constrained VMs (public CI)
+set "CMAKE_ARGS=%CMAKE_ARGS% -DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=FALSE"
+
+:: try to detect SYCL resource/include dir from icpx
+for /f "usebackq delims=" %%R in (`icpx --print-resource-dir 2^>NUL`) do (
+  set "SYCL_RESOURCE_DIR=%%R"
+)
+
+if defined SYCL_RESOURCE_DIR (
+  if exist "%SYCL_RESOURCE_DIR%\include" (
+    set "SYCL_INCLUDE_DIR_HINT=%SYCL_RESOURCE_DIR%"
+  )
+)
+
+set "CC=icx"
+set "CXX=icx"
+
+set "CMAKE_GENERATOR=Ninja"
+:: make CMake verbose
+set "VERBOSE=1"
+
+:: set CMAKE to use less threads to avoid OOM
+set CMAKE_BUILD_PARALLEL_LEVEL=%CPU_COUNT%
+
+:: flags mean: --wheel --no-isolation --skip-dependency-check
+%PYTHON% -m build -w -n -x
+if %errorlevel% neq 0 exit 1
+
+:: wheel file was renamed
+for /f %%f in ('dir /b /S .\dist') do (
+  %PYTHON% -m pip install %%f ^
+    --no-build-isolation ^
+    --no-deps ^
+    --only-binary :all: ^
+    --no-index ^
+    --prefix %PREFIX% ^
+    -vv
+    if errorlevel 1 exit 1
+)

--- a/recipes/dpnp/build.sh
+++ b/recipes/dpnp/build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# conda-forge folds the Intel compiler runtime libs (libircmt.lib, ...) into the
+# build-only dpcpp_impl package (not visible from the host env), so they live
+# in the build prefix and are off the linker's default LIBRARY_PATH
+export LIBRARY_PATH="$LIBRARY_PATH:${BUILD_PREFIX}/lib"
+
+# Intel LLVM must cooperate with compiler and sysroot from conda
+echo "--gcc-toolchain=${BUILD_PREFIX} --sysroot=${BUILD_PREFIX}/${HOST}/sysroot -target ${HOST}" > icpx_for_conda.cfg
+export ICPXCFG="${PWD}/icpx_for_conda.cfg"
+export ICXCFG="${ICPXCFG}"
+
+if [ -e "_skbuild" ]; then
+    ${PYTHON} setup.py clean --all
+fi
+
+export CC=icx
+export CXX=icpx
+
+# conda-forge's gcc/g++ activation injects -fno-merge-constants into CFLAGS/CXXFLAGS
+# when CONDA_BUILD==1, while icx/icpx doesn't support it and emit the warning.
+export CFLAGS="${CFLAGS//-fno-merge-constants/}"
+export CXXFLAGS="${CXXFLAGS//-fno-merge-constants/}"
+
+export CMAKE_GENERATOR=Ninja
+# Make CMake verbose
+export VERBOSE=1
+
+# set CMAKE to use less threads to avoid OOM
+export CMAKE_BUILD_PARALLEL_LEVEL=${CPU_COUNT}
+
+CMAKE_ARGS="${CMAKE_ARGS} -DDPNP_WITH_REDIST:BOOL=ON"
+
+# -wnx flags mean: --wheel --no-isolation --skip-dependency-check
+${PYTHON} -m build -w -n -x
+
+${PYTHON} -m pip install dist/dpnp*.whl \
+    --no-build-isolation \
+    --no-deps \
+    --only-binary :all: \
+    --no-index \
+    --prefix "${PREFIX}" \
+    -vv

--- a/recipes/dpnp/conda_build_config.yaml
+++ b/recipes/dpnp/conda_build_config.yaml
@@ -1,0 +1,2 @@
+c_stdlib_version:             # [linux]
+  - '2.28'                    # [linux]

--- a/recipes/dpnp/recipe.yaml
+++ b/recipes/dpnp/recipe.yaml
@@ -1,0 +1,89 @@
+schema_version: 1
+
+context:
+  version: "0.20.0"
+  buildnumber: 0
+
+package:
+  name: dpnp
+  version: ${{ version }}
+
+source:
+  url: https://github.com/IntelPython/dpnp/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 4b12c63358ff656868e33d16c62633c6ddd1c7981e6c9f62ba67cb1146b2a874
+
+build:
+  number: ${{ buildnumber }}
+  skip: osx or match(python, "<3.10")
+  dynamic_linking:
+    missing_dso_allowlist:
+      - '*DPCTLSyclInterface*'
+      - if: win
+        then: '*/dpnp_backend_c.dll'
+
+requirements:
+  build:
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('dpcpp') }}
+    - if: linux
+      then: ninja
+    - cmake
+  host:
+    - python
+    - pip
+    - pybind11
+    - setuptools
+    - wheel
+    - python-build
+    - scikit-build
+    - cython >=3
+    - numpy
+    - versioneer ==0.29
+    # versioneer dependency
+    - if: match(python, "<3.11")
+      then: tomli
+    - dpctl
+    - mkl-devel-dpcpp
+    - onedpl-devel
+    - tbb-devel
+  run:
+    - python
+    - ${{ pin_compatible('dpctl', lower_bound='x.x.x', upper_bound=None) }}
+    # the Intel OpenCL runtime intentionally leaves the ICD loader to the consumer
+    - if: linux
+      then: ocl-icd-system
+    - if: win
+      then: khronos-opencl-icd-loader
+  ignore_run_exports:
+    by_name:
+      # built with Intel DPC++ (icx), which links the Intel runtime, not the MSVC one
+      - if: win
+        then: vc14_runtime
+      - if: win
+        then: ucrt
+
+tests:
+  - requirements:
+      run:
+        - pip
+    script:
+      - pip check
+      - python -c "import dpnp; print(dpnp.__version__)"
+      - python -m dpctl -f
+
+about:
+  homepage: https://github.com/IntelPython/dpnp
+  license: BSD-3-Clause
+  license_file: LICENSE.txt
+  summary: 'Data Parallel Extension for NumPy'
+  description: |
+    Data Parallel Extension for NumPy (dpnp) is a Python library that
+    implements a subset of the NumPy API using SYCL, providing array
+    computations that can be offloaded to Intel GPUs and other SYCL devices.
+
+extra:
+  recipe-maintainers:
+    - antonwolfy
+    - vlad-perevezentsev
+    - ndgrigorian


### PR DESCRIPTION
Data Parallel Extension for NumPy (dpnp) implements a subset of the NumPy API using SYCL, offloading array computations to Intel GPUs and other SYCL devices. Built with the Intel DPC++ (icx) compiler against the conda-forge oneAPI stack (dpctl, mkl-devel-dpcpp, onedpl, tbb).

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
