### PR TITLE
Add bsuite 0.3.6

### DIFF
--- a/recipes/bsuite/recipe.yaml
+++ b/recipes/bsuite/recipe.yaml
@@ -1,0 +1,62 @@
+schema_version: 1
+
+context:
+  version: "0.3.6"
+
+package:
+  name: bsuite
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/b/bsuite/bsuite-${{ version }}.tar.gz
+  sha256: 18f1e6c49ff4092288b657e4f983c7794693300fb853cd65d59e027defa18a40
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+  run:
+    - python >=${{ python_min }}
+    - absl-py
+    - dm-env
+    - immutabledict
+    - matplotlib-base
+    - numpy
+    - pandas
+    - plotnine
+    - scipy
+    - scikit-image
+    - six
+    - termcolor
+
+tests:
+  - python:
+      imports:
+        - bsuite
+        - bsuite.environments
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - python -c "import bsuite; env = bsuite.load_from_id('bandit/0'); env.reset(); env.step(0)"
+
+about:
+  summary: Core RL Behaviour Suite. A collection of reinforcement learning experiments.
+  license: Apache-2.0
+  license_file: LICENSE
+  homepage: https://github.com/google-deepmind/bsuite
+  repository: https://github.com/google-deepmind/bsuite
+
+extra:
+  recipe-maintainers:
+    - jeongseok-meta


### PR DESCRIPTION
Closes #23131.

This adds bsuite 0.3.6 as a pure-Python package using the v1 recipe format. The recipe includes the core runtime dependencies; optional JAX, TensorFlow, and legacy third-party baseline extras are intentionally left to users so the base package stays portable.

Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License file is packaged.
- [x] Source is the official PyPI sdist.
- [x] Package does not vendor other packages.
- [x] No static libraries are linked or shipped.
- [x] Build number is 0.
- [x] A release tarball is used.
- [x] I confirm that I am willing to maintain this package.

Local validation

- `conda-smithy recipe-lint --conda-forge recipes/*`
- Full rattler-build package build and tests on Linux x86-64 with Python 3.10 and 3.14
- `pip check`, package imports, and a real `bandit/0` environment reset/step passed
- The complete runtime dependency set solves for Linux x86-64/AArch64/PPC64LE, macOS x86-64/arm64, and Windows x86-64
- Hosted draft-state [Azure build 1581213](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1581213) and ready-state [GitHub Actions](https://github.com/conda-forge/staged-recipes/actions/runs/33925917454) plus [Azure build 1581235](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1581235) passed across Linux, macOS, Windows, lint, skip, and aggregate checks
