### PR TITLE
Add lazyrsync

### DIFF
--- a/recipes/lazyrsync/recipe.yaml
+++ b/recipes/lazyrsync/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "0.3.0"
+
+package:
+  name: lazyrsync
+  version: ${{ version }}
+
+source:
+  url: https://github.com/westpoint-io/lazyrsync/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 7ddb32c20688c1e56032207a5ed8edd5db09f9aaaad43741de13bef715bc1a4d
+
+build:
+  number: 0
+  # lazyrsync shells out to the system rsync and is only supported on Linux and macOS
+  skip: win
+  script:
+    env:
+      CARGO_PROFILE_RELEASE_STRIP: symbols
+      CARGO_PROFILE_RELEASE_LTO: fat
+    content:
+      - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+  run:
+    # --info=progress2 requires rsync 3.1 or newer
+    - rsync >=3.1
+
+tests:
+  - script: lazyrsync --help
+  - package_contents:
+      bin:
+        - lazyrsync
+      strict: true
+
+about:
+  homepage: https://lazyrsync.westpoint.io
+  summary: A terminal UI for rsync — profiles, honest dry-run preview, live progress
+  description: |
+    lazyrsync is a front-end for the system rsync rather than a
+    reimplementation of it. It provides reusable profiles and tasks, a dry-run
+    preview of what would change, a live progress bar, and snapshot support,
+    plus a headless mode for scheduled runs over cron.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  documentation: https://lazyrsync.westpoint.io/docs/install
+  repository: https://github.com/westpoint-io/lazyrsync
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adding [lazyrsync](https://github.com/westpoint-io/lazyrsync), a Rust terminal UI front-end for rsync (reusable profiles, dry-run preview, live progress, snapshots, plus a headless mode for cron).

Windows is skipped: lazyrsync shells out to the system `rsync` and upstream only supports Linux and macOS. `rsync >=3.1` is a run dependency because the live progress bar relies on `--info=progress2`, added in rsync 3.1.0.

Built and tested locally on osx-arm64.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
