### PR TITLE
Add typer-static-completion

### DIFF
--- a/recipes/typer-static-completion/recipe.yaml
+++ b/recipes/typer-static-completion/recipe.yaml
@@ -1,0 +1,79 @@
+context:
+  version: "0.0.2"
+
+package:
+  name: typer-static-completion
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/t/typer-static-completion/typer_static_completion-${{ version }}.tar.gz
+  sha256: b164f7ae41ea1a4452e3726ef957d0a0da69cdcb58b2ab0b64978207c0c8df92
+
+build:
+  number: 0
+  noarch: python
+  python:
+    entry_points:
+      - typer-static-completion=typer_static_completion.cli:main
+  script:
+    - python -m pip install . -vv --no-deps --no-build-isolation
+    - python -m typer_static_completion.cli generate typer_static_completion.cli:app
+      --prog-name typer-static-completion --shell bash
+      -o $PREFIX/share/bash-completion/completions/typer-static-completion
+    - python -m typer_static_completion.cli generate typer_static_completion.cli:app
+      --prog-name typer-static-completion --shell zsh
+      -o $PREFIX/share/zsh/site-functions/_typer-static-completion
+    - python -m typer_static_completion.cli generate typer_static_completion.cli:app
+      --prog-name typer-static-completion --shell fish
+      -o $PREFIX/share/fish/vendor_completions.d/typer-static-completion.fish
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - hatchling
+    # imported by the build script to generate the shell completions
+    - typer >=0.26,<0.27
+  run:
+    - python >=${{ python_min }}
+    - typer >=0.26,<0.27
+
+tests:
+  - python:
+      imports:
+        - typer_static_completion
+        - typer_static_completion.generators
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+  - script:
+      - typer-static-completion --help
+      - typer-static-completion generate typer_static_completion.cli:app --prog-name typer-static-completion --shell fish -o -
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+  - package_contents:
+      site_packages:
+        - typer_static_completion/core.py
+      files:
+        - share/bash-completion/completions/typer-static-completion
+        - share/zsh/site-functions/_typer-static-completion
+        - share/fish/vendor_completions.d/typer-static-completion.fish
+
+about:
+  homepage: https://github.com/pavelzw/typer-static-completion
+  repository: https://github.com/pavelzw/typer-static-completion
+  summary: Generate static shell completions for typer applications
+  description: |
+    typer-static-completion renders bash, zsh, and fish completion scripts for
+    Typer applications ahead of time, so tab completion runs entirely in the
+    shell without invoking Python. It introspects nested commands, flags,
+    choices, tuple options, and scalar/tuple/variadic arguments, and is usable
+    both as a build-time CLI and as a Python API.
+  license: BSD-3-Clause
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adding [typer-static-completion](https://github.com/pavelzw/typer-static-completion) — generates static shell completion scripts (bash/zsh/fish) for Typer applications ahead of time, so tab completion runs entirely in the shell without invoking Python.

The recipe dogfoods the tool: its own bash/zsh/fish completions are generated during the build via `typer_static_completion.cli generate` and installed into the standard `share/` locations, so `pixi global install typer-static-completion` gets tab completion out of the box.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
