### PR TITLE
Add intel-sde

### DIFF
--- a/recipes/intel-sde/recipe.yaml
+++ b/recipes/intel-sde/recipe.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+
+context:
+  version: "9.53.0"
+  release_date: "2025-03-16"
+
+package:
+  name: intel-sde
+  version: ${{ version }}
+
+source:
+  url: https://downloadmirror.intel.com/850782/sde-external-${{ version }}-${{ release_date }}-lin.tar.xz
+  sha256: f55138df53378198e8c0a89598351cdb3c5e7f8819e63e472b0bc179afaad34c
+
+build:
+  number: 0
+  skip: target_platform != "linux-64"
+  dynamic_linking:
+    binary_relocation: false
+  script:
+    - mkdir -p "$PREFIX/share/intel-sde" "$PREFIX/bin"
+    - cp -a . "$PREFIX/share/intel-sde/"
+    - ln -s ../share/intel-sde/sde64 "$PREFIX/bin/sde64"
+
+tests:
+  - script:
+      - sde64 -skx -- /bin/true
+      - test -f "$PREFIX/share/intel-sde/Licenses/third-party-programs.txt"
+
+about:
+  homepage: https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html
+  summary: Intel Software Development Emulator
+  description: |
+    Intel Software Development Emulator (Intel SDE) is a Pin-based software
+    emulator for Intel instruction-set extensions. This package preserves the
+    complete upstream distribution and its bundled license notices unchanged.
+  license: LicenseRef-IntelSimplifiedSoftwareFeb2020
+  license_file: Licenses/
+  documentation: https://www.intel.com/content/www/us/en/developer/articles/tool/software-development-emulator.html
+
+extra:
+  recipe-maintainers:
+    - wolfv


### PR DESCRIPTION
## Description

Adds Intel Software Development Emulator 9.53.0 for linux-64.

The complete upstream distribution is installed unchanged under `share/intel-sde`, including all Intel and third-party license notices. Only a `bin/sde64` symlink is added for convenient invocation. Binary relocation is disabled so packaged executables are not modified.

Intel's bundled Simplified Software License permits redistribution without modification. This package is intended to replace direct Intel SDE downloads in conda-forge CI when testing x86-64-v4 builds on older runners.

## Verification

- `pixi run lint`
- Local rattler-build build and package test (`sde64 -skx -- /bin/true`)
