### PR TITLE
Add grads

### DIFF
--- a/recipes/grads/0001-cross-platform-build.patch
+++ b/recipes/grads/0001-cross-platform-build.patch
@@ -1055,3 +1055,41 @@ index 0000000..1ec0ae2
 +HIST_ENTRY *remove_history(int which);
 +
 +#endif
+diff --git a/data/UDUNITS2-COPYRIGHT b/data/UDUNITS2-COPYRIGHT
+new file mode 100644
+index 0000000..36e1810
+--- /dev/null
++++ b/data/UDUNITS2-COPYRIGHT
+@@ -0,0 +1,32 @@
++Copyright 2014 University Corporation for Atmospheric Research and contributors.
++All rights reserved.
++
++This software was developed by the Unidata Program Center of the
++University Corporation for Atmospheric Research (UCAR)
++<http://www.unidata.ucar.edu>.
++
++Redistribution and use in source and binary forms, with or without modification,
++are permitted provided that the following conditions are met:
++
++   1) Redistributions of source code must retain the above copyright notice,
++      this list of conditions and the following disclaimer.
++   2) Redistributions in binary form must reproduce the above copyright notice,
++      this list of conditions and the following disclaimer in the documentation
++      and/or other materials provided with the distribution.
++   3) Neither the names of the development group, the copyright holders, nor the
++      names of contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++   4) This license shall terminate automatically and you may no longer exercise
++      any of the rights granted to you by this license as of the date you
++      commence an action, including a cross-claim or counterclaim, against
++      the copyright holders or any contributor alleging that this software
++      infringes a patent. This termination provision shall not apply for an
++      action alleging patent infringement by combinations of this software with
++      other software or hardware.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
++FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS
++OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
++CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.

--- a/recipes/grads/0001-cross-platform-build.patch
+++ b/recipes/grads/0001-cross-platform-build.patch
@@ -1,0 +1,1057 @@
+diff --git a/configure.ac b/configure.ac
+index fc7338d..274e608 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -171,6 +171,11 @@ echo ---------------------------------------------------------
+ 
+ AC_CHECK_LIB(m,cos,, AC_MSG_ERROR([Fatal: Math library not found]))
+ AC_PATH_XTRA
++AC_SEARCH_LIBS([dlopen], [dl],
++  [DLOPEN_LIBS="$ac_cv_search_dlopen"],
++  [AC_MSG_ERROR([Fatal: dynamic loading support not found])])
++AS_IF([test "x$DLOPEN_LIBS" = "xnone required"], [DLOPEN_LIBS=""])
++AC_SUBST([DLOPEN_LIBS])
+ 
+ echo
+ 
+@@ -544,10 +549,14 @@ if test "Z$ga_supplib_dir" != "Z" ; then
+   echo looking in $ga_supplib_dir 
+     GA_SET_FLAGS([])
+     AC_CHECK_HEADER(grib2.h,
+-    [ AC_CHECK_LIB([grib2c], [main], 
+-      [ use_grib2=yes 
+-#        GA_SET_LIB_VAR([grib2_libs], [grib2c jasper png z])
++    [ AC_CHECK_LIB([grib2c], [main],
++      [ use_grib2=yes
+         GA_SET_DYNLIB_VAR([grib2_libs], [grib2c jasper png z])
++      ],
++      [ AC_CHECK_LIB([g2c], [main],
++        [ use_grib2=yes
++          GA_SET_DYNLIB_VAR([grib2_libs], [g2c jasper png z])
++        ])
+       ])
+     ])
+     GA_UNSET_FLAGS
+diff --git a/m4/grib2.m4 b/m4/grib2.m4
+index af4b655..a6f13b1 100644
+--- a/m4/grib2.m4
++++ b/m4/grib2.m4
+@@ -4,17 +4,19 @@ AC_DEFUN([GA_CHECK_LIB_GRIB2],
+ [
+   ga_check_grib2="no"
+   AC_CHECK_HEADER(grib2.h,
+-  [ AC_CHECK_LIB(grib2c, main, [
+-    AC_CHECK_LIB([png15], [main], [
+-    AC_CHECK_LIB([z], [compress], [
+-    AC_CHECK_LIB([jpeg], [main], [
+-    AC_CHECK_LIB([jasper], [main], [
+-      ga_check_grib2="yes"
+-      G2_LIBS="-lgrib2c -ljasper -lpng15 -lz"
+-    ])
+-    ])
+-    ])
+-    ])
++  [ AC_CHECK_LIB([grib2c], [main],
++      [ga_grib2_library="grib2c"],
++      [AC_CHECK_LIB([g2c], [main], [ga_grib2_library="g2c"],
++                    [ga_grib2_library=""])])
++    AS_IF([test "x$ga_grib2_library" != "x"], [
++      AC_CHECK_LIB([png], [png_create_read_struct], [
++      AC_CHECK_LIB([z], [compress], [
++      AC_CHECK_LIB([jasper], [jas_init], [
++        ga_check_grib2="yes"
++        G2_LIBS="-l$ga_grib2_library -ljasper -lpng -lz"
++      ])
++      ])
++      ])
+     ])
+   ])
+   if test $ga_check_grib2 = "yes" ; then
+diff --git a/src/Makefile.am b/src/Makefile.am
+index 21c49be..0daf52d 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -49,7 +49,7 @@ libgxdummy_la_SOURCES  = gxdummy.c
+ libgxdX11_la_SOURCES   = gxX11.c 
+ 
+ ## GrADS source files to be compiled
+-grads_SOURCES =	grads.c  gxsubs.c gxmeta.c  gxchpl.c gxcntr.c gxstrm.c gxdb.c \
++grads_SOURCES =	grads.c ga_dynload.c gxsubs.c gxmeta.c  gxchpl.c gxcntr.c gxstrm.c gxdb.c \
+ 		gxwmap.c gxshad.c gxshad2.c gaexpr.c gafunc.c gautil.c gagx.c \
+ 		gscrpt.c gamach.c gatxt.c   galloc.c gaddes.c gacfg.c  gaio.c \
+                 gauser.c gasdf.c  bufrstn.c gabufr.c gabufrtbl.c \
+@@ -66,7 +66,7 @@ EXTRA_grads_SOURCES = gagmap.c gagui.c gsgui.c dodstn.c \
+ 
+ ## Headers must be listed here to be included in the distribution.
+ ## The "noinst_" prefix prevents "make install" from trying to do anything with them
+-hdr_core  = grads.h  gatypes.h bitmaps.h bitmaps2.h gvt.h wx.h gs.h
++hdr_core  = grads.h gatypes.h ga_dynload.h bitmaps.h bitmaps2.h gvt.h wx.h gs.h
+ hdr_ga    = gagmap.h gagui.h gabufr.h gasdf.h gasdf_std_time.h 
+ hdr_gx    = gx.h gxGD.h gxC.h gxmap.h 
+ 
+@@ -97,7 +97,7 @@ AM_CPPFLAGS		= -I. -I$(supp_include_dir) $(gui_inc) $(nc_inc) \
+ ## libraries needed
+ grads_LDADD	      = $(common_ldadd) $(readline_libs) $(grib2_libs) \
+ 			$(hdf_libs) $(hdf5_libs) $(nc_libs) $(geotiff_libs) \
+-			$(shp_libs) $(gadap_libs) $(gui_libs) -ldl 
++			$(shp_libs) $(gadap_libs) $(gui_libs) $(DLOPEN_LIBS)
+ 
+ # print with GD
+ if USEGD
+@@ -131,7 +131,7 @@ libgxdummy_la_CPPFLAGS = -I.
+ ##---------------------------------------------------------------------
+ ## GradsPy 
+ 
+-libgradspy_la_SOURCES  = grads.c gxsubs.c gxmeta.c  gxchpl.c gxcntr.c gxstrm.c gxdb.c \
++libgradspy_la_SOURCES  = grads.c ga_dynload.c gxsubs.c gxmeta.c  gxchpl.c gxcntr.c gxstrm.c gxdb.c \
+ 		gxwmap.c gxshad.c gxshad2.c gaexpr.c gafunc.c gautil.c gagx.c \
+ 		gscrpt.c gamach.c gatxt.c   galloc.c gaddes.c gacfg.c  gaio.c \
+                 gauser.c gasdf.c  bufrstn.c gabufr.c gabufrtbl.c \
+@@ -147,7 +147,7 @@ libgradspy_la_CPPFLAGS = -I. -I$(SUPPLIBS)/include $(gui_inc) $(geotiff_inc) \
+                          $(shp_inc) $(gadap_inc) $(X_CFLAGS) $(XAW_CFLAGS) 
+ libgradspy_la_LIBADD   = $(common_ldadd) $(readline_libs) $(grib2_libs) \
+ 			 $(hdf_libs) $(hdf5_libs) $(nc_libs) $(geotiff_libs) \
+-			 $(shp_libs) $(gadap_libs) $(gui_libs) 
++			 $(shp_libs) $(gadap_libs) $(gui_libs) $(DLOPEN_LIBS)
+ libgradspy_la_LDFLAGS  = -version-info $(LIBGX_VERSION)
+ 
+ 
+@@ -195,4 +195,3 @@ grib2scan_LDADD	       = gautil.sa.o gatxt.o $(LDADD) $(readline_libs)
+ 
+ ## bufrscan
+ bufrscan_SOURCES       = bufrscan.c gabufr.c gabufrtbl.c gamach.c
+-
+diff --git a/src/gafunc.c b/src/gafunc.c
+index 6deb55f..6bf33db 100644
+--- a/src/gafunc.c
++++ b/src/gafunc.c
+@@ -16,7 +16,7 @@
+ #include <math.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+-#include <dlfcn.h>
++#include "ga_dynload.h"
+ #include <string.h>
+ #include "grads.h"
+ 
+@@ -7200,7 +7200,7 @@ size_t sz;
+ 
+ gaint ffudpi (struct gafunc *pfc, struct gastat *pst2, struct gaupb *upb) {
+ struct gaudpinfo *pudpinfo;
+-void *handle;
++ga_dlhandle handle;
+ char *error;
+ gaint rc;
+ gaint (*pfunc)(struct gafunc *, struct gastat *, struct gaudpinfo *);
+@@ -7212,15 +7212,15 @@ gaint (*pfunc)(struct gafunc *, struct gastat *, struct gaudpinfo *);
+ 
+   /* load the shared object file and get the function pointer */
+   if (upb->pfunc == NULL) {
+-    handle = dlopen(upb->fname,RTLD_LAZY);
++    handle = ga_dlopen(upb->fname,GA_RTLD_LAZY);
+     if (handle==NULL) {
+       snprintf (pout,1255,"Error: dlopen failed to get a handle on %s \n",upb->fname);
+       gaprnt (0,pout);
+       return (1);
+     }
+-    dlerror();
+-    pfunc = dlsym(handle,upb->alias);
+-    if ((error=dlerror()) != NULL) {
++    ga_dlerror();
++    pfunc = ga_dlsym(handle,upb->alias);
++    if ((error=(char *)ga_dlerror()) != NULL) {
+       snprintf (pout,1255,"Error: dlsym failed to load %s \n%s \n",upb->alias,error);
+       gaprnt (0,pout);
+       return (1);
+diff --git a/src/gagmap.c b/src/gagmap.c
+index 5386218..03e1714 100644
+--- a/src/gagmap.c
++++ b/src/gagmap.c
+@@ -40,7 +40,11 @@
+ #include <stdlib.h>
+ #include <stddef.h>
+ #include <string.h>
++#ifdef _WIN32
++#include <io.h>
++#else
+ #include <unistd.h>
++#endif
+ #include <sys/types.h>
+ #include "grads.h"
+ #include "gagmap.h"
+diff --git a/src/gasdf.c b/src/gasdf.c
+index 45383e3..1b90213 100644
+--- a/src/gasdf.c
++++ b/src/gasdf.c
+@@ -22,7 +22,11 @@
+ #define DFLTORIGIN " since 1-1-1 00:00:0.0"
+ 
+ #include <stdlib.h>
++#ifdef _WIN32
++#include <io.h>
++#else
+ #include <unistd.h>
++#endif
+ #include <stdio.h>
+ #include <string.h>
+ #include <math.h>
+diff --git a/src/gauser.c b/src/gauser.c
+index 45f0f1c..8f75d2b 100644
+--- a/src/gauser.c
++++ b/src/gauser.c
+@@ -2102,6 +2102,11 @@ char *mbuf, *ch;
+    return (mbuf);
+ }
+ 
++/* Release a command result in the same C runtime that allocated it. */
++void gapystrfree (void *buffer) {
++  free(buffer);
++}
++
+ /* Handle exec command.  Read exec file, then recursively
+    call gacmd.  */
+ 
+diff --git a/src/gautil.c b/src/gautil.c
+index 2af8682..2ad182c 100644
+--- a/src/gautil.c
++++ b/src/gautil.c
+@@ -2394,9 +2394,11 @@ off_t ftello(FILE *stream) {
+ 
+ #if READLINE==1
+ #include <sys/types.h>
++#ifndef _WIN32
+ #include <sys/file.h>
+ #include <sys/stat.h>
+ #include <sys/errno.h>
++#endif
+ #include <readline/readline.h>
+ #include <readline/history.h>
+ 
+diff --git a/src/grads.c b/src/grads.c
+index a9cc186..73164dc 100644
+--- a/src/grads.c
++++ b/src/grads.c
+@@ -314,7 +314,7 @@ int main (int argc, char *argv[])  {
+   /* Inform gaio.c what the global scale factor for netcdf4/hdf5 cache */
+   setcachesf(gcmn.cachesf);
+ 
+-#if !defined(__CYGWIN32__) && !defined(__GO32__)
++#if !defined(_WIN32) && !defined(__CYGWIN32__) && !defined(__GO32__)
+   signal(CPULIMSIG, gasigcpu) ;  /* CPU time limit signal; just exit */
+ #endif
+   
+@@ -816,4 +816,3 @@ struct gaupb *upb;
+   }
+   return (NULL);
+ }
+-
+diff --git a/src/grads.h b/src/grads.h
+index 5963d26..569a43c 100644
+--- a/src/grads.h
++++ b/src/grads.h
+@@ -37,7 +37,9 @@
+ #define RPTNUM 200
+ #define BLKNUM 50000
+ 
+-#ifdef __hpux
++#ifdef _WIN32
++#define CPULIMSIG SIGTERM
++#elif defined(__hpux)
+ #define CPULIMSIG _SIGXCPU
+ #else
+ #define CPULIMSIG SIGXCPU
+@@ -879,6 +881,7 @@ gaint gadraw (char *, struct gacmn *);
+ gaint gardrw (char *, struct gacmn *);
+ gaint gaexec (char *, struct gacmn *);
+ char *gagsdo (char *, gaint *);
++void gapystrfree (void *);
+ gaint gadef (char *, struct gacmn *, gaint);
+ gaint gaudef (char *, struct gacmn *);
+ gaint gamodf (char *, struct gacmn *);
+diff --git a/src/gradspy.c b/src/gradspy.c
+index ad71ac5..5786f61 100644
+--- a/src/gradspy.c
++++ b/src/gradspy.c
+@@ -12,10 +12,13 @@
+ #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+ #include <Python.h>
+ #include <numpy/arrayobject.h>
+-#include <dlfcn.h>
++#include "ga_dynload.h"
+ #include <stdio.h>
+ #include "gradspy.h"
+ 
++#define dlerror ga_dlerror
++#define dlsym ga_dlsym
++
+ static int gapyerror;
+ static int gapystart;
+ 
+@@ -78,7 +81,7 @@ static PyObject* cmd(PyObject* self,PyObject *args) {
+   
+   if (rc<0) exit(0);
+   resstr = Py_BuildValue("s", str);
+-  free(str);
++  (*pystrfree)(str);
+   return resstr;
+ }
+ 
+@@ -588,7 +591,7 @@ static struct PyModuleDef moduledef = {
+ PyMODINIT_FUNC PyInit_gradspy(void) {
+ 
+   PyObject *m;
+-  void *handle;
++  ga_dlhandle handle;
+   char *libname=NULL;
+   const char *error;
+ 
+@@ -601,20 +604,26 @@ PyMODINIT_FUNC PyInit_gradspy(void) {
+      Using an environment variable called $GAGPY to override the default (.so for unix), 
+      and added a comment in the error message to inform users how to set it. */ 
+ 
+-  if ((libname = getenv("GAGPY"))==NULL) 
+-    handle = dlopen ("libgradspy.so", RTLD_LAZY | RTLD_GLOBAL );
++  if ((libname = getenv("GAGPY"))==NULL)
++#ifdef _WIN32
++    handle = ga_dlopen ("gradspy.dll", GA_RTLD_LAZY | GA_RTLD_GLOBAL );
++#elif defined(__APPLE__)
++    handle = ga_dlopen ("libgradspy.dylib", GA_RTLD_LAZY | GA_RTLD_GLOBAL );
++#else
++    handle = ga_dlopen ("libgradspy.so", GA_RTLD_LAZY | GA_RTLD_GLOBAL );
++#endif
+   else
+-    handle = dlopen (libname, RTLD_LAZY | RTLD_GLOBAL );  
++    handle = ga_dlopen (libname, GA_RTLD_LAZY | GA_RTLD_GLOBAL );
+ 
+   if (!handle) {
+-    fputs (dlerror(), stderr);
++    fputs (ga_dlerror(), stderr);
+     fputs ("\n", stderr);
+     fputs ("Use the environment variable $GAGPY to specify the shared object filename if different from `libgradspy.so`\n", stderr);
+     goto err; 
+   } 
+   else {
+-    pgainit = dlsym(handle, "gamain");    /* starts GrADS */
+-    if ((error = dlerror()) != NULL)  {
++    pgainit = ga_dlsym(handle, "gamain");    /* starts GrADS */
++    if ((error = ga_dlerror()) != NULL)  {
+       fputs(error, stderr);
+       fputs ("\n", stderr);
+       goto err;
+@@ -625,6 +634,12 @@ PyMODINIT_FUNC PyInit_gradspy(void) {
+       fputs ("\n", stderr);
+       goto err;
+     }
++    pystrfree = dlsym(handle, "gapystrfree"); /* releases command output */
++    if ((error = dlerror()) != NULL)  {
++      fputs(error, stderr);
++      fputs("\n", stderr);
++      goto err;
++    }
+     pdoexpr = dlsym(handle, "gadoexpr");  /* evaluates an expression */
+     if ((error = dlerror()) != NULL)  {
+       fputs(error, stderr);
+diff --git a/src/gradspy.h b/src/gradspy.h
+index 4196ec2..028be83 100644
+--- a/src/gradspy.h
++++ b/src/gradspy.h
+@@ -24,3 +24,4 @@ static int   (*pdoexpr)(char *,struct pygagrid *);
+ static int   (*pdoget)(char *,struct pygagrid *);
+ static int   (*psetup)(char *,struct pygagrid *);
+ static void  (*pyfre)(struct pygagrid *);
++static void  (*pystrfree)(void *);
+diff --git a/src/gradspy.py b/src/gradspy.py
+index 2060e38..64f41f2 100644
+--- a/src/gradspy.py
++++ b/src/gradspy.py
+@@ -2,7 +2,7 @@
+ gradspy - Python interface to GrADS using ctypes + xarray.
+ 
+ Provides the :class:`GrADS` class for interacting with the GrADS (Grid
+-Analysis and Display System) engine via its shared library (libgradspy.so).
++Analysis and Display System) engine via its shared library.
+ All grid results are returned as :class:`xarray.DataArray` objects with
+ named dimension coordinates (``lon``, ``lat``, ``lev``, ``time``,
+ ``ensemble``).  Non-varying dimensions are attached as scalar coordinates
+@@ -12,7 +12,8 @@ The library to load is resolved in this order:
+ 
+ 1. The ``lib`` argument to :class:`GrADS`.
+ 2. The ``$GAGPY`` environment variable.
+-3. ``libgradspy.so`` on the system library path.
++3. The platform default (``libgradspy.so``, ``libgradspy.dylib``, or
++   ``gradspy.dll``) on the system library path.
+ 
+ Typical usage::
+ 
+@@ -36,6 +37,7 @@ more information.
+ 
+ import ctypes
+ import os
++import sys
+ from typing import Optional
+ 
+ import numpy as np
+@@ -135,16 +137,21 @@ class GrADS:
+         Parameters
+         ----------
+         lib : str, optional
+-            Full path to ``libgradspy.so``.  Falls back to ``$GAGPY``, then
+-            ``libgradspy.so`` on the system library path.
++            Full path to the GradsPy shared library. Falls back to ``$GAGPY``,
++            then the platform-specific library name on the system path.
+         """
+-        lib_path = lib or os.environ.get("GAGPY", "libgradspy.so")
+-        self._lib = ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
++        if sys.platform == "win32":
++            default_library = "gradspy.dll"
++        elif sys.platform == "darwin":
++            default_library = "libgradspy.dylib"
++        else:
++            default_library = "libgradspy.so"
+ 
+-        # libc free() for releasing strings malloc'd inside GrADS
+-        self._free = ctypes.CDLL(None).free
+-        self._free.argtypes = [ctypes.c_void_p]
+-        self._free.restype  = None
++        lib_path = lib or os.environ.get("GAGPY", default_library)
++        if sys.platform == "win32":
++            self._lib = ctypes.CDLL(lib_path)
++        else:
++            self._lib = ctypes.CDLL(lib_path, mode=ctypes.RTLD_GLOBAL)
+ 
+         self._setup_signatures()
+         self._started = False
+@@ -198,7 +205,7 @@ class GrADS:
+         if not ptr:
+             return ""
+         text = ctypes.cast(ptr, ctypes.c_char_p).value.decode()
+-        self._free(ptr)
++        self._lib.gapystrfree(ptr)
+         return text
+ 
+     def result(self, expr: str) -> xr.DataArray:
+@@ -387,6 +394,9 @@ class GrADS:
+         lib.gagsdo.restype   = ctypes.c_void_p   # malloc'd; freed after copy
+         lib.gagsdo.argtypes  = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_int)]
+ 
++        lib.gapystrfree.restype  = None
++        lib.gapystrfree.argtypes = [ctypes.c_void_p]
++
+         lib.gadoexpr.restype  = ctypes.c_int
+         lib.gadoexpr.argtypes = [ctypes.c_char_p, ctypes.POINTER(_PyGaGrid)]
+ 
+@@ -613,4 +623,3 @@ class GrADS:
+                 pygr.tincr = (t1.year - t0.year) * 12 + (t1.month - t0.month)
+         else:
+             pygr.tincr = 1
+-
+diff --git a/src/gxsubs.c b/src/gxsubs.c
+index 343d63c..140f13c 100644
+--- a/src/gxsubs.c
++++ b/src/gxsubs.c
+@@ -22,10 +22,14 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <math.h>
+-#include <dlfcn.h>
++#include "ga_dynload.h"
+ #include "gatypes.h"
+ #include "gx.h"
+ 
++/* Keep the symbol-table initialization below readable. */
++#define dlerror ga_dlerror
++#define dlsym ga_dlsym
++
+ char *gaqupb (char *, gaint);
+ void gree (void *, char *);
+ 
+@@ -110,7 +114,7 @@ gaint gxstrt (gadouble xmx, gadouble ymx, gaint batch, gaint hbufsz, char *gxdop
+ 
+ /* Loads the graphics back end shared libraries and define the required subroutines */
+ gaint gxload(char *gxdopt, char *gxpopt) {
+-  void *phandle=NULL,*dhandle=NULL; 
++  ga_dlhandle phandle=NULL,dhandle=NULL;
+   const char *err=NULL,*dname=NULL,*pname=NULL;
+   char *cname=NULL;
+   FILE *cfile;
+@@ -147,11 +151,11 @@ gaint gxload(char *gxdopt, char *gxpopt) {
+     printf("  Please read the documentation at https://wetterzentrale.de/grads/docs/plugins.html\n");
+     return(1);
+   }
+-  dlerror();
+-  dhandle = dlopen (dname, RTLD_LAZY | RTLD_GLOBAL);
++  ga_dlerror();
++  dhandle = ga_dlopen (dname, GA_RTLD_LAZY | GA_RTLD_GLOBAL);
+   if (!dhandle) {
+     printf("GX Package Error: dlopen failed to get a a handle on gxdisplay plug-in named \"%s\" \n",gxdopt); 
+-    if ((err=dlerror())!=NULL) printf("   %s\n",err); 
++    if ((err=ga_dlerror())!=NULL) printf("   %s\n",err);
+     return(2);
+   }
+ 
+@@ -187,11 +191,11 @@ gaint gxload(char *gxdopt, char *gxpopt) {
+     printf("  Please read the documentation at https://wetterzentrale.de/grads/docs/plugins.html\n");
+     return(1);
+   }
+-  dlerror();
+-  phandle = dlopen (pname, RTLD_LAZY);
++  ga_dlerror();
++  phandle = ga_dlopen (pname, GA_RTLD_LAZY);
+   if (!phandle) {
+     printf("GX Package Error: dlopen failed to get a handle on gxprint plug-in named \"%s\" \n",gxpopt); 
+-    if ((err=dlerror())!=NULL) printf("   %s\n",err); 
++    if ((err=ga_dlerror())!=NULL) printf("   %s\n",err);
+     return(1);
+   }
+   
+diff --git a/src/setup.py b/src/setup.py
+index 1f6d32c..439b11d 100644
+--- a/src/setup.py
++++ b/src/setup.py
+@@ -1,3 +1,3 @@
+ from distutils.core import setup, Extension
+ setup(name='gradspy', version='1.1',  \
+-      ext_modules=[Extension('gradspy', ['gradspy.c'])])
++      ext_modules=[Extension('gradspy', ['gradspy.c', 'ga_dynload.c'])])
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+new file mode 100644
+index 0000000..0ffba3b
+--- /dev/null
++++ b/CMakeLists.txt
+@@ -0,0 +1,152 @@
++cmake_minimum_required(VERSION 3.24)
++project(GrADS VERSION 2.2.3 LANGUAGES C)
++
++if(NOT WIN32)
++  message(FATAL_ERROR "The CMake build currently targets native Windows; use configure/make on Unix")
++endif()
++
++include(GNUInstallDirs)
++set(CMAKE_C_STANDARD 99)
++set(CMAKE_C_STANDARD_REQUIRED ON)
++set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
++
++set(GRADS_VERSION "${PROJECT_VERSION}")
++set(GRADS_GENERATED_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
++file(MAKE_DIRECTORY "${GRADS_GENERATED_DIR}")
++configure_file(cmake/config.h.in "${GRADS_GENERATED_DIR}/config.h" @ONLY)
++file(WRITE "${GRADS_GENERATED_DIR}/buildinfo.h"
++  "static char *buildinfo = \"Configured with CMake ${CMAKE_VERSION} for native Windows\";\n")
++
++set(GRADS_PREFIX "$ENV{LIBRARY_PREFIX}")
++if(NOT GRADS_PREFIX)
++  set(GRADS_PREFIX "$ENV{PREFIX}")
++endif()
++
++set(GRADS_INCLUDE_HINTS
++  "${GRADS_PREFIX}/include"
++  "${GRADS_PREFIX}/include/cairo"
++  "${GRADS_PREFIX}/include/freetype2"
++  "${GRADS_PREFIX}/include/geotiff"
++  "${GRADS_PREFIX}/include/hdf4"
++  "${GRADS_PREFIX}/include/hdf5"
++  "${GRADS_PREFIX}/include/libxml2")
++set(GRADS_LIBRARY_HINTS "${GRADS_PREFIX}/lib" "${GRADS_PREFIX}/bin")
++
++function(grads_find_library variable)
++  find_library(${variable} NAMES ${ARGN} HINTS ${GRADS_LIBRARY_HINTS} REQUIRED)
++  set(${variable} "${${variable}}" PARENT_SCOPE)
++endfunction()
++
++find_path(GRADS_NETCDF_INCLUDE netcdf.h HINTS ${GRADS_INCLUDE_HINTS} REQUIRED)
++find_path(GRADS_HDF4_INCLUDE mfhdf.h HINTS ${GRADS_INCLUDE_HINTS} PATH_SUFFIXES hdf4 REQUIRED)
++find_path(GRADS_HDF5_INCLUDE hdf5.h HINTS ${GRADS_INCLUDE_HINTS} PATH_SUFFIXES hdf5 REQUIRED)
++find_path(GRADS_UDUNITS_INCLUDE udunits2.h HINTS ${GRADS_INCLUDE_HINTS} REQUIRED)
++find_path(GRADS_GRIB2_INCLUDE grib2.h HINTS ${GRADS_INCLUDE_HINTS} REQUIRED)
++find_path(GRADS_GEOTIFF_INCLUDE geotiff.h HINTS ${GRADS_INCLUDE_HINTS} PATH_SUFFIXES geotiff REQUIRED)
++find_path(GRADS_SHAPE_INCLUDE shapefil.h HINTS ${GRADS_INCLUDE_HINTS} REQUIRED)
++find_path(GRADS_CAIRO_INCLUDE cairo.h HINTS ${GRADS_INCLUDE_HINTS} PATH_SUFFIXES cairo REQUIRED)
++find_path(GRADS_GD_INCLUDE gd.h HINTS ${GRADS_INCLUDE_HINTS} REQUIRED)
++find_path(GRADS_X11_INCLUDE X11/Xlib.h HINTS ${GRADS_INCLUDE_HINTS} REQUIRED)
++
++grads_find_library(GRADS_NETCDF_LIBRARY netcdf)
++grads_find_library(GRADS_HDF4_MFHDF_LIBRARY mfhdf)
++grads_find_library(GRADS_HDF4_DF_LIBRARY hdf libhdf df)
++grads_find_library(GRADS_HDF5_LIBRARY hdf5)
++grads_find_library(GRADS_HDF5_HL_LIBRARY hdf5_hl)
++grads_find_library(GRADS_UDUNITS_LIBRARY udunits2)
++if(NOT GRADS_G2C_LIBRARY)
++  grads_find_library(GRADS_G2C_LIBRARY g2c)
++endif()
++grads_find_library(GRADS_JASPER_LIBRARY jasper)
++grads_find_library(GRADS_PNG_LIBRARY png16 png libpng16)
++grads_find_library(GRADS_ZLIB_LIBRARY zlib z)
++grads_find_library(GRADS_JPEG_LIBRARY jpeg)
++grads_find_library(GRADS_GEOTIFF_LIBRARY geotiff geotiff_i)
++grads_find_library(GRADS_TIFF_LIBRARY tiff)
++grads_find_library(GRADS_SHAPE_LIBRARY shapefile shp)
++grads_find_library(GRADS_CAIRO_LIBRARY cairo)
++grads_find_library(GRADS_GD_LIBRARY gd)
++grads_find_library(GRADS_X11_LIBRARY X11 libX11)
++grads_find_library(GRADS_XEXT_LIBRARY Xext libXext)
++
++set(GRADS_INCLUDE_DIRS
++  src "${GRADS_GENERATED_DIR}" src/wincompat
++  ${GRADS_NETCDF_INCLUDE} ${GRADS_HDF4_INCLUDE} ${GRADS_HDF5_INCLUDE}
++  ${GRADS_UDUNITS_INCLUDE} ${GRADS_GRIB2_INCLUDE} ${GRADS_GEOTIFF_INCLUDE}
++  ${GRADS_SHAPE_INCLUDE} ${GRADS_CAIRO_INCLUDE} ${GRADS_GD_INCLUDE}
++  ${GRADS_X11_INCLUDE} ${GRADS_INCLUDE_HINTS})
++
++set(GRADS_DEPENDENCY_LIBRARIES
++  ${GRADS_NETCDF_LIBRARY} ${GRADS_HDF4_MFHDF_LIBRARY} ${GRADS_HDF4_DF_LIBRARY}
++  ${GRADS_HDF5_HL_LIBRARY} ${GRADS_HDF5_LIBRARY} ${GRADS_UDUNITS_LIBRARY}
++  ${GRADS_G2C_LIBRARY} ${GRADS_JASPER_LIBRARY} ${GRADS_PNG_LIBRARY}
++  ${GRADS_ZLIB_LIBRARY} ${GRADS_JPEG_LIBRARY} ${GRADS_GEOTIFF_LIBRARY}
++  ${GRADS_TIFF_LIBRARY} ${GRADS_SHAPE_LIBRARY} ${GRADS_CAIRO_LIBRARY}
++  ${GRADS_GD_LIBRARY} ${GRADS_X11_LIBRARY} ${GRADS_XEXT_LIBRARY})
++
++set(GRADS_ENGINE_SOURCES
++  src/grads.c src/ga_dynload.c src/ga_readline_win.c src/gxsubs.c src/gxmeta.c
++  src/gxchpl.c src/gxcntr.c src/gxstrm.c src/gxdb.c src/gxwmap.c src/gxshad.c
++  src/gxshad2.c src/gaexpr.c src/gafunc.c src/gautil.c src/gagx.c src/gscrpt.c
++  src/gamach.c src/gatxt.c src/galloc.c src/gaddes.c src/gacfg.c src/gaio.c
++  src/gauser.c src/gasdf.c src/bufrstn.c src/gabufr.c src/gabufrtbl.c)
++
++function(grads_configure_target target)
++  target_include_directories(${target} PRIVATE ${GRADS_INCLUDE_DIRS})
++  target_compile_definitions(${target} PRIVATE HAVE_CONFIG_H _CRT_SECURE_NO_WARNINGS)
++  if(MSVC)
++    target_compile_options(${target} PRIVATE "/FI${CMAKE_CURRENT_SOURCE_DIR}/src/ga_wincompat.h")
++  else()
++    target_compile_options(${target} PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/src/ga_wincompat.h")
++  endif()
++endfunction()
++
++add_library(gradspy SHARED ${GRADS_ENGINE_SOURCES})
++target_compile_definitions(gradspy PRIVATE SHRDOBJ)
++target_link_libraries(gradspy PRIVATE ${GRADS_DEPENDENCY_LIBRARIES})
++grads_configure_target(gradspy)
++set_target_properties(gradspy PROPERTIES PREFIX "" OUTPUT_NAME "gradspy")
++
++add_executable(grads src/grads_main.c)
++target_link_libraries(grads PRIVATE gradspy)
++grads_configure_target(grads)
++
++add_library(gxdummy SHARED src/gxdummy.c)
++add_library(gxdX11 SHARED src/gxX11.c)
++add_library(gxpGD SHARED src/gxprintGD.c src/gxGD.c)
++add_library(gxpCairo SHARED src/gxprint.c src/gxC.c)
++add_library(gxdCairo SHARED src/gxX.c src/gxC.c)
++
++foreach(plugin gxdummy gxdX11 gxpGD gxpCairo gxdCairo)
++  grads_configure_target(${plugin})
++  target_link_libraries(${plugin} PRIVATE gradspy ${GRADS_DEPENDENCY_LIBRARIES})
++  set_target_properties(${plugin} PROPERTIES PREFIX "lib")
++endforeach()
++
++add_library(grads_utility_common OBJECT src/gautil.c src/gatxt.c)
++target_compile_definitions(grads_utility_common PRIVATE STNDALN)
++grads_configure_target(grads_utility_common)
++
++add_library(grads_descriptor OBJECT src/gaddes.c)
++target_compile_definitions(grads_descriptor PRIVATE STNDALN)
++grads_configure_target(grads_descriptor)
++
++function(grads_add_utility target)
++  add_executable(${target} ${ARGN} $<TARGET_OBJECTS:grads_utility_common>)
++  grads_configure_target(${target})
++  target_link_libraries(${target} PRIVATE ${GRADS_DEPENDENCY_LIBRARIES})
++endfunction()
++
++grads_add_utility(stnmap src/stnmap.c src/gamach.c src/galloc.c $<TARGET_OBJECTS:grads_descriptor>)
++grads_add_utility(gribmap src/gribmap.c src/gagmap.c src/gamach.c src/galloc.c $<TARGET_OBJECTS:grads_descriptor>)
++grads_add_utility(gribscan src/gribscan.c src/gamach.c src/galloc.c)
++grads_add_utility(grib2scan src/grib2scan.c src/gamach.c src/galloc.c)
++add_executable(bufrscan src/bufrscan.c src/gabufr.c src/gabufrtbl.c src/gamach.c)
++grads_configure_target(bufrscan)
++target_link_libraries(bufrscan PRIVATE ${GRADS_DEPENDENCY_LIBRARIES})
++
++install(TARGETS grads gradspy gxdummy gxdX11 gxpGD gxpCairo gxdCairo
++  stnmap gribmap gribscan grib2scan bufrscan
++  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
++  LIBRARY DESTINATION ${CMAKE_INSTALL_BINDIR}
++  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+diff --git a/cmake/config.h.in b/cmake/config.h.in
+new file mode 100644
+index 0000000..46d37a1
+--- /dev/null
++++ b/cmake/config.h.in
+@@ -0,0 +1,40 @@
++#ifndef GRADS_CMAKE_CONFIG_H
++#define GRADS_CMAKE_CONFIG_H
++
++#define BYTEORDER 0
++#define GEOTIFF 1
++#define GRADS_CRAY 0
++#define GRADS_HP64 0
++#define GRADS_VERSION "@GRADS_VERSION@"
++#define GRIB2 1
++#define HAVENETCDF4 1
++#define HAVE_FSEEKO 1
++#define HAVE_HDF4_NETCDF_H 1
++#define HAVE_INTTYPES_H 1
++#define HAVE_MALLOC_H 1
++#define HAVE_MEMORY_H 1
++#define HAVE_READLINE_HISTORY 1
++#define HAVE_READLINE_HISTORY_H 1
++#define HAVE_READLINE_READLINE_H 1
++#define HAVE_STDINT_H 1
++#define HAVE_STDLIB_H 1
++#define HAVE_STRING_H 1
++#define HAVE_SYS_STAT_H 1
++#define HAVE_SYS_TYPES_H 1
++#define HDF_HAVE_NETCDF 1
++#define HDF_NETCDF_NAME(name) sd_ ## name
++#define READLINE 1
++#define STDC_HEADERS 1
++#define USECAIRO 1
++#define USEDAP 1
++#define USEFREQ 0
++#define USEGADAP 0
++#define USEGD 1
++#define USEGUI 0
++#define USEHDF 1
++#define USEHDF5 1
++#define USENETCDF 1
++#define USESHP 1
++#define X_DISPLAY_MISSING 0
++
++#endif
+diff --git a/src/ga_dynload.c b/src/ga_dynload.c
+new file mode 100644
+index 0000000..c4da382
+--- /dev/null
++++ b/src/ga_dynload.c
+@@ -0,0 +1,72 @@
++/* Copyright (C) 1988-2022 by George Mason University. See file COPYRIGHT. */
++
++#include "ga_dynload.h"
++
++#ifdef _WIN32
++
++#include <stdio.h>
++
++static char ga_dlerror_buffer[512];
++
++static void ga_set_dlerror(const char *operation) {
++  DWORD error = GetLastError();
++  char message[384] = "unknown error";
++  DWORD length;
++
++  length = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
++                          FORMAT_MESSAGE_IGNORE_INSERTS,
++                          NULL, error, 0, message, (DWORD)sizeof(message), NULL);
++  if (length == 0) snprintf(message, sizeof(message), "Win32 error %lu", (unsigned long)error);
++  snprintf(ga_dlerror_buffer, sizeof(ga_dlerror_buffer), "%s: %s", operation, message);
++}
++
++ga_dlhandle ga_dlopen(const char *filename, int flags) {
++  ga_dlhandle handle;
++  (void)flags;
++  ga_dlerror_buffer[0] = '\0';
++  handle = LoadLibraryA(filename);
++  if (handle == NULL) ga_set_dlerror("LoadLibrary");
++  return handle;
++}
++
++void *ga_dlsym(ga_dlhandle handle, const char *symbol) {
++  FARPROC address;
++  ga_dlerror_buffer[0] = '\0';
++  address = GetProcAddress(handle, symbol);
++  if (address == NULL) ga_set_dlerror("GetProcAddress");
++  return (void *)address;
++}
++
++const char *ga_dlerror(void) {
++  return ga_dlerror_buffer[0] == '\0' ? NULL : ga_dlerror_buffer;
++}
++
++int ga_dlclose(ga_dlhandle handle) {
++  ga_dlerror_buffer[0] = '\0';
++  if (FreeLibrary(handle)) return 0;
++  ga_set_dlerror("FreeLibrary");
++  return -1;
++}
++
++#else
++
++ga_dlhandle ga_dlopen(const char *filename, int flags) {
++  int native_flags = 0;
++  if (flags & GA_RTLD_LAZY) native_flags |= RTLD_LAZY;
++  if (flags & GA_RTLD_GLOBAL) native_flags |= RTLD_GLOBAL;
++  return dlopen(filename, native_flags);
++}
++
++void *ga_dlsym(ga_dlhandle handle, const char *symbol) {
++  return dlsym(handle, symbol);
++}
++
++const char *ga_dlerror(void) {
++  return dlerror();
++}
++
++int ga_dlclose(ga_dlhandle handle) {
++  return dlclose(handle);
++}
++
++#endif
+diff --git a/src/ga_dynload.h b/src/ga_dynload.h
+new file mode 100644
+index 0000000..cd7f3a9
+--- /dev/null
++++ b/src/ga_dynload.h
+@@ -0,0 +1,28 @@
++/* Copyright (C) 1988-2022 by George Mason University. See file COPYRIGHT. */
++
++#ifndef GA_DYNLOAD_H
++#define GA_DYNLOAD_H
++
++/*
++ * Small cross-platform wrapper around the process dynamic loader.  Keeping
++ * the platform API here prevents the graphics and user-defined plug-in code
++ * from depending directly on either dlfcn(3) or the Win32 loader.
++ */
++
++#ifdef _WIN32
++#include <windows.h>
++typedef HMODULE ga_dlhandle;
++#else
++#include <dlfcn.h>
++typedef void *ga_dlhandle;
++#endif
++
++#define GA_RTLD_LAZY   0x01
++#define GA_RTLD_GLOBAL 0x02
++
++ga_dlhandle ga_dlopen(const char *filename, int flags);
++void *ga_dlsym(ga_dlhandle handle, const char *symbol);
++const char *ga_dlerror(void);
++int ga_dlclose(ga_dlhandle handle);
++
++#endif
+diff --git a/src/ga_readline_win.c b/src/ga_readline_win.c
+new file mode 100644
+index 0000000..c25ea9b
+--- /dev/null
++++ b/src/ga_readline_win.c
+@@ -0,0 +1,144 @@
++/* Minimal readline/history compatibility layer for native Windows builds. */
++
++#ifdef _WIN32
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include <readline/readline.h>
++#include <readline/history.h>
++
++#define GA_HISTORY_INITIAL_CAPACITY 64
++
++int history_length = 0;
++static int history_capacity = 0;
++static HIST_ENTRY **history_entries = NULL;
++
++static char *ga_strdup(const char *value) {
++  size_t length = strlen(value) + 1;
++  char *copy = (char *)malloc(length);
++  if (copy != NULL) memcpy(copy, value, length);
++  return copy;
++}
++
++static int ga_history_reserve(int required) {
++  HIST_ENTRY **resized;
++  int capacity = history_capacity == 0 ? GA_HISTORY_INITIAL_CAPACITY : history_capacity;
++  while (capacity < required + 1) capacity *= 2;
++  if (capacity == history_capacity) return 0;
++  resized = (HIST_ENTRY **)realloc(history_entries, sizeof(HIST_ENTRY *) * capacity);
++  if (resized == NULL) return -1;
++  history_entries = resized;
++  history_capacity = capacity;
++  history_entries[history_length] = NULL;
++  return 0;
++}
++
++char *readline(const char *prompt) {
++  char buffer[4096];
++  size_t length;
++  if (prompt != NULL) {
++    fputs(prompt, stdout);
++    fflush(stdout);
++  }
++  if (fgets(buffer, sizeof(buffer), stdin) == NULL) return NULL;
++  length = strlen(buffer);
++  while (length > 0 && (buffer[length - 1] == '\n' || buffer[length - 1] == '\r')) {
++    buffer[--length] = '\0';
++  }
++  return ga_strdup(buffer);
++}
++
++void add_history(const char *line) {
++  HIST_ENTRY *entry;
++  if (line == NULL || ga_history_reserve(history_length + 1) != 0) return;
++  entry = (HIST_ENTRY *)calloc(1, sizeof(HIST_ENTRY));
++  if (entry == NULL) return;
++  entry->line = ga_strdup(line);
++  if (entry->line == NULL) {
++    free(entry);
++    return;
++  }
++  history_entries[history_length++] = entry;
++  history_entries[history_length] = NULL;
++}
++
++HIST_ENTRY **history_list(void) {
++  return history_entries;
++}
++
++int history_search_pos(const char *string, int direction, int pos) {
++  int index;
++  if (string == NULL || history_length == 0) return -1;
++  if (pos < 0 || pos >= history_length) pos = direction < 0 ? history_length - 1 : 0;
++  for (index = pos; index >= 0 && index < history_length; index += direction < 0 ? -1 : 1) {
++    if (strstr(history_entries[index]->line, string) != NULL) return index;
++  }
++  return -1;
++}
++
++int read_history(const char *filename) {
++  FILE *file;
++  char buffer[4096];
++  size_t length;
++  if (filename == NULL || (file = fopen(filename, "r")) == NULL) return -1;
++  while (fgets(buffer, sizeof(buffer), file) != NULL) {
++    length = strlen(buffer);
++    while (length > 0 && (buffer[length - 1] == '\n' || buffer[length - 1] == '\r')) buffer[--length] = '\0';
++    add_history(buffer);
++  }
++  fclose(file);
++  return 0;
++}
++
++int write_history(const char *filename) {
++  FILE *file;
++  int index;
++  if (filename == NULL || (file = fopen(filename, "w")) == NULL) return -1;
++  for (index = 0; index < history_length; ++index) fprintf(file, "%s\n", history_entries[index]->line);
++  fclose(file);
++  return 0;
++}
++
++int history_truncate_file(const char *filename, int lines) {
++  FILE *file;
++  char **saved = NULL;
++  char buffer[4096];
++  int count = 0, capacity = 0, index, first;
++  if (filename == NULL || lines < 0 || (file = fopen(filename, "r")) == NULL) return -1;
++  while (fgets(buffer, sizeof(buffer), file) != NULL) {
++    if (count == capacity) {
++      int next = capacity == 0 ? 64 : capacity * 2;
++      char **resized = (char **)realloc(saved, sizeof(char *) * next);
++      if (resized == NULL) break;
++      saved = resized;
++      capacity = next;
++    }
++    saved[count++] = ga_strdup(buffer);
++  }
++  fclose(file);
++  if ((file = fopen(filename, "w")) == NULL) return -1;
++  first = count > lines ? count - lines : 0;
++  for (index = first; index < count; ++index) fputs(saved[index], file);
++  fclose(file);
++  for (index = 0; index < count; ++index) free(saved[index]);
++  free(saved);
++  return 0;
++}
++
++int where_history(void) {
++  return history_length;
++}
++
++HIST_ENTRY *remove_history(int which) {
++  HIST_ENTRY *removed;
++  int index;
++  if (which < 0 || which >= history_length) return NULL;
++  removed = history_entries[which];
++  for (index = which; index < history_length - 1; ++index) history_entries[index] = history_entries[index + 1];
++  history_entries[--history_length] = NULL;
++  return removed;
++}
++
++#endif
+diff --git a/src/ga_wincompat.h b/src/ga_wincompat.h
+new file mode 100644
+index 0000000..00bd2fb
+--- /dev/null
++++ b/src/ga_wincompat.h
+@@ -0,0 +1,18 @@
++#ifndef GA_WINCOMPAT_H
++#define GA_WINCOMPAT_H
++
++#ifdef _WIN32
++#include <io.h>
++#include <stdio.h>
++#include <string.h>
++
++#define strcasecmp _stricmp
++#define strncasecmp _strnicmp
++#define popen _popen
++#define pclose _pclose
++#define fseeko _fseeki64
++#define ftello _ftelli64
++
++#endif
++
++#endif
+diff --git a/src/grads_main.c b/src/grads_main.c
+new file mode 100644
+index 0000000..bb985c2
+--- /dev/null
++++ b/src/grads_main.c
+@@ -0,0 +1,7 @@
++/* Native Windows launcher. The engine itself lives in gradspy.dll. */
++
++int gamain(int argc, char **argv);
++
++int main(int argc, char **argv) {
++  return gamain(argc, argv);
++}
+diff --git a/src/wincompat/readline/readline.h b/src/wincompat/readline/readline.h
+new file mode 100644
+index 0000000..cbd2c54
+--- /dev/null
++++ b/src/wincompat/readline/readline.h
+@@ -0,0 +1,6 @@
++#ifndef GRADS_WINCOMPAT_READLINE_H
++#define GRADS_WINCOMPAT_READLINE_H
++
++char *readline(const char *prompt);
++
++#endif
+diff --git a/src/wincompat/readline/history.h b/src/wincompat/readline/history.h
+new file mode 100644
+index 0000000..1ec0ae2
+--- /dev/null
++++ b/src/wincompat/readline/history.h
+@@ -0,0 +1,21 @@
++#ifndef GRADS_WINCOMPAT_HISTORY_H
++#define GRADS_WINCOMPAT_HISTORY_H
++
++typedef struct _hist_entry {
++  char *line;
++  char *timestamp;
++  void *data;
++} HIST_ENTRY;
++
++extern int history_length;
++
++void add_history(const char *line);
++HIST_ENTRY **history_list(void);
++int history_search_pos(const char *string, int direction, int pos);
++int read_history(const char *filename);
++int write_history(const char *filename);
++int history_truncate_file(const char *filename, int lines);
++int where_history(void);
++HIST_ENTRY *remove_history(int which);
++
++#endif

--- a/recipes/grads/bld.bat
+++ b/recipes/grads/bld.bat
@@ -1,0 +1,63 @@
+@echo on
+setlocal EnableExtensions
+
+cmake -S nceplibs-g2c -B build-g2c -G Ninja ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc ^
+  -DBUILD_SHARED_LIBS=OFF ^
+  -DBUILD_STATIC_LIBS=ON ^
+  -DBUILD_TESTING=OFF ^
+  -DUTILS=OFF
+if errorlevel 1 exit /b 1
+cmake --build build-g2c --parallel %CPU_COUNT%
+if errorlevel 1 exit /b 1
+
+cmake -S . -B build -G Ninja ^
+  -DCMAKE_BUILD_TYPE=Release ^
+  -DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc ^
+  -DGRADS_G2C_LIBRARY=%SRC_DIR%\build-g2c\src\libg2c.a ^
+  -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%
+if errorlevel 1 exit /b 1
+
+cmake --build build --parallel %CPU_COUNT%
+if errorlevel 1 exit /b 1
+cmake --install build
+if errorlevel 1 exit /b 1
+
+if not exist "%LIBRARY_PREFIX%\share\grads" mkdir "%LIBRARY_PREFIX%\share\grads"
+xcopy /E /I /Y data "%LIBRARY_PREFIX%\share\grads"
+if errorlevel 1 exit /b 1
+
+(
+  echo # Type     Name     Full path to shared object file
+  echo gxdisplay  Cairo    %LIBRARY_BIN%\libgxdCairo.dll
+  echo gxdisplay  X11      %LIBRARY_BIN%\libgxdX11.dll
+  echo gxdisplay  gxdummy  %LIBRARY_BIN%\libgxdummy.dll
+  echo *
+  echo gxprint    Cairo    %LIBRARY_BIN%\libgxpCairo.dll
+  echo gxprint    GD       %LIBRARY_BIN%\libgxpGD.dll
+  echo gxprint    gxdummy  %LIBRARY_BIN%\libgxdummy.dll
+) > "%LIBRARY_PREFIX%\share\grads\udpt"
+
+if not exist "%PREFIX%\etc\conda\activate.d" mkdir "%PREFIX%\etc\conda\activate.d"
+if not exist "%PREFIX%\etc\conda\deactivate.d" mkdir "%PREFIX%\etc\conda\deactivate.d"
+
+(
+  echo @set "GADDIR_BACKUP=%%GADDIR%%"
+  echo @set "GAUDPT_BACKUP=%%GAUDPT%%"
+  echo @set "GAGPY_BACKUP=%%GAGPY%%"
+  echo @set "GADDIR=%LIBRARY_PREFIX%\share\grads"
+  echo @set "GAUDPT=%LIBRARY_PREFIX%\share\grads\udpt"
+  echo @set "GAGPY=%LIBRARY_BIN%\gradspy.dll"
+) > "%PREFIX%\etc\conda\activate.d\grads-env.bat"
+
+(
+  echo @set "GADDIR=%%GADDIR_BACKUP%%"
+  echo @set "GAUDPT=%%GAUDPT_BACKUP%%"
+  echo @set "GAGPY=%%GAGPY_BACKUP%%"
+  echo @set GADDIR_BACKUP=
+  echo @set GAUDPT_BACKUP=
+  echo @set GAGPY_BACKUP=
+) > "%PREFIX%\etc\conda\deactivate.d\grads-env.bat"
+
+endlocal

--- a/recipes/grads/build.sh
+++ b/recipes/grads/build.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Regenerate configure so the portability patch is reflected in release
+# archives that also ship pregenerated Autotools files.
+autoreconf -fi
+
+SUPPLIBS="${PREFIX}" ./configure \
+  --prefix="${PREFIX}" \
+  --with-netcdf="${PREFIX}" \
+  --with-hdf5="${PREFIX}" \
+  --enable-dyn-supplibs \
+  CAIRO_CFLAGS="-I${PREFIX}/include/cairo -I${PREFIX}/include/freetype2" \
+  CAIRO_LIBS="-L${PREFIX}/lib -lcairo" \
+  GD_CFLAGS="-I${PREFIX}/include" \
+  GD_LIBS="-L${PREFIX}/lib -lgd" \
+  CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/freetype2" \
+  LDFLAGS="-L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib"
+
+make -j"${CPU_COUNT:-1}"
+make install
+
+find "${PREFIX}/lib" -name '*.la' -delete
+
+mkdir -p "${PREFIX}/share/grads"
+cp -r data/* "${PREFIX}/share/grads/"
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  shared_ext="dylib"
+else
+  shared_ext="so"
+fi
+
+cat > "${PREFIX}/share/grads/udpt" <<EOF
+# Type     Name     Full path to shared object file
+gxdisplay  Cairo    ${PREFIX}/lib/libgxdCairo.${shared_ext}
+gxdisplay  X11      ${PREFIX}/lib/libgxdX11.${shared_ext}
+gxdisplay  gxdummy  ${PREFIX}/lib/libgxdummy.${shared_ext}
+*
+gxprint    Cairo    ${PREFIX}/lib/libgxpCairo.${shared_ext}
+gxprint    GD       ${PREFIX}/lib/libgxpGD.${shared_ext}
+gxprint    gxdummy  ${PREFIX}/lib/libgxdummy.${shared_ext}
+EOF
+
+mkdir -p "${PREFIX}/etc/conda/activate.d"
+mkdir -p "${PREFIX}/etc/conda/deactivate.d"
+
+cat > "${PREFIX}/etc/conda/activate.d/grads-env.sh" <<EOF
+#!/bin/bash
+export GADDIR_BACKUP="\${GADDIR}"
+export GAUDPT_BACKUP="\${GAUDPT}"
+export GAGPY_BACKUP="\${GAGPY}"
+export GADDIR="${PREFIX}/share/grads"
+export GAUDPT="${PREFIX}/share/grads/udpt"
+export GAGPY="${PREFIX}/lib/libgradspy.${shared_ext}"
+EOF
+
+cat > "${PREFIX}/etc/conda/deactivate.d/grads-env.sh" <<'EOF'
+#!/bin/bash
+export GADDIR="${GADDIR_BACKUP}"
+export GAUDPT="${GAUDPT_BACKUP}"
+export GAGPY="${GAGPY_BACKUP}"
+unset GADDIR_BACKUP
+unset GAUDPT_BACKUP
+unset GAGPY_BACKUP
+EOF

--- a/recipes/grads/recipe.yaml
+++ b/recipes/grads/recipe.yaml
@@ -198,7 +198,9 @@ about:
   documentation: https://wetterzentrale.de/grads/docs/index.html
   repository: https://github.com/RogierFloors/GrADS
   license: GPL-2.0-only
-  license_file: COPYRIGHT
+  license_file:
+    - COPYRIGHT
+    - data/UDUNITS2-COPYRIGHT
   summary: Grid Analysis and Display System
   description: |
     GrADS is an interactive desktop tool for access, manipulation, and

--- a/recipes/grads/recipe.yaml
+++ b/recipes/grads/recipe.yaml
@@ -3,6 +3,7 @@ schema_version: 1
 context:
   version: "2.2.3.post3"
   tag: "v2.2.3.post3"
+  python_min: "3.10"
 
 recipe:
   name: grads

--- a/recipes/grads/recipe.yaml
+++ b/recipes/grads/recipe.yaml
@@ -52,7 +52,8 @@ outputs:
         - xorg-libx11
         - freetype
         - libnetcdf
-        - hdf5
+        # Keep GrADS on the HDF5 ABI supported by netcdf4 and h5py.
+        - hdf5 >=1.14.6,<1.15
         - hdf4
         - udunits2
         - g2clib
@@ -111,7 +112,7 @@ outputs:
     requirements:
       run:
         - libnetcdf
-        - hdf5
+        - hdf5 >=1.14.6,<1.15
         - hdf4
         - libudunits2
         - g2clib
@@ -188,15 +189,6 @@ outputs:
             - "*"
           imports:
             - gradspy
-      - script:
-          - python -c "import gradspy, h5py, netCDF4, pandas, pyarrow, rasterio"
-        requirements:
-          run:
-            - python ${{ python_min }}.*
-            - h5py
-            - netcdf4
-            - pyarrow
-            - rasterio
       - script:
           - python -c "import h5py, netCDF4, pandas, pyarrow, rasterio"
           - python -c "from gradspy import GrADS; print(GrADS)"

--- a/recipes/grads/recipe.yaml
+++ b/recipes/grads/recipe.yaml
@@ -1,0 +1,209 @@
+schema_version: 1
+
+context:
+  version: "2.2.3.post3"
+  tag: "v2.2.3.post3"
+
+recipe:
+  name: grads
+  version: ${{ version }}
+
+source:
+  - url: https://github.com/RogierFloors/GrADS/archive/refs/tags/${{ tag }}.tar.gz
+    sha256: b057832862c098bf1ae813f5bae71857281c9d943b5fb15957c96c3e3ce22e62
+    patches:
+      - 0001-cross-platform-build.patch
+  - if: win
+    then:
+      url: https://github.com/NOAA-EMC/NCEPLIBS-g2c/archive/refs/tags/v1.9.0.tar.gz
+      sha256: 5554276e18bdcddf387a08c2dd23f9da310c6598905df6a2a244516c22ded9aa
+      target_directory: nceplibs-g2c
+
+outputs:
+  - staging:
+      name: grads-build
+    build:
+      script:
+        - if: win
+          then: bld.bat
+          else: build.sh
+    requirements:
+      build:
+        - if: unix
+          then:
+            - ${{ compiler('c') }}
+            - ${{ stdlib('c') }}
+            - make
+            - autoconf
+            - automake
+            - libtool
+            - pkg-config
+        - if: win
+          then:
+            - cmake
+            - ninja
+            - m2w64-toolchain
+            - pkg-config
+        - xorg-xproto
+      host:
+        - xorg-xproto
+        - libxcb
+        - xorg-libx11
+        - freetype
+        - libnetcdf
+        - hdf5
+        - hdf4
+        - udunits2
+        - g2clib
+        - if: unix
+          then: nceplibs-g2c
+        - geotiff
+        - libtiff
+        - cairo
+        - if: unix
+          then:
+            - readline
+            - ncurses
+        - libpng
+        - zlib
+        - libjpeg-turbo
+        - jasper
+        - libgd
+        - libxml2
+        - curl
+        - shapelib
+
+  - package:
+      name: grads
+    inherit: grads-build
+    build:
+      number: 0
+      files:
+        - if: unix
+          then:
+            - bin/grads
+            - bin/gribmap
+            - bin/stnmap
+            - bin/gribscan
+            - bin/grib2scan
+            - bin/bufrscan
+            - lib/libgxd*
+            - lib/libgxp*
+            - lib/libgradspy*
+            - share/grads
+            - etc/conda/activate.d/grads-env.sh
+            - etc/conda/deactivate.d/grads-env.sh
+        - if: win
+          then:
+            - Library/bin/grads.exe
+            - Library/bin/gribmap.exe
+            - Library/bin/stnmap.exe
+            - Library/bin/gribscan.exe
+            - Library/bin/grib2scan.exe
+            - Library/bin/bufrscan.exe
+            - Library/bin/libgxd*.dll
+            - Library/bin/libgxp*.dll
+            - Library/bin/gradspy.dll
+            - Library/share/grads
+            - etc/conda/activate.d/grads-env.bat
+            - etc/conda/deactivate.d/grads-env.bat
+    requirements:
+      run:
+        - libnetcdf
+        - hdf5
+        - hdf4
+        - libudunits2
+        - g2clib
+        - if: unix
+          then: nceplibs-g2c
+        - geotiff
+        - libtiff
+        - jasper
+        - cairo
+        - libcurl
+        - if: unix
+          then: readline
+        - libpng
+        - if: unix
+          then: ncurses
+        - libgd
+        - shapelib
+        - xorg-libice
+        - xorg-libsm
+        - xorg-libx11
+        - xorg-libxext
+    tests:
+      - if: unix
+        then:
+          - script:
+              - printf "q config\nquit\n" | grads -bl | grep "grib2.*netcdf.*hdf4-sds.*hdf5.*geotiff.*shapefile"
+              - test -x "$PREFIX/bin/gribmap"
+              - test -f "$PREFIX/share/grads/udpt"
+              - test -f "$PREFIX/share/grads/ne10m"
+              - test -f "$PREFIX/share/grads/ne50m"
+              - test -f "$PREFIX/share/grads/ne110m"
+              - test -f "$PREFIX/share/grads/nebasemap.gs"
+              - test -f "$PREFIX/share/grads/natural_earth_masks.json"
+              - test -f "$PREFIX/share/grads/ne110m_land.shp"
+              - test -f "$PREFIX/share/grads/ne110m_ocean.shp"
+              - test -f "$PREFIX/share/grads/ne50m_land.shp"
+              - test -f "$PREFIX/share/grads/ne50m_ocean.shp"
+              - test -f "$PREFIX/share/grads/ne10m_land.shp"
+              - test -f "$PREFIX/share/grads/ne10m_ocean.shp"
+              - test -f "$PREFIX/share/grads/ne10m_land.shx"
+              - test -f "$PREFIX/share/grads/ne10m_land.dbf"
+              - test -f "$PREFIX/share/grads/ne10m_land.prj"
+              - test -f "$GAGPY"
+      - if: win
+        then:
+          - script:
+              - '(echo q config& echo quit) | grads -bl | findstr /r "grib2.*netcdf.*hdf4-sds.*hdf5.*geotiff.*shapefile"'
+              - if not exist "%LIBRARY_BIN%\gribmap.exe" exit /b 1
+              - if not exist "%LIBRARY_PREFIX%\share\grads\udpt" exit /b 1
+              - if not exist "%LIBRARY_PREFIX%\share\grads\natural_earth_masks.json" exit /b 1
+              - if not exist "%GAGPY%" exit /b 1
+
+  - package:
+      name: gradspy
+    inherit: grads-build
+    build:
+      number: 0
+      script:
+        - if: win
+          then: copy src\gradspy.py "%SP_DIR%\gradspy.py"
+          else: install -Dm644 src/gradspy.py "${SP_DIR}/gradspy.py"
+      files:
+        - if: win
+          then: Lib/site-packages/gradspy.py
+          else: lib/python*/site-packages/gradspy.py
+    requirements:
+      host:
+        - python >=3.9
+      run:
+        - python >=3.9
+        - numpy >=1.23
+        - pandas
+        - xarray
+        - grads ==${{ version }}
+    tests:
+      - python:
+          imports:
+            - gradspy
+      - script:
+          - python -c "from gradspy import GrADS; print(GrADS)"
+          - python -c "from gradspy import GrADS; ga = GrADS(); assert ga.start('-b') == 0; print(ga.cmd('q config'))"
+
+about:
+  homepage: https://wetterzentrale.de/grads/docs/index.html
+  documentation: https://wetterzentrale.de/grads/docs/index.html
+  repository: https://github.com/RogierFloors/GrADS
+  license: GPL-2.0-only
+  license_file: COPYRIGHT
+  summary: Grid Analysis and Display System
+  description: |
+    GrADS is an interactive desktop tool for access, manipulation, and
+    visualization of earth science data.
+
+extra:
+  recipe-maintainers:
+    - RogierFloors

--- a/recipes/grads/recipe.yaml
+++ b/recipes/grads/recipe.yaml
@@ -165,33 +165,48 @@ outputs:
 
   - package:
       name: gradspy
-    inherit: grads-build
     build:
       number: 0
-      script:
-        - if: win
-          then: copy src\gradspy.py "%SP_DIR%\gradspy.py"
-          else: install -Dm644 src/gradspy.py "${SP_DIR}/gradspy.py"
+      noarch: python
+      script: install -Dm644 src/gradspy.py "${SP_DIR}/gradspy.py"
       files:
-        - if: win
-          then: Lib/site-packages/gradspy.py
-          else: lib/python*/site-packages/gradspy.py
+        - lib/python*/site-packages/gradspy.py
     requirements:
       host:
-        - python >=3.9
+        - python ${{ python_min }}.*
       run:
-        - python >=3.9
+        - python >=${{ python_min }}
         - numpy >=1.23
         - pandas
         - xarray
         - grads ==${{ version }}
     tests:
       - python:
+          python_version:
+            - ${{ python_min }}.*
+            - "*"
           imports:
             - gradspy
       - script:
+          - python -c "import gradspy, h5py, netCDF4, pandas, pyarrow, rasterio"
+        requirements:
+          run:
+            - python ${{ python_min }}.*
+            - h5py
+            - netcdf4
+            - pyarrow
+            - rasterio
+      - script:
+          - python -c "import h5py, netCDF4, pandas, pyarrow, rasterio"
           - python -c "from gradspy import GrADS; print(GrADS)"
           - python -c "from gradspy import GrADS; ga = GrADS(); assert ga.start('-b') == 0; print(ga.cmd('q config'))"
+        requirements:
+          run:
+            - python
+            - h5py
+            - netcdf4
+            - pyarrow
+            - rasterio
 
 about:
   homepage: https://wetterzentrale.de/grads/docs/index.html

--- a/recipes/grads/recipe.yaml
+++ b/recipes/grads/recipe.yaml
@@ -52,8 +52,7 @@ outputs:
         - xorg-libx11
         - freetype
         - libnetcdf
-        # Keep GrADS on the HDF5 ABI supported by netcdf4 and h5py.
-        - hdf5 >=1.14.6,<1.15
+        - hdf5
         - hdf4
         - udunits2
         - g2clib
@@ -112,7 +111,7 @@ outputs:
     requirements:
       run:
         - libnetcdf
-        - hdf5 >=1.14.6,<1.15
+        - hdf5
         - hdf4
         - libudunits2
         - g2clib
@@ -190,16 +189,8 @@ outputs:
           imports:
             - gradspy
       - script:
-          - python -c "import h5py, netCDF4, pandas, pyarrow, rasterio"
           - python -c "from gradspy import GrADS; print(GrADS)"
           - python -c "from gradspy import GrADS; ga = GrADS(); assert ga.start('-b') == 0; print(ga.cmd('q config'))"
-        requirements:
-          run:
-            - python
-            - h5py
-            - netcdf4
-            - pyarrow
-            - rasterio
 
 about:
   homepage: https://wetterzentrale.de/grads/docs/index.html


### PR DESCRIPTION
Adds conda-forge recipes for GrADS 2.3 and the optional `gradspy` Python wrapper.

The recipe builds from the authorized GrADS source release at `v2.3`. It supports Linux x86_64, Linux aarch64, macOS x86_64, macOS arm64, and Windows. The Windows build compiles
NCEPLIBS-g2c from its separate source archive and includes its license notice; the package does not ship static libraries.

Local checks:
- Recipe rendered and dependencies solved for all five target platforms.
- Full Linux x86_64 build and package tests passed, including the GrADS configuration smoke test and `gradspy` tests.
- macOS and Windows builds await hosted CI.

Checklist

- [x] Title is meaningful.
- [x] Recipe uses the v1 `recipe.yaml` format.
- [x] License files are packaged: GrADS `COPYRIGHT`, the UDUNITS notice, and the NCEPLIBS-g2c license on Windows.
- [x] Source is from the authorized GrADS project fork; Jennifer M. Adams (@j-m-adams) gave permission for the fork (she does not have the bandwidth to maintain it at the moment).
- [x] NCEPLIBS-g2c is provided as a separate source archive; its license is packaged for the Windows build.
- [x] Package outputs do not ship static libraries.
- [x] Build number is 0.
- [x] Source is fetched as a tarball.
- [x] I confirm that I am willing to be listed as a recipe maintainer
- [x] No unresolved local build issue; I’ll consult the knowledge base if an issue arises.


