### PR TITLE
Adding xberg

### DIFF
--- a/recipes/xberg/recipe.yaml
+++ b/recipes/xberg/recipe.yaml
@@ -97,3 +97,4 @@ about:
 extra:
   recipe-maintainers:
     - Goldziher
+    - MannXo

--- a/recipes/xberg/recipe.yaml
+++ b/recipes/xberg/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 context:
   name: xberg
-  version: "1.1.1"
+  version: "1.1.2"
 
 package:
   name: ${{ name|lower }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 90cd912b2507dc6a543bbc2ffe9bef0ae0e10628cc0fd9d6883e76dc704f3377
+  sha256: 374ad881a41ef05bf9cced389a12569fc697a1a40ba9dc7311afbf7158b50203
 
 build:
   number: 0

--- a/recipes/xberg/recipe.yaml
+++ b/recipes/xberg/recipe.yaml
@@ -96,4 +96,4 @@ about:
 
 extra:
   recipe-maintainers:
-    - MannXo
+    - Goldziher

--- a/recipes/xberg/recipe.yaml
+++ b/recipes/xberg/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 
 context:
   name: xberg
-  version: "1.1.2"
+  version: "1.1.5"
 
 package:
   name: ${{ name|lower }}
@@ -12,7 +12,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
-  sha256: 374ad881a41ef05bf9cced389a12569fc697a1a40ba9dc7311afbf7158b50203
+  sha256: 10329860e2c633650c400fae6ce98e0d631f6dbbdffc67e54d72301f34f93a2e
 
 build:
   number: 0

--- a/recipes/xberg/recipe.yaml
+++ b/recipes/xberg/recipe.yaml
@@ -1,0 +1,96 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
+schema_version: 1
+
+context:
+  name: xberg
+  version: "1.1.1"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/${{ name }}-${{ version }}.tar.gz
+  sha256: 90cd912b2507dc6a543bbc2ffe9bef0ae0e10628cc0fd9d6883e76dc704f3377
+
+build:
+  number: 0
+  skip:
+    # No onnxruntime-cpp is published for osx-64 at any version from 1.24 onward, and the
+    # extension links ONNX Runtime unconditionally on this target.
+    - osx and x86_64
+    # Upstream builds Windows against a reduced feature set with no OCR, so a win-64
+    # package would not match the others. Left for a follow-up rather than shipped asymmetric.
+    - win
+    # abi3 extensions do not load on a free-threaded interpreter.
+    - python.endswith("t")
+  script:
+    env:
+      # The published sdist pins `xberg` from crates.io with `ocr` enabled, whose default
+      # linking mode downloads and builds Tesseract and Leptonica from source. This selects
+      # the crate's `system-linking` path instead, so the build links the Tesseract and
+      # Leptonica in this environment. The feature is additive, so the sdist needs no patch.
+      MATURIN_BUILD_ARGS: --features xberg/tesseract-dynamic
+      # Link this environment's ONNX Runtime rather than letting `ort` fetch a prebuilt.
+      ORT_STRATEGY: system
+      ORT_SKIP_DOWNLOAD: "1"
+      ORT_PREFER_DYNAMIC_LINK: "1"
+      # The extension is built abi3-py310, so it compiles against a newer interpreter than
+      # its abi3 target across most of the matrix.
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+    content:
+      - export ORT_LIB_LOCATION="$PREFIX/lib"
+      - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+      - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - ${{ compiler('rust') }}
+    - maturin >=1,<2
+    - cargo-bundle-licenses
+    # xberg-tesseract's `dynamic-linking` probes for tesseract.pc.
+    - pkg-config
+  host:
+    - python
+    - pip
+    - maturin >=1,<2
+    - tesseract
+    - leptonica
+    - libheif
+    - onnxruntime-cpp
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - xberg
+      pip_check: true
+  - script:
+      - python -c "import xberg; print(xberg.__version__)"
+
+about:
+  homepage: https://xberg.io
+  repository: https://github.com/xberg-io/xberg
+  documentation: https://docs.xberg.io
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: High-performance document intelligence library
+  description: |
+    Document intelligence with a Rust core. Extracts text, metadata, images and
+    structured data from a wide range of document formats, with built-in OCR.
+
+extra:
+  recipe-maintainers:
+    - MannXo

--- a/recipes/xberg/recipe.yaml
+++ b/recipes/xberg/recipe.yaml
@@ -31,7 +31,10 @@ build:
       # linking mode downloads and builds Tesseract and Leptonica from source. This selects
       # the crate's `system-linking` path instead, so the build links the Tesseract and
       # Leptonica in this environment. The feature is additive, so the sdist needs no patch.
-      MATURIN_BUILD_ARGS: --features xberg/tesseract-dynamic
+      # `MATURIN_PEP517_ARGS` is the variable maturin's PEP 517 backend reads; cmake is
+      # deliberately absent from the build requirements so a regression here fails loudly
+      # rather than silently falling back to the vendored build.
+      MATURIN_PEP517_ARGS: --features xberg/tesseract-dynamic
       # Link this environment's ONNX Runtime rather than letting `ort` fetch a prebuilt.
       ORT_STRATEGY: system
       ORT_SKIP_DOWNLOAD: "1"


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

---

`xberg` is a document extraction library: a Rust core with a PyO3 extension module built by
maturin, published as an sdist on PyPI. Requested upstream in
[xberg-io/xberg#1407](https://github.com/xberg-io/xberg/issues/1407), where a user on a
conda-managed stack could not use it because the system libheif was too old for the wheel. That is
the gap this recipe fills, so the recipe links this environment's native libraries rather than
bundling its own.

Three things in the recipe are worth a reviewer's attention.

**Tesseract and Leptonica are linked from the environment, not built.** The published sdist pins
`xberg` from crates.io with the `ocr` feature, and that crate's default linking mode downloads
Tesseract 5.5.3 and Leptonica 1.87.0 and builds them with CMake. Upstream added a
`tesseract-dynamic` feature for exactly this case ([xberg-io/xberg#1483][1]), first released in
1.1.0. The recipe selects it through `MATURIN_BUILD_ARGS`, which works because the feature is
additive, so the sdist needs no patch. Verified by resolving the released 1.1.1 sdist both ways:
`system-linking` and `dynamic-linking` appear on `xberg-tesseract` only with the flag present.

`xberg-tesseract`'s `dynamic-linking` probes for `tesseract.pc`, hence `pkg-config` in the build
requirements.

**ONNX Runtime comes from `onnxruntime-cpp`.** The extension links the C++ library rather than
using the Python `onnxruntime` package, and `ORT_STRATEGY=system` with `ORT_SKIP_DOWNLOAD=1` stops
the `ort` crate fetching its own prebuilt.

**osx-64 is skipped.** No `onnxruntime-cpp` is published for osx-64 at 1.24 or later, and the
extension links ONNX Runtime unconditionally on that target. Upstream also documents Intel macOS as
a legacy, best-effort target. Happy to revisit if the constraint changes.

The Rust dependency tree is statically linked into the extension module, as with other
maturin-built recipes here, so `cargo-bundle-licenses` writes `THIRDPARTY.yml` and it is packaged
alongside `LICENSE`.

## What I could and could not check locally

`conda-smithy recipe-lint --conda-forge` was run against this recipe. I could not build it locally
on any platform this recipe targets: this machine is osx-arm64, and a full build compiles the Rust
core with the sdist's feature set, which is considerably larger than a typical extension module.
Two consequences I would rather state than have discovered in review:

- The build may be slow enough to matter on CI. If it exceeds the time limit, say so and I will look
  at what can be trimmed.
- The `tesseract.pc` probe is the step most likely to need adjusting, since it depends on the
  pkg-config file conda-forge's `tesseract` installs.

`xberg` also publishes a CLI. That needs a different source tarball and belongs in a separate
recipe, so it is not here.

[1]: https://github.com/xberg-io/xberg/pull/1483
