### PR TITLE
Add recipe for rubberband 4.0.0

### DIFF
--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -43,8 +43,13 @@ tests:
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h
-      lib:
-        - rubberband
+      files:
+        - if: unix
+          then: lib/librubberband${SHLIB_EXT}
+        - if: win
+          then:
+            - Library/lib/rubberband.lib
+            - Library/bin/rubberband*.dll
 
 about:
   homepage: https://breakfastquay.com/rubberband/

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -28,7 +28,6 @@ requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
-    - ${{ stdlib('c') }}
     - meson
     - ninja
     - pkg-config

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -13,6 +13,8 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - ${{ pin_subpackage("rubberband", upper_bound="x") }}
   script:
     - if: unix
       then:
@@ -34,8 +36,6 @@ requirements:
     - pkg-config
   host:
     - libsndfile
-  run_exports:
-    - ${{ pin_subpackage("rubberband", upper_bound="x") }}
 
 tests:
   - script:

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -20,7 +20,7 @@ build:
         - meson compile -C builddir
         - meson install -C builddir
       else:
-        - meson setup builddir %MESON_ARGS% --prefix=%LIBRARY_PREFIX% -Ddefault_library=both
+        - meson setup builddir %MESON_ARGS% -Ddefault_library=both
         - meson compile -C builddir
         - meson install -C builddir
 

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - if: unix
       then:
-        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both -Dcpp_args=-include,stddef.h
+        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both
         - meson compile -C builddir
         - meson install -C builddir
       else:

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - if: unix
       then:
-        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both
+        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both -Dcpp_args=-include,stddef.h
         - meson compile -C builddir
         - meson install -C builddir
       else:

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -43,9 +43,9 @@ tests:
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h
-      lib:
+      files:
         - if: unix
-          then: rubberband
+          then: lib/librubberband${SHLIB_EXT}
         - if: win
           then:
             - Library/lib/rubberband.lib

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -13,14 +13,16 @@ source:
 
 build:
   number: 0
+  run_exports:
+    - ${{ pin_subpackage("rubberband", upper_bound="x") }}
   script:
     - if: unix
       then:
-        - meson setup builddir --prefix=${PREFIX} --libdir=lib -Ddefault_library=both -Dcpp_args="-include cstddef"
+        - meson setup builddir ${MESON_ARGS} --prefix=${PREFIX} --libdir=lib -Ddefault_library=both -Dcpp_args="-include cstddef"
         - meson compile -C builddir
         - meson install -C builddir
       else:
-        - meson setup builddir --prefix=%LIBRARY_PREFIX% -Ddefault_library=both
+        - meson setup builddir %MESON_ARGS% --prefix=%LIBRARY_PREFIX% -Ddefault_library=both
         - meson compile -C builddir
         - meson install -C builddir
 
@@ -33,21 +35,21 @@ requirements:
     - ninja
     - pkg-config
   host:
-    - fftw
     - libsndfile
 
 tests:
   - script:
-      - rubberband -h || true
-      - if: unix
-        then:
-          - test -f ${PREFIX}/include/rubberband/RubberBandStretcher.h
-          - test -f ${PREFIX}/lib/librubberband${SHLIB_EXT}
+      - rubberband --version
+  - package_contents:
+      include:
+        - rubberband/RubberBandStretcher.h
+      lib:
+        - rubberband
 
 about:
   homepage: https://breakfastquay.com/rubberband/
   summary: Audio time-stretching and pitch-shifting library and CLI tool
-  repository: https://github.com/breakfastquay/rubberband
+  repository: https://hg.sr.ht/~breakfastquay/rubberband
   license: GPL-2.0-or-later
   license_file: COPYING
 

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -44,9 +44,12 @@ tests:
       include:
         - rubberband/RubberBandStretcher.h
       files:
-        - lib/librubberband${SHLIB_EXT}      # [unix]
-        - Library/lib/rubberband.lib         # [win]
-        - Library/bin/rubberband*.dll        # [win]
+        - if: unix
+          then: lib/librubberband${SHLIB_EXT}
+        - if: win
+          then:
+            - Library/lib/rubberband.lib
+            - Library/bin/rubberband*.dll
 
 about:
   homepage: https://breakfastquay.com/rubberband/

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - if: unix
       then:
-        - meson setup builddir ${MESON_ARGS} --prefix=${PREFIX} --libdir=lib -Ddefault_library=both -Dcpp_args="-include cstddef"
+        - meson setup builddir ${MESON_ARGS} --prefix=${PREFIX} --libdir=lib -Ddefault_library=both
         - meson compile -C builddir
         - meson install -C builddir
       else:
@@ -43,8 +43,10 @@ tests:
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h
-      lib:
-        - rubberband
+      files:
+        - lib/librubberband${SHLIB_EXT}      # [unix]
+        - Library/lib/rubberband.lib         # [win]
+        - Library/bin/rubberband*.dll        # [win]
 
 about:
   homepage: https://breakfastquay.com/rubberband/

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -28,6 +28,7 @@ requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
     - meson
     - ninja
     - pkg-config

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -43,13 +43,13 @@ tests:
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h
-      files:
+      lib:
         - if: unix
-          then: lib/librubberband${SHLIB_EXT}
+          then: rubberband
         - if: win
           then:
             - Library/lib/rubberband.lib
-            - Library/bin/rubberband*.dll
+            - Library/bin/rubberband-*.dll
 
 about:
   homepage: https://breakfastquay.com/rubberband/

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -43,13 +43,13 @@ tests:
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h
-      files:
+      lib:
         - if: unix
-          then: lib/librubberband${SHLIB_EXT}
+          then: rubberband
         - if: win
           then:
-            - Library/lib/rubberband.lib
-            - Library/bin/rubberband-*.dll
+            - rubberband.lib
+            - rubberband-*.dll
 
 about:
   homepage: https://breakfastquay.com/rubberband/

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - if: unix
       then:
-        - meson setup builddir ${MESON_ARGS} --prefix=${PREFIX} --libdir=lib -Ddefault_library=both
+        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both
         - meson compile -C builddir
         - meson install -C builddir
       else:

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -43,13 +43,8 @@ tests:
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h
-      files:
-        - if: unix
-          then: lib/librubberband${SHLIB_EXT}
-        - if: win
-          then:
-            - Library/lib/rubberband.lib
-            - Library/bin/rubberband*.dll
+      lib:
+        - rubberband
 
 about:
   homepage: https://breakfastquay.com/rubberband/

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - if: unix
       then:
-        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both
+        - meson setup builddir ${MESON_ARGS} -Ddefault_library=both "-Dcpp_args=-include stddef.h"
         - meson compile -C builddir
         - meson install -C builddir
       else:
@@ -39,7 +39,9 @@ requirements:
 
 tests:
   - script:
-      - rubberband --version
+      - if: win
+        then: rubberband-program --version
+        else: rubberband --version
   - package_contents:
       include:
         - rubberband/RubberBandStretcher.h

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+
+context:
+  version: "4.0.0"
+
+package:
+  name: rubberband
+  version: ${{ version }}
+
+source:
+  url: https://breakfastquay.com/files/releases/rubberband-${{ version }}.tar.bz2
+  sha256: af050313ee63bc18b35b2e064e5dce05b276aaf6d1aa2b8a82ced1fe2f8028e9
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - meson setup builddir --prefix=${PREFIX} --libdir=lib -Ddefault_library=both -Dcpp_args="-include cstddef"
+        - meson compile -C builddir
+        - meson install -C builddir
+      else:
+        - meson setup builddir --prefix=%LIBRARY_PREFIX% -Ddefault_library=both
+        - meson compile -C builddir
+        - meson install -C builddir
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - ${{ stdlib('c') }}
+    - meson
+    - ninja
+    - pkg-config
+  host:
+    - fftw
+    - libsndfile
+
+tests:
+  - script:
+      - rubberband -h || true
+      - if: unix
+        then:
+          - test -f ${PREFIX}/include/rubberband/RubberBandStretcher.h
+          - test -f ${PREFIX}/lib/librubberband${SHLIB_EXT}
+
+about:
+  homepage: https://breakfastquay.com/rubberband/
+  summary: Audio time-stretching and pitch-shifting library and CLI tool
+  repository: https://github.com/breakfastquay/rubberband
+  license: GPL-2.0-or-later
+  license_file: COPYING
+
+extra:
+  recipe-maintainers:
+    - Yash990-bit

--- a/recipes/rubberband/recipe.yaml
+++ b/recipes/rubberband/recipe.yaml
@@ -13,8 +13,6 @@ source:
 
 build:
   number: 0
-  run_exports:
-    - ${{ pin_subpackage("rubberband", upper_bound="x") }}
   script:
     - if: unix
       then:
@@ -36,6 +34,8 @@ requirements:
     - pkg-config
   host:
     - libsndfile
+  run_exports:
+    - ${{ pin_subpackage("rubberband", upper_bound="x") }}
 
 tests:
   - script:


### PR DESCRIPTION

Adds a conda-forge recipe for [rubberband](https://breakfastquay.com/rubberband/),
an audio time-stretching and pitch-shifting C/C++ library and CLI tool.

### Checklist
- [x] `schema_version: 1` set
- [x] Native C/C++ package (no `noarch`)
- [x] Meson build system with Unix & Windows support
- [x] ~~`fftw`~~ and `libsndfile` host dependencies added
- [x] Tests verify CLI and installed headers/library
- [x] License: GPL-2.0-or-later
@conda-forge/help-c-cpp
