### PR TITLE
Add camber-toolkit

### DIFF
--- a/recipes/camber-toolkit/recipe.yaml
+++ b/recipes/camber-toolkit/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: camber-toolkit
-  version: "0.74.1"
+  version: "0.79.0"
 
 package:
   name: ${{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name|replace('-', '_') }}-${{ version }}.tar.gz
-  sha256: b31dd1d30848b12123ce3c48d580e043b0c2725b35d1e6b96a3430e561bebe2b
+  sha256: f2d0f61de20e0a418d3e1724a8734e5498baa1e994fad5229536a15e60423708
 
 build:
   noarch: python
@@ -46,7 +46,7 @@ tests:
 about:
   homepage: https://github.com/yroussev/camber
   repository: https://github.com/yroussev/camber
-  documentation: https://github.com/yroussev/camber/blob/main/docs
+  documentation: https://yroussev.github.io/camber/
   license: Apache-2.0
   license_file:
     - LICENSE

--- a/recipes/camber-toolkit/recipe.yaml
+++ b/recipes/camber-toolkit/recipe.yaml
@@ -37,7 +37,9 @@ tests:
         - camber.mandv
         - camber.rules
       pip_check: true
-      python_version: ${{ python_min }}
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - camber --help
 

--- a/recipes/camber-toolkit/recipe.yaml
+++ b/recipes/camber-toolkit/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: camber-toolkit
-  version: "0.74.0"
+  version: "0.74.1"
 
 package:
   name: ${{ name|lower }}
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name|replace('-', '_') }}-${{ version }}.tar.gz
-  sha256: 10e20cee79f19d5b7e1c632489f361fdef713f815c17f6a1ac129ff309d12935
+  sha256: b31dd1d30848b12123ce3c48d580e043b0c2725b35d1e6b96a3430e561bebe2b
 
 build:
   noarch: python

--- a/recipes/camber-toolkit/recipe.yaml
+++ b/recipes/camber-toolkit/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  name: camber-toolkit
+  version: "0.74.0"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name|replace('-', '_') }}-${{ version }}.tar.gz
+  sha256: 10e20cee79f19d5b7e1c632489f361fdef713f815c17f6a1ac129ff309d12935
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - camber = camber.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=64
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.24,<3
+    - pandas >=2.0,<3
+    - matplotlib-base >=3.7
+    - pyarrow >=14
+
+tests:
+  - python:
+      imports:
+        - camber
+        - camber.mandv
+        - camber.rules
+      pip_check: true
+      python_version: ${{ python_min }}
+  - script:
+      - camber --help
+
+about:
+  homepage: https://github.com/yroussev/camber
+  repository: https://github.com/yroussev/camber
+  documentation: https://github.com/yroussev/camber/blob/main/docs
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE
+  summary: Vendor-neutral building-automation-system trend analysis (FDD, M&V, RCx)
+  description: |
+    CAMBER is a dependency-light, vendor-neutral toolkit for building-automation-system (BAS)
+    trend analysis: fault detection & diagnostics (ASHRAE G36 / PNNL Re-tuning), measurement &
+    verification (IPMVP A/B/C/D), and retro-commissioning, all speaking a common Role vocabulary.
+
+extra:
+  recipe-maintainers:
+    - yroussev


### PR DESCRIPTION
Adds a recipe for **camber-toolkit** — a dependency-light, vendor-neutral Python toolkit for building-automation-system (BAS) trend analysis: fault detection & diagnostics (ASHRAE G36 / PNNL Re-tuning), measurement & verification (IPMVP A/B/C/D), and retro-commissioning.

- PyPI: https://pypi.org/project/camber-toolkit/
- Source: https://github.com/yroussev/camber
- License: Apache-2.0 (`LICENSE` + `NOTICE` packaged in the sdist)
- `noarch: python`, pure-Python; runtime deps (numpy / pandas / matplotlib-base / pyarrow) are all on conda-forge.

Recipe is the v1 `recipe.yaml` format. Validated locally with `conda-smithy lint` (clean) and a full `rattler-build` noarch build against conda-forge: sdist sha256 verified, deps resolved, and the test block passed (imports, `pip check`, `camber --help`).

### Checklist
- [x] Title of this PR is "Add camber-toolkit"
- [x] License file is packaged (see `about/license_file`) and is an OSI-approved SPDX license (Apache-2.0)
- [x] Source is from a stable URL (PyPI sdist) with a `sha256` hash
- [x] Recipe maintainer(s) listed; maintainer will comment to confirm
- [x] Build number is 0