### PR TITLE
Adding codeburn

### DIFF
--- a/recipes/codeburn/build.bat
+++ b/recipes/codeburn/build.bat
@@ -1,0 +1,24 @@
+@echo on
+
+call npm pack --ignore-scripts || goto :error
+
+:: --prefix %PREFIX%\lib keeps the Windows install at lib\node_modules, matching
+:: the Unix layout the shipped noarch package is built from
+call npm install -ddd --global --no-bin-links --prefix "%PREFIX%\lib" "%SRC_DIR%\%PKG_NAME%-%PKG_VERSION%.tgz" || goto :error
+
+:: License report for the bundled runtime dependency tree
+call pnpm install --prod --ignore-scripts || goto :error
+call pnpm-licenses generate-disclaimer --prod --output-file=third-party-licenses.txt || goto :error
+
+mkdir "%PREFIX%\bin" 2>nul
+(
+echo #!/bin/sh
+echo exec "$CONDA_PREFIX/bin/node" "$CONDA_PREFIX/lib/node_modules/codeburn/dist/cli.js" "$@"
+) > "%PREFIX%\bin\codeburn" || goto :error
+(echo @call "%%CONDA_PREFIX%%\node.exe" "%%CONDA_PREFIX%%\lib\node_modules\codeburn\dist\cli.js" %%*) > "%PREFIX%\bin\codeburn.cmd" || goto :error
+
+goto :eof
+
+:error
+echo Failed with error #%errorlevel%.
+exit 1

--- a/recipes/codeburn/build.sh
+++ b/recipes/codeburn/build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -o xtrace -o nounset -o pipefail -o errexit
+
+# Repack the extracted npm tarball so npm installs exactly the published files
+npm pack --ignore-scripts
+npm install -ddd --global --no-bin-links "${SRC_DIR}/${PKG_NAME}-${PKG_VERSION}.tgz"
+
+# License report for the bundled runtime dependency tree
+pnpm install --prod --ignore-scripts
+pnpm licenses list --json --prod | pnpm-licenses generate-disclaimer --prod --json-input --output-file=third-party-licenses.txt
+
+mkdir -p "${PREFIX}/bin"
+tee "${PREFIX}/bin/codeburn" <<SHIM
+#!/bin/sh
+exec "\${CONDA_PREFIX}/bin/node" "\${CONDA_PREFIX}/lib/node_modules/codeburn/dist/cli.js" "\$@"
+SHIM
+chmod +x "${PREFIX}/bin/codeburn"
+
+tee "${PREFIX}/bin/codeburn.cmd" <<SHIM
+call %CONDA_PREFIX%\node.exe %CONDA_PREFIX%\lib\node_modules\codeburn\dist\cli.js %*
+SHIM

--- a/recipes/codeburn/build.sh
+++ b/recipes/codeburn/build.sh
@@ -8,7 +8,7 @@ npm install -ddd --global --no-bin-links "${SRC_DIR}/${PKG_NAME}-${PKG_VERSION}.
 
 # License report for the bundled runtime dependency tree
 pnpm install --prod --ignore-scripts
-pnpm licenses list --json --prod | pnpm-licenses generate-disclaimer --prod --json-input --output-file=third-party-licenses.txt
+pnpm-licenses generate-disclaimer --prod --output-file=third-party-licenses.txt
 
 mkdir -p "${PREFIX}/bin"
 tee "${PREFIX}/bin/codeburn" <<SHIM

--- a/recipes/codeburn/recipe.yaml
+++ b/recipes/codeburn/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: "0.9.24"
+
+package:
+  name: codeburn
+  version: ${{ version }}
+
+source:
+  url: https://registry.npmjs.org/codeburn/-/codeburn-${{ version }}.tgz
+  sha256: cd6a68a665c15916f4bb507b361d08ea4a0967821e0a9d594229d4009a4b034b
+
+build:
+  number: 0
+  noarch: generic
+
+requirements:
+  build:
+    - nodejs
+    - pnpm
+    - pnpm-licenses
+  host:
+    - nodejs
+  run:
+    - nodejs >=22.13.0
+
+tests:
+  - script:
+      - codeburn --version
+      - codeburn --help
+      - codeburn doctor
+  - package_contents:
+      bin:
+        - codeburn
+
+about:
+  homepage: https://github.com/getagentseal/codeburn
+  summary: Track AI coding token usage and cost across coding tools and agents
+  description: |
+    CodeBurn reads the session logs that coding agents already write to disk and
+    reports the tokens they consumed and what those tokens cost, broken down by
+    model, project and task. It supports Claude Code, Cursor, Codex, Gemini and
+    other agents, runs entirely on the machine it reads, and can also serve the
+    same data as a local dashboard or over MCP.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRD_PARTY_NOTICES.md
+    - third-party-licenses.txt
+  repository: https://github.com/getagentseal/codeburn
+
+extra:
+  recipe-maintainers:
+    - ManuelLerchner


### PR DESCRIPTION
Adding [codeburn](https://github.com/getagentseal/codeburn) — a local-only CLI that reads the session logs coding agents already write to disk (Claude Code, Cursor, Codex, Gemini and others) and reports token usage and cost by model, project and task.

Notes on the recipe:

- **Source is the published npm tarball.** npm is this tool's official distribution channel (`npx codeburn`), and the registry tarball is immutable and checksummable. This follows the ~200 existing conda-forge recipes that source from `registry.npmjs.org`, and specifically the two closest analogues, `typescript` and `fish-lsp`: `noarch: generic`, `npm pack` + `npm install --global --no-bin-links`, plus hand-written shims in `bin/`.
- **Dependency licenses.** The install vendors the runtime dependency tree under `lib/node_modules/codeburn`, so the recipe generates `third-party-licenses.txt` with `pnpm-licenses` and packages it alongside upstream's `LICENSE` and `THIRD_PARTY_NOTICES.md`.
- **Windows shim path.** The `.cmd` shim calls `%CONDA_PREFIX%\node.exe`, not `%CONDA_PREFIX%\bin\node` as some existing node recipes do. conda-forge's `nodejs` package for win-64 places `node.exe` at the prefix root and has no `bin/` directory, so the latter form does not resolve. Flagging it so it doesn't look like a typo.
- **Node floor.** Upstream declares `engines: node >=22.13.0`, mirrored as a run constraint.

Built and tested locally on osx-arm64 with rattler-build; `conda-smithy recipe-lint --conda-forge` is clean. The test block runs `codeburn doctor`, which exercises the full parsing stack and exits 0 when no agent logs are present.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
