### PR TITLE
Add adbcbridge (ADBC driver over ODBC)

### DIFF
--- a/recipes/adbcbridge/build-lib.sh
+++ b/recipes/adbcbridge/build-lib.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euxo pipefail
+
+cmake -S "${SRC_DIR}" -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DADBC_ODBC_BUILD_TESTS=OFF \
+  -DADBCBRIDGE_INSTALL_MANIFEST=ON
+cmake --build build --parallel "${CPU_COUNT}"
+cmake --install build

--- a/recipes/adbcbridge/build-py.sh
+++ b/recipes/adbcbridge/build-py.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Do not bundle a copy of the library into the wheel: libadbcbridge already installed it
+# to $PREFIX/lib, where adbcbridge.driver_path() looks. Pointing the build dir at a path
+# that does not exist makes setup.py skip the bundling step.
+export ADBCBRIDGE_BUILD_DIR="${SRC_DIR}/no-such-build-dir"
+cd "${SRC_DIR}/python"
+${PYTHON} -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/adbcbridge/meta.yaml
+++ b/recipes/adbcbridge/meta.yaml
@@ -1,0 +1,90 @@
+{% set name = "adbcbridge" %}
+{% set version = "0.1.1" %}
+
+package:
+  name: adbcbridge-split
+  version: {{ version }}
+
+source:
+  url: https://github.com/singhpratech/adbcbridge/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 081998a2dc88e99d6f72d2b5e28bbf0471a1045030e2c958c82bf0f10c191240
+
+build:
+  number: 0
+  skip: true  # [win]
+
+outputs:
+  # The driver itself: one shared library, plus the ADBC driver manifest (odbc.toml)
+  # so `driver="odbc"` resolves by name through the ADBC driver manager.
+  - name: libadbcbridge
+    script: build-lib.sh
+    build:
+      run_exports:
+        - {{ pin_subpackage("libadbcbridge", max_pin="x.x") }}
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ stdlib("c") }}
+        - cmake
+        - ninja
+      host:
+        - unixodbc
+      run:
+        - unixodbc
+    test:
+      commands:
+        - test -f $PREFIX/lib/libadbc_driver_odbc${SHLIB_EXT}
+    about:
+      summary: ADBC (Apache Arrow) driver over ODBC — the driver library
+      license: Apache-2.0
+      license_file:
+        - LICENSE
+        - NOTICE
+
+  # The Python package. It does not bundle a copy of the library here: adbcbridge's
+  # driver_path() looks in <sys.prefix>/lib, which is where libadbcbridge installs it.
+  - name: adbcbridge
+    script: build-py.sh
+    requirements:
+      host:
+        - python
+        - pip
+        - setuptools >=77
+      run:
+        - python
+        - {{ pin_subpackage("libadbcbridge", exact=True) }}
+        - adbc-driver-manager >=1.0
+        - pyarrow >=14
+    test:
+      imports:
+        - adbcbridge
+      commands:
+        - python -c "import adbcbridge, os; p = adbcbridge.driver_path(); assert os.path.exists(p), p; print(p)"
+        - adbcbridge --help
+    about:
+      summary: ADBC (Apache Arrow) driver for any ODBC data source — Python package
+      license: Apache-2.0
+      license_file:
+        - LICENSE
+        - NOTICE
+
+about:
+  home: https://adbcbridge.org
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE
+  summary: adbcBridge — an ADBC (Apache Arrow) driver that loads any ODBC driver
+  description: |
+    adbcBridge is an ADBC driver written in C that loads an ODBC driver and exposes it
+    through the ADBC API, giving Arrow record batches from databases that have an ODBC
+    driver but no native ADBC one. It reads with ODBC block cursors, converts
+    column-wise into Arrow, and supports bulk ingest, partitioned reads and catalog
+    metadata. Verified against 53 databases on Linux, macOS and Windows.
+  doc_url: https://adbcbridge.org/docs/
+  dev_url: https://github.com/singhpratech/adbcbridge
+
+extra:
+  recipe-maintainers:
+    - singhpratech
+  feedstock-name: adbcbridge


### PR DESCRIPTION
Checklist
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated meta.yaml".
- [x] License file is packaged (see [here](https://github.com/conda-forge/staged-recipes/blob/5eddbd7fc9d1502169089da06c3688d9759be978/recipes/example/meta.yaml#L64-L73) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

adbcBridge is an ADBC (Apache Arrow Database Connectivity) driver, written in C, that loads an ODBC driver and exposes it through the ADBC API — an Arrow path to databases that have an ODBC driver but no native ADBC one. Apache-2.0. Listed in the Apache Arrow ADBC documentation's Tools & Integrations page; 0.1.1 is on PyPI, crates.io, nuget.org and Maven Central.

Two outputs from one source tarball:
- `libadbcbridge`: the shared library (`libadbc_driver_odbc`) and the ADBC driver manifest (`etc/adbc/drivers/odbc.toml`), linked against `unixodbc`.
- `adbcbridge`: the Python package (`adbcbridge.connect(...)` returns an `adbc_driver_manager.dbapi.Connection`). It locates the library in `$PREFIX/lib`, so nothing is bundled twice. Depends on `adbc-driver-manager` and `pyarrow`, both on conda-forge.

Linux and macOS in this submission; Windows in a follow-up.

I am the upstream author and the listed maintainer.
