### PR TITLE
Add ancestree

### DIFF
--- a/recipes/ancestree/recipe.yaml
+++ b/recipes/ancestree/recipe.yaml
@@ -1,0 +1,65 @@
+schema_version: 1
+
+context:
+  version: "0.1.1"
+
+package:
+  name: ancestree
+  version: ${{ version }}
+
+source:
+  # The PyPI distribution is 'ancestree-popgen'. The import name and this conda package are 'ancestree'.
+  url: https://pypi.org/packages/source/a/ancestree-popgen/ancestree_popgen-${{ version }}.tar.gz
+  sha256: f0962fad12b883af6fc178372582bbcb1652e9a2f6268ec26b1963da199cfac1
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  python:
+    entry_points:
+      - ancestree = ancestree.cli:main
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - poetry-core >=2.0
+  run:
+    - python >=${{ python_min }},<3.14
+    - numpy >=1.24,<3
+    - scipy >=1.10,<2
+    - tskit >=1.0,<2
+    - tqdm >=4.60,<5
+    - numba >=0.59,<1
+    - llvmlite >=0.42,<1
+
+tests:
+  - python:
+      imports:
+        - ancestree
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
+      pip_check: true
+  - script:
+      - ancestree --help
+
+about:
+  homepage: https://github.com/Sendrowski/Ancestree
+  license: GPL-3.0-or-later
+  license_file: LICENSE
+  summary: Ancestral allele annotation via Felsenstein likelihood on ARGs and fixed trees, with or without outgroups
+  description: |
+    ancestree performs likelihood-based, per-site ancestral-allele annotation, unifying
+    outgroup-based (EST-SFS-style) and ARG-based (PolarBEAR-style) inference behind a single
+    likelihood kernel. It runs in three modes: fixed-tree, ARG, and local-tree, the last inferring
+    its own local genealogies from the variant data. Every site receives a full posterior over the
+    four nucleotide states. The import name is `ancestree`. On PyPI the distribution is named
+    `ancestree-popgen`.
+  documentation: https://ancestree.readthedocs.io/
+  repository: https://github.com/Sendrowski/Ancestree
+
+extra:
+  recipe-maintainers:
+    - Sendrowski


### PR DESCRIPTION
Adds a recipe for ancestree, a package for likelihood-based, per-site ancestral-allele annotation. It unifies outgroup-based (EST-SFS-style) and ARG-based (PolarBEAR-style) inference behind a single Felsenstein likelihood kernel and runs in three modes: fixed-tree, ARG, and local-tree, the last inferring its own local genealogies from the variant data. Every site receives a full posterior over the four nucleotide states.

- v1 `recipe.yaml`, `noarch: python`, single output, pure-Python (poetry-core backend). The numba kernels are JIT-compiled at runtime, so `numba` and `llvmlite` are ordinary run dependencies.
- Import name and this conda package are `ancestree`. On PyPI the distribution is `ancestree-popgen`, so `source.url` points at the `ancestree-popgen` sdist while the package is named `ancestree`.
- Optional I/O backends (cyvcf2, bio2zarr, zarr, msprime, newick, matplotlib) are lazy-imported and kept out of `run`, as cyvcf2 and bio2zarr are hosted on bioconda. The installation docs cover adding them.
- License: `GPL-3.0-or-later` (`LICENSE` bundled in the sdist).
- Tests: `imports: ancestree` on `python_min` and the latest Python, `pip check`, and the `ancestree --help` CLI.

Repo: https://github.com/Sendrowski/Ancestree · Docs: https://ancestree.readthedocs.io/

Checklist:
- [x] Title of this PR is meaningful.
- [x] License file is packaged (`license_file: LICENSE`).
- [x] Source is from a tagged PyPI release with a pinned `sha256`.
- [x] All top-level dependencies are listed under `run`.
