### PR TITLE
Add hfda recipe

### DIFF
--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+context:
+  version: "0.1.1"
+
+package:
+  name: hfda
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/h/hfda/hfda-${{ version }}.tar.gz
+  sha256: 6337cc0c117093c4dcf8d1d17be4e53c6975556979bc6ed3fcf3986cbcb71a74
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+
+tests:
+  - python:
+      imports:
+        - hfda
+      pip_check: false
+
+about:
+  homepage: https://github.com/hiroki-kojima/HFDA
+  license: MIT
+  license_file: LICENSE
+  summary: Higuchi Fractal Dimension Analysis
+
+extra:
+  recipe-maintainers:
+    - futro

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
 


### PR DESCRIPTION
hfda is a pure-Python, zero-dependency package for Higuchi Fractal Dimension Analysis.

Adding it to conda-forge to unblock the qbiocode recipe (conda-forge/staged-recipes#32878).