### PR TITLE
Adding resvg-py

### DIFF
--- a/recipes/resvg-py/recipe.yaml
+++ b/recipes/resvg-py/recipe.yaml
@@ -1,0 +1,67 @@
+schema_version: 1
+
+context:
+  version: "0.5.0"
+
+package:
+  name: resvg-py
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/r/resvg-py/resvg_py-${{ version }}.tar.gz
+  sha256: 6d3bf8e866b4e129524d9432a809138b2d100931d8d635bc81294002abcdfd46
+
+build:
+  number: 0
+  script:
+    - ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
+
+requirements:
+  build:
+    - if: build_platform != target_platform
+      then:
+        - python
+        - cross-python_${{ target_platform }}
+        - crossenv
+        - maturin >=1,<2
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - ${{ stdlib('c') }}
+    - cargo-bundle-licenses
+  host:
+    - python
+    - pip
+    - maturin >=1,<2
+  run:
+    - python
+
+tests:
+  - python:
+      imports:
+        - resvg_py
+      pip_check: true
+  - script:
+      - python test_render.py
+    files:
+      recipe:
+        - test_render.py
+
+about:
+  homepage: https://github.com/baseplate-admin/resvg-py
+  summary: A safe and high level Python binding for the resvg SVG rendering library
+  description: |
+    resvg_py exposes the resvg SVG renderer to Python, rendering SVG documents
+    to PNG bytes. It covers most of the resvg option surface, including custom
+    font files and directories, style sheets, zoom and DPI, and embedded
+    raster images.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://resvg-py.readthedocs.io/
+  repository: https://github.com/baseplate-admin/resvg-py
+
+extra:
+  recipe-maintainers:
+    - ewels

--- a/recipes/resvg-py/test_render.py
+++ b/recipes/resvg-py/test_render.py
@@ -1,0 +1,19 @@
+"""Render a trivial SVG and check we get a real PNG back.
+
+Verifies the compiled extension actually works, rather than merely importing.
+"""
+
+import resvg_py
+
+SVG = """
+<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8">
+  <rect width="8" height="8" fill="red" />
+</svg>
+"""
+
+png = bytes(resvg_py.svg_to_bytes(svg_string=SVG))
+
+assert png.startswith(b"\x89PNG\r\n\x1a\n"), png[:16]
+assert resvg_py.__resvg_version__, "resvg version not reported"
+
+print(f"resvg_py {resvg_py.__version__} (resvg {resvg_py.__resvg_version__}): {len(png)} byte PNG")


### PR DESCRIPTION
Adds [resvg-py](https://github.com/baseplate-admin/resvg-py), Python bindings for the [resvg](https://github.com/linebender/resvg) SVG renderer. Built with maturin and pyo3, so the recipe follows the pattern used by `orjson-feedstock`.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.