### PR TITLE
Add nfit

### DIFF
--- a/recipes/nfit/recipe.yaml
+++ b/recipes/nfit/recipe.yaml
@@ -1,5 +1,6 @@
 context:
   version: "0.89.13"
+  python_min: "3.12"
 
 package:
   name: nfit
@@ -16,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.12
+    - python ${{ python_min }}.*
     - pip
     - setuptools >=77.0.3
     - wheel
   run:
-    - python >=3.12
+    - python >=${{ python_min }}
     - packaging >=25
     - certifi >=2026.7.22
     - numpy >=2.5
@@ -48,6 +49,9 @@ tests:
       imports:
         - nfit
         - nfit.project_gui
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
       # cmcrameri 1.10 reports 0.0.0 through Python package metadata in its
       # conda-forge build, so pip check incorrectly treats it as too old.
       pip_check: false

--- a/recipes/nfit/recipe.yaml
+++ b/recipes/nfit/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "0.89.13"
+  version: "0.89.14"
   python_min: "3.12"
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/n/nfit/nfit-${{ version }}.tar.gz
-  sha256: ff1429559901cff444f1765ed8b0c4ee96e709bab2121562d2ccf9cee0c646bc
+  sha256: 2888ed82321f19eee97304bf0e260ade2f11e81a298bb57a7a50809afb58ba20
 
 build:
   noarch: python

--- a/recipes/nfit/recipe.yaml
+++ b/recipes/nfit/recipe.yaml
@@ -1,0 +1,72 @@
+context:
+  version: "0.89.13"
+
+package:
+  name: nfit
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/n/nfit/nfit-${{ version }}.tar.gz
+  sha256: ff1429559901cff444f1765ed8b0c4ee96e709bab2121562d2ccf9cee0c646bc
+
+build:
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+  number: 0
+
+requirements:
+  host:
+    - python >=3.12
+    - pip
+    - setuptools >=77.0.3
+    - wheel
+  run:
+    - python >=3.12
+    - packaging >=25
+    - certifi >=2026.7.22
+    - numpy >=2.5
+    - scipy >=1.18
+    - matplotlib-base >=3.11.1
+    - colorcet >=3.1
+    - cmcrameri >=1.10
+    - cmocean >=4.0.3
+    - palettable >=3.3.3
+    - h5py >=3.16
+    - pyside6 >=6.11.2
+    - emcee >=3.1
+    - gemmi >=0.6
+    - ase >=3.23
+    - seekpath >=2.2
+    - threadpoolctl >=3.1
+    - pyvista >=0.48.4
+    - pyvistaqt >=0.13.1
+    - imageio >=2.31
+    - imageio-ffmpeg >=0.4
+
+tests:
+  - python:
+      imports:
+        - nfit
+        - nfit.project_gui
+      # cmcrameri 1.10 reports 0.0.0 through Python package metadata in its
+      # conda-forge build, so pip check incorrectly treats it as too old.
+      pip_check: false
+  - script:
+      - python -c "from importlib.metadata import version; assert version('nfit') == '${{ version }}'"
+      - python -c "import shutil; assert shutil.which('nfit')"
+
+about:
+  homepage: https://github.com/pmneves7/nfit
+  summary: Reduced magnetic-scattering analysis for nearly magnetic metals
+  description: |
+    nfit is experimental beta software for analyzing magnetic neutron-scattering
+    and related bulk measurements. Paul M. Neves developed nfit with assistance
+    from AI coding tools.
+  license: MIT
+  license_file: LICENSE
+  documentation: https://nfit.readthedocs.io/
+  repository: https://github.com/pmneves7/nfit
+
+extra:
+  recipe-maintainers:
+    - pmneves7


### PR DESCRIPTION
nfit is experimental beta software for magnetic neutron-scattering and related bulk measurements.

The recipe builds the published PyPI sdist as a noarch Python package and verifies the package imports, published version, and `nfit` command. Its runtime dependencies solve together on conda-forge.

Local validation with `rattler-build` passed on macOS arm64, including both import tests and command discovery. `pip_check` is disabled because conda-forge's `cmcrameri` 1.10 package reports Python distribution metadata version 0.0.0, which causes a false dependency-version failure.

The project is public at https://github.com/pmneves7/nfit and the release is published at https://pypi.org/project/nfit/0.89.13/.
