### PR TITLE
Add shar-production-manifest-gate

### DIFF
--- a/recipes/shar-production-manifest-gate/recipe.yaml
+++ b/recipes/shar-production-manifest-gate/recipe.yaml
@@ -1,0 +1,40 @@
+context:
+  version: "1.0.0"
+
+package:
+  name: shar-production-manifest-gate
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/d2/27/7ae1fb0ae97b7a1fc29af8b3c78e34fb9e27d56e8f1973083cfe29c6176c/shar_production_manifest_gate-${{ version }}.tar.gz
+  sha256: 37f826c8cf8e9ac60d09c7007b64cc4388232135c0229f2a1c1bc9ef808bd2d7
+
+build:
+  noarch: python
+  script: python -m pip install . -vv
+  number: 0
+
+requirements:
+  host:
+    - python >=3.9
+    - pip
+    - setuptools >=68
+  run:
+    - python >=3.9
+
+tests:
+  - python:
+      imports:
+        - production_manifest_gate
+      pip_check: true
+
+about:
+  homepage: https://sharprod.com/
+  repository: https://github.com/SHARProduction/production-manifest-gate-py
+  summary: Rights-aware production manifest gate for Python pipelines
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Ares3333333


### PR DESCRIPTION
## New Python recipe

Adds the existing public PyPI package `shar-production-manifest-gate` 1.0.0 as a noarch Python recipe.

- Source is the PyPI sdist with its published SHA-256.
- Upstream is MIT licensed and has no runtime dependencies beyond Python >=3.9.
- A clean PyPI installation was exercised locally: the public `production-manifest-gate` CLI returned a successful releasable-manifest result.
- I will maintain the resulting feedstock.