### PR TITLE
Sync swap file setup with conda-smithy

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -23,17 +23,18 @@ jobs:
     displayName: Manage disk space
 
   - script: |
+      set -ex
       SWAPFILE=/swapfile
       # If there is already a swapfile, disable it and remove it
-      if swapon --show | grep -q $SWAPFILE; then
-          echo "Disabling existing swapfile..."
-          sudo swapoff $SWAPFILE || true
+      if swapon --show | grep -q "^${SWAPFILE}"; then
+          sudo swapoff "${SWAPFILE}" || true
       fi
-      [ -f "$SWAPFILE" ] && sudo rm -f $SWAPFILE
-      sudo fallocate -l 10GiB $SWAPFILE
-      sudo chmod 600 $SWAPFILE
-      sudo mkswap $SWAPFILE
-      sudo swapon $SWAPFILE
+      [[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
+
+      sudo fallocate -l 10GiB "${SWAPFILE}"
+      sudo chmod 600 "${SWAPFILE}"
+      sudo mkswap "${SWAPFILE}"
+      sudo swapon "${SWAPFILE}"
     displayName: Create swap file
 
   - script: |
@@ -86,10 +87,18 @@ jobs:
     displayName: Manage disk space
 
   - script: |
-      sudo fallocate -l 10GiB /swapfile || true
-      sudo chmod 600 /swapfile || true
-      sudo mkswap /swapfile || true
-      sudo swapon /swapfile || true
+      set -ex
+      SWAPFILE=/swapfile
+      # If there is already a swapfile, disable it and remove it
+      if swapon --show | grep -q "^${SWAPFILE}"; then
+          sudo swapoff "${SWAPFILE}" || true
+      fi
+      [[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
+
+      sudo fallocate -l 10GiB "${SWAPFILE}"
+      sudo chmod 600 "${SWAPFILE}"
+      sudo mkswap "${SWAPFILE}"
+      sudo swapon "${SWAPFILE}"
     displayName: Create swap file
 
   - script: |
@@ -137,10 +146,18 @@ jobs:
     displayName: Manage disk space
 
   - script: |
-      sudo fallocate -l 10GiB /swapfile || true
-      sudo chmod 600 /swapfile || true
-      sudo mkswap /swapfile || true
-      sudo swapon /swapfile || true
+      set -ex
+      SWAPFILE=/swapfile
+      # If there is already a swapfile, disable it and remove it
+      if swapon --show | grep -q "^${SWAPFILE}"; then
+          sudo swapoff "${SWAPFILE}" || true
+      fi
+      [[ -f ${SWAPFILE} ]] && sudo rm -f "${SWAPFILE}"
+
+      sudo fallocate -l 10GiB "${SWAPFILE}"
+      sudo chmod 600 "${SWAPFILE}"
+      sudo mkswap "${SWAPFILE}"
+      sudo swapon "${SWAPFILE}"
     displayName: Create swap file
 
   - script: |


### PR DESCRIPTION
The hosted image now boots with an active / swapfile that cannot be resized in place, so the two CUDA jobs failed to create their 10 GiB swap (silently, via "|| true"). Match upstream, which swapoffs and recreates it: https://github.com/conda-forge/conda-smithy/blob/2321daf13bde82119d361c73dede14e64435f176/conda_smithy/templates/create_pagefile.sh.tmpl

This logic was [already patched for the linux non-CUDA job](https://github.com/conda-forge/staged-recipes/pull/31925), so not updating the CUDA jobs too was an oversight.