### PR TITLE
Adding tuxedo

### DIFF
--- a/recipes/tuxedo/recipe.yaml
+++ b/recipes/tuxedo/recipe.yaml
@@ -1,0 +1,59 @@
+context:
+  version: "2026.8.1"
+
+package:
+  name: tuxedo
+  version: ${{ version }}
+
+source:
+  url: https://github.com/webstonehq/tuxedo/archive/refs/tags/v${{ version }}.tar.gz
+  sha256: 3135e38b61bdf12f751143b5f704ebd3b1ec6f25dd7625baeb7f7f30e56b13ea
+
+build:
+  number: 0
+  script:
+    content:
+      - if: unix
+        then:
+          - cargo auditable install --locked --no-track --bins --root ${{ PREFIX }} --path .
+        else:
+          - cargo auditable install --locked --no-track --bins --root %LIBRARY_PREFIX% --path .
+      - cargo-bundle-licenses --format yaml --output ./THIRDPARTY.yml
+
+requirements:
+  build:
+    - ${{ stdlib('c') }}
+    - ${{ compiler('c') }}
+    - ${{ compiler('rust') }}
+    - cargo-bundle-licenses
+    - cargo-auditable
+
+tests:
+  - script:
+      - tuxedo --help
+      - tuxedo --version
+  - package_contents:
+      bin:
+        - tuxedo
+      strict: true
+
+about:
+  homepage: https://github.com/webstonehq/tuxedo
+  summary: A fast, keyboard-driven terminal UI for todo.txt
+  description: |
+    tuxedo is a terminal user interface for the todo.txt format. It reads and
+    writes plain todo.txt and done.txt files, so it stays compatible with other
+    todo.txt tooling and with syncing via any file-based mechanism.
+
+    Alongside the TUI it offers one-shot CLI subcommands for scripting,
+    projects, contexts, priorities, due dates and thresholds, recurring tasks,
+    fuzzy search, an archive view grouped by completion date, and theming.
+  license: MIT
+  license_file:
+    - LICENSE
+    - THIRDPARTY.yml
+  repository: https://github.com/webstonehq/tuxedo
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adding [tuxedo](https://github.com/webstonehq/tuxedo) — a fast, keyboard-driven terminal UI for the todo.txt format, with one-shot CLI subcommands for scripting.

Pure-Rust dependency tree (ratatui/crossterm/notify/tiny_http/qrcode), no native libraries needed. Upstream's `Cargo.toml` already sets the release profile (strip, fat LTO, `opt-level = "z"`), so the recipe does not override it.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
