### PR TITLE
Add pyhelpers recipe

### DIFF
--- a/recipes/pyhelpers/recipe.yaml
+++ b/recipes/pyhelpers/recipe.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+
+context:
+  version: "2.5.2"
+
+package:
+  name: pyhelpers
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/p/pyhelpers/pyhelpers-${{ version }}.tar.gz
+  sha256: 7a1c2982363bdaaa2fc557c7ce6b47eeda501ccf0bfe28a8db31a38a6db90740
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.12
+    - hatchling
+    - pip
+  run:
+    - python >=3.12
+    - numpy
+    - pandas
+    - psycopg2
+    - pyproj
+    - requests
+    - shapely
+    - sqlalchemy
+
+tests:
+  - python:
+      imports:
+        - pyhelpers
+      pip_check: true
+
+about:
+  summary: An open-source toolkit for facilitating Python users' data manipulation tasks.
+  license: MIT
+  license_file: LICENSE
+  homepage: https://github.com/mikeqfu/pyhelpers
+  documentation: https://pyhelpers.readthedocs.io/en/latest/
+
+extra:
+  recipe-maintainers:
+    - mikeqfu

--- a/recipes/pyhelpers/recipe.yaml
+++ b/recipes/pyhelpers/recipe.yaml
@@ -2,6 +2,7 @@ schema_version: 1
 
 context:
   version: "2.5.2"
+  python_min: "3.12"
 
 package:
   name: pyhelpers
@@ -18,11 +19,11 @@ build:
 
 requirements:
   host:
-    - python >=3.12
+    - python ${{ python_min }}.*
     - hatchling
     - pip
   run:
-    - python >=3.12
+    - python >=${{ python_min }}
     - numpy
     - pandas
     - psycopg2
@@ -33,6 +34,9 @@ requirements:
 
 tests:
   - python:
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
       imports:
         - pyhelpers
       pip_check: true


### PR DESCRIPTION
Initial recipe submission for `pyhelpers` version 2.5.2 using the v1 `recipe.yaml` format.

### Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
