### PR TITLE
Add scientificfitting 0.2.0

### DIFF
--- a/recipes/scientificfitting/recipe.yaml
+++ b/recipes/scientificfitting/recipe.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   number: 0
-  script: python -m pip install . --no-deps --no-build-isolation -vv
+  script: ${{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipes/scientificfitting/recipe.yaml
+++ b/recipes/scientificfitting/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.2.0"
+
+package:
+  name: scientificfitting
+  version: ${{ version }}
+
+source:
+  url: https://github.com/Amin-El-Sayed/ScientificFitting.jl/releases/download/v${{ version }}/scientificfitting-${{ version }}.tar.gz
+  sha256: 059ff5ce38512bd7bf6168ce8ff9266c8580401ac00d9fc90570e24408fb2166
+
+build:
+  noarch: python
+  number: 0
+  script: python -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.24
+    # Match upstream's cap for the JuliaCall 0.9.35 symlink-loader regression.
+    - pyjuliacall >=0.9.34,<0.9.35
+  run_constraints:
+    - matplotlib-base >=3.7
+    - scipy >=1.10
+
+tests:
+  - python:
+      imports:
+        - scientificfitting
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - python -c "import scientificfitting as sf, sys; assert callable(sf.fit_likelihood_model); assert 'juliacall' not in sys.modules; assert 'matplotlib' not in sys.modules"
+      - python -c "from importlib.resources import files; p = files('scientificfitting'); assert p.joinpath('_bridge.jl').is_file(); assert p.joinpath('juliapkg.json').is_file()"
+
+about:
+  homepage: https://github.com/Amin-El-Sayed/ScientificFitting.jl
+  summary: Python interface to the ScientificFitting Julia numerical core
+  description: |
+    Fit NumPy model functions with measurement uncertainties, parameter
+    constraints, and user-defined likelihoods. Results include parameter
+    covariance, profiles, diagnostics, and optional editable Matplotlib plots.
+    JuliaCall manages the Julia runtime and registered ScientificFitting core;
+    the first fit requires network access and Julia package compilation.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://amin-el-sayed.github.io/ScientificFitting.jl/python.html
+  repository: https://github.com/Amin-El-Sayed/ScientificFitting.jl
+
+extra:
+  recipe-maintainers:
+    - Amin-El-Sayed

--- a/recipes/scientificfitting/recipe.yaml
+++ b/recipes/scientificfitting/recipe.yaml
@@ -39,6 +39,9 @@ tests:
   - script:
       - python -c "import scientificfitting as sf, sys; assert callable(sf.fit_likelihood_model); assert 'juliacall' not in sys.modules; assert 'matplotlib' not in sys.modules"
       - python -c "from importlib.resources import files; p = files('scientificfitting'); assert p.joinpath('_bridge.jl').is_file(); assert p.joinpath('juliapkg.json').is_file()"
+    requirements:
+      run:
+       - python ${{ python_min }}.*
 
 about:
   homepage: https://github.com/Amin-El-Sayed/ScientificFitting.jl

--- a/recipes/scientificfitting/recipe.yaml
+++ b/recipes/scientificfitting/recipe.yaml
@@ -6,8 +6,8 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://github.com/Amin-El-Sayed/ScientificFitting.jl/releases/download/v${{ version }}/scientificfitting-${{ version }}.tar.gz
-  sha256: 059ff5ce38512bd7bf6168ce8ff9266c8580401ac00d9fc90570e24408fb2166
+  url: https://pypi.org/packages/source/s/scientificfitting/scientificfitting-${{ version }}.tar.gz
+  sha256: 16d07a3d4cc2fad9ac46e68c74a1192b38e75defc341eb2cc4f57d6495ab9a5a
 
 build:
   noarch: python


### PR DESCRIPTION
Adds `scientificfitting` 0.2.0, a NumPy-facing interface to the registered ScientificFitting Julia numerical core, with optional native Matplotlib plots.

The recipe builds the small Python sdist published on [PyPI](https://pypi.org/project/scientificfitting/0.2.0/), not the full Julia repository archive. NumPy and `pyjuliacall` are runtime dependencies; Matplotlib and SciPy remain optional.

Runtime provisioning is explicit: the first fit lets JuliaCall/JuliaPkg locate or download Julia and install the registered ScientificFitting core. This needs network access and compilation. Importing `scientificfitting` does not start Julia, and there are no post-link scripts or bundled third-party runtimes. The JuliaCall upper bound matches upstream's documented loader regression workaround.

Validation:
- `conda-smithy recipe-lint --conda-forge`: no findings.
- `rattler-build` with current conda-forge pinnings: built and tested on macOS ARM64, including Python 3.11 and 3.14 imports, `pip check`, lazy initialization, and required Julia bridge/package data.
- [Upstream Python CI](https://github.com/Amin-El-Sayed/ScientificFitting.jl/actions/runs/34257148451) covers installed wheels and numerical/plotting APIs on Linux, macOS, and Windows, plus a Conda installation on Linux. Separate fresh wheel and Conda environments were also checked against the registered 0.2.0 core without a development checkout.

Checklist:
- [x] Descriptive PR title and v1 `recipe.yaml` format.
- [x] Official source tarball with SHA-256; no `git_url` source.
- [x] MIT license file included.
- [x] No vendored dependencies or static libraries.
- [x] Build number is zero.
- [x] Listed maintainer is the upstream author and PR author, Amin-El-Sayed.

I am willing to maintain this recipe.
