### PR TITLE
Add wisprflow-sdk recipe

### DIFF
--- a/recipes/wisprflow-sdk/recipe.yaml
+++ b/recipes/wisprflow-sdk/recipe.yaml
@@ -1,0 +1,53 @@
+schema_version: 1
+
+context:
+  name: wisprflow-sdk
+  version: "0.1.3"
+
+package:
+  name: ${{ name }}
+  version: ${{ version }}
+
+source:
+  url: https://github.com/ThisisShashwat/wisprflow-sdk/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: a88994f1e6b2a4d7475a1bf4ea8976a94fd81860189897e17303254b820397ea
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - wisprflow = wisprflow_sdk._core:main
+      - wisprflow-patch = wisprflow_sdk._installer:run_patch
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - uv-build >=0.7.19,<0.8.0
+  run:
+    - python >=${{ python_min }}
+    - grpcio
+    - requests
+
+tests:
+  - python:
+      imports:
+        - wisprflow_sdk
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - script:
+      - wisprflow --help
+
+about:
+  homepage: https://github.com/ThisisShashwat/wisprflow-sdk
+  summary: Unofficial Python SDK for Wispr Flow — transcription and command APIs
+  license: MIT
+  license_file: LICENSE
+  repository: https://github.com/ThisisShashwat/wisprflow-sdk
+  documentation: https://github.com/ThisisShashwat/wisprflow-sdk/blob/main/DOCS.md
+
+extra:
+  recipe-maintainers:
+    - Yash990-bit

--- a/recipes/wisprflow-sdk/recipe.yaml
+++ b/recipes/wisprflow-sdk/recipe.yaml
@@ -36,7 +36,9 @@ tests:
       imports:
         - wisprflow_sdk
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
   - script:
       - wisprflow --help
 

--- a/recipes/wisprflow-sdk/recipe.yaml
+++ b/recipes/wisprflow-sdk/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: wisprflow-sdk
   version: "0.1.3"
 
 package:
-  name: ${{ name }}
+  name: wisprflow-sdk
   version: ${{ version }}
 
 source:


### PR DESCRIPTION
## Adding `wisprflow-sdk` (v0.1.3)

### Links & Metadata
- **Source Repository:** https://github.com/ThisisShashwat/wisprflow-sdk
- **PyPI:** https://pypi.org/project/wisprflow-sdk/
- **Documentation:** https://github.com/ThisisShashwat/wisprflow-sdk/blob/main/DOCS.md

---

### About the package
`wisprflow-sdk` is an unofficial Python SDK and CLI tool for Wispr Flow — providing streaming transcription, context injection, and command APIs.

### What was packaged
- Pure Python package (`noarch: python`)
- CLI entrypoints: `wisprflow` and `wisprflow-patch`
- Dependencies: `grpcio`, `requests`

---

### Checklist
- [x] Title is formatted as `Adding <package-name>`
- [x] All tests pass
- [x] Recipe uses standard conda-forge v1 schema
- [x] Maintainer confirmed
