### PR TITLE
Adding merge-gatekeeper

### DIFF
--- a/recipes/merge-gatekeeper/recipe.yaml
+++ b/recipes/merge-gatekeeper/recipe.yaml
@@ -8,15 +8,21 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/upsidr/merge-gatekeeper/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 579f93de4cc4336c1b133e0d7e9bce5e596f02616f15efb4a1a148cf59875418
-  target_directory: src
+  - url: https://github.com/upsidr/merge-gatekeeper/archive/refs/tags/v${{ version }}.tar.gz
+    sha256: 579f93de4cc4336c1b133e0d7e9bce5e596f02616f15efb4a1a148cf59875418
+    target_directory: src
+  # cobra pulls in mousetrap on Windows, and go-licenses cannot classify its
+  # license file, so it is skipped below and shipped from here instead. The text
+  # is Apache-2.0 with only the copyright line prepended.
+  - url: https://raw.githubusercontent.com/inconshreveable/mousetrap/v1.0.0/LICENSE
+    sha256: f42d670262f9aed37a33c97d93fa2c1324f439ee03d7690710c5fe002561b0b5
+    file_name: LICENSE-mousetrap
 
 build:
   number: 0
   script:
     - cd src
-    - go-licenses save ./cmd/merge-gatekeeper --save_path ../library_licenses
+    - go-licenses save ./cmd/merge-gatekeeper --save_path ../library_licenses --ignore github.com/inconshreveable/mousetrap
     # `main.version` is populated from an embedded version.txt that upstream
     # never bumped past v0.1.0, so the real tag is linked in instead.
     - if: unix
@@ -51,6 +57,7 @@ about:
   license_file:
     - src/LICENSE
     - library_licenses/
+    - LICENSE-mousetrap
   documentation: https://pkg.go.dev/github.com/upsidr/merge-gatekeeper
   repository: https://github.com/upsidr/merge-gatekeeper
 

--- a/recipes/merge-gatekeeper/recipe.yaml
+++ b/recipes/merge-gatekeeper/recipe.yaml
@@ -1,0 +1,59 @@
+schema_version: 1
+
+context:
+  version: "1.2.1"
+
+package:
+  name: merge-gatekeeper
+  version: ${{ version }}
+
+source:
+  url: https://github.com/upsidr/merge-gatekeeper/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 579f93de4cc4336c1b133e0d7e9bce5e596f02616f15efb4a1a148cf59875418
+  target_directory: src
+
+build:
+  number: 0
+  script:
+    - cd src
+    - go-licenses save ./cmd/merge-gatekeeper --save_path ../library_licenses
+    # `main.version` is populated from an embedded version.txt that upstream
+    # never bumped past v0.1.0, so the real tag is linked in instead.
+    - if: unix
+      then: go build -v -o $PREFIX/bin/merge-gatekeeper -ldflags="-s -w -X main.version=v${{ version }}" ./cmd/merge-gatekeeper
+      else: go build -v -o %LIBRARY_BIN%\merge-gatekeeper.exe -ldflags="-s -X main.version=v${{ version }}" .\cmd\merge-gatekeeper
+
+requirements:
+  build:
+    - ${{ compiler("go-nocgo") }}
+    - go-licenses
+
+tests:
+  - script:
+      - merge-gatekeeper --help
+      - merge-gatekeeper --version
+  - package_contents:
+      bin:
+        - merge-gatekeeper
+      strict: true
+
+about:
+  homepage: https://github.com/upsidr/merge-gatekeeper
+  summary: Merge Gatekeeper provides extra control for Pull Request management
+  description: |
+    Merge Gatekeeper adds merge control on top of GitHub's branch protection.
+    Running as a single check for every Pull Request, it inspects all the other
+    CI jobs kicked off for that PR and only succeeds once they have all
+    completed successfully. This makes branch protection work for monorepos,
+    where jobs are triggered conditionally on the files a PR touches and cannot
+    be listed up front as required checks.
+  license: MIT
+  license_file:
+    - src/LICENSE
+    - library_licenses/
+  documentation: https://pkg.go.dev/github.com/upsidr/merge-gatekeeper
+  repository: https://github.com/upsidr/merge-gatekeeper
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds a recipe for [merge-gatekeeper](https://github.com/upsidr/merge-gatekeeper), a Go CLI that acts as a single GitHub status check which waits for all other CI jobs of a PR to complete successfully — making branch protection usable in monorepos with conditionally triggered jobs.

Notes:

- Upstream never bumped the embedded `cmd/merge-gatekeeper/version.txt` past `v0.1.0`, so the real tag is linked in via `-ldflags "-X main.version=v${version}"`; `merge-gatekeeper --version` reports `v1.2.1`.
- Built and tested locally on `osx-arm64` with `rattler-build`; dependency licenses are collected with `go-licenses`.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
