### PR TITLE
Add Hfda

### DIFF
--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -1,0 +1,40 @@
+schema_version: 1
+
+context:
+  version: "0.1.1"
+
+package:
+  name: hfda
+  version: ${{ version }}
+
+source:
+  url: https://pypi.io/packages/source/h/hfda/hfda-${{ version }}.tar.gz
+  sha256: 6337cc0c117093c4dcf8d1d17be4e53c6975556979bc6ed3fcf3986cbcb71a74
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv
+
+requirements:
+  host:
+    - python >=3.6
+    - pip
+  run:
+    - python >=3.6
+
+tests:
+  - python:
+      imports:
+        - hfda
+      pip_check: false
+
+about:
+  homepage: https://github.com/hiroki-kojima/HFDA
+  license: MIT
+  license_file: LICENSE
+  summary: Higuchi Fractal Dimension Analysis
+
+extra:
+  recipe-maintainers:
+    - futro

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -27,6 +27,9 @@ requirements:
     - wheel
   run:
     - python >=${{ python_min }}
+    - numpy
+
+
 
 tests:
   - python:

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -35,7 +35,6 @@ tests:
   - python:
       imports:
         - hfda
-      pip_check: false
 
 about:
   homepage: https://github.com/hiroki-kojima/HFDA

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -9,8 +9,11 @@ package:
   version: ${{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/source/h/hfda/hfda-${{ version }}.tar.gz
-  sha256: 6337cc0c117093c4dcf8d1d17be4e53c6975556979bc6ed3fcf3986cbcb71a74
+  - url: https://files.pythonhosted.org/packages/source/h/hfda/hfda-${{ version }}.tar.gz
+    sha256: 6337cc0c117093c4dcf8d1d17be4e53c6975556979bc6ed3fcf3986cbcb71a74
+  - url: https://raw.githubusercontent.com/hiroki-kojima/HFDA/main/LICENSE
+    sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+    file_name: LICENSE
 
 build:
   number: 0
@@ -39,7 +42,6 @@ about:
   homepage: https://github.com/hiroki-kojima/HFDA
   license: MIT
   license_file: LICENSE
-  license_url: https://raw.githubusercontent.com/hiroki-kojima/HFDA/main/LICENSE
   summary: Higuchi Fractal Dimension Analysis
 
 extra:

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -33,9 +33,6 @@ tests:
       imports:
         - hfda
       pip_check: false
-      python_version:
-        - ${{ python_min }}.*
-        - "*"
 
 about:
   homepage: https://github.com/hiroki-kojima/HFDA
@@ -46,5 +43,4 @@ about:
 extra:
   recipe-maintainers:
     - f-utro
-  
   

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -2,13 +2,14 @@ schema_version: 1
 
 context:
   version: "0.1.1"
+  python_min: "3.6"
 
 package:
   name: hfda
   version: ${{ version }}
 
 source:
-  url: https://pypi.io/packages/source/h/hfda/hfda-${{ version }}.tar.gz
+  url: https://files.pythonhosted.org/packages/source/h/hfda/hfda-${{ version }}.tar.gz
   sha256: 6337cc0c117093c4dcf8d1d17be4e53c6975556979bc6ed3fcf3986cbcb71a74
 
 build:
@@ -18,25 +19,29 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python ${{ python_min }}.*
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python >=${{ python_min }}
 
 tests:
   - python:
       imports:
         - hfda
       pip_check: false
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
   homepage: https://github.com/hiroki-kojima/HFDA
   license: MIT
-  license_url: https://github.com/hiroki-kojima/HFDA/blob/main/LICENSE
+  license_file: LICENSE
+  license_url: https://raw.githubusercontent.com/hiroki-kojima/HFDA/main/LICENSE
   summary: Higuchi Fractal Dimension Analysis
 
 extra:
   recipe-maintainers:
-    - futro
+    - f-utro

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python >=3.6
     - pip
+    - setuptools
+    - wheel
   run:
     - python >=3.6
 

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -11,8 +11,8 @@ package:
 source:
   - url: https://files.pythonhosted.org/packages/source/h/hfda/hfda-${{ version }}.tar.gz
     sha256: 6337cc0c117093c4dcf8d1d17be4e53c6975556979bc6ed3fcf3986cbcb71a74
-  - url: https://raw.githubusercontent.com/hiroki-kojima/HFDA/main/LICENSE
-    sha256: d5558cd419c8d46bdc958064cb97f963d1ea793866414c025906ec15033512ed
+  - url: https://raw.githubusercontent.com/hiroki-kojima/HFDA/master/LICENSE
+    sha256: 9c231f8e67dadd37623053064663097a53a86aa8fdd39249daa9ebc40d357241
     file_name: LICENSE
 
 build:

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -34,7 +34,7 @@ tests:
 about:
   homepage: https://github.com/hiroki-kojima/HFDA
   license: MIT
-  license_file: LICENSE
+  license_url: https://github.com/hiroki-kojima/HFDA/blob/main/LICENSE
   summary: Higuchi Fractal Dimension Analysis
 
 extra:

--- a/recipes/hfda/recipe.yaml
+++ b/recipes/hfda/recipe.yaml
@@ -2,7 +2,6 @@ schema_version: 1
 
 context:
   version: "0.1.1"
-  python_min: "3.6"
 
 package:
   name: hfda
@@ -47,3 +46,5 @@ about:
 extra:
   recipe-maintainers:
     - f-utro
+  
+  


### PR DESCRIPTION
hfda is a pure-Python, zero-dependency package for Higuchi Fractal Dimension Analysis.

Adding it to conda-forge to unblock the qbiocode recipe (https://github.com/conda-forge/staged-recipes/pull/32878).