### PR TITLE
Adding torchdr

### DIFF
--- a/recipes/torchdr/recipe.yaml
+++ b/recipes/torchdr/recipe.yaml
@@ -15,6 +15,9 @@ build:
   number: 0
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - torchdr = torchdr.cli:main
 
 requirements:
   host:
@@ -31,6 +34,8 @@ requirements:
     - scipy
 
 tests:
+  - script:
+      - torchdr --help
   - python:
       imports:
         - torchdr

--- a/recipes/torchdr/recipe.yaml
+++ b/recipes/torchdr/recipe.yaml
@@ -24,9 +24,11 @@ requirements:
     - setuptools-scm
   run:
     - python >=${{ python_min }}
+    - matplotlib-base
     - numpy
     - pytorch
     - scikit-learn
+    - scipy
 
 tests:
   - python:

--- a/recipes/torchdr/recipe.yaml
+++ b/recipes/torchdr/recipe.yaml
@@ -1,0 +1,60 @@
+schema_version: 1
+
+context:
+  version: "0.4"
+
+package:
+  name: torchdr
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/torchdr/torchdr-${{ version }}.tar.gz
+  sha256: 1da342e2a46670ec939e3239828f6e67a944124888db159f29328f3e1aa743a0
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools
+    - setuptools-scm
+  run:
+    - python >=${{ python_min }}
+    - numpy
+    - pytorch
+    - scikit-learn
+
+tests:
+  - python:
+      imports:
+        - torchdr
+        - torchdr.affinity
+        - torchdr.distance
+        - torchdr.distributed
+        - torchdr.eval
+        - torchdr.neighbor_embedding
+        - torchdr.spectral_embedding
+        - torchdr.utils
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/TorchDR/TorchDR
+  summary: High-performance dimensionality reduction with PyTorch
+  description: |
+    TorchDR provides GPU and multi-GPU implementations of dimensionality reduction
+    methods through a scikit-learn-compatible API.
+  license: BSD-3-Clause
+  license_file: LICENSE
+  documentation: https://torchdr.github.io/
+  repository: https://github.com/TorchDR/TorchDR
+
+extra:
+  recipe-maintainers:
+    - huguesva


### PR DESCRIPTION
## Summary

Adds a conda-forge recipe for [TorchDR](https://github.com/TorchDR/TorchDR), a PyTorch library for scalable dimensionality reduction with a scikit-learn-compatible API.

## Validation

- `conda-smithy recipe-lint --conda-forge recipes/torchdr` passes locally.
- The recipe tests imports for the public package modules and runs `pip check`.

## Checklist

- [x] Title of this PR is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License file is packaged.
- [x] Source is from the official PyPI release.
- [x] Package does not vendor other packages.
- [x] No static libraries are linked in or shipped.
- [x] Build number is 0.
- [x] Source is a release tarball.
- [x] The listed maintainer confirms willingness to maintain the feedstock.
- [x] The conda-forge knowledge base was consulted.