### PR TITLE
Add ddsim

### DIFF
--- a/recipes/ddsim/recipe.yaml
+++ b/recipes/ddsim/recipe.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+
+context:
+  version: "0.2.0"
+
+package:
+  name: ddsim
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/d/ddsim/ddsim-${{ version }}.tar.gz
+  sha256: eb206f10d01791797b553bfc33268d2e66ace4b1e492fcc85f57e838195ac2d9
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - setuptools >=69.0
+    - wheel
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - pyyaml
+    - rhapsody-py
+    - radical.asyncflow >=0.3.0
+
+tests:
+  - python:
+      imports:
+        - ddsim
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  homepage: https://github.com/radical-collaboration/DeepDriveSim
+  summary: AI-driven adaptive molecular dynamics simulation framework
+  description: |
+    DeepDriveSim (DDSim) couples AI-driven steering with ensemble
+    molecular dynamics workflows, built on RHAPSODY and
+    RADICAL-AsyncFlow. The optional Dragon backend is installed
+    separately (`pip install dragonhpc`).
+  license: MIT
+  license_file: LICENSE
+  documentation: https://radical-collaboration.github.io/DeepDriveSim/
+  repository: https://github.com/radical-collaboration/DeepDriveSim
+
+extra:
+  recipe-maintainers:
+    - andre-merzky

--- a/recipes/ddsim/recipe.yaml
+++ b/recipes/ddsim/recipe.yaml
@@ -1,7 +1,7 @@
 schema_version: 1
 
 context:
-  version: "0.2.0"
+  version: "0.2.1"
 
 package:
   name: ddsim
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/d/ddsim/ddsim-${{ version }}.tar.gz
-  sha256: eb206f10d01791797b553bfc33268d2e66ace4b1e492fcc85f57e838195ac2d9
+  sha256: 42e79e7eefad9c5cdeef1171df7c16b6c3d21702029ea9bfabdbbb2d16f5be98
 
 build:
   number: 0


### PR DESCRIPTION
Adds **ddsim 0.2.0** (DeepDriveSim): AI-driven adaptive molecular dynamics simulation framework, part of the SINAPSE SDK (NSF award 2514139). Depends on rhapsody-py and radical.asyncflow, both on conda-forge (#34581); the optional Dragon backend (dragonhpc) is PyPI-only and documented as pip-on-top.

Noarch python, v1 recipe, sha256 verified against the PyPI sdist.

Checklist:
- [x] License file is packaged (MIT, LICENSE in sdist)
- [x] Source is from the official PyPI sdist
- [x] Build number is 0
- [x] A meaningful project description is in the recipe
- [x] Maintainer consent: I am the maintainer (@andre-merzky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHdYAup83HGHJkmjbo96ts