### PR TITLE
Adding geoparquet-validator

### DIFF
--- a/recipes/geoparquet-validator/recipe.yaml
+++ b/recipes/geoparquet-validator/recipe.yaml
@@ -6,9 +6,8 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://crates.io/api/v1/crates/geoparquet-validator/${{ version }}/download
-  file_name: geoparquet-validator-${{ version }}.tar.gz
-  sha256: 635d8fec62b0add1cf54e63d7bd360bafe106b1693ca4554a65a2325bf89dd27
+  url: https://github.com/geoparquet/geoparquet-validator/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: a5eaa695d4d3b6430fca45a820de6b34046780b1751bff790682371e78728e94
 
 build:
   number: 0

--- a/recipes/geoparquet-validator/recipe.yaml
+++ b/recipes/geoparquet-validator/recipe.yaml
@@ -1,0 +1,64 @@
+context:
+  version: "0.2.0"
+
+package:
+  name: geoparquet-validator
+  version: ${{ version }}
+
+source:
+  url: https://crates.io/api/v1/crates/geoparquet-validator/${{ version }}/download
+  file_name: geoparquet-validator-${{ version }}.tar.gz
+  sha256: 635d8fec62b0add1cf54e63d7bd360bafe106b1693ca4554a65a2325bf89dd27
+
+build:
+  number: 0
+  script:
+    - if: unix
+      then:
+        - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+        - cargo install --locked --root "$PREFIX" --path .
+        - rm -f "$PREFIX/.crates.toml" "$PREFIX/.crates2.json"
+      else:
+        - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+        - cargo install --locked --root "%LIBRARY_PREFIX%" --path .
+        - del "%LIBRARY_PREFIX%\.crates.toml" "%LIBRARY_PREFIX%\.crates2.json"
+
+requirements:
+  build:
+    - ${{ compiler('rust') }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib('c') }}
+    - cargo-bundle-licenses
+    - cmake
+    - if: unix
+      then: make
+
+tests:
+  - package_contents:
+      bin:
+        - geoparquet-validator
+  - script:
+      - geoparquet-validator --version
+      - geoparquet-validator check --help
+
+about:
+  homepage: https://validator.geoparquet.org/
+  repository: https://github.com/geoparquet/geoparquet-validator
+  documentation: https://github.com/geoparquet/geoparquet-validator#readme
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  summary: Validate GeoParquet files against the OGC abstract tests and the 1.0/1.1 community specifications
+  description: |
+    A single command that runs the abstract tests of the OGC GeoParquet 2.0 draft on a file, a
+    directory or an object-store URL (s3://, gs://, az://, https://, read with range requests),
+    checks GeoParquet 1.0 and 1.1 files against their own community specification, and reports the
+    distribution best practices (spatial ordering, row group size, compression, bbox covering) as
+    advice. Reports are JSON with a published schema; exit codes 0 conformant, 1 a test failed,
+    2 the tool could not run.
+
+extra:
+  recipe-maintainers:
+    - jatorre
+    - cholmes


### PR DESCRIPTION
Adds `geoparquet-validator`, a Rust command that validates GeoParquet files against the abstract tests of the OGC GeoParquet 2.0 draft and the 1.0/1.1 community specifications, and reports the distribution best practices as advice. Homepage: https://validator.geoparquet.org/. Source: https://github.com/geoparquet/geoparquet-validator (Apache-2.0).

The recipe builds from the crates.io tarball with `cargo install --locked` and bundles the dependency licences with `cargo-bundle-licenses`. It is the same crate published to crates.io and PyPI; requested by the GeoParquet maintainers in geoparquet/geoparquet-validator#3.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [ ] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there. (I am @jatorre and confirm; @cholmes will confirm in a comment.)
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.

https://claude.ai/code/session_015wJ16bE4vEfrojEzqRG9ab
