### PR TITLE
polyxml: add version 0.19.0

### DIFF
--- a/recipes/polyxml/meta.yaml
+++ b/recipes/polyxml/meta.yaml
@@ -1,0 +1,48 @@
+{% set name = "polyxml" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/nth-bailey/PolyXML/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: ac4ec8256f88ccc4696c9902b288e2cb5347094e9a09421e065994c1574167e4
+
+build:
+  number: 0
+  script: cd crates/polyxml-python && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
+  host:
+    - python >=3.12
+    - maturin >=1.5,<2.0
+    - pip
+  run:
+    - python >=3.12
+
+test:
+  imports:
+    - polyxml
+  commands:
+    - python -c "import polyxml; print(polyxml.__version__)"
+
+about:
+  home: https://github.com/nth-bailey/PolyXML
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: High-performance, polyglot native XML data-binding engine built in Rust
+  description: |
+    PolyXML is a high-performance, polyglot native XML data-binding engine built
+    in Rust, providing streaming XML deserialization directly into Python dataclasses
+    and Pydantic v2 models with zero unnecessary allocations.
+  doc_url: https://nth-bailey.github.io/PolyXML/
+  dev_url: https://github.com/nth-bailey/PolyXML
+
+extra:
+  recipe-maintainers:
+    - nth-bailey

--- a/recipes/polyxml/recipe.yaml
+++ b/recipes/polyxml/recipe.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   number: 0
+  skip:
+    - match(python, "<3.12")
   script:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     - cd crates/polyxml-python && python -m pip install . -vv --no-deps --no-build-isolation

--- a/recipes/polyxml/recipe.yaml
+++ b/recipes/polyxml/recipe.yaml
@@ -11,19 +11,22 @@ source:
 
 build:
   number: 0
-  script: cd crates/polyxml-python && python -m pip install . -vv --no-deps --no-build-isolation
+  script:
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+    - cd crates/polyxml-python && python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ compiler('rust') }}
     - ${{ stdlib('c') }}
+    - cargo-bundle-licenses
   host:
-    - python >=3.12
+    - python
     - maturin >=1.5,<2.0
     - pip
   run:
-    - python >=3.12
+    - python
 
 tests:
   - python:
@@ -36,7 +39,9 @@ tests:
 about:
   homepage: https://github.com/nth-bailey/PolyXML
   license: MIT
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
   summary: High-performance, polyglot native XML data-binding engine built in Rust
   description: |
     PolyXML is a high-performance, polyglot native XML data-binding engine built

--- a/recipes/polyxml/recipe.yaml
+++ b/recipes/polyxml/recipe.yaml
@@ -1,22 +1,23 @@
-{% set name = "polyxml" %}
-{% set version = "0.1.0" %}
+context:
+  version: "0.1.0"
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: polyxml
+  version: ${{ version }}
 
 source:
-  url: https://github.com/nth-bailey/PolyXML/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/nth-bailey/PolyXML/archive/refs/tags/v${{ version }}.tar.gz
   sha256: ac4ec8256f88ccc4696c9902b288e2cb5347094e9a09421e065994c1574167e4
 
 build:
   number: 0
-  script: cd crates/polyxml-python && {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  script: cd crates/polyxml-python && python -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
-    - {{ compiler('c') }}
-    - {{ compiler('rust') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - ${{ stdlib('c') }}
   host:
     - python >=3.12
     - maturin >=1.5,<2.0
@@ -24,24 +25,25 @@ requirements:
   run:
     - python >=3.12
 
-test:
-  imports:
-    - polyxml
-  commands:
-    - python -c "import polyxml; print(polyxml.__version__)"
+tests:
+  - python:
+      imports:
+        - polyxml
+      pip_check: true
+  - script:
+      - python -c "import polyxml; print(polyxml.__version__)"
 
 about:
-  home: https://github.com/nth-bailey/PolyXML
+  homepage: https://github.com/nth-bailey/PolyXML
   license: MIT
-  license_family: MIT
   license_file: LICENSE
   summary: High-performance, polyglot native XML data-binding engine built in Rust
   description: |
     PolyXML is a high-performance, polyglot native XML data-binding engine built
     in Rust, providing streaming XML deserialization directly into Python dataclasses
     and Pydantic v2 models with zero unnecessary allocations.
-  doc_url: https://nth-bailey.github.io/PolyXML/
-  dev_url: https://github.com/nth-bailey/PolyXML
+  documentation: https://nth-bailey.github.io/PolyXML/
+  repository: https://github.com/nth-bailey/PolyXML
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
﻿### Summary
Adding package `polyxml` version `0.1.0`.

PolyXML is a high-performance, polyglot native XML data-binding engine built in Rust, providing streaming XML deserialization directly into Python dataclasses and Pydantic v2 models with zero unnecessary allocations.

Checklist:
- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged.
- [x] Source is from official source.
- [x] Package does not vendor other packages.
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries.
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo is used in your recipe.
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
