### PR TITLE
Add complgen

### DIFF
--- a/recipes/complgen/patches/0001-build-honor-a-preset-COMPLGEN_VERSION.patch
+++ b/recipes/complgen/patches/0001-build-honor-a-preset-COMPLGEN_VERSION.patch
@@ -1,0 +1,22 @@
+From: conda-forge
+Subject: [PATCH] build: honor a preset COMPLGEN_VERSION
+
+When building from a source tarball there is no git repository around, so
+`git describe` fails and its empty stdout ends up baked into the binary,
+making `complgen --version` print an empty string.  Allow packagers to pass
+the version in explicitly via the environment.
+
+--- a/build.rs
++++ b/build.rs
+@@ -1,6 +1,11 @@
+ use std::process::Command;
+
+ fn main() {
++    println!("cargo:rerun-if-env-changed=COMPLGEN_VERSION");
++    if let Ok(version) = std::env::var("COMPLGEN_VERSION") {
++        println!("cargo:rustc-env=COMPLGEN_VERSION={}", version);
++        return;
++    }
+     let Ok(output) = Command::new("git")
+         .args([
+             "describe",

--- a/recipes/complgen/recipe.yaml
+++ b/recipes/complgen/recipe.yaml
@@ -1,0 +1,74 @@
+context:
+  version: "0.11.0"
+
+package:
+  name: complgen
+  version: ${{ version }}
+
+source:
+  url: https://github.com/adaszko/complgen/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 216d4c1f5f7e18ad3164c8ba0e1f85511b1ece20345419908c7d564ff46908b0
+  patches:
+    - patches/0001-build-honor-a-preset-COMPLGEN_VERSION.patch
+
+build:
+  number: 0
+  script:
+    env:
+      COMPLGEN_VERSION: ${{ version }}
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script:
+      - complgen --help
+      - complgen --version
+      - if: unix
+        then: printf 'hello world;\n' > hello.usage
+        else: echo hello world;> hello.usage
+      - complgen --bash hello.bash hello.usage
+      - complgen --fish hello.fish hello.usage
+      - complgen --zsh _hello hello.usage
+      - complgen --pwsh hello.pwsh hello.usage
+  - package_contents:
+      bin:
+        - complgen
+      strict: true
+
+about:
+  homepage: https://github.com/adaszko/complgen
+  summary: Declarative bash/fish/zsh/pwsh completions without writing shell scripts
+  description: |
+    complgen is a command line program that takes a .usage file as input and
+    outputs a standalone, distributable shell completion script.
+
+    One grammar file can be compiled for popular shells like bash, fish, zsh
+    and PowerShell, freeing you from having to reimplement logic for each of
+    the shells separately. complgen grammars are declarative and
+    shell-agnostic, unless you need to reach for a shell-specific behavior.
+    Its strong suit is in handling complex subcommands completion and sourcing
+    candidates from external, run-time shell commands.
+  license: GPL-3.0-only
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  repository: https://github.com/adaszko/complgen
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds a recipe for [complgen](https://github.com/adaszko/complgen), a Rust CLI that compiles a declarative `.usage` grammar into standalone bash/fish/zsh/pwsh completion scripts.

One patch is included: upstream's `build.rs` derives the version from `git describe` and, when that fails (as it does for a source tarball), bakes an empty string into the binary, so `complgen --version` prints nothing. The patch makes `build.rs` honor a preset `COMPLGEN_VERSION` environment variable, which the recipe sets to the packaged version.

Built and tested locally on osx-arm64.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
