### PR TITLE
Adding ghgrab

### DIFF
--- a/recipes/ghgrab/recipe.yaml
+++ b/recipes/ghgrab/recipe.yaml
@@ -1,0 +1,70 @@
+context:
+  version: "2.0.2"
+
+package:
+  name: ghgrab
+  version: ${{ version }}
+
+source:
+  url: https://github.com/abhixdd/ghgrab/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: a30a9b812cad290ded124924b3443073e80dcabc4fe479ca98fa01d942b69a41
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+    - pkg-config
+  host:
+    - liblzma-devel
+
+tests:
+  - script:
+      - ghgrab --help
+      - ghgrab --version
+      - ghg --help
+  - package_contents:
+      bin:
+        - ghgrab
+        - ghg
+      strict: true
+
+about:
+  homepage: https://github.com/abhixdd/ghgrab
+  summary: Browse and download files from GitHub, GitLab, Codeberg, Gitea and Forgejo from your terminal
+  description: |
+    ghgrab provides a streamlined command-line interface for cherry-picking
+    specific files or folders from supported Git forges, powered by the Rust
+    tokio and ratatui ecosystem. Focused on speed and ease of use, it offers a
+    TUI that lets you grab exactly what you need without the wait times of a
+    full git clone.
+
+    It also supports fuzzy search and repository discovery, in-TUI file
+    previews, GitHub LFS, batch downloads and OS/architecture-aware GitHub
+    release asset downloads.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://ghgrab.readthedocs.io
+  repository: https://github.com/abhixdd/ghgrab
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adding [ghgrab](https://github.com/abhixdd/ghgrab) — a Rust TUI/CLI for browsing and downloading individual files, folders and release assets from GitHub, GitLab, Codeberg, Gitea and Forgejo without a full clone.

The recipe installs both binaries the crate provides (`ghgrab` and its short alias `ghg`) and links against conda-forge's `liblzma` instead of letting `lzma-sys` vendor xz.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
