### PR TITLE
Adding fluidtop

### DIFF
--- a/recipes/fluidtop/recipe.yaml
+++ b/recipes/fluidtop/recipe.yaml
@@ -1,0 +1,60 @@
+context:
+  version: "0.1.5"
+
+package:
+  name: fluidtop
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/f/fluidtop/fluidtop-${{ version }}.tar.gz
+  sha256: c28a0c060f6bd9bb323abbf70a72ff4b3607c48d9b858c7c94d41143a8511936
+
+build:
+  number: 0
+  # fluidtop reads Apple Silicon hardware counters via powermetrics
+  skip: not (osx and arm64)
+  python:
+    entry_points:
+      - fluidtop=fluidtop.fluidtop:main
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
+  run:
+    - python
+    - click >=8.2.0
+    - psutil >=7.0.0
+    - textual >=3.0.0
+    - textual-plotext >=1.0.0
+    - plotext
+
+tests:
+  - python:
+      imports:
+        - fluidtop
+      pip_check: true
+  - script:
+      - fluidtop --help
+
+about:
+  homepage: https://github.com/FluidInference/fluidtop
+  repository: https://github.com/FluidInference/fluidtop
+  documentation: https://github.com/FluidInference/fluidtop#readme
+  summary: Real-time hardware performance monitoring for Apple Silicon with AI workload focus
+  description: |
+    fluidtop is a terminal-based performance monitor for Apple Silicon Macs
+    (M1/M2/M3/M4). It reports CPU, GPU, Apple Neural Engine, memory and power
+    usage in real time, with a focus on AI/ML workloads. It is an enhanced
+    alternative to asitop.
+
+    Most metrics come from macOS' powermetrics, so fluidtop should be run with
+    sudo to get full readings.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - pavelzw


### PR DESCRIPTION
Adds a recipe for [fluidtop](https://github.com/FluidInference/fluidtop), a terminal-based real-time
performance monitor for Apple Silicon Macs (CPU/GPU/ANE/memory/power), built from the PyPI sdist.

The package is pure Python but macOS/Apple-Silicon-only (it parses `powermetrics` output and reads
Apple Silicon SoC info via `sysctl`), so it is not `noarch: python`; it is restricted to osx-arm64
via `skip: not (osx and arm64)` so it cannot be installed where it would not work.

Checklist

- [x] Title of this PR is meaningful: e.g. "Adding my_nifty_package", not "updated recipe".
- [x] Recipe uses the v1 `recipe.yaml` format, or this PR explains the exceptional requirement for deprecated v0.
- [x] License file is packaged (see the [v1 example recipe](https://github.com/conda-forge/staged-recipes/blob/main/recipes/example-v1/recipe.yaml) for an example).
- [x] Source is from official source.
- [x] Package does not vendor other packages. (If a package uses the source of another package, they should be separate packages or the licenses of all packages need to be packaged).
- [x] If static libraries are linked in, the license of the static library is packaged.
- [x] Package does not ship static libraries. If static libraries are needed, [follow CFEP-18](https://github.com/conda-forge/cfep/blob/main/cfep-18.md).
- [x] Build number is 0.
- [x] A tarball (`url`) rather than a repo (e.g. `git_url`) is used in your recipe (see [here](https://conda-forge.org/docs/maintainer/adding_pkgs.html#build-from-tarballs-not-repos) for more details).
- [x] GitHub users listed in the maintainer section have posted a comment confirming they are willing to be listed there.
- [x] When in trouble, please check our [knowledge base documentation](https://conda-forge.org/docs/maintainer/knowledge_base.html) before pinging a team.
