### PR TITLE
Add promtool

### DIFF
--- a/recipes/promtool/go-jmespath-LICENSE
+++ b/recipes/promtool/go-jmespath-LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 James Saryerwinnie
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/recipes/promtool/recipe.yaml
+++ b/recipes/promtool/recipe.yaml
@@ -1,0 +1,48 @@
+context:
+  version: "3.14.0"
+
+package:
+  name: promtool
+  version: ${{ version }}
+
+source:
+  url: https://github.com/prometheus/prometheus/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 9294e72722fe8f90e54994ce36f331ea6176cb0edc4149cbf1d023bc89536505
+
+build:
+  number: 0
+  script:
+    - go-licenses save ./cmd/promtool --save_path ./library_licenses
+    - if: unix
+      then:
+        - go build -v -o "${PREFIX}/bin/promtool" -ldflags="-s -w -X github.com/prometheus/common/version.Version=${{ version }}" ./cmd/promtool
+      else:
+        - go build -v -o "%LIBRARY_BIN%\promtool.exe" -ldflags="-s -X github.com/prometheus/common/version.Version=${{ version }}" ./cmd/promtool
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+
+tests:
+  - script:
+      - promtool --version
+
+about:
+  homepage: https://prometheus.io/
+  repository: https://github.com/prometheus/prometheus
+  documentation: https://prometheus.io/docs/prometheus/latest/command-line/promtool/
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - library_licenses/
+  summary: Prometheus CLI tool for config/rule validation and TSDB management
+  description: |
+    promtool is the official command-line utility shipped with Prometheus.
+    It validates Prometheus configuration and alerting/recording rules,
+    inspects and manages TSDB data, backfills time series from OpenMetrics
+    files, and queries or pushes metrics for debugging.
+
+extra:
+  recipe-maintainers:
+    - trim21

--- a/recipes/promtool/recipe.yaml
+++ b/recipes/promtool/recipe.yaml
@@ -12,7 +12,9 @@ source:
 build:
   number: 0
   script:
-    - go-licenses save ./cmd/promtool --save_path ./library_licenses
+    # go-licenses cannot classify github.com/jmespath/go-jmespath; its
+    # Apache-2.0 LICENSE is bundled next to this recipe as go-jmespath-LICENSE
+    - go-licenses save ./cmd/promtool --save_path ./library_licenses --ignore github.com/jmespath/go-jmespath
     - if: unix
       then:
         - go build -v -o "${PREFIX}/bin/promtool" -ldflags="-s -w -X github.com/prometheus/common/version.Version=${{ version }}" ./cmd/promtool
@@ -35,6 +37,7 @@ about:
   license: Apache-2.0
   license_file:
     - LICENSE
+    - go-jmespath-LICENSE
     - library_licenses/
   summary: Prometheus CLI tool for config/rule validation and TSDB management
   description: |


### PR DESCRIPTION
Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

Description

`promtool` is the command-line tool shipped with Prometheus ([cmd/promtool](https://github.com/prometheus/prometheus/blob/main/cmd/promtool/main.go)): it validates Prometheus configuration and alerting/recording rules, inspects and manages TSDB data, and backfills time series from OpenMetrics files.

The recipe builds only the `promtool` binary from the official Prometheus v3.14.0 source tarball with the conda-forge Go compiler (no cgo, no web UI assets needed). All Go dependency licenses are bundled via `go-licenses`; `github.com/jmespath/go-jmespath` (Apache-2.0) cannot be classified by `go-licenses`, so its LICENSE is bundled directly next to the recipe. This is a new standalone package and is unrelated to the existing `prometheus` feedstock.