### PR TITLE
Adding leaf-markdown-viewer

### DIFF
--- a/recipes/leaf-markdown-viewer/recipe.yaml
+++ b/recipes/leaf-markdown-viewer/recipe.yaml
@@ -1,0 +1,75 @@
+context:
+  version: "1.28.1"
+
+package:
+  name: leaf-markdown-viewer
+  version: ${{ version }}
+
+source:
+  url: https://github.com/RivoLink/leaf/archive/refs/tags/${{ version }}.tar.gz
+  sha256: 594693cf012f51963f95090b7439dfd1c5194f18f12d93293dc7ad2c8909101b
+
+build:
+  number: 0
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+      # Upstream ships hand-written completions; `leaf --auto-complete` only
+      # installs them into the user's shell config, so copy the files directly.
+      - if: unix
+        then:
+          - mkdir -p $PREFIX/share/bash-completion/completions $PREFIX/share/zsh/site-functions $PREFIX/share/fish/vendor_completions.d
+          - cp completions/leaf.bash $PREFIX/share/bash-completion/completions/leaf
+          - cp completions/leaf.zsh $PREFIX/share/zsh/site-functions/_leaf
+          - cp completions/leaf.fish $PREFIX/share/fish/vendor_completions.d/leaf.fish
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script:
+      - leaf --version
+      - leaf --help
+  - package_contents:
+      bin:
+        - leaf
+      files:
+        - if: unix
+          then:
+            - share/bash-completion/completions/leaf
+            - share/zsh/site-functions/_leaf
+            - share/fish/vendor_completions.d/leaf.fish
+      strict: true
+
+about:
+  homepage: https://leaf.rivolink.mg
+  summary: Terminal Markdown previewer with a GUI-like experience
+  description: |
+    leaf is a terminal Markdown previewer that renders Markdown files in a
+    full-screen TUI with syntax-highlighted code blocks, tables, images and
+    links. It offers a watch mode that reloads on save, fuzzy and directory
+    file pickers, selectable color themes, an inline mode that renders to
+    stdout, and shell completions.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://github.com/RivoLink/leaf/blob/main/README.md
+  repository: https://github.com/RivoLink/leaf
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adding [leaf-markdown-viewer](https://github.com/RivoLink/leaf) — a terminal Markdown previewer written in Rust. Binary is `leaf`.

The recipe also installs the hand-written bash/zsh/fish completion scripts shipped in the upstream `completions/` directory (upstream's `leaf --auto-complete` only writes into the user's shell config, so the files are copied directly — no binary execution, so this works under cross-compilation too).

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
