### PR TITLE
Add pydantic-graph and pydantic-ai-slim recipes

### DIFF
--- a/recipes/pydantic-ai/recipe.yaml
+++ b/recipes/pydantic-ai/recipe.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+
+context:
+  version: "2.42.0"
+
+package:
+  name: pydantic-ai-slim
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/47/ec/59161f7aa44251775afec888615b84905634252b7dac6f0acf2f430ffadf/pydantic_ai_slim-${{ version }}.tar.gz
+  sha256: 045c788b1636e0ed79542f2b7562d2688a3e3701744ed7379a928fceec446336
+
+build:
+  number: 0
+  script: pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - anyio >=4.7.0
+    - genai-prices >=0.1.6
+    - griffe >=2.0
+    - httpx2 >=2.7
+    - opentelemetry-api >=1.28.0
+    - pydantic >=2.12
+    - pydantic-graph ==${{ version }}
+    - typing-inspection >=0.4.0
+
+tests:
+  - python:
+      imports:
+        - pydantic_ai
+  - script:
+      - pip check
+    requirements:
+      run:
+        - pip
+
+about:
+  homepage: https://ai.pydantic.dev
+  summary: AI Agent Framework, the Pydantic way (slim package without extras)
+  repository: https://github.com/pydantic/pydantic-ai
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Yash990-bit

--- a/recipes/pydantic-ai/recipe.yaml
+++ b/recipes/pydantic-ai/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "2.42.0"
-  python_min: "3.9"
 
 package:
   name: pydantic-ai-slim

--- a/recipes/pydantic-ai/recipe.yaml
+++ b/recipes/pydantic-ai/recipe.yaml
@@ -21,6 +21,7 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - hatchling
+    - uv-dynamic-versioning
   run:
     - python >=${{ python_min }}
     - anyio >=4.7.0

--- a/recipes/pydantic-ai/recipe.yaml
+++ b/recipes/pydantic-ai/recipe.yaml
@@ -2,26 +2,28 @@ schema_version: 1
 
 context:
   version: "2.42.0"
+  python_min: "3.9"
 
 package:
   name: pydantic-ai-slim
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/47/ec/59161f7aa44251775afec888615b84905634252b7dac6f0acf2f430ffadf/pydantic_ai_slim-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pydantic-ai-slim/pydantic_ai_slim-${{ version }}.tar.gz
   sha256: 045c788b1636e0ed79542f2b7562d2688a3e3701744ed7379a928fceec446336
 
 build:
+  noarch: python
   number: 0
-  script: pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python
+    - python ${{ python_min }}.*
     - pip
-    - setuptools
+    - hatchling
   run:
-    - python
+    - python >=${{ python_min }}
     - anyio >=4.7.0
     - genai-prices >=0.1.6
     - griffe >=2.0
@@ -35,6 +37,9 @@ tests:
   - python:
       imports:
         - pydantic_ai
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - pip check
     requirements:

--- a/recipes/pydantic-graph/recipe.yaml
+++ b/recipes/pydantic-graph/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "2.42.0"
-  python_min: "3.9"
 
 package:
   name: pydantic-graph

--- a/recipes/pydantic-graph/recipe.yaml
+++ b/recipes/pydantic-graph/recipe.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+
+context:
+  version: "2.42.0"
+
+package:
+  name: pydantic-graph
+  version: ${{ version }}
+
+source:
+  url: https://files.pythonhosted.org/packages/a3/c2/f14d82d10c7f4e4e4d20c880593745e05686b176ac397fe52a5ec40959a9/pydantic_graph-${{ version }}.tar.gz
+  sha256: eb6c416dee9e3415195194c44ca3abeeae8853bff095d38ac798c7c3395f815d
+
+build:
+  number: 0
+  script: pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - anyio >=4.7.0
+    - logfire-api >=3.14.1
+    - pydantic >=2.12
+    - typing-inspection >=0.4.0
+
+tests:
+  - python:
+      imports:
+        - pydantic_graph
+  - script:
+      - pip check
+    requirements:
+      run:
+        - pip
+
+about:
+  homepage: https://github.com/pydantic/pydantic-ai
+  summary: Graph execution engine for pydantic-ai
+  repository: https://github.com/pydantic/pydantic-ai
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - Yash990-bit

--- a/recipes/pydantic-graph/recipe.yaml
+++ b/recipes/pydantic-graph/recipe.yaml
@@ -21,6 +21,7 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - hatchling
+    - uv-dynamic-versioning
   run:
     - python >=${{ python_min }}
     - anyio >=4.7.0

--- a/recipes/pydantic-graph/recipe.yaml
+++ b/recipes/pydantic-graph/recipe.yaml
@@ -2,26 +2,28 @@ schema_version: 1
 
 context:
   version: "2.42.0"
+  python_min: "3.9"
 
 package:
   name: pydantic-graph
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/a3/c2/f14d82d10c7f4e4e4d20c880593745e05686b176ac397fe52a5ec40959a9/pydantic_graph-${{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pydantic-graph/pydantic_graph-${{ version }}.tar.gz
   sha256: eb6c416dee9e3415195194c44ca3abeeae8853bff095d38ac798c7c3395f815d
 
 build:
+  noarch: python
   number: 0
-  script: pip install . -vv --no-deps --no-build-isolation
+  script: ${{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python
+    - python ${{ python_min }}.*
     - pip
-    - setuptools
+    - hatchling
   run:
-    - python
+    - python >=${{ python_min }}
     - anyio >=4.7.0
     - logfire-api >=3.14.1
     - pydantic >=2.12
@@ -31,6 +33,9 @@ tests:
   - python:
       imports:
         - pydantic_graph
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - pip check
     requirements:


### PR DESCRIPTION
Adds two new pure-Python packages from the [pydantic-ai](https://github.com/pydantic/pydantic-ai) ecosystem:

### `pydantic-graph`
- Lightweight graph execution engine, used internally by pydantic-ai
- PyPI: https://pypi.org/project/pydantic-graph/
- License: MIT

### `pydantic-ai-slim`
- Core AI Agent Framework by the Pydantic team (slim build, without optional extras)
- PyPI: https://pypi.org/project/pydantic-ai-slim/
- License: MIT
- Depends on `pydantic-graph` (packaged in this same PR)

Both packages are pure Python (`noarch: python`), build from official PyPI tarballs, include LICENSE files, and have build number 0.
---

## Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License file is packaged.
- [x] Source is from official source (PyPI tarball).
- [x] Package does not vendor other packages.
- [x] Build number is 0.
- [x] A tarball (`url`) is used in the recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.

@conda-forge/help-python, ready for review!
