### PR TITLE
Adding ccusage

### DIFF
--- a/recipes/ccusage/recipe.yaml
+++ b/recipes/ccusage/recipe.yaml
@@ -1,0 +1,64 @@
+schema_version: 1
+
+context:
+  version: "20.0.20"
+
+package:
+  name: ccusage
+  version: ${{ version }}
+
+source:
+  url: https://github.com/ccusage/ccusage/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 24f81ac3dc5ca049b4170256402d67675fe7c2aa084274326726acf5cfcc8428
+
+build:
+  number: 0
+  script:
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --features fetch-litellm-pricing --root ${{ PREFIX }} --path rust/crates/ccusage
+        else:
+          - cargo auditable install --locked --no-track --bins --features fetch-litellm-pricing --root %LIBRARY_PREFIX% --path rust/crates/ccusage
+      - cd rust
+      - cargo-bundle-licenses --format yaml --features fetch-litellm-pricing --output ../THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-auditable
+    - cargo-bundle-licenses
+
+tests:
+  - script:
+      - ccusage --version
+      - ccusage --help
+      - ccusage daily --help
+      - ccusage claude --help
+  - package_contents:
+      bin:
+        - ccusage
+      strict: true
+
+about:
+  homepage: https://github.com/ccusage/ccusage
+  summary: Analyze coding (agent) CLI token usage and costs from local data
+  description: |
+    ccusage reads the local session logs written by coding agent CLIs -- Claude
+    Code, Codex, Copilot CLI, Gemini CLI, OpenCode and others -- and reports the
+    tokens they consumed and what those tokens cost. Reports can be grouped by
+    day, week, month, session or billing block, printed as tables or JSON, and
+    rendered as a compact status line for Claude Code hooks.
+  license: MIT
+  license_file:
+    - LICENSE
+    - apps/ccusage/LICENSE
+    - THIRDPARTY.yml
+  documentation: https://ccusage.com
+  repository: https://github.com/ccusage/ccusage
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adding ccusage — a CLI that analyzes coding agent (Claude Code, Codex, Copilot CLI, Gemini CLI, OpenCode, …) token usage and costs from local session logs.

Note on the second source: as of v20 ccusage is a Rust CLI (the npm package is only a thin wrapper that spawns a prebuilt native binary), so this recipe builds from the GitHub tag with cargo. `ccusage-core`'s `build.rs` embeds a LiteLLM pricing snapshot and downloads it at build time unless `CCUSAGE_PRICING_JSON_PATH` points at a local copy. The recipe therefore adds the snapshot as a second, checksummed source pinned to the exact `BerriAI/litellm` revision that upstream pins in `flake.lock` for this tag, and sets that env var, keeping the build network-free and reproducible.

Built and tested locally on osx-arm64.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
