### PR TITLE
Adding json-with-comments / jsonc package

### DIFF
--- a/recipes/json-with-comments/recipe.yaml
+++ b/recipes/json-with-comments/recipe.yaml
@@ -1,7 +1,6 @@
 schema_version: 1
 
 context:
-  python_min: "3.9"
   version: "1.2.10"
 
 package:
@@ -31,7 +30,9 @@ tests:
       imports:
         - jsonc
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   summary: JSON with Comments (jsonc) for Python

--- a/recipes/json-with-comments/recipe.yaml
+++ b/recipes/json-with-comments/recipe.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+
+context:
+  python_min: "3.9"
+  version: "1.2.10"
+
+package:
+  name: json-with-comments
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/j/json-with-comments/json_with_comments-${{ version }}.tar.gz
+  sha256: 0020b321cf6c80963c85f95ce985e71332f1797ed49abfd1cd675b3bdee24a28
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - hatch-vcs
+    - pip
+  run:
+    - python >=${{ python_min }}
+
+tests:
+  - python:
+      imports:
+        - jsonc
+      pip_check: true
+      python_version: ${{ python_min }}.*
+
+about:
+  summary: JSON with Comments (jsonc) for Python
+  license: MIT
+  license_file: LICENSE
+  homepage: https://pypi.org/project/json-with-comments/
+  repository: https://github.com/n-takumasa/json-with-comments
+  documentation: https://github.com/n-takumasa/json-with-comments
+
+extra:
+  recipe-maintainers:
+    - achimgaedke


### PR DESCRIPTION
This is a new requirement for https://github.com/conda-forge/cvat-cli-feedstock, blocking

* https://github.com/conda-forge/cvat-cli-feedstock/pull/69
* https://github.com/conda-forge/cvat-cli-feedstock/pull/70
* https://github.com/conda-forge/cvat-cli-feedstock/pull/71

The version 1.2.10 is required for cvat-cli. I'll update to 1.3.0 when accepted/merged.

The recipe is generated with grayskull.
I worked through the checklist and tested the package build locally.