### PR TITLE
Add sinapse-sdk (meta-package)

### DIFF
--- a/recipes/sinapse-sdk/recipe.yaml
+++ b/recipes/sinapse-sdk/recipe.yaml
@@ -1,0 +1,58 @@
+schema_version: 1
+
+context:
+  version: "0.1.0"
+
+package:
+  name: sinapse-sdk
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/sinapse-sdk/sinapse_sdk-${{ version }}.tar.gz
+  sha256: 0cdc05a3df283749c11d4127b49d936cd4ffedfd66fdab4fa6e9410c5f734c42
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=77
+    - pip
+  run:
+    # meta-package: pulls the SDK component packages
+    - python >=${{ python_min }}
+    - rhapsody-py >=0.5.0
+    - radical.asyncflow >=0.5.0
+    - quacc
+    - rootstock
+
+# meta-package installs no module of its own, so no import test
+tests:
+  - python:
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: http://project-sinapse.org
+  summary: SINAPSE SDK — curated software components for AI-coupled HPC workflows
+  description: |
+    The SINAPSE SDK is a curated collection of software components for
+    AI-coupled HPC workflows (NSF award 2514139). This meta-package
+    installs a mutually compatible set of the released components:
+    RHAPSODY (rhapsody-py), AsyncFlow (radical.asyncflow), QuAcc, and
+    Rootstock. Further components (seekrflow, DDSim) join as their
+    packaging lands. The Dragon backend for RHAPSODY is PyPI-only:
+    `pip install dragonhpc` into the conda env.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://sinapse-sdk.readthedocs.io/
+  repository: https://github.com/SINAPSE-NSF/sinapse-sdk
+
+extra:
+  recipe-maintainers:
+    - andre-merzky


### PR DESCRIPTION
Adds **sinapse-sdk 0.1.0**, the meta-package of the SINAPSE SDK (NSF award 2514139, https://project-sinapse.org). It installs no module of its own; it pins a mutually compatible set of the released SDK components, all already on conda-forge: rhapsody-py, radical.asyncflow, quacc, rootstock (rhapsody-py and radical.asyncflow were added in #34581).

Noarch python, v1 recipe. No import test since the wheel ships metadata only; pip_check covers consistency.

Checklist:
- [x] License file is packaged (MIT, LICENSE in sdist)
- [x] Source is from the official PyPI sdist
- [x] Build number is 0
- [x] A meaningful project description is in the recipe
- [x] Maintainer commented consent: I am the maintainer (@andre-merzky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHdYAup83HGHJkmjbo96ts