### PR TITLE
Add cdp-use recipe

### DIFF
--- a/recipes/cdp-use/recipe.yaml
+++ b/recipes/cdp-use/recipe.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+schema_version: 1
+
+context:
+  name: cdp-use
+  version: "1.4.5"
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/cdp_use-${{ version }}.tar.gz
+  sha256: 0da3a32df46336a03ff5a22bc6bc442cd7d2f2d50a118fd4856f29d37f6d26a0
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - hatchling
+    - pip
+  run:
+    - python >=${{ python_min }}
+    - httpx >=0.28.1
+    - typing-extensions >=4.12.2
+    - websockets >=15.0.1
+
+tests:
+  - python:
+      imports:
+        - cdp_use
+      pip_check: true
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+
+about:
+  summary: Type safe generator/client library for CDP
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/browser-use/cdp-use
+  repository: https://github.com/browser-use/cdp-use
+
+extra:
+  recipe-maintainers:
+    - SatyamKumarCS


### PR DESCRIPTION
This PR adds the recipe for **`cdp-use`** (`v1.4.5`).

- **PyPI:** https://pypi.org/project/cdp-use/
- **Repository:** https://github.com/browser-use/cdp-use
- **Summary:** Type-safe Chrome DevTools Protocol (CDP) generator and client library for Python.

I confirm that I (@SatyamKumarCS) am willing to be listed as a recipe maintainer.

---

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
