### PR TITLE
Add vamp-plugin-sdk recipe

### DIFF
--- a/recipes/vamp-plugin-sdk/build.sh
+++ b/recipes/vamp-plugin-sdk/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+./configure --prefix=$PREFIX
+make -j${CPU_COUNT}
+make install

--- a/recipes/vamp-plugin-sdk/build.sh
+++ b/recipes/vamp-plugin-sdk/build.sh
@@ -2,6 +2,10 @@
 set -ex
 
 ./configure --prefix=$PREFIX
-make -j${CPU_COUNT}
-make test
-make install
+make -j"${CPU_COUNT}" AR="${AR}" RANLIB="${RANLIB}" sdk plugins host rdfgen
+
+if [[ "${CONDA_BUILD_CROSS_COMPILATION:-}" != "1" || "${CROSSCOMPILING_EMULATOR:-}" != "" ]]; then
+    make AR="${AR}" RANLIB="${RANLIB}" test
+fi
+
+make AR="${AR}" RANLIB="${RANLIB}" install

--- a/recipes/vamp-plugin-sdk/build.sh
+++ b/recipes/vamp-plugin-sdk/build.sh
@@ -3,4 +3,5 @@ set -ex
 
 ./configure --prefix=$PREFIX
 make -j${CPU_COUNT}
+make test
 make install

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -29,14 +29,26 @@ requirements:
     - ${{ pin_subpackage("vamp-plugin-sdk", upper_bound="x") }}
 
 tests:
+  - package_contents:
+      bin:
+        - vamp-simple-host
+        - vamp-rdf-template-generator
+      lib:
+        - if: linux
+          then: vamp-sdk
+        - if: osx
+          then: vamp-sdk-dynamic
+        - vamp-hostsdk
+      include:
+        - vamp/vamp.h
+        - vamp-sdk/PluginBase.h
+        - vamp-hostsdk/PluginHostAdapter.h
+      files:
+        - lib/libvamp-sdk.a
+        - lib/libvamp-hostsdk.a
+        - lib/vamp/vamp-example-plugins.so
   - script:
-      - compgen -G "${PREFIX}/lib/libvamp-sdk*${SHLIB_EXT}*" >/dev/null
-      - compgen -G "${PREFIX}/lib/libvamp-hostsdk*${SHLIB_EXT}*" >/dev/null
-      - test -f $PREFIX/lib/libvamp-sdk.a
-      - test -f $PREFIX/lib/libvamp-hostsdk.a
-      - test -f $PREFIX/include/vamp/vamp.h
-      - test -f $PREFIX/include/vamp-sdk/PluginBase.h
-      - test -f $PREFIX/include/vamp-hostsdk/PluginHostAdapter.h
+      - VAMP_PATH="${PREFIX}/lib/vamp" vamp-simple-host -l
 
 about:
   homepage: https://vamp-plugins.org/

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -29,11 +29,15 @@ requirements:
 
 tests:
   - script:
-      - test -f $PREFIX/lib/libvamp-sdk${SHLIB_EXT}
-      - test -f $PREFIX/lib/libvamp-hostsdk${SHLIB_EXT}
+      - test -f $PREFIX/lib/libvamp-sdk.a
+      - test -f $PREFIX/lib/libvamp-hostsdk.a
       - test -f $PREFIX/include/vamp/vamp.h
       - test -f $PREFIX/include/vamp-sdk/PluginBase.h
       - test -f $PREFIX/include/vamp-hostsdk/PluginHostAdapter.h
+      - if: unix
+        then:
+          - test -f $PREFIX/lib/libvamp-sdk.so || test -f $PREFIX/lib/libvamp-sdk-dynamic.2.dylib || test -f $PREFIX/lib/libvamp-sdk.dylib
+          - test -f $PREFIX/lib/libvamp-hostsdk.so || test -f $PREFIX/lib/libvamp-hostsdk.3.dylib || test -f $PREFIX/lib/libvamp-hostsdk.dylib
 
 about:
   homepage: https://vamp-plugins.org/

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 context:
   name: vamp-plugin-sdk
-  version: 2.10
+  version: "2.10"
 
 package:
   name: ${{ name }}
@@ -14,12 +14,14 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  skip:
+    - win
 
 requirements:
   build:
     - ${{ compiler('c') }}
     - ${{ compiler('cxx') }}
+    - ${{ stdlib("c") }}
     - make
     - pkg-config
   host:

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -25,6 +25,8 @@ requirements:
     - pkg-config
   host:
     - libsndfile
+  run_exports:
+    - ${{ pin_subpackage("vamp-plugin-sdk", upper_bound="x") }}
 
 tests:
   - script:

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: vamp-plugin-sdk
   version: "2.10"
 
 package:
-  name: ${{ name }}
+  name: vamp-plugin-sdk
   version: ${{ version }}
 
 source:

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -41,7 +41,7 @@ tests:
 about:
   homepage: https://vamp-plugins.org/
   summary: An API for audio analysis and feature extraction plugins
-  license: BSD-3-Clause
+  license: X11 AND BSD-3-Clause
   license_file: COPYING
   repository: https://github.com/vamp-plugins/vamp-plugin-sdk
 

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+context:
+  name: vamp-plugin-sdk
+  version: 2.10
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/vamp-plugins/vamp-plugin-sdk/archive/refs/tags/vamp-plugin-sdk-v${{ version }}.tar.gz
+  sha256: b552bc91817294c7f90ea07d70938642ebf15d5e3bafc81cf7d55efab9995399
+
+build:
+  number: 0
+  skip: true  # [win]
+
+requirements:
+  build:
+    - ${{ compiler('c') }}
+    - ${{ compiler('cxx') }}
+    - make
+    - pkg-config
+  host:
+    - libsndfile
+
+tests:
+  - script:
+      - test -f $PREFIX/lib/libvamp-sdk${SHLIB_EXT}
+      - test -f $PREFIX/lib/libvamp-hostsdk${SHLIB_EXT}
+      - test -f $PREFIX/include/vamp/vamp.h
+      - test -f $PREFIX/include/vamp-sdk/PluginBase.h
+      - test -f $PREFIX/include/vamp-hostsdk/PluginHostAdapter.h
+
+about:
+  homepage: https://vamp-plugins.org/
+  summary: An API for audio analysis and feature extraction plugins
+  license: BSD-3-Clause
+  license_file: COPYING
+  repository: https://github.com/vamp-plugins/vamp-plugin-sdk
+
+extra:
+  recipe-maintainers:
+    - Yash990-bit

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -29,15 +29,13 @@ requirements:
 
 tests:
   - script:
+      - test -f $PREFIX/lib/libvamp-sdk${SHLIB_EXT}
+      - test -f $PREFIX/lib/libvamp-hostsdk${SHLIB_EXT}
       - test -f $PREFIX/lib/libvamp-sdk.a
       - test -f $PREFIX/lib/libvamp-hostsdk.a
       - test -f $PREFIX/include/vamp/vamp.h
       - test -f $PREFIX/include/vamp-sdk/PluginBase.h
       - test -f $PREFIX/include/vamp-hostsdk/PluginHostAdapter.h
-      - if: unix
-        then:
-          - test -f $PREFIX/lib/libvamp-sdk.so || test -f $PREFIX/lib/libvamp-sdk-dynamic.2.dylib || test -f $PREFIX/lib/libvamp-sdk.dylib
-          - test -f $PREFIX/lib/libvamp-hostsdk.so || test -f $PREFIX/lib/libvamp-hostsdk.3.dylib || test -f $PREFIX/lib/libvamp-hostsdk.dylib
 
 about:
   homepage: https://vamp-plugins.org/

--- a/recipes/vamp-plugin-sdk/recipe.yaml
+++ b/recipes/vamp-plugin-sdk/recipe.yaml
@@ -30,8 +30,8 @@ requirements:
 
 tests:
   - script:
-      - test -f $PREFIX/lib/libvamp-sdk${SHLIB_EXT}
-      - test -f $PREFIX/lib/libvamp-hostsdk${SHLIB_EXT}
+      - compgen -G "${PREFIX}/lib/libvamp-sdk*${SHLIB_EXT}*" >/dev/null
+      - compgen -G "${PREFIX}/lib/libvamp-hostsdk*${SHLIB_EXT}*" >/dev/null
       - test -f $PREFIX/lib/libvamp-sdk.a
       - test -f $PREFIX/lib/libvamp-hostsdk.a
       - test -f $PREFIX/include/vamp/vamp.h


### PR DESCRIPTION
## Adding `vamp-plugin-sdk` (v2.10)

- **Project Homepage:** https://vamp-plugins.org/
- **Source Repository:** https://github.com/vamp-plugins/vamp-plugin-sdk
- **Download Source Tarball:** https://github.com/vamp-plugins/vamp-plugin-sdk/archive/refs/tags/vamp-plugin-sdk-v2.10.tar.gz

### About the package
`vamp-plugin-sdk` is a C/C++ SDK for building audio analysis and feature extraction plugins. 
It is widely used in audio tools like **Audacity**, **Sonic Visualiser**, and is a required 
dependency for building **Ardour**.

### What was packaged
This recipe packages the **Vamp Plugin SDK v2.10** which provides two libraries:
- `libvamp-sdk` — for **plugin authors** to implement Vamp plugins
- `libvamp-hostsdk` — for **host applications** to load and use Vamp plugins
- C/C++ headers under `include/vamp/`, `include/vamp-sdk/`, `include/vamp-hostsdk/`

### Build method
The SDK uses a standard GNU Autotools build system (`./configure` + `make` + `make install`).
The build script (`build.sh`) runs:
```bash
./configure --prefix=$PREFIX   # configures install paths to conda prefix
make -j${CPU_COUNT}            # parallel compile using all available CPU cores
make install                   # installs libraries and headers to $PREFIX
