### PR TITLE
Add skgrad

### DIFF
--- a/recipes/skgrad/recipe.yaml
+++ b/recipes/skgrad/recipe.yaml
@@ -1,0 +1,63 @@
+schema_version: 1
+
+context:
+  version: "0.1.6"
+
+package:
+  name: skgrad
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/s/skgrad/skgrad-${{ version }}.tar.gz
+  sha256: 826663ef4efb5e290e59f8572ade2dcfd3da9fb9e8296c416ee89e97991bc779
+
+build:
+  noarch: python
+  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python ${{ python_min }}.*
+    - pip
+    - setuptools >=77
+  run:
+    - python >=${{ python_min }}
+    - numpy >=1.23
+    - scikit-learn >=1.2
+    - scipy >=1.3.2
+    - threadpoolctl >=3.1
+
+tests:
+  - python:
+      imports:
+        - skgrad
+      python_version:
+        - ${{ python_min }}.*
+        - '*'
+      pip_check: true
+  - script: python run_test.py
+    requirements:
+      run:
+        - python ${{ python_min }}.*
+    files:
+      recipe:
+        - run_test.py
+
+about:
+  homepage: https://github.com/LudgerHentschel/skgrad
+  repository: https://github.com/LudgerHentschel/skgrad
+  documentation: https://ludgerhentschel.github.io/skgrad/
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Analytic input gradients and Jacobians for fitted scikit-learn models.
+  description: |
+    skgrad computes analytic input derivatives for supported fitted scikit-learn
+    linear models, kernel SVMs, multilayer perceptrons, and preprocessing
+    pipelines. Classification derivatives use decision scores or logits rather
+    than probabilities. It supports local sensitivity analysis and supplies
+    gradients for downstream Integrated Gradients attribution.
+
+extra:
+  recipe-maintainers:
+    - LudgerHentschel

--- a/recipes/skgrad/run_test.py
+++ b/recipes/skgrad/run_test.py
@@ -1,0 +1,24 @@
+"""Check installed-package score semantics and preprocessing derivatives."""
+import numpy as np
+from sklearn.linear_model import LogisticRegression, Ridge
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
+
+import skgrad
+
+X = np.array([[-2., 1.], [-1., -1.], [1., 2.], [2., -2.]])
+classifier = LogisticRegression().fit(X, [0, 0, 1, 1])
+values, jacobian = skgrad.value_and_jacobian(classifier, X)
+np.testing.assert_allclose(values[:, 0], classifier.decision_function(X))
+np.testing.assert_allclose(
+    jacobian[:, 0, :], np.broadcast_to(classifier.coef_[0], X.shape)
+)
+np.testing.assert_allclose(skgrad.input_gradient(classifier, X), jacobian[:, 0, :])
+
+pipeline = make_pipeline(StandardScaler(), Ridge()).fit(X, X @ [2., -3.])
+expected_gradient = pipeline[-1].coef_ / pipeline[0].scale_
+np.testing.assert_allclose(
+    skgrad.input_gradient(pipeline, X), np.broadcast_to(expected_gradient, X.shape)
+)
+np.testing.assert_allclose(skgrad.model_output(pipeline, X)[:, 0], pipeline.predict(X))
+print("skgrad score and pipeline gradient checks passed")


### PR DESCRIPTION
Add skgrad 0.1.6 as a noarch Python package from the official PyPI source archive with a verified SHA-256 checksum.

Validation passed: conda-forge recipe lint; local macOS arm64 rattler-build; imports and pip checks on Python 3.11 and 3.14; installed-package checks for classification scores and pipeline gradients.

Runtime dependencies: NumPy, SciPy, scikit-learn, threadpoolctl. BSD-3-Clause license file included. No vendored packages or static libraries; build number 0. Uses the v1 recipe format. Other platforms remain for CI.

I am the package author and confirm that I am willing to maintain this recipe as LudgerHentschel.

## Checklist

- [x] The pull request title is meaningful.
- [x] The recipe uses the v1 `recipe.yaml` format.
- [x] The BSD-3-Clause license file is included.
- [x] The source is the official PyPI release tarball.
- [x] The package does not vendor other packages.
- [x] The package does not link or ship static libraries.
- [x] The build number is 0.
- [x] The source uses a tarball URL rather than a Git checkout.
- [x] I confirm that I am willing to maintain the recipe as LudgerHentschel.
- [x] The conda-forge contribution guidance has been reviewed.