### PR TITLE
Adding ycleptic

### DIFF
--- a/recipes/ycleptic/recipe.yaml
+++ b/recipes/ycleptic/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "2.3.0"
+  version: "2.4.1"
 
 package:
   name: ycleptic
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/y/ycleptic/ycleptic-${{ version }}.tar.gz
-  sha256: 9e0d32a217d51a97d47c1944261e0ba697d303d661ec6f4db2a4d3ab8d8ee243
+  sha256: 77a4207aab6c2caad4988a6fef4dc4643c49082de0688849cae696304832f873
 
 build:
   noarch: python

--- a/recipes/ycleptic/recipe.yaml
+++ b/recipes/ycleptic/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: "2.3.0"
+
+package:
+  name: ycleptic
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/y/ycleptic/ycleptic-${{ version }}.tar.gz
+  sha256: 9e0d32a217d51a97d47c1944261e0ba697d303d661ec6f4db2a4d3ab8d8ee243
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling
+  run:
+    - python >=${{ python_min }}
+    - pyyaml >=6
+
+tests:
+  - python:
+      imports:
+        - ycleptic
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - yclept --help
+      - yclept check-spec --help
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+
+about:
+  homepage: https://github.com/cameronabrams/ycleptic
+  summary: Self-documenting YAML configuration for Python applications
+  description: |
+    Ycleptic turns one structured YAML file -- a base configuration that
+    describes an application's configuration schema as data -- into three
+    things that normally live in three separate places: validation of a
+    user's config with defaults filled in, a generated Sphinx/RTD
+    documentation tree, and an interactive help browser.
+
+    Because the schema is data rather than a set of Python classes, editing
+    that one file keeps validation, documentation and help in lockstep, which
+    suits scientific and command-line applications whose users are domain
+    experts rather than programmers.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://ycleptic.readthedocs.io/
+  repository: https://github.com/cameronabrams/ycleptic
+
+extra:
+  recipe-maintainers:
+    - cameronabrams

--- a/recipes/ycleptic/recipe.yaml
+++ b/recipes/ycleptic/recipe.yaml
@@ -11,6 +11,9 @@ source:
 
 build:
   noarch: python
+  python:
+    entry_points:
+      - yclept = ycleptic.cli:cli
   script: python -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 


### PR DESCRIPTION
Adds a recipe for [ycleptic](https://github.com/cameronabrams/ycleptic), a small pure-Python library that turns one structured YAML file — a schema written as data — into validation of a user's config, a generated Sphinx documentation tree, and an interactive help browser.

Pure Python, `noarch: python`, one runtime dependency (`pyyaml`). Built with `hatchling`. Source is the PyPI sdist; the `sha256` was verified against a downloaded copy.

I am the package author and the sole maintainer listed, and I am willing to be listed as recipe maintainer.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.