### PR TITLE
Add r-icio

### DIFF
--- a/recipes/r-icio/build.bat
+++ b/recipes/r-icio/build.bat
@@ -1,0 +1,2 @@
+"%R%" CMD INSTALL --build . %R_ARGS%
+IF %ERRORLEVEL% NEQ 0 exit /B 1

--- a/recipes/r-icio/build.sh
+++ b/recipes/r-icio/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export DISABLE_AUTOBREW=1
+${R} CMD INSTALL --build . ${R_ARGS}

--- a/recipes/r-icio/recipe.yaml
+++ b/recipes/r-icio/recipe.yaml
@@ -1,0 +1,91 @@
+schema_version: 1
+
+context:
+  version: "1.0.0"
+
+package:
+  name: r-icio
+  version: ${{ version }}
+
+source:
+  url:
+    - ${{ cran_mirror }}/src/contrib/icio_${{ version }}.tar.gz
+    - ${{ cran_mirror }}/src/contrib/Archive/icio/icio_${{ version }}.tar.gz
+  sha256: 55b36a515ea8484c580c849fb8d70ef006377763ba82cdc773a24ee1191fad80
+
+build:
+  number: 0
+  dynamic_linking:
+    rpaths:
+      - lib/R/lib/
+      - lib/
+    missing_dso_allowlist:
+      - if: win
+        then:
+          - "*/R.dll"
+          - "*/Rblas.dll"
+          - "*/Rlapack.dll"
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - cross-r-base ${{ r_base }}.*
+    - if: not win
+      then:
+        - ${{ compiler('c') }}
+        - ${{ stdlib('c') }}
+        - make
+    - if: win
+      then:
+        - ${{ compiler('m2w64_c') }}
+        - ${{ stdlib('m2w64_c') }}
+        - m2-filesystem
+        - m2-make
+        - m2-sed
+        - m2-coreutils
+        - m2-zip
+  host:
+    - r-base
+    - r-data.table
+    - r-matrixstats
+  run:
+    - r-base
+    - r-data.table
+    - r-matrixstats
+
+tests:
+  - if: build_platform == target_platform
+    then:
+      - script:
+          - Rscript -e "library('icio')"
+
+about:
+  homepage: https://sebkrantz.github.io/icio/
+  repository: https://github.com/SebKrantz/icio
+  documentation: https://sebkrantz.github.io/icio/
+  license: GPL-3.0-only
+  license_family: GPL3
+  license_file:
+    - ${{ PREFIX }}/lib/R/share/licenses/GPL-3
+  summary: Global Value Chain Decomposition of Inter-Country Input-Output Tables
+  description: |
+    Four global value chain (GVC) decompositions of gross exports from
+    inter-country input-output tables are implemented. The Leontief
+    decomposition derives the value added origin of exports by country and
+    industry, as in Hummels, Ishii and Yi (2001)
+    <doi:10.1016/S0022-1996(00)00093-3>. The Koopman, Wang and Wei (2014)
+    <doi:10.1257/aer.104.2.459> decomposition splits country-level exports into
+    9 value added components, and the Wang, Wei and Zhu (2013)
+    <doi:10.3386/w19677> decomposition splits bilateral exports into 16 value
+    added components. The Borin and Mancini (2019) <doi:10.1596/1813-9450-8804>
+    decomposition splits country-, sector- or bilateral-level exports into up to
+    13 value added and GVC components, and also provides a corrected version of
+    the (biased) Koopman-Wang-Wei decomposition. It is the recommended method
+    and reproduces the 'icio' command for 'Stata' described in Belotti, Borin
+    and Mancini (2021) <doi:10.1177/1536867X211045573>.
+
+extra:
+  recipe-maintainers:
+    - conda-forge/r
+    - SebKrantz


### PR DESCRIPTION
Adds a recipe for [icio](https://cran.r-project.org/package=icio) 1.0.0, an R package implementing four global value chain (GVC) decompositions of gross exports from inter-country input-output tables (Leontief; Koopman-Wang-Wei 2014; Wang-Wei-Zhu 2013; Borin-Mancini 2019). It is the R counterpart of the `icio` command for Stata.

I am the package author and maintainer, and I am happy to be listed as a recipe maintainer.

The recipe was generated with [`conda_r_skeleton_helper`](https://github.com/bgruening/conda_r_skeleton_helper) (i.e. `conda skeleton cran` plus the conda-forge R conventions it applies) and then translated to the v1 `recipe.yaml` format, using [r-gribr](https://github.com/conda-forge/r-gribr-feedstock/blob/main/recipe/recipe.yaml) as the reference for a compiled CRAN package in v1. Relative to the raw helper output I additionally added the `stdlib` entries, which the helper does not yet emit.

Verification:

- `conda-smithy recipe-lint --conda-forge recipes/r-icio` passes.
- Built locally for `osx_arm64` via `build-locally.py`; the package builds and `library('icio')` loads.

Pure C sources, no external libraries, no vendored code. Runtime dependencies (`r-data.table`, `r-matrixstats`) are available on all target subdirs, so no platform is skipped.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (GPL-3 from `$PREFIX/lib/R/share/licenses/GPL-3`, the standard for CRAN GPL packages).
- [x] Source is from official source (CRAN).
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
